### PR TITLE
docs: add comprehensive .env.example documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,26 +1,74 @@
-# Postgres connection string
+# ============================================================================
+# Rudel — Environment Variables
+# ============================================================================
+# Copy this file to .env and fill in the values.
+# For local development with Docker (bun run dev:local), all defaults work
+# out of the box — you only need to set BETTER_AUTH_SECRET.
+# ============================================================================
+
+# --- Required ----------------------------------------------------------------
+
+# Postgres connection string (Neon in production, local Docker in dev)
 PG_CONNECTION_STRING=postgres://postgres:postgres@localhost:5432/rudel
 
-# better-auth secret (generate with: openssl rand -base64 32)
+# Auth secret used by better-auth for signing tokens/cookies.
+# Generate with: openssl rand -base64 32
 BETTER_AUTH_SECRET=
 
-# ClickHouse
+# --- ClickHouse ---------------------------------------------------------------
+# For local dev, the Docker container (bun run dev:local) provides ClickHouse.
+# For hosted ClickHouse, get credentials at https://obsessiondb.com
+
+# ClickHouse HTTP endpoint. Local Docker uses port 8123; production is behind
+# a reverse proxy on port 443 (https://...).
 CLICKHOUSE_URL=http://localhost:8123
+
+# ClickHouse credentials. The API accepts both CLICKHOUSE_USERNAME and
+# CLICKHOUSE_USER (prefers CLICKHOUSE_USERNAME). Local Docker default password
+# is "clickhouse".
 CLICKHOUSE_USERNAME=default
 CLICKHOUSE_PASSWORD=
 
-# API server
-APP_URL=http://localhost:4010
-ALLOWED_ORIGIN=http://localhost:4011
+# ClickHouse database name. Used by chkit tooling for schema migrations.
+# Not read by the API at runtime (hardcoded to "rudel" in queries).
+# CLICKHOUSE_DB=rudel
+
+# --- API Server ---------------------------------------------------------------
+
+# Base URL of the API server. Used as better-auth's baseURL and automatically
+# added to trusted origins. Default: http://localhost:4010
+# APP_URL=http://localhost:4010
+
+# CORS allowed origin. Requests with a different Origin header won't get CORS
+# headers. Default: http://localhost:4011
+# ALLOWED_ORIGIN=http://localhost:4011
+
+# Comma-separated list of trusted origins for better-auth CSRF protection.
+# APP_URL is automatically appended. Default: http://localhost:4011
 # TRUSTED_ORIGINS=http://localhost:4011
 
-# Google OAuth (optional)
+# Server listen port. Default: 4010. Overridden to 3000 in the Docker image.
+# PORT=4010
+
+# Directory for static file serving (SPA). Relative to apps/api/.
+# In production, the web app is built and copied to apps/api/public/.
+# Default: public
+# STATIC_DIR=public
+
+# --- OAuth Providers (optional) -----------------------------------------------
+# Enable social login by providing OAuth credentials. If not set, only
+# email/password authentication is available.
+
+# Google OAuth
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=
 
-# GitHub OAuth (optional)
+# GitHub OAuth
 # GITHUB_CLIENT_ID=
 # GITHUB_CLIENT_SECRET=
 
-# Slack signup notifications (optional)
-# SLACK_WEBHOOK_URL=
+# --- Integrations (optional) --------------------------------------------------
+
+# Slack incoming webhook URL. When set, sends a notification to the channel
+# on every new user signup.
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,16 +1,19 @@
-# Postgres connection string
-PG_CONNECTION_STRING=postgres://postgres:postgres@localhost:5432/rudel
+# See root .env.example for full documentation of all variables.
 
-# better-auth secret (generate with: openssl rand -base64 32)
+# Required
+PG_CONNECTION_STRING=postgres://postgres:postgres@localhost:5432/rudel
 BETTER_AUTH_SECRET=
 
-# Google OAuth (optional — only needed for Google sign-in)
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
+# ClickHouse (get hosted credentials at https://obsessiondb.com)
+CLICKHOUSE_URL=http://localhost:8123
+CLICKHOUSE_USERNAME=default
+CLICKHOUSE_PASSWORD=
 
-# GitHub OAuth (optional — only needed for GitHub sign-in)
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
+# OAuth (optional)
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
 
-# Slack signup notifications (optional)
+# Slack notifications (optional)
 # SLACK_WEBHOOK_URL=


### PR DESCRIPTION
## Summary
Updated `.env.example` files with detailed documentation of all environment variables. Variables are now organized by context (Required, ClickHouse, API Server, OAuth, Integrations) with explanations of what's needed for local dev vs production, default values, and links to ObsessionDB for hosted ClickHouse credentials.

## Changes
- Root `.env.example`: Added comprehensive header, organized variables by section with clear explanations of each variable's purpose, runtime vs deployment-only usage
- `apps/api/.env.example`: Simplified with a reference to the root file for full documentation, includes ClickHouse credentials (previously missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)