### PR TITLE
fix: preserve user ID as organization ID on sign-up

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -55,6 +55,7 @@ export function createAuth(db: object, config: AuthConfig) {
 								slug,
 								createdAt: new Date(),
 							},
+							forceAllowId: true,
 						});
 
 						if (org) {


### PR DESCRIPTION
## Summary
- Adds `forceAllowId: true` to the Drizzle adapter `create()` call when creating a user's personal workspace organization on sign-up
- Ensures the org ID in Postgres matches the user ID, keeping it consistent with the `organization_id` used in ClickHouse
- Eliminates the Better Auth warning: "You are trying to create a record with an id...The id will be ignored"

## Test plan
- [ ] Sign up a new user locally via standalone setup
- [ ] Confirm no "forceAllowId" / ID warning in API logs
- [ ] Confirm `listMyOrganizations` returns an org whose `id` equals the user's `id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)