### PR TITLE
Cache Bun install on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,14 @@ jobs:
         with:
           bun-version: 1.3.5
 
+      - name: Cache bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions cache for Bun's package manager cache (~/.bun/install/cache)
- Cache is keyed on the bun.lock file hash, reducing dependency installation time on subsequent CI runs

## Rationale
This improves CI speed by reusing cached packages across runs, following the same pattern used in the flick project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)