### PR TITLE
fix: clear query cache and localStorage on sign out

### DIFF
--- a/apps/web/src/components/analytics/Sidebar.tsx
+++ b/apps/web/src/components/analytics/Sidebar.tsx
@@ -18,7 +18,7 @@ import {
 import { useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useOrganization } from "../../contexts/OrganizationContext";
-import { authClient } from "../../lib/auth-client";
+import { authClient, signOut } from "../../lib/auth-client";
 import { cn } from "../../lib/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
 
@@ -224,7 +224,7 @@ export function Sidebar() {
 					{!collapsed && (
 						<button
 							type="button"
-							onClick={() => authClient.signOut()}
+							onClick={() => signOut()}
 							className="p-1 rounded-md text-muted hover:text-foreground hover:bg-hover transition-colors shrink-0"
 							title="Sign out"
 						>

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,7 +1,15 @@
 import { organizationClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
+import { queryClient } from "./query-client";
 
 export const authClient = createAuthClient({
 	baseURL: "",
 	plugins: [organizationClient()],
 });
+
+export async function signOut() {
+	await authClient.signOut();
+	queryClient.clear();
+	localStorage.removeItem("dateRange");
+	localStorage.removeItem("globalFilters");
+}

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient();

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,12 +1,11 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App.tsx";
 import "./index.css";
+import { queryClient } from "./lib/query-client";
 import { ThemeProvider } from "./providers/ThemeProvider";
-
-const queryClient = new QueryClient();
 
 // biome-ignore lint/style/noNonNullAssertion: root element always exists
 createRoot(document.getElementById("root")!).render(

--- a/apps/web/src/pages/dashboard/ProfilePage.tsx
+++ b/apps/web/src/pages/dashboard/ProfilePage.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { AnalyticsCard } from "../../components/analytics/AnalyticsCard";
 import { PageHeader } from "../../components/analytics/PageHeader";
 import { Button } from "../../components/ui/button";
-import { authClient } from "../../lib/auth-client";
+import { authClient, signOut } from "../../lib/auth-client";
 
 interface Account {
 	id: string;
@@ -63,15 +63,7 @@ export function ProfilePage() {
 						</div>
 					</div>
 
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={() => {
-							authClient.signOut().then(() => {
-								window.location.reload();
-							});
-						}}
-					>
+					<Button variant="outline" size="sm" onClick={() => signOut()}>
 						<LogOut className="h-4 w-4 mr-2" />
 						Sign out
 					</Button>


### PR DESCRIPTION
## Summary
- Extract `QueryClient` to a shared `query-client.ts` module so it can be imported outside the component tree
- Create a centralized `signOut()` function in `auth-client.ts` that clears the React Query cache and removes persisted filters (`dateRange`, `globalFilters`) from localStorage
- Replace direct `authClient.signOut()` calls in Sidebar and ProfilePage with the new `signOut()` function

## Test plan
- [ ] Sign in, navigate around to populate the query cache, then sign out — verify redirect to login
- [ ] Sign in as a different user — verify no stale data from the previous session
- [ ] Confirm `dateRange` and `globalFilters` are removed from localStorage after sign out

🤖 Generated with [Claude Code](https://claude.com/claude-code)