### PR TITLE
Refactor sidebar layout: consolidate user controls

### DIFF
--- a/apps/web/src/components/analytics/Sidebar.tsx
+++ b/apps/web/src/components/analytics/Sidebar.tsx
@@ -9,7 +9,6 @@ import {
 	FolderKanban,
 	LayoutDashboard,
 	LogOut,
-	User,
 	UserCircle,
 } from "lucide-react";
 import { useState } from "react";
@@ -57,10 +56,23 @@ export function Sidebar() {
 			<div className="flex h-10 items-center gap-1.5 px-4 overflow-hidden border-b border-border">
 				<Activity className="h-5 w-5 shrink-0 text-accent" />
 				{!collapsed && (
-					<span className="text-sm font-bold text-heading whitespace-nowrap">
+					<span className="flex-1 text-sm font-bold text-heading whitespace-nowrap">
 						Rudel Analytics
 					</span>
 				)}
+				{!collapsed && <ThemeToggle />}
+				<button
+					type="button"
+					onClick={() => setCollapsed(!collapsed)}
+					className="p-1 rounded-md text-muted hover:text-foreground hover:bg-hover transition-colors"
+					title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+				>
+					{collapsed ? (
+						<ChevronsRight className="h-4 w-4" />
+					) : (
+						<ChevronsLeft className="h-4 w-4" />
+					)}
+				</button>
 			</div>
 
 			<nav className="flex-1 px-2 pt-2 pb-1 flex flex-col gap-[1px]">
@@ -98,99 +110,46 @@ export function Sidebar() {
 				})}
 			</nav>
 
-			<div className="px-2 pb-1">
-				<div className="relative group">
+			{session?.user && (
+				<div
+					className={cn(
+						"border-t border-border p-2 relative group flex items-center gap-2",
+						collapsed ? "justify-center" : "px-2",
+					)}
+				>
 					<Link
 						to="/dashboard/profile"
-						className={cn(
-							"flex items-center gap-2 rounded-lg px-2 py-2 text-[0.8125rem] font-medium transition-colors duration-150",
-							collapsed && "justify-center",
-							pathname === "/dashboard/profile"
-								? "bg-hover text-heading"
-								: "text-muted hover:bg-hover hover:text-foreground",
-						)}
+						className="flex-1 flex items-center gap-2 min-w-0"
 					>
-						{session?.user.image ? (
-							<img
-								src={session.user.image}
-								alt=""
-								className="h-4 w-4 rounded-full shrink-0"
-							/>
-						) : (
-							<User className="h-4 w-4 shrink-0" />
-						)}
-						{!collapsed && (
-							<span className="whitespace-nowrap overflow-hidden text-ellipsis">
-								{session?.user.name ?? "Profile"}
-							</span>
-						)}
-					</Link>
-
-					{collapsed && (
-						<div className="absolute left-full top-1/2 -translate-y-1/2 ml-2 px-2.5 py-1.5 rounded-md bg-heading text-surface text-xs font-medium whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity duration-150 z-50">
-							{session?.user.name ?? "Profile"}
-						</div>
-					)}
-				</div>
-			</div>
-
-			<div className="border-t border-border p-2 flex flex-col gap-2">
-				{session?.user && (
-					<div
-						className={cn(
-							"relative group flex items-center gap-2",
-							collapsed ? "justify-center" : "px-2",
-						)}
-					>
-						<Avatar size="sm">
+						<Avatar size="sm" className="shrink-0">
 							{session.user.image && (
 								<AvatarImage src={session.user.image} alt={session.user.name} />
 							)}
 							<AvatarFallback>{getInitials(session.user.name)}</AvatarFallback>
 						</Avatar>
 						{!collapsed && (
-							<>
-								<span className="flex-1 truncate text-xs font-medium text-foreground">
-									{session.user.name}
-								</span>
-								<button
-									type="button"
-									onClick={() => authClient.signOut()}
-									className="p-1 rounded-md text-muted hover:text-foreground hover:bg-hover transition-colors"
-									title="Sign out"
-								>
-									<LogOut className="h-3.5 w-3.5" />
-								</button>
-							</>
-						)}
-						{collapsed && (
-							<div className="absolute left-full top-1/2 -translate-y-1/2 ml-2 px-2.5 py-1.5 rounded-md bg-heading text-surface text-xs font-medium whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity duration-150 z-50">
+							<span className="flex-1 truncate text-xs font-medium text-foreground hover:text-heading transition-colors">
 								{session.user.name}
-							</div>
+							</span>
 						)}
-					</div>
-				)}
-				<div
-					className={cn(
-						"flex items-center",
-						collapsed ? "justify-center flex-col gap-2" : "justify-end gap-2",
+					</Link>
+					{!collapsed && (
+						<button
+							type="button"
+							onClick={() => authClient.signOut()}
+							className="p-1 rounded-md text-muted hover:text-foreground hover:bg-hover transition-colors shrink-0"
+							title="Sign out"
+						>
+							<LogOut className="h-3.5 w-3.5" />
+						</button>
 					)}
-				>
-					<ThemeToggle />
-					<button
-						type="button"
-						onClick={() => setCollapsed(!collapsed)}
-						className="p-1 rounded-md text-muted hover:text-foreground hover:bg-hover transition-colors"
-						title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-					>
-						{collapsed ? (
-							<ChevronsRight className="h-4 w-4" />
-						) : (
-							<ChevronsLeft className="h-4 w-4" />
-						)}
-					</button>
+					{collapsed && (
+						<div className="absolute left-full top-1/2 -translate-y-1/2 ml-2 px-2.5 py-1.5 rounded-md bg-heading text-surface text-xs font-medium whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity duration-150 z-50">
+							{session.user.name}
+						</div>
+					)}
 				</div>
-			</div>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- Merge profile link and logout button into a single footer row with right-aligned logout
- Move theme toggle and collapse button to the sidebar header next to the logo
- Remove the redundant standalone profile link row
- Simplify sidebar component structure by eliminating unnecessary nested containers

## Motivation
The sidebar footer had redundant rows (separate profile link and user/logout row). This refactor consolidates those UI elements into a single, more efficient row while moving secondary controls (theme toggle, collapse) to the header where they have room and are more discoverable.