### PR TITLE
Refactor API to use Bun.serve() instead of tsx

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,8 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"dev": "tsx watch src/index.ts",
-		"build": "tsc",
+		"dev": "bun --watch src/index.ts",
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
@@ -14,8 +13,7 @@
 	},
 	"devDependencies": {
 		"@repo/typescript-config": "workspace:*",
-		"@types/node": "^22.0.0",
-		"tsx": "^4.19.0",
+		"bun-types": "latest",
 		"typescript": "5.9.2"
 	}
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,4 @@
-import { createServer } from "node:http";
-import { RPCHandler } from "@orpc/server/node";
+import { RPCHandler } from "@orpc/server/fetch";
 import { CORSPlugin } from "@orpc/server/plugins";
 import { router } from "./router.js";
 
@@ -7,22 +6,22 @@ const handler = new RPCHandler(router, {
 	plugins: [new CORSPlugin()],
 });
 
-const server = createServer(async (req, res) => {
-	const { matched } = await handler.handle(req, res, {
-		prefix: "/rpc",
-		context: {},
-	});
-
-	if (matched) {
-		return;
-	}
-
-	res.statusCode = 404;
-	res.end("Not found");
-});
-
 const port = process.env.PORT ?? 4010;
 
-server.listen(port, () => {
-	console.log(`API server listening on http://localhost:${port}`);
+Bun.serve({
+	port,
+	async fetch(request) {
+		const { matched, response } = await handler.handle(request, {
+			prefix: "/rpc",
+			context: {},
+		});
+
+		if (matched) {
+			return response;
+		}
+
+		return new Response("Not found", { status: 404 });
+	},
 });
+
+console.log(`API server listening on http://localhost:${port}`);

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"outDir": "./dist",
 		"rootDir": "./src",
-		"types": ["node"]
+		"types": ["bun-types"]
 	},
 	"include": ["src"]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -19,8 +19,7 @@
       },
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
-        "@types/node": "^22.0.0",
-        "tsx": "^4.19.0",
+        "bun-types": "latest",
         "typescript": "5.9.2",
       },
     },
@@ -562,6 +561,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 


### PR DESCRIPTION
## Summary
- Replace `node:http` createServer with `Bun.serve()` and switch from `@orpc/server/node` to `@orpc/server/fetch` adapter
- Remove `tsx` and `@types/node` dev dependencies in favor of `bun-types`
- Simplify dev script to `bun --watch src/index.ts` and remove unnecessary `build` script

## Test plan
- [x] Server starts on port 4010
- [x] `POST /rpc/health` returns `{"json":{"status":"ok","timestamp":...}}`
- [x] Non-matching routes return 404
- [x] `check-types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)