### PR TITLE
Add pre-push verification checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,3 +282,13 @@ bun run --cwd apps/api dev:env
 # Run tests locally
 doppler run --project rudel --config ci -- bun run verify
 ```
+
+## Pre-Push Checklist
+
+Before pushing and creating a pull request, always run:
+
+```bash
+bun run verify
+```
+
+This runs type checking, linting, and tests across the monorepo. Do not push or create a PR if `bun run verify` fails.


### PR DESCRIPTION
## Summary

Added a Pre-Push Checklist section to CLAUDE.md that reminds contributors to run `bun verify` before pushing and creating pull requests.

## Changes

- Added "Pre-Push Checklist" section at the end of CLAUDE.md
- Documents the requirement to run `bun verify` (which runs type checking, linting, tests, and build) before pushing
- Ensures code quality standards are met before contributions are submitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)