### PR TITLE
Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify lockfile unchanged
+        run: git diff --exit-code bun.lock
+
+      - name: Verify
+        run: bun run verify

--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
 	"name": "melbourne",
 	"private": true,
 	"scripts": {
-		"build": "turbo run build --filter='*'",
-		"dev": "turbo run dev --filter='*'",
+		"build": "turbo run build",
+		"dev": "turbo run dev",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",
 		"format": "biome format --write .",
-		"check-types": "turbo run check-types --filter='*'"
+		"check-types": "turbo run check-types",
+		"test": "turbo run test",
+		"verify": "turbo run lint check-types test build"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.0",

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,8 @@
 		"check-types": {
 			"dependsOn": ["^check-types"]
 		},
+		"//#lint": {},
+		"test": {},
 		"dev": {
 			"cache": false,
 			"persistent": true


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow that runs on PRs and pushes to main
- Configure turborepo with `lint`, `check-types`, `test`, and `build` tasks in a single `verify` command
- Add `//#lint` root task and `test` task to turbo.json

## Test plan
- [ ] CI workflow triggers and passes on this PR
- [ ] Lint, typecheck, and build all run via single `turbo run` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)