### PR TITLE
fix: clear invite link when typing new email in org invite form

### DIFF
--- a/apps/web/src/pages/dashboard/OrganizationPage.tsx
+++ b/apps/web/src/pages/dashboard/OrganizationPage.tsx
@@ -149,7 +149,10 @@ export function OrganizationPage() {
 							type="email"
 							placeholder="Email address"
 							value={inviteEmail}
-							onChange={(e) => setInviteEmail(e.target.value)}
+							onChange={(e) => {
+								setInviteEmail(e.target.value);
+								if (inviteLink) setInviteLink(null);
+							}}
 							className="flex-1"
 						/>
 						<select


### PR DESCRIPTION
## Summary
When inviting a user to an organization, the invitation link would remain visible after the first invite, making the UI appear "locked" for subsequent invites. Users couldn't easily see that they could type a new email to invite additional members.

## Changes
Auto-dismiss the previous invitation link when the user starts typing a new email address. This provides clear visual feedback that the form is ready for the next invitation.

## Behavior
- User invites first person → sees invitation link
- User starts typing new email → link is auto-dismissed
- User can now clearly proceed with next invite