### PR TITLE
ci: use blacksmith runner and bun caching composite action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,20 @@
+name: "Setup Bun"
+description: "Setup Bun and install dependencies with caching"
+runs:
+  using: "composite"
+  steps:
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: 1.3.5
+
+    - uses: actions/cache@v3
+      name: Setup bun cache
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-store-${{ hashFiles('**/bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-store-
+
+    - name: Install dependencies
+      run: bun install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,26 +8,13 @@ on:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.5
-
-      - name: Cache bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+        uses: ./.github/actions/setup
 
       - name: Verify lockfile unchanged
         run: git diff --exit-code bun.lock


### PR DESCRIPTION
## Summary
- Extract bun setup, caching, and installation into a reusable composite action at `.github/actions/setup/action.yml`
- Switch CI runner from `ubuntu-latest` to `blacksmith-2vcpu-ubuntu-2404` for faster builds
- Simplify workflow by delegating setup to the composite action

This follows the same pattern as flick to improve CI performance and maintainability.