### PR TITLE
Add browser-based CLI authentication

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,10 @@ import { router } from "./router.js";
 
 const rpcHandler = new RPCHandler(router);
 
+// Auto-create tables on startup (no-op if they already exist)
+const ctx = await auth.$context;
+await ctx.runMigrations();
+
 const ALLOWED_ORIGIN = "http://localhost:4011";
 
 function corsHeaders(origin: string | null): Record<string, string> {
@@ -29,6 +33,22 @@ Bun.serve({
 		}
 
 		const url = new URL(request.url);
+
+		if (url.pathname === "/api/cli-token") {
+			const session = await auth.api.getSession({
+				headers: request.headers,
+			});
+			if (!session) {
+				return new Response(JSON.stringify({ error: "Not authenticated" }), {
+					status: 401,
+					headers: { ...cors, "Content-Type": "application/json" },
+				});
+			}
+			return new Response(JSON.stringify({ token: session.session.token }), {
+				status: 200,
+				headers: { ...cors, "Content-Type": "application/json" },
+			});
+		}
 
 		if (url.pathname.startsWith("/api/auth")) {
 			const response = await auth.handler(request);

--- a/apps/cli/src/__tests__/auth.e2e.test.ts
+++ b/apps/cli/src/__tests__/auth.e2e.test.ts
@@ -1,0 +1,285 @@
+import {
+	afterAll,
+	beforeAll,
+	describe,
+	expect,
+	setDefaultTimeout,
+	test,
+} from "bun:test";
+
+setDefaultTimeout(30_000);
+
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Subprocess } from "bun";
+
+let apiProcess: Subprocess;
+let apiPort: number;
+let apiBaseUrl: string;
+let tempDir: string;
+let configDir: string;
+let sessionToken: string;
+
+async function waitForServer(url: string, timeoutMs = 10_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(url, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: "{}",
+			});
+			if (res.ok) return;
+		} catch {
+			// not ready yet
+		}
+		await Bun.sleep(100);
+	}
+	throw new Error(`Server at ${url} did not start within ${timeoutMs}ms`);
+}
+
+beforeAll(async () => {
+	// Create temp directories
+	tempDir = mkdtempSync(join(tmpdir(), "rudel-auth-test-"));
+	configDir = join(tempDir, "config");
+	mkdirSync(configDir, { recursive: true });
+
+	// Create data dir for SQLite DB
+	const dataDir = join(tempDir, "data");
+	mkdirSync(dataDir, { recursive: true });
+
+	// Find a free port by briefly binding
+	const tempServer = Bun.serve({
+		port: 0,
+		hostname: "127.0.0.1",
+		fetch: () => new Response(""),
+	});
+	apiPort = tempServer.port as number;
+	tempServer.stop(true);
+
+	apiBaseUrl = `http://localhost:${apiPort}`;
+
+	// Start real API server with test PORT and working directory
+	const apiEntrypoint = join(
+		import.meta.dir,
+		"..",
+		"..",
+		"..",
+		"api",
+		"src",
+		"index.ts",
+	);
+	apiProcess = Bun.spawn(["bun", apiEntrypoint], {
+		env: {
+			...process.env,
+			PORT: String(apiPort),
+		},
+		cwd: tempDir,
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+
+	// Wait for server to be ready
+	await waitForServer(`${apiBaseUrl}/rpc/health`, 15_000);
+
+	// Create a test user via sign-up and extract session token
+	const signupResponse = await fetch(`${apiBaseUrl}/api/auth/sign-up/email`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			name: "Test User",
+			email: "test@example.com",
+			password: "testpassword123",
+		}),
+	});
+
+	expect(signupResponse.ok).toBe(true);
+
+	// Extract session token from response body
+	const signupData = (await signupResponse.json()) as { token: string };
+	sessionToken = signupData.token;
+});
+
+afterAll(async () => {
+	if (apiProcess) {
+		apiProcess.kill();
+		await apiProcess.exited;
+	}
+	rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("auth e2e", () => {
+	test("login: callback server receives token and stores credentials", async () => {
+		// Clear any existing credentials first
+		clearCredentialsFromDir(configDir);
+
+		const cliPath = join(import.meta.dir, "..", "bin", "cli.ts");
+		const stdoutLogPath = join(tempDir, "login-stdout.log");
+
+		// Start login via shell, tee stdout to a file so we can poll it
+		const loginProcess = Bun.spawn(
+			[
+				"bash",
+				"-c",
+				`bun "${cliPath}" login --api-base="${apiBaseUrl}" --web-url=http://localhost:9999 2>&1 | tee "${stdoutLogPath}"`,
+			],
+			{
+				env: {
+					...process.env,
+					RUDEL_CONFIG_DIR: configDir,
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+
+		// Poll the log file for the "Opening browser" message
+		const { readFileSync, existsSync } = require("node:fs");
+		let output = "";
+		const deadline = Date.now() + 10_000;
+
+		while (Date.now() < deadline) {
+			if (existsSync(stdoutLogPath)) {
+				output = readFileSync(stdoutLogPath, "utf-8");
+				if (output.includes("Opening browser")) break;
+			}
+			await Bun.sleep(100);
+		}
+
+		// Extract the callback URL from the output
+		const callbackMatch = output.match(/cli_callback=([^&]+)/);
+		expect(callbackMatch).not.toBeNull();
+		const callbackUrl = decodeURIComponent(callbackMatch?.[1] ?? "");
+
+		// Extract the state
+		const stateMatch = output.match(/state=([a-f0-9]+)/);
+		expect(stateMatch).not.toBeNull();
+		const state = stateMatch?.[1] ?? "";
+
+		// Simulate what the web app does: hit the callback with token + state
+		const callbackResponse = await fetch(
+			`${callbackUrl}?token=${sessionToken}&state=${state}`,
+		);
+		expect(callbackResponse.ok).toBe(true);
+		const callbackBody = await callbackResponse.text();
+		expect(callbackBody).toContain("Login successful");
+
+		// Wait for the process to finish
+		const exitCode = await loginProcess.exited;
+		expect(exitCode).toBe(0);
+
+		// Verify credentials were stored
+		const savedCredentials = loadCredentialsFromDir(configDir);
+		expect(savedCredentials).not.toBeNull();
+		expect(savedCredentials?.token).toBe(sessionToken);
+		expect(savedCredentials?.apiBaseUrl).toBe(apiBaseUrl);
+	});
+
+	test("whoami: shows user info with valid credentials", async () => {
+		// Ensure credentials are stored
+		saveCredentialsToDir(configDir, sessionToken, apiBaseUrl);
+
+		const cliPath = join(import.meta.dir, "..", "bin", "cli.ts");
+		const proc = Bun.spawn(["bun", cliPath, "whoami"], {
+			env: {
+				...process.env,
+				RUDEL_CONFIG_DIR: configDir,
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+
+		const exitCode = await proc.exited;
+		const stdout = await new Response(proc.stdout).text();
+		const stderr = await new Response(proc.stderr).text();
+
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain("Test User");
+		expect(stdout).toContain("test@example.com");
+		expect(stderr).toBe("");
+	});
+
+	test("logout: clears credentials", async () => {
+		// Ensure credentials exist
+		saveCredentialsToDir(configDir, sessionToken, apiBaseUrl);
+
+		const cliPath = join(import.meta.dir, "..", "bin", "cli.ts");
+		const proc = Bun.spawn(["bun", cliPath, "logout"], {
+			env: {
+				...process.env,
+				RUDEL_CONFIG_DIR: configDir,
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+
+		const exitCode = await proc.exited;
+		const stdout = await new Response(proc.stdout).text();
+
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain("Logged out successfully");
+
+		// Verify credentials are gone
+		const credentials = loadCredentialsFromDir(configDir);
+		expect(credentials).toBeNull();
+	});
+
+	test("whoami: shows not logged in after logout", async () => {
+		// Ensure no credentials
+		clearCredentialsFromDir(configDir);
+
+		const cliPath = join(import.meta.dir, "..", "bin", "cli.ts");
+		const proc = Bun.spawn(["bun", cliPath, "whoami"], {
+			env: {
+				...process.env,
+				RUDEL_CONFIG_DIR: configDir,
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+
+		const exitCode = await proc.exited;
+		const stdout = await new Response(proc.stdout).text();
+
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain("Not logged in");
+	});
+});
+
+// Helpers that operate on a specific config dir (matching the RUDEL_CONFIG_DIR env var)
+function saveCredentialsToDir(
+	dir: string,
+	token: string,
+	apiBaseUrl: string,
+): void {
+	const { writeFileSync } = require("node:fs");
+	writeFileSync(
+		join(dir, "credentials.json"),
+		JSON.stringify({ token, apiBaseUrl }, null, 2),
+		{ mode: 0o600 },
+	);
+}
+
+function loadCredentialsFromDir(
+	dir: string,
+): { token: string; apiBaseUrl: string } | null {
+	const path = join(dir, "credentials.json");
+	try {
+		const { readFileSync } = require("node:fs");
+		const content = readFileSync(path, "utf-8");
+		return JSON.parse(content);
+	} catch {
+		return null;
+	}
+}
+
+function clearCredentialsFromDir(dir: string): void {
+	const path = join(dir, "credentials.json");
+	try {
+		const { rmSync } = require("node:fs");
+		rmSync(path);
+	} catch {
+		// already gone
+	}
+}

--- a/apps/cli/src/app.ts
+++ b/apps/cli/src/app.ts
@@ -1,8 +1,14 @@
 import { buildApplication, buildRouteMap } from "@stricli/core";
+import { loginCommand } from "./commands/login.js";
+import { logoutCommand } from "./commands/logout.js";
 import { uploadCommand } from "./commands/upload.js";
+import { whoamiCommand } from "./commands/whoami.js";
 
 const routes = buildRouteMap({
 	routes: {
+		login: loginCommand,
+		logout: logoutCommand,
+		whoami: whoamiCommand,
 		upload: uploadCommand,
 	},
 	docs: {

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -1,0 +1,148 @@
+import { randomBytes } from "node:crypto";
+import { buildCommand } from "@stricli/core";
+import { loadCredentials, saveCredentials } from "../lib/credentials.js";
+
+const DEFAULT_API_BASE = "http://localhost:4010";
+const DEFAULT_WEB_URL = "http://localhost:4011";
+const CALLBACK_TIMEOUT_MS = 120_000;
+
+async function runLogin(flags: {
+	apiBase: string;
+	webUrl: string;
+}): Promise<void> {
+	const write = (msg: string) => process.stdout.write(`${msg}\n`);
+	const writeError = (msg: string) => process.stderr.write(`${msg}\n`);
+
+	const existing = loadCredentials();
+	if (existing) {
+		write("Already logged in. Run `rudel logout` first to switch accounts.");
+		return;
+	}
+
+	const state = randomBytes(16).toString("hex");
+
+	let resolveCallback: (token: string) => void;
+	let rejectCallback: (error: Error) => void;
+	const tokenPromise = new Promise<string>((resolve, reject) => {
+		resolveCallback = resolve;
+		rejectCallback = reject;
+	});
+
+	const server = Bun.serve({
+		port: 0,
+		hostname: "127.0.0.1",
+		fetch(request) {
+			const url = new URL(request.url);
+			if (url.pathname !== "/callback") {
+				return new Response("Not found", { status: 404 });
+			}
+
+			const receivedToken = url.searchParams.get("token");
+			const receivedState = url.searchParams.get("state");
+
+			if (receivedState !== state) {
+				rejectCallback(new Error("State mismatch — possible CSRF attack"));
+				return new Response(
+					"<html><body><h1>Login failed</h1><p>State mismatch. Please try again.</p></body></html>",
+					{ headers: { "Content-Type": "text/html" } },
+				);
+			}
+
+			if (!receivedToken) {
+				rejectCallback(new Error("No token received"));
+				return new Response(
+					"<html><body><h1>Login failed</h1><p>No token received.</p></body></html>",
+					{ headers: { "Content-Type": "text/html" } },
+				);
+			}
+
+			resolveCallback(receivedToken);
+			return new Response(
+				"<html><body><h1>Login successful!</h1><p>You can close this tab and return to the terminal.</p></body></html>",
+				{ headers: { "Content-Type": "text/html" } },
+			);
+		},
+	});
+
+	const callbackUrl = `http://127.0.0.1:${server.port}/callback`;
+	const loginUrl = `${flags.webUrl}?cli_callback=${encodeURIComponent(callbackUrl)}&state=${state}`;
+
+	write("Opening browser for authentication...");
+	write(`If the browser doesn't open, visit: ${loginUrl}`);
+
+	// Open browser
+	const opener =
+		process.platform === "darwin"
+			? "open"
+			: process.platform === "win32"
+				? "start"
+				: "xdg-open";
+	Bun.spawn([opener, loginUrl], { stdout: "ignore", stderr: "ignore" });
+
+	// Wait for callback with timeout
+	const timeout = setTimeout(() => {
+		rejectCallback(new Error("Login timed out after 120 seconds"));
+	}, CALLBACK_TIMEOUT_MS);
+
+	let token: string;
+	try {
+		token = await tokenPromise;
+	} catch (error) {
+		clearTimeout(timeout);
+		server.stop();
+		writeError(
+			`Login failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		process.exitCode = 1;
+		return;
+	}
+	clearTimeout(timeout);
+	server.stop();
+
+	// Validate token via /rpc/me
+	write("Validating token...");
+	const meResponse = await fetch(`${flags.apiBase}/rpc/me`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${token}`,
+		},
+		body: JSON.stringify({}),
+	});
+
+	if (!meResponse.ok) {
+		writeError("Login failed: token validation failed");
+		process.exitCode = 1;
+		return;
+	}
+
+	const body = (await meResponse.json()) as {
+		json: { id: string; email: string; name: string };
+	};
+
+	saveCredentials(token, flags.apiBase);
+	write(`Logged in as ${body.json.name} (${body.json.email})`);
+}
+
+export const loginCommand = buildCommand({
+	loader: async () => ({ default: runLogin }),
+	parameters: {
+		flags: {
+			apiBase: {
+				kind: "parsed",
+				parse: String,
+				brief: "API server base URL",
+				default: DEFAULT_API_BASE,
+			},
+			webUrl: {
+				kind: "parsed",
+				parse: String,
+				brief: "Web app URL for authentication",
+				default: DEFAULT_WEB_URL,
+			},
+		},
+	},
+	docs: {
+		brief: "Authenticate with the Rudel API via browser login",
+	},
+});

--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -1,0 +1,23 @@
+import { buildCommand } from "@stricli/core";
+import { clearCredentials, loadCredentials } from "../lib/credentials.js";
+
+async function runLogout(): Promise<void> {
+	const write = (msg: string) => process.stdout.write(`${msg}\n`);
+
+	const credentials = loadCredentials();
+	if (!credentials) {
+		write("Not logged in.");
+		return;
+	}
+
+	clearCredentials();
+	write("Logged out successfully.");
+}
+
+export const logoutCommand = buildCommand({
+	loader: async () => ({ default: runLogout }),
+	parameters: {},
+	docs: {
+		brief: "Log out and remove stored credentials",
+	},
+});

--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -1,5 +1,6 @@
 import { buildCommand } from "@stricli/core";
 import { classifySession } from "../lib/classifier.js";
+import { loadCredentials } from "../lib/credentials.js";
 import { getGitInfo } from "../lib/git-info.js";
 import { resolveSession } from "../lib/session-resolver.js";
 import { readSubagentFiles } from "../lib/subagent-reader.js";
@@ -17,7 +18,6 @@ async function runUpload(
 	flags: {
 		tag?: SessionTag;
 		endpoint: string;
-		apiKey?: string;
 		classify: boolean;
 		dryRun: boolean;
 	},
@@ -30,12 +30,10 @@ async function runUpload(
 		process.stderr.write(`${msg}\n`);
 	};
 
-	// Resolve API key
-	const apiKey = flags.apiKey ?? process.env.FLICK_COMPOUND_API_KEY;
-	if (!apiKey && !flags.dryRun) {
-		writeError(
-			"Error: API key required. Set FLICK_COMPOUND_API_KEY or use --api-key",
-		);
+	// Load credentials
+	const credentials = loadCredentials();
+	if (!credentials && !flags.dryRun) {
+		writeError("Error: Not authenticated. Run `rudel login` first.");
 		process.exitCode = 1;
 		return;
 	}
@@ -127,7 +125,7 @@ async function runUpload(
 	const result = await uploadSession(request, {
 		endpoint: flags.endpoint,
 		// biome-ignore lint/style/noNonNullAssertion: validated above with early return
-		apiKey: apiKey!,
+		token: credentials!.token,
 	});
 
 	if (result.success) {
@@ -164,12 +162,6 @@ export const uploadCommand = buildCommand({
 				brief: "Override the upload endpoint URL",
 				default: DEFAULT_ENDPOINT,
 			},
-			apiKey: {
-				kind: "parsed",
-				parse: String,
-				brief: "API key (overrides FLICK_COMPOUND_API_KEY env var)",
-				optional: true,
-			},
 			classify: {
 				kind: "boolean",
 				brief: "Auto-classify session tag using Claude CLI",
@@ -183,7 +175,6 @@ export const uploadCommand = buildCommand({
 		},
 		aliases: {
 			t: "tag",
-			k: "apiKey",
 			c: "classify",
 			n: "dryRun",
 		},

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -1,0 +1,43 @@
+import { buildCommand } from "@stricli/core";
+import { loadCredentials } from "../lib/credentials.js";
+
+async function runWhoami(): Promise<void> {
+	const write = (msg: string) => process.stdout.write(`${msg}\n`);
+	const writeError = (msg: string) => process.stderr.write(`${msg}\n`);
+
+	const credentials = loadCredentials();
+	if (!credentials) {
+		write("Not logged in. Run `rudel login` to authenticate.");
+		return;
+	}
+
+	const response = await fetch(`${credentials.apiBaseUrl}/rpc/me`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${credentials.token}`,
+		},
+		body: JSON.stringify({}),
+	});
+
+	if (!response.ok) {
+		writeError(
+			"Session expired or invalid. Run `rudel login` to re-authenticate.",
+		);
+		process.exitCode = 1;
+		return;
+	}
+
+	const body = (await response.json()) as {
+		json: { id: string; email: string; name: string };
+	};
+	write(`Logged in as ${body.json.name} (${body.json.email})`);
+}
+
+export const whoamiCommand = buildCommand({
+	loader: async () => ({ default: runWhoami }),
+	parameters: {},
+	docs: {
+		brief: "Show the currently authenticated user",
+	},
+});

--- a/apps/cli/src/lib/credentials.ts
+++ b/apps/cli/src/lib/credentials.ts
@@ -1,0 +1,48 @@
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+interface Credentials {
+	token: string;
+	apiBaseUrl: string;
+}
+
+function getConfigDir(): string {
+	return (
+		process.env.RUDEL_CONFIG_DIR ?? join(process.env.HOME ?? "~", ".rudel")
+	);
+}
+
+function getCredentialsPath(): string {
+	return join(getConfigDir(), "credentials.json");
+}
+
+export function saveCredentials(token: string, apiBaseUrl: string): void {
+	const dir = getConfigDir();
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true, mode: 0o700 });
+	}
+	const data: Credentials = { token, apiBaseUrl };
+	writeFileSync(getCredentialsPath(), JSON.stringify(data, null, 2), {
+		mode: 0o600,
+	});
+}
+
+export function loadCredentials(): Credentials | null {
+	const path = getCredentialsPath();
+	if (!existsSync(path)) return null;
+	const content = readFileSync(path, "utf-8");
+	return JSON.parse(content) as Credentials;
+}
+
+export function clearCredentials(): void {
+	const path = getCredentialsPath();
+	if (existsSync(path)) {
+		rmSync(path);
+	}
+}

--- a/apps/cli/src/lib/uploader.ts
+++ b/apps/cli/src/lib/uploader.ts
@@ -2,7 +2,7 @@ import type { IngestRequest, UploadResult } from "./types.js";
 
 export interface UploadConfig {
 	endpoint: string;
-	apiKey: string;
+	token: string;
 }
 
 /**
@@ -17,7 +17,7 @@ export async function uploadSession(
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				"x-api-key": config.apiKey,
+				Authorization: `Bearer ${config.token}`,
 			},
 			body: JSON.stringify(request),
 		});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { LoginForm } from "./components/auth/login-form";
 import { SignupForm } from "./components/auth/signup-form";
 import { Button } from "./components/ui/button";
@@ -8,15 +8,51 @@ import { orpc } from "./lib/orpc";
 
 type Page = "login" | "signup";
 
+function getCliParams(): { cliCallback: string; state: string } | null {
+	const params = new URLSearchParams(window.location.search);
+	const cliCallback = params.get("cli_callback");
+	const state = params.get("state");
+	if (!cliCallback || !state) return null;
+	try {
+		const url = new URL(cliCallback);
+		if (url.hostname !== "127.0.0.1") return null;
+	} catch {
+		return null;
+	}
+	return { cliCallback, state };
+}
+
 function App() {
 	const { data: session, isPending } = authClient.useSession();
 	const [page, setPage] = useState<Page>("login");
+	const [cliRedirecting, setCliRedirecting] = useState(false);
 	const health = useQuery(orpc.health.queryOptions({}));
+	const cliParams = getCliParams();
+
+	useEffect(() => {
+		if (!session || !cliParams || cliRedirecting) return;
+		setCliRedirecting(true);
+
+		fetch("/api/cli-token", { credentials: "include" })
+			.then((res) => res.json())
+			.then((data: { token: string }) => {
+				const redirectUrl = `${cliParams.cliCallback}?token=${encodeURIComponent(data.token)}&state=${encodeURIComponent(cliParams.state)}`;
+				window.location.href = redirectUrl;
+			});
+	}, [session, cliParams, cliRedirecting]);
 
 	if (isPending) {
 		return (
 			<div className="flex min-h-screen items-center justify-center">
 				<p className="text-muted-foreground">Loading...</p>
+			</div>
+		);
+	}
+
+	if (cliRedirecting) {
+		return (
+			<div className="flex min-h-screen items-center justify-center">
+				<p className="text-muted-foreground">Completing CLI login...</p>
 			</div>
 		);
 	}

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -12,6 +12,16 @@ import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { Separator } from "../ui/separator";
 
+function getCallbackURL(): string {
+	const params = new URLSearchParams(window.location.search);
+	const cliCallback = params.get("cli_callback");
+	const state = params.get("state");
+	if (cliCallback && state) {
+		return `/?cli_callback=${encodeURIComponent(cliCallback)}&state=${encodeURIComponent(state)}`;
+	}
+	return "/";
+}
+
 export function LoginForm({
 	onSwitchToSignup,
 }: {
@@ -82,7 +92,7 @@ export function LoginForm({
 						onClick={() =>
 							authClient.signIn.social({
 								provider: "google",
-								callbackURL: "/",
+								callbackURL: getCallbackURL(),
 							})
 						}
 					>
@@ -93,7 +103,7 @@ export function LoginForm({
 						onClick={() =>
 							authClient.signIn.social({
 								provider: "github",
-								callbackURL: "/",
+								callbackURL: getCallbackURL(),
 							})
 						}
 					>


### PR DESCRIPTION
## Summary

- Replace static `x-api-key` auth in the CLI with browser-based login using the existing better-auth system
- Add `rudel login` (opens browser, receives token via local callback server), `rudel logout`, and `rudel whoami` commands
- Update `rudel upload` to use `Authorization: Bearer` from stored credentials instead of `--api-key` flag
- Add `/api/cli-token` endpoint and CLI auth redirect handling in the web app
- Add e2e tests running against a real API server instance

## Test plan

- [x] `bun run check-types` passes across all packages
- [x] `bun test apps/cli` — 20 tests pass (16 existing + 4 new auth e2e)
- [ ] Manual: `rudel login` opens browser, authenticates, stores credentials
- [ ] Manual: `rudel whoami` shows authenticated user
- [ ] Manual: `rudel upload <session> --dry-run` uses bearer auth
- [ ] Manual: `rudel logout` clears credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)