### PR TITLE
fix: scope ingestSession authorization to authenticated user

### DIFF
--- a/apps/api/src/__tests__/router-auth.test.ts
+++ b/apps/api/src/__tests__/router-auth.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let mockQueryResult: unknown[] = [];
+
+const chainMock = {
+	select: mock(() => chainMock),
+	from: mock(() => chainMock),
+	where: mock(() => chainMock),
+	innerJoin: mock(() => chainMock),
+	limit: mock(() => Promise.resolve(mockQueryResult)),
+};
+
+const mockIngestSession = mock(() => Promise.resolve());
+
+mock.module("../db.js", () => ({ db: chainMock }));
+mock.module("../clickhouse.js", () => ({ getClickhouse: () => ({}) }));
+mock.module("../ingest.js", () => ({
+	ingestSession: mockIngestSession,
+	buildSessionRow: mock(() => ({})),
+}));
+mock.module("../handlers/analytics/index.js", () => ({
+	analyticsRouter: {},
+}));
+
+const { RPCHandler } = await import("@orpc/server/fetch");
+const { router } = await import("../router.js");
+
+const handler = new RPCHandler(router);
+
+function rpcRequest(path: string, body: unknown) {
+	return new Request(`http://localhost/rpc/${path}`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ json: body, meta: [] }),
+	});
+}
+
+const authedContext = {
+	user: {
+		id: "user-1",
+		email: "test@example.com",
+		name: "Test User",
+		image: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		emailVerified: true,
+	},
+	session: {
+		id: "sess-1",
+		token: "tok",
+		userId: "user-1",
+		activeOrganizationId: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		expiresAt: new Date(Date.now() + 86400000),
+	},
+};
+
+const validInput = {
+	sessionId: "s1",
+	projectPath: "/test",
+	content: "test content",
+};
+
+describe("ingestSession authorization", () => {
+	beforeEach(() => {
+		mockQueryResult = [];
+		mockIngestSession.mockReset();
+		mockIngestSession.mockImplementation(() => Promise.resolve());
+		for (const fn of Object.values(chainMock)) {
+			(fn as ReturnType<typeof mock>).mockClear();
+		}
+	});
+
+	test("user can ingest into an org they belong to", async () => {
+		mockQueryResult = [{ id: "membership-1" }];
+
+		const result = await handler.handle(
+			rpcRequest("ingestSession", { ...validInput, organizationId: "org-1" }),
+			{ prefix: "/rpc", context: authedContext },
+		);
+
+		expect(result.matched).toBe(true);
+		expect(result.response?.status).toBe(200);
+		expect(mockIngestSession).toHaveBeenCalledTimes(1);
+	});
+
+	test("user cannot ingest into an org they do not belong to", async () => {
+		mockQueryResult = [];
+
+		const result = await handler.handle(
+			rpcRequest("ingestSession", {
+				...validInput,
+				organizationId: "other-org",
+			}),
+			{ prefix: "/rpc", context: authedContext },
+		);
+
+		expect(result.matched).toBe(true);
+		expect(result.response?.status).not.toBe(200);
+		expect(mockIngestSession).not.toHaveBeenCalled();
+	});
+
+	test("omitting organizationId skips membership check and succeeds", async () => {
+		const result = await handler.handle(
+			rpcRequest("ingestSession", validInput),
+			{ prefix: "/rpc", context: authedContext },
+		);
+
+		expect(result.matched).toBe(true);
+		expect(result.response?.status).toBe(200);
+		expect(mockIngestSession).toHaveBeenCalledTimes(1);
+		// Should not query for membership at all
+		expect(chainMock.where).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1,6 +1,6 @@
 import { ORPCError } from "@orpc/server";
 import { member, organization } from "@rudel/sql-schema";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { getClickhouse } from "./clickhouse.js";
 import { db } from "./db.js";
 import { analyticsRouter } from "./handlers/analytics/index.js";
@@ -63,7 +63,12 @@ const ingestSessionHandler = os.ingestSession
 			const membership = await db
 				.select({ id: member.id })
 				.from(member)
-				.where(eq(member.organizationId, input.organizationId))
+				.where(
+					and(
+						eq(member.organizationId, input.organizationId),
+						eq(member.userId, context.user.id),
+					),
+				)
 				.limit(1);
 
 			if (membership.length === 0) {


### PR DESCRIPTION
## Security fix

Fixed authorization bypass in `ingestSession` handler. The membership check only verified that the target organization had members, not that the authenticated user was one of them. An attacker could ingest sessions into any org they knew the ID of.

## Changes

- Updated WHERE clause in router.ts to check both `organizationId` and `userId` for membership
- Added 3 unit tests covering: user can ingest into own org, user cannot ingest into org they don't belong to, and fallback to user.id when organizationId omitted

## Testing

All 9 API tests pass (6 existing + 3 new authorization tests). Full verify suite: ✅ typecheck, ✅ lint, ✅ tests, ✅ build.