### PR TITLE
Clarify Doppler setup scope in development docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ Manage containers separately: `bun run infra:up` / `bun run infra:down`. To wipe
 
 ### 2. Dev (production databases)
 
+> **Note**: This mode is used by the core team to develop against the hosted `app.rudel.ai` production data. If you're self-hosting or contributing, use **Standalone** above — it's the fully functional default.
+
 Connects to production Neon Postgres and ObsessionDB ClickHouse via the `prd_local` Doppler config. Runs API + web locally but with real data. Requires Doppler access.
 
 ```bash


### PR DESCRIPTION
## Summary
Added a clear note explaining that the Doppler-based "Dev" setup is specifically for the core team developing against production databases (app.rudel.ai). External developers and self-hosters should use the Standalone mode, which is the fully functional default.

## Changes
- Added clarifying note to CLAUDE.md section 2 (Dev production databases) to eliminate ambiguity for newcomers about which setup path to follow

Resolves NUM-6483