### PR TITLE
Fix Volta shim conflict by removing rudel from root deps

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -69,6 +69,16 @@
             "command": "entire hooks claude-code session-end"
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "RUDEL_API_BASE=http://localhost:4010 bun apps/cli/src/bin/cli.ts hooks claude session-end",
+            "async": true
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/apps/cli/src/commands/hooks/claude/session-end.ts
+++ b/apps/cli/src/commands/hooks/claude/session-end.ts
@@ -56,7 +56,8 @@ async function runSessionEnd(): Promise<void> {
 			subagents: subagents.length > 0 ? subagents : undefined,
 		};
 
-		const endpoint = `${credentials.apiBaseUrl}/rpc`;
+		const apiBase = process.env.RUDEL_API_BASE ?? credentials.apiBaseUrl;
+		const endpoint = `${apiBase}/rpc`;
 		await uploadSession(request, { endpoint, token: credentials.token });
 	} catch {
 		// Swallow all errors — this runs async in the background

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "melbourne",
       "dependencies": {
         "postgres": "^3.4.8",
-        "rudel": "^0.1.4",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 		"@chkit/clickhouse": "0.1.0-beta.7"
 	},
 	"dependencies": {
-		"postgres": "^3.4.8",
-		"rudel": "^0.1.4"
+		"postgres": "^3.4.8"
 	}
 }


### PR DESCRIPTION
## Summary
- Removes `rudel` from root `package.json` dependencies. Bun resolved it to the local `apps/cli` workspace, which caused Volta's shim to treat `rudel` as a project-level package instead of falling back to the global install — breaking all `rudel` CLI commands inside this repo.
- Adds `RUDEL_API_BASE` env var override to the CLI's session-end hook, allowing local dev to point uploads at `localhost:4010`.
- Configures the Claude Code SessionEnd hook to run the CLI from TypeScript source (`bun apps/cli/src/bin/cli.ts`) targeting the local API.

## Test plan
- [ ] Run `rudel --version` inside the repo to verify the global install resolves correctly
- [ ] Confirm `bun install` completes without errors
- [ ] Verify the session-end hook runs against the local API when `RUDEL_API_BASE` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)