### PR TITLE
docs: add OSS governance and packaging files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+conduct@obsessiondb.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to Rudel
+
+Thanks for your interest in contributing! This guide covers setup, workflow, and expectations.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) (v1.3+)
+- [Docker](https://docker.com) (or [OrbStack](https://orbstack.dev))
+
+## Setup
+
+```bash
+git clone https://github.com/obsessiondb/rudel.git
+cd rudel
+bun install
+bun run dev:local
+```
+
+This starts local Postgres + ClickHouse via Docker Compose, runs migrations, and launches:
+
+- **API** at `http://localhost:4010`
+- **Web app** at `http://localhost:4011`
+
+Sign up with email/password to create a local account. Social login (Google/GitHub) is not available in local mode.
+
+## Development Commands
+
+```bash
+bun run dev:local     # Start everything (infra + API + web)
+bun run infra:up      # Start database containers only
+bun run infra:down    # Stop database containers
+bun run lint          # Run Biome linter
+bun run lint:fix      # Auto-fix lint issues
+bun run format        # Format code with Biome
+bun run check-types   # TypeScript type checking
+bun run test          # Run tests
+```
+
+## Before Submitting a PR
+
+Run the full verification suite:
+
+```bash
+bun run verify
+```
+
+This runs linting, type checking, tests, and builds across the entire monorepo. Do not open a PR if `verify` fails.
+
+## Pull Request Guidelines
+
+- **PR titles must use [conventional commit](https://www.conventionalcommits.org/) format**. This is enforced by CI. Use one of:
+  `feat:` | `fix:` | `docs:` | `style:` | `refactor:` | `perf:` | `test:` | `build:` | `ci:` | `chore:` | `revert:`
+- Keep PRs focused — one logical change per PR.
+- Include a description of what changed and why.
+- If your change affects the CLI, test it locally with `bun run --cwd apps/cli dev`.
+
+## Project Structure
+
+```
+apps/
+  api/          HTTP API server (Bun)
+  cli/          CLI tool (published to npm as `rudel`)
+  web/          React SPA (Vite + Tailwind + shadcn)
+
+packages/
+  api-routes/   Shared RPC contract
+  ch-schema/    ClickHouse schemas, migrations, codegen
+  sql-schema/   Drizzle ORM schema for Postgres
+  typescript-config/  Shared tsconfig bases
+```
+
+## Reporting Bugs
+
+Open an issue at [github.com/obsessiondb/rudel/issues](https://github.com/obsessiondb/rudel/issues) with steps to reproduce.
+
+## Security Issues
+
+Please report security vulnerabilities privately. See [SECURITY.md](SECURITY.md) for details.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ObsessionDB
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -59,3 +59,15 @@ packages/
 ## Self-Hosting
 
 See [docs/self-hosting.md](docs/self-hosting.md) for deploying your own instance.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, development workflow, and PR guidelines.
+
+## Security
+
+To report a vulnerability, see [SECURITY.md](SECURITY.md). Do not open public issues for security concerns.
+
+## License
+
+[MIT](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | Yes       |
+
+Only the latest released version receives security updates.
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please report vulnerabilities privately via [GitHub Security Advisories](https://github.com/obsessiondb/rudel/security/advisories/new).
+
+Include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+## Response
+
+We aim to acknowledge reports within 48 hours and provide a fix or mitigation plan within 7 days for confirmed vulnerabilities.
+
+## Scope
+
+This policy covers the Rudel platform:
+
+- API server (`apps/api`)
+- CLI tool (`apps/cli`, published as `rudel` on npm)
+- Web application (`apps/web`)

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.4
+
+Initial open-source release.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -3,7 +3,25 @@
 	"version": "0.1.4",
 	"type": "module",
 	"description": "CLI for the Coding Agent Analytics Platform rudel.ai",
+	"license": "MIT",
 	"homepage": "https://app.rudel.ai",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/obsessiondb/rudel.git",
+		"directory": "apps/cli"
+	},
+	"bugs": {
+		"url": "https://github.com/obsessiondb/rudel/issues"
+	},
+	"keywords": [
+		"claude",
+		"claude-code",
+		"analytics",
+		"session",
+		"transcript",
+		"coding-agent"
+	],
+	"author": "ObsessionDB",
 	"bin": {
 		"rudel": "./dist/cli.js"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "rudel-monorepo",
 	"private": true,
+	"license": "MIT",
 	"scripts": {
 		"build": "turbo run build",
 		"dev": "turbo run dev",


### PR DESCRIPTION
## Summary

Establish open-source governance and npm packaging standards. Adds MIT LICENSE, Contributor Covenant Code of Conduct, CONTRIBUTING.md with setup/workflow instructions, and SECURITY.md with vulnerability reporting policy. Updates package.json files with OSS metadata (license, repository, bugs, keywords, author). Creates CLI CHANGELOG.md for release-please automation and updates root README with contribution/security/license pointers.

## Changes

- **LICENSE**: MIT license (copyright ObsessionDB 2025)
- **CODE_OF_CONDUCT.md**: Contributor Covenant v2.1
- **CONTRIBUTING.md**: Local setup, dev commands, PR expectations (conventional commits)
- **SECURITY.md**: Vulnerability reporting via GitHub Security Advisories
- **apps/cli/CHANGELOG.md**: Stub for release-please
- **package.json files**: Added `license`, `repository`, `bugs`, `keywords`, `author` fields
- **README.md**: Added Contributing, Security, License sections

Verified with lint, type check, and build—all passing.