### PR TITLE
feat: send Slack notification on new user signup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ ALLOWED_ORIGIN=http://localhost:4011
 # GitHub OAuth (optional)
 # GITHUB_CLIENT_ID=
 # GITHUB_CLIENT_SECRET=
+
+# Slack signup notifications (optional)
+# SLACK_WEBHOOK_URL=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -11,3 +11,6 @@ GOOGLE_CLIENT_SECRET=
 # GitHub OAuth (optional — only needed for GitHub sign-in)
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+
+# Slack signup notifications (optional)
+# SLACK_WEBHOOK_URL=

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -2,12 +2,14 @@ import * as schema from "@rudel/sql-schema";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { bearer, organization } from "better-auth/plugins";
+import { fetchGitHubHandle, notifySignup } from "./slack.js";
 
 export interface AuthConfig {
 	appURL: string;
 	secret?: string;
 	socialProviders?: Record<string, { clientId: string; clientSecret: string }>;
 	trustedOrigins?: string[];
+	slackWebhookUrl?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- drizzleAdapter accepts { [key: string]: any }
@@ -69,6 +71,27 @@ export function createAuth(db: object, config: AuthConfig) {
 										createdAt: new Date(),
 									},
 								});
+							}
+
+							if (config.slackWebhookUrl) {
+								let githubHandle: string | null = null;
+								const accounts = (await adapter.findMany({
+									model: "account",
+									where: [{ field: "userId", value: user.id }],
+								})) as Array<{ providerId: string; accountId: string }>;
+								const githubAccount = accounts.find(
+									(a) => a.providerId === "github",
+								);
+								if (githubAccount) {
+									githubHandle = await fetchGitHubHandle(
+										githubAccount.accountId,
+									);
+								}
+								await notifySignup(
+									config.slackWebhookUrl,
+									{ name: user.name, email: user.email },
+									githubHandle,
+								);
 							}
 						} catch (err) {
 							console.error(

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -31,6 +31,7 @@ const auth = createAuth(db, {
 	secret: process.env.BETTER_AUTH_SECRET,
 	socialProviders,
 	trustedOrigins,
+	slackWebhookUrl: process.env.SLACK_WEBHOOK_URL,
 });
 
 const rpcHandler = new RPCHandler(router);

--- a/apps/api/src/slack.ts
+++ b/apps/api/src/slack.ts
@@ -1,0 +1,40 @@
+export async function fetchGitHubHandle(
+	accountId: string,
+): Promise<string | null> {
+	try {
+		const res = await fetch(`https://api.github.com/user/${accountId}`, {
+			headers: { Accept: "application/vnd.github.v3+json" },
+		});
+		if (!res.ok) return null;
+		const data = (await res.json()) as { login?: string };
+		return data.login ?? null;
+	} catch (err) {
+		console.error("Failed to fetch GitHub handle for account", accountId, err);
+		return null;
+	}
+}
+
+export async function notifySignup(
+	webhookUrl: string,
+	user: { name: string; email: string },
+	githubHandle?: string | null,
+): Promise<void> {
+	try {
+		const lines = [
+			`*New signup* on Rudel AI`,
+			`*Name:* ${user.name}`,
+			`*Email:* ${user.email}`,
+		];
+		if (githubHandle) {
+			lines.push(`*GitHub:* ${githubHandle}`);
+		}
+
+		await fetch(webhookUrl, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ text: lines.join("\n") }),
+		});
+	} catch (err) {
+		console.error("Failed to send Slack signup notification", err);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds optional `SLACK_WEBHOOK_URL` env var to send a Slack message on each new signup
- Notification includes user name, email, and GitHub handle (if they signed up via GitHub)
- GitHub handle is enriched by querying the GitHub API with the OAuth account ID
- All Slack/GitHub API failures are caught and logged — they never break signup

## Test plan

- [ ] Set `SLACK_WEBHOOK_URL` to a real Slack incoming webhook, start the API locally, sign up — confirm message arrives in Slack
- [ ] Sign up without the env var set — confirm no errors and signup works normally
- [ ] `bun run verify` passes (types, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)