### PR TITLE
Fix local dev setup and improve documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,10 @@
 node_modules
 .git
-data
 .turbo
+.context
+data
 dist
 *.md
-.context
+Dockerfile
+docker-compose.yml
+scripts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ There are two ways to run the app locally:
 
 Uses Docker containers for Postgres and ClickHouse. No Doppler or external accounts required. Good for working on auth, UI, or API logic without needing real data.
 
+**Prerequisites**: Docker (or [OrbStack](https://orbstack.dev)) must be installed and running.
+
 ```bash
 bun install
 bun run dev:local
@@ -65,9 +67,11 @@ This runs `scripts/dev-local.sh`, which:
 2. Runs Postgres migrations
 3. Launches the API (`:4010`) and web app (`:4011`) in parallel
 
-Environment is hardcoded in the script: local Postgres (`postgres://postgres:postgres@localhost:5432/rudel`), local ClickHouse (`http://localhost:8123`), and a static auth secret. Social login (Google/GitHub) is not available in this mode since there are no OAuth client credentials.
+Open **http://localhost:4011** in your browser. Sign up with email/password to create a local account. Social login (Google/GitHub) is not available in this mode since there are no OAuth client credentials.
 
-Manage containers separately: `bun run infra:up` / `bun run infra:down`.
+Environment is hardcoded in the script: local Postgres (`postgres://postgres:postgres@localhost:5432/rudel`), local ClickHouse (`http://localhost:8123`, password: `clickhouse`), and a static auth secret.
+
+Manage containers separately: `bun run infra:up` / `bun run infra:down`. To wipe all data and start fresh: `docker compose down -v`.
 
 ### 2. Dev (production databases)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM oven/bun:1.3.5 AS base
+WORKDIR /app
+
+# Install dependencies
+COPY package.json bun.lock ./
+COPY apps/api/package.json apps/api/package.json
+COPY apps/cli/package.json apps/cli/package.json
+COPY apps/web/package.json apps/web/package.json
+COPY packages/api-routes/package.json packages/api-routes/package.json
+COPY packages/ch-schema/package.json packages/ch-schema/package.json
+COPY packages/sql-schema/package.json packages/sql-schema/package.json
+COPY packages/typescript-config/package.json packages/typescript-config/package.json
+RUN bun install --frozen-lockfile
+
+# Copy source
+COPY apps/ apps/
+COPY packages/ packages/
+COPY turbo.json turbo.json
+
+# Build web app and place output where the API serves static files
+RUN bun run --cwd apps/web build
+RUN cp -r apps/web/dist/ apps/api/public/
+
+EXPOSE 3000
+ENV PORT=3000
+
+CMD ["bun", "apps/api/src/index.ts"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Rudel
 
-A platform for ingesting, storing, and analyzing Claude Code session transcripts.
+A platform for ingesting, storing, and analyzing [Claude Code](https://docs.anthropic.com/en/docs/claude-code) session transcripts. Rudel gives you a dashboard with analytics on your coding sessions — token usage, session duration, activity patterns, model usage, and more.
 
-Users authenticate via the web app, use the [CLI](apps/cli/README.md) to upload `.jsonl` session transcripts, which are stored in ClickHouse for analytics.
+**How it works**: Users authenticate via the web app, install the [CLI](apps/cli/README.md), and enable automatic uploads. The CLI registers a Claude Code [hook](https://docs.anthropic.com/en/docs/claude-code/hooks) that uploads session transcripts when a session ends. Transcripts are stored in ClickHouse and processed into analytics via a materialized view.
 
-**Stack**: Bun, TypeScript, Postgres, ClickHouse
+**Stack**: Bun, TypeScript, Postgres (auth), ClickHouse (analytics)
 
 ## Local Development
 
@@ -15,7 +15,10 @@ bun install
 bun run dev:local
 ```
 
-This starts local Postgres + ClickHouse via Docker, runs migrations, and launches the API (`:4010`) and web app (`:4011`).
+This starts local Postgres + ClickHouse via Docker Compose, runs migrations, and launches:
+
+- **API** at `http://localhost:4010`
+- **Web app** at `http://localhost:4011`
 
 To manage the database containers separately:
 
@@ -24,6 +27,35 @@ bun run infra:up    # start Postgres + ClickHouse
 bun run infra:down  # stop them
 ```
 
+> **Note**: Social login (Google, GitHub OAuth) is not available in local mode — there are no OAuth client credentials configured. You can still sign up and log in with email/password.
+
+## CLI
+
+The [`rudel` CLI](apps/cli/README.md) is published on npm and handles authentication and session uploads:
+
+```bash
+npm install -g rudel
+rudel login
+rudel enable   # auto-upload sessions via Claude Code hook
+```
+
+See the [CLI README](apps/cli/README.md) for all commands.
+
+## Project Structure
+
+```
+apps/
+  api/          HTTP API server (Bun). Auth, RPC, session ingestion.
+  cli/          CLI for authenticating and uploading session transcripts.
+  web/          React SPA (Vite + Tailwind + shadcn). Dashboard and auth UI.
+
+packages/
+  api-routes/   Shared RPC contract (@orpc/contract + Zod schemas).
+  ch-schema/    ClickHouse table schemas, migrations, and TypeScript codegen.
+  sql-schema/   Drizzle ORM schema for Postgres auth tables.
+  typescript-config/  Shared tsconfig base files.
+```
+
 ## Self-Hosting
 
-See [docs/self-hosting.md](docs/self-hosting.md) for deploying with ObsessionDB + Neon + Fly.io.
+See [docs/self-hosting.md](docs/self-hosting.md) for deploying your own instance.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -63,4 +63,4 @@ Clear stored credentials.
 ## Links
 
 - **Web App**: [app.rudel.ai](https://app.rudel.ai)
-- **Issues**: [GitHub Issues](https://github.com/KeKs0r/kinshasa/issues)
+- **Issues**: [GitHub Issues](https://github.com/obsessiondb/rudel/issues)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,11 +19,13 @@ services:
     image: clickhouse/clickhouse-server:latest
     ports:
       - "8123:8123"
+    environment:
+      CLICKHOUSE_PASSWORD: clickhouse
     volumes:
       - clickhouse_data:/var/lib/clickhouse
       - ./scripts/init-clickhouse-local.sql:/docker-entrypoint-initdb.d/init.sql:ro
     healthcheck:
-      test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
+      test: ["CMD", "clickhouse-client", "--password", "clickhouse", "--query", "SELECT 1"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,41 +1,45 @@
 # Self-Hosting Rudel
 
-This guide covers deploying Rudel with managed services.
+This guide walks through deploying Rudel using **ObsessionDB** (ClickHouse), **Neon** (Postgres), and **Fly.io** (app server). This is the same stack we use in production.
+
+> **This is an opinionated guide.** Rudel is a Bun server that needs Postgres and ClickHouse — it can run anywhere those are available. You don't have to use these specific providers. Any Postgres instance, any ClickHouse instance (that supports `SharedReplacingMergeTree` or `ReplacingMergeTree`), and any platform that can run a Bun/Node.js server will work. We use ObsessionDB, Neon, and Fly.io because they all have free tiers and are easy to set up.
 
 ## Services
 
-| Component | Provider | Purpose |
-|-----------|----------|---------|
-| **ClickHouse** | [ObsessionDB](https://obsessiondb.com) | Session transcript storage and analytics |
-| **Postgres** | [Neon](https://neon.tech) | Authentication (users, sessions, accounts) |
-| **API Server** | [Fly.io](https://fly.io) | HTTP API + static frontend serving |
+| Component | Provider | Free Tier | Purpose |
+|-----------|----------|-----------|---------|
+| **ClickHouse** | [ObsessionDB](https://obsessiondb.com) | Yes | Session transcript storage and analytics |
+| **Postgres** | [Neon](https://neon.tech) | Yes (0.5 GB) | Authentication (users, sessions, accounts) |
+| **App Server** | [Fly.io](https://fly.io) | Yes (3 shared VMs) | HTTP API + static frontend serving |
 
 ## 1. Provision ClickHouse (ObsessionDB)
 
 1. Create an account at [obsessiondb.com](https://obsessiondb.com)
 2. Create a new ClickHouse instance
 3. Note your connection details:
-   - `CLICKHOUSE_URL` — the HTTPS endpoint (e.g. `https://your-instance.obsessiondb.com`)
-   - `CLICKHOUSE_USERNAME` — your username
-   - `CLICKHOUSE_PASSWORD` — your password
+   - **Host** — the HTTPS endpoint (e.g. `https://your-instance.obsessiondb.com`)
+   - **Username** — your username
+   - **Password** — your password
 4. Apply the schema migration:
 
 ```bash
-# Set your ClickHouse credentials
-export CLICKHOUSE_URL=https://your-instance.obsessiondb.com
-export CLICKHOUSE_USERNAME=your-username
-export CLICKHOUSE_PASSWORD=your-password
-
-# Run the migration (from the repo root)
-# The migration uses SharedReplacingMergeTree for cloud ClickHouse
-bun run --cwd packages/ch-schema ch:migrate
+# From the repo root — set the env vars that chkit reads
+CLICKHOUSE_URL=https://your-instance.obsessiondb.com \
+CLICKHOUSE_USER=your-username \
+CLICKHOUSE_PASSWORD=your-password \
+CLICKHOUSE_DB=default \
+  bun --bun --cwd packages/ch-schema chkit migrate --apply
 ```
+
+The migration creates the `rudel` database, the `claude_sessions` and `session_analytics` tables, and a materialized view that computes analytics on insert. The cloud migration uses `SharedReplacingMergeTree` for `claude_sessions`.
+
+> **Note**: `CLICKHOUSE_DB` must be set to `default` for the migration because the `rudel` database doesn't exist yet — the migration creates it. `CLICKHOUSE_USER` (not `CLICKHOUSE_USERNAME`) is the env var name that the migration tool expects.
 
 ## 2. Provision Postgres (Neon)
 
 1. Create an account at [neon.tech](https://neon.tech)
 2. Create a new project and database named `rudel`
-3. Note your connection string: `postgres://user:pass@host/rudel?sslmode=require`
+3. Copy your connection string (looks like `postgres://user:pass@host/rudel?sslmode=require`)
 4. Run the Drizzle migrations:
 
 ```bash
@@ -43,16 +47,19 @@ PG_CONNECTION_STRING="postgres://user:pass@host/rudel?sslmode=require" \
   bun run --cwd packages/sql-schema migrate
 ```
 
+This creates the auth tables (users, sessions, accounts, verification tokens) used by `better-auth`.
+
 ## 3. Deploy to Fly.io
 
 1. Install the Fly CLI: `curl -L https://fly.io/install.sh | sh`
-2. Create a new app:
+2. Sign up or log in: `fly auth login`
+3. Create a new app:
 
 ```bash
-fly launch --name rudel --no-deploy
+fly launch --name your-app-name --no-deploy
 ```
 
-3. Set environment variables:
+4. Set secrets (the API reads `CLICKHOUSE_USERNAME`, not `CLICKHOUSE_USER`):
 
 ```bash
 fly secrets set \
@@ -61,19 +68,51 @@ fly secrets set \
   CLICKHOUSE_URL="https://your-instance.obsessiondb.com" \
   CLICKHOUSE_USERNAME="your-username" \
   CLICKHOUSE_PASSWORD="your-password" \
-  APP_URL="https://rudel.fly.dev" \
-  ALLOWED_ORIGIN="https://rudel.fly.dev"
+  APP_URL="https://your-app-name.fly.dev" \
+  ALLOWED_ORIGIN="https://your-app-name.fly.dev"
 ```
 
-4. Build and deploy:
+5. Deploy (the `Dockerfile` in the repo root handles building the frontend and running the API):
 
 ```bash
-# Build the frontend
-bun run build
-
-# Deploy
 fly deploy
 ```
+
+6. Verify it's running:
+
+```bash
+curl https://your-app-name.fly.dev/health
+```
+
+### Custom domain
+
+If you want to use a custom domain instead of `*.fly.dev`:
+
+```bash
+fly certs add your-domain.com
+```
+
+Then update `APP_URL` and `ALLOWED_ORIGIN` to match:
+
+```bash
+fly secrets set \
+  APP_URL="https://your-domain.com" \
+  ALLOWED_ORIGIN="https://your-domain.com"
+```
+
+## Social Login (Optional)
+
+To enable GitHub or Google OAuth login, create OAuth apps with the respective providers and set the client credentials:
+
+```bash
+fly secrets set \
+  GITHUB_CLIENT_ID="your-client-id" \
+  GITHUB_CLIENT_SECRET="your-client-secret"
+```
+
+Set the OAuth callback URL to `https://your-domain.com/api/auth/callback/github` (or `/google`).
+
+Without these, users can still sign up and log in with email/password.
 
 ## Environment Variables Reference
 
@@ -84,9 +123,9 @@ fly deploy
 | `CLICKHOUSE_URL` | Yes | ClickHouse HTTPS endpoint |
 | `CLICKHOUSE_USERNAME` | Yes | ClickHouse username |
 | `CLICKHOUSE_PASSWORD` | Yes | ClickHouse password |
-| `APP_URL` | Yes | Public URL of the API server |
+| `APP_URL` | Yes | Public URL of the deployed app |
 | `ALLOWED_ORIGIN` | Yes | CORS origin (same as `APP_URL` for single-domain) |
-| `GOOGLE_CLIENT_ID` | No | Google OAuth client ID |
-| `GOOGLE_CLIENT_SECRET` | No | Google OAuth client secret |
 | `GITHUB_CLIENT_ID` | No | GitHub OAuth client ID |
 | `GITHUB_CLIENT_SECRET` | No | GitHub OAuth client secret |
+| `GOOGLE_CLIENT_ID` | No | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | No | Google OAuth client secret |

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -10,14 +10,15 @@ PG_CONNECTION_STRING=postgres://postgres:postgres@localhost:5432/rudel \
 
 # 3. Start API + Web in parallel with local env vars
 export PG_CONNECTION_STRING=postgres://postgres:postgres@localhost:5432/rudel
-export BETTER_AUTH_SECRET=local-dev-secret
+export BETTER_AUTH_SECRET=local-dev-secret-that-is-at-least-32-chars-long
 export CLICKHOUSE_URL=http://localhost:8123
+export CLICKHOUSE_PASSWORD=clickhouse
 export APP_URL=http://localhost:4011
 
 # Run API and Web in parallel, kill both on Ctrl+C
 bun --watch apps/api/src/index.ts &
 API_PID=$!
-bun --cwd apps/web vite &
+bun run --cwd apps/web dev &
 WEB_PID=$!
 
 trap "kill $API_PID $WEB_PID 2>/dev/null" EXIT

--- a/scripts/init-clickhouse-local.sql
+++ b/scripts/init-clickhouse-local.sql
@@ -71,10 +71,10 @@ CREATE TABLE IF NOT EXISTS rudel.session_analytics
   `used_plan_mode` UInt8 DEFAULT 0,
   `inference_duration_sec` UInt32 DEFAULT 0,
   `human_duration_sec` UInt32 DEFAULT 0,
-  INDEX `idx_model_used` (model_used) TYPE set GRANULARITY 4,
-  INDEX `idx_project_path` (project_path) TYPE set GRANULARITY 4,
-  INDEX `idx_repository` (repository) TYPE set GRANULARITY 4,
-  INDEX `idx_user_id` (user_id) TYPE set GRANULARITY 4
+  INDEX `idx_model_used` (model_used) TYPE set(0) GRANULARITY 4,
+  INDEX `idx_project_path` (project_path) TYPE set(0) GRANULARITY 4,
+  INDEX `idx_repository` (repository) TYPE set(0) GRANULARITY 4,
+  INDEX `idx_user_id` (user_id) TYPE set(0) GRANULARITY 4
 ) ENGINE = ReplacingMergeTree(ingested_at)
 PARTITION BY toYYYYMM(toDate(session_date))
 ORDER BY (`organization_id`, `session_date`, `session_id`)


### PR DESCRIPTION
## Summary

Fixed 3 critical bugs that prevented `bun run dev:local` from working:

1. **ClickHouse Docker compatibility**: Latest ClickHouse image requires `TYPE set(0)` syntax instead of `TYPE set` for secondary indexes. Container was crashing on startup.
2. **ClickHouse authentication**: Added password requirement (`CLICKHOUSE_PASSWORD: clickhouse`) to docker-compose.yml and dev script, as latest image enforces authentication.
3. **Vite script resolution**: Changed `bun --cwd apps/web vite` to `bun run --cwd apps/web dev` for proper binary resolution.

Also expanded documentation across README, CLAUDE.md, and self-hosting.md to clarify local development setup, prerequisite requirements, and deployment procedures.

**Verified working**: Docker Compose, migrations, signup, authenticated RPC calls all functional end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)