### PR TITLE
Add CLI README

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,66 @@
+# rudel
+
+CLI for uploading [Claude Code](https://docs.anthropic.com/en/docs/claude-code) session transcripts to [Rudel](https://app.rudel.ai) for analytics.
+
+## Installation
+
+```bash
+npm install -g rudel
+```
+
+## Quick Start
+
+```bash
+# 1. Log in via your browser
+rudel login
+
+# 2. Enable automatic session uploads
+rudel enable
+
+# That's it! Your Claude Code sessions will now be uploaded automatically.
+```
+
+## Commands
+
+### `rudel login`
+
+Authenticate with Rudel. Opens your browser to [app.rudel.ai](https://app.rudel.ai) where you sign in, then the CLI receives a token automatically.
+
+### `rudel enable`
+
+Registers a [Claude Code hook](https://docs.anthropic.com/en/docs/claude-code/hooks) that automatically uploads your session transcript when a Claude Code session ends. This is the recommended way to use Rudel -- set it and forget it.
+
+### `rudel disable`
+
+Removes the auto-upload hook.
+
+### `rudel upload <session>`
+
+Manually upload a session transcript. Accepts a session ID or path to a `.jsonl` file.
+
+```bash
+# Upload by session ID
+rudel upload abc123
+
+# Upload a specific file
+rudel upload ./path/to/session.jsonl
+
+# Preview without uploading
+rudel upload abc123 --dry-run
+
+# Auto-classify the session
+rudel upload abc123 --classify
+```
+
+### `rudel whoami`
+
+Show the currently authenticated user.
+
+### `rudel logout`
+
+Clear stored credentials.
+
+## Links
+
+- **Web App**: [app.rudel.ai](https://app.rudel.ai)
+- **Issues**: [GitHub Issues](https://github.com/KeKs0r/kinshasa/issues)

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -6,7 +6,8 @@
 		"rudel": "./dist/cli.js"
 	},
 	"files": [
-		"dist"
+		"dist",
+		"README.md"
 	],
 	"scripts": {
 		"dev": "bun run src/bin/cli.ts",


### PR DESCRIPTION
## Summary
- Add comprehensive README to the CLI package with installation instructions (`npm install -g rudel`), quick start guide (login + enable workflow), and documentation for all CLI commands
- Include README in npm package distribution via `package.json` files array

## What's included
- Installation steps
- Quick start flow demonstrating the recommended `enable` command for automatic session uploads
- Full command documentation (`login`, `enable`, `disable`, `upload`, `whoami`, `logout`)
- Links to [app.rudel.ai](https://app.rudel.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)