### PR TITLE
refactor: replace hand-rolled UI with shadcn components

### DIFF
--- a/apps/web/src/components/analytics/DatePicker.tsx
+++ b/apps/web/src/components/analytics/DatePicker.tsx
@@ -1,5 +1,13 @@
 import { Calendar } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
 
 interface DatePickerProps {
 	startDate: string;
@@ -98,39 +106,27 @@ export function DatePicker({
 	onStartDateChange,
 	onEndDateChange,
 }: DatePickerProps) {
-	const [isOpen, setIsOpen] = useState(false);
+	const [open, setOpen] = useState(false);
 	const [tempStartDate, setTempStartDate] = useState(startDate);
 	const [tempEndDate, setTempEndDate] = useState(endDate);
-	const dropdownRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		setTempStartDate(startDate);
 		setTempEndDate(endDate);
 	}, [startDate, endDate]);
 
-	useEffect(() => {
-		function handleClickOutside(event: MouseEvent) {
-			if (
-				dropdownRef.current &&
-				!dropdownRef.current.contains(event.target as Node)
-			) {
-				setIsOpen(false);
-				setTempStartDate(startDate);
-				setTempEndDate(endDate);
-			}
+	const handleOpenChange = (nextOpen: boolean) => {
+		setOpen(nextOpen);
+		if (!nextOpen) {
+			setTempStartDate(startDate);
+			setTempEndDate(endDate);
 		}
-
-		if (isOpen) {
-			document.addEventListener("mousedown", handleClickOutside);
-			return () =>
-				document.removeEventListener("mousedown", handleClickOutside);
-		}
-	}, [isOpen, startDate, endDate]);
+	};
 
 	const handleApply = () => {
 		onStartDateChange(tempStartDate);
 		onEndDateChange(tempEndDate);
-		setIsOpen(false);
+		setOpen(false);
 	};
 
 	const handlePresetClick = (preset: DatePreset) => {
@@ -139,7 +135,7 @@ export function DatePicker({
 		setTempEndDate(end);
 		onStartDateChange(start);
 		onEndDateChange(end);
-		setIsOpen(false);
+		setOpen(false);
 	};
 
 	const formatDateRange = () => {
@@ -158,20 +154,15 @@ export function DatePicker({
 	};
 
 	return (
-		<div className="relative" ref={dropdownRef}>
-			<button
-				type="button"
-				onClick={() => setIsOpen(!isOpen)}
-				className="flex items-center gap-2 bg-input border border-border rounded-lg px-4 py-2 hover:bg-hover transition-colors"
-			>
-				<Calendar className="h-4 w-4 text-muted" />
-				<span className="text-sm font-medium text-foreground">
-					{formatDateRange()}
-				</span>
-			</button>
-
-			{isOpen && (
-				<div className="absolute right-0 mt-2 bg-input border border-border rounded-lg z-50 flex overflow-hidden">
+		<Popover open={open} onOpenChange={handleOpenChange}>
+			<PopoverTrigger asChild>
+				<Button variant="outline" className="gap-2">
+					<Calendar className="h-4 w-4 text-muted" />
+					<span className="text-sm font-medium">{formatDateRange()}</span>
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent className="w-auto p-0" align="end">
+				<div className="flex overflow-hidden">
 					<div className="w-40 border-r border-border bg-surface">
 						{DATE_PRESETS.map((preset) => (
 							<button
@@ -188,53 +179,47 @@ export function DatePicker({
 					<div className="p-4 w-64">
 						<div className="space-y-3">
 							<div>
-								<label
+								<Label
 									htmlFor="date-picker-start"
-									className="block text-xs font-medium text-muted mb-1"
+									className="text-xs text-muted mb-1"
 								>
 									Start date
-								</label>
-								<input
+								</Label>
+								<Input
 									id="date-picker-start"
 									type="date"
 									value={tempStartDate}
 									onChange={(e) => setTempStartDate(e.target.value)}
 									max={tempEndDate}
-									className="w-full px-3 py-2 text-sm border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
 								/>
 							</div>
 
 							<div>
-								<label
+								<Label
 									htmlFor="date-picker-end"
-									className="block text-xs font-medium text-muted mb-1"
+									className="text-xs text-muted mb-1"
 								>
 									End date
-								</label>
-								<input
+								</Label>
+								<Input
 									id="date-picker-end"
 									type="date"
 									value={tempEndDate}
 									onChange={(e) => setTempEndDate(e.target.value)}
 									min={tempStartDate}
 									max={new Date().toISOString().split("T")[0]}
-									className="w-full px-3 py-2 text-sm border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
 								/>
 							</div>
 
 							<div className="pt-2">
-								<button
-									type="button"
-									onClick={handleApply}
-									className="w-full px-4 py-2 bg-accent text-accent-foreground text-sm font-medium rounded-md hover:bg-accent-hover transition-colors"
-								>
+								<Button className="w-full" onClick={handleApply}>
 									Apply
-								</button>
+								</Button>
 							</div>
 						</div>
 					</div>
 				</div>
-			)}
-		</div>
+			</PopoverContent>
+		</Popover>
 	);
 }

--- a/apps/web/src/components/analytics/MultiSelect.tsx
+++ b/apps/web/src/components/analytics/MultiSelect.tsx
@@ -1,6 +1,12 @@
 import { Check, ChevronDown, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-import { cn } from "../../lib/utils";
+import { useState } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
 
 interface MultiSelectProps {
 	options: string[];
@@ -17,22 +23,7 @@ export function MultiSelect({
 	placeholder = "Select items...",
 	className = "",
 }: MultiSelectProps) {
-	const [isOpen, setIsOpen] = useState(false);
-	const dropdownRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		function handleClickOutside(event: MouseEvent) {
-			if (
-				dropdownRef.current &&
-				!dropdownRef.current.contains(event.target as Node)
-			) {
-				setIsOpen(false);
-			}
-		}
-
-		document.addEventListener("mousedown", handleClickOutside);
-		return () => document.removeEventListener("mousedown", handleClickOutside);
-	}, []);
+	const [open, setOpen] = useState(false);
 
 	const toggleOption = (option: string) => {
 		if (selected.includes(option)) {
@@ -55,46 +46,54 @@ export function MultiSelect({
 				: `${selected.length} selected`;
 
 	return (
-		<div ref={dropdownRef} className={cn("relative", className)}>
-			<button
-				type="button"
-				onClick={() => setIsOpen(!isOpen)}
-				className="w-full px-3 py-1.5 text-sm border border-border rounded-lg bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-accent flex items-center justify-between gap-2"
-			>
-				<span className={cn("truncate", selected.length === 0 && "text-muted")}>
-					{selected.length > 0 && (
-						<Check className="w-3 h-3 inline mr-1 text-status-success-icon" />
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					className={cn(
+						"w-full px-3 py-1.5 text-sm border border-border rounded-lg bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-accent flex items-center justify-between gap-2",
+						className,
 					)}
-					{displayText}
-				</span>
-				<div className="flex items-center gap-1">
-					{selected.length > 0 && (
-						<button
-							type="button"
-							onClick={clearAll}
-							className="p-0.5 hover:bg-hover rounded"
-							title="Clear all"
-						>
-							<X className="w-3 h-3 text-muted" />
-						</button>
-					)}
-					<ChevronDown
-						className={cn(
-							"w-4 h-4 text-muted transition-transform",
-							isOpen && "rotate-180",
+				>
+					<span
+						className={cn("truncate", selected.length === 0 && "text-muted")}
+					>
+						{selected.length > 0 && (
+							<Check className="w-3 h-3 inline mr-1 text-status-success-icon" />
 						)}
-					/>
-				</div>
-			</button>
-
-			{isOpen && (
-				<div className="absolute z-50 w-full mt-1 bg-input border border-border rounded-lg max-h-60 overflow-y-auto">
-					{options.length === 0 ? (
-						<div className="px-3 py-2 text-sm text-muted text-center">
-							No options available
-						</div>
-					) : (
-						options.map((option) => {
+						{displayText}
+					</span>
+					<div className="flex items-center gap-1">
+						{selected.length > 0 && (
+							<button
+								type="button"
+								onClick={clearAll}
+								className="p-0.5 hover:bg-hover rounded"
+								title="Clear all"
+							>
+								<X className="w-3 h-3 text-muted" />
+							</button>
+						)}
+						<ChevronDown
+							className={cn(
+								"w-4 h-4 text-muted transition-transform",
+								open && "rotate-180",
+							)}
+						/>
+					</div>
+				</button>
+			</PopoverTrigger>
+			<PopoverContent
+				className="w-[var(--radix-popover-trigger-width)] p-0"
+				align="start"
+			>
+				{options.length === 0 ? (
+					<div className="px-3 py-2 text-sm text-muted text-center">
+						No options available
+					</div>
+				) : (
+					<div className="max-h-60 overflow-y-auto">
+						{options.map((option) => {
 							const isSelected = selected.includes(option);
 							return (
 								<button
@@ -106,16 +105,11 @@ export function MultiSelect({
 										isSelected && "bg-accent-light",
 									)}
 								>
-									<div
-										className={cn(
-											"w-4 h-4 border rounded flex items-center justify-center",
-											isSelected ? "bg-accent border-accent" : "border-border",
-										)}
-									>
-										{isSelected && (
-											<Check className="w-3 h-3 text-accent-foreground" />
-										)}
-									</div>
+									<Checkbox
+										checked={isSelected}
+										tabIndex={-1}
+										className="pointer-events-none"
+									/>
 									<span
 										className={cn(
 											isSelected
@@ -127,10 +121,10 @@ export function MultiSelect({
 									</span>
 								</button>
 							);
-						})
-					)}
-				</div>
-			)}
-		</div>
+						})}
+					</div>
+				)}
+			</PopoverContent>
+		</Popover>
 	);
 }

--- a/apps/web/src/components/analytics/Sidebar.tsx
+++ b/apps/web/src/components/analytics/Sidebar.tsx
@@ -16,12 +16,25 @@ import {
 	UserCircle,
 } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useOrganization } from "../../contexts/OrganizationContext";
 import { authClient, signOut } from "../../lib/auth-client";
 import { cn } from "../../lib/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "../ui/tooltip";
 import { ThemeToggle } from "./ThemeToggle";
 
 const navigation = [
@@ -49,89 +62,63 @@ function getInitials(name: string) {
 
 function OrgSwitcher({ collapsed }: { collapsed: boolean }) {
 	const { activeOrg, organizations, switchOrg } = useOrganization();
-	const [open, setOpen] = useState(false);
-	const ref = useRef<HTMLDivElement>(null);
 
 	const handleSelect = async (orgId: string) => {
-		setOpen(false);
 		if (orgId !== activeOrg?.id) {
 			await switchOrg(orgId);
 		}
 	};
 
 	return (
-		<div ref={ref} className="relative">
-			<button
-				type="button"
-				onClick={() => setOpen(!open)}
-				className={cn(
-					"flex w-full items-center gap-1.5 px-4 h-10 overflow-hidden hover:bg-hover transition-colors",
-					collapsed && "justify-center px-0",
-				)}
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					className={cn(
+						"flex w-full items-center gap-1.5 px-4 h-10 overflow-hidden hover:bg-hover transition-colors",
+						collapsed && "justify-center px-0",
+					)}
+				>
+					<Building2 className="h-4 w-4 shrink-0 text-accent" />
+					{!collapsed && (
+						<>
+							<span className="flex-1 truncate text-left text-sm font-bold text-heading">
+								{activeOrg?.name ?? "Select org"}
+							</span>
+							<ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-muted" />
+						</>
+					)}
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				side={collapsed ? "right" : "bottom"}
+				align="start"
+				className="w-56"
 			>
-				<Building2 className="h-4 w-4 shrink-0 text-accent" />
-				{!collapsed && (
-					<>
-						<span className="flex-1 truncate text-left text-sm font-bold text-heading">
-							{activeOrg?.name ?? "Select org"}
-						</span>
-						<ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-muted" />
-					</>
-				)}
-			</button>
-
-			{open && (
-				<>
-					{/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop overlay */}
-					<div
-						className="fixed inset-0 z-40"
-						onClick={() => setOpen(false)}
-						onKeyDown={() => {}}
-					/>
-					<div
-						className={cn(
-							"absolute z-50 mt-1 w-56 rounded-lg border border-border bg-surface shadow-lg",
-							collapsed ? "left-full top-0 ml-2" : "left-2 right-2 w-auto",
+				{organizations.map((org) => (
+					<DropdownMenuItem key={org.id} onClick={() => handleSelect(org.id)}>
+						<Building2 className="h-3.5 w-3.5 shrink-0 text-muted" />
+						<span className="flex-1 truncate">{org.name}</span>
+						{org.id === activeOrg?.id && (
+							<Check className="h-3.5 w-3.5 shrink-0 text-accent" />
 						)}
-					>
-						<div className="p-1">
-							{organizations.map((org) => (
-								<button
-									key={org.id}
-									type="button"
-									onClick={() => handleSelect(org.id)}
-									className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-hover transition-colors"
-								>
-									<Building2 className="h-3.5 w-3.5 shrink-0 text-muted" />
-									<span className="flex-1 truncate text-left">{org.name}</span>
-									{org.id === activeOrg?.id && (
-										<Check className="h-3.5 w-3.5 shrink-0 text-accent" />
-									)}
-								</button>
-							))}
-						</div>
-						<div className="border-t border-border p-1">
-							<Link
-								to="/dashboard/organization"
-								onClick={() => setOpen(false)}
-								className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted hover:bg-hover hover:text-foreground transition-colors"
-							>
-								<Settings className="h-3.5 w-3.5 shrink-0" />
-								<span>Manage organization</span>
-							</Link>
-							<Link
-								to="/dashboard/organization/new"
-								onClick={() => setOpen(false)}
-								className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted hover:bg-hover hover:text-foreground transition-colors"
-							>
-								<Plus className="h-3.5 w-3.5 shrink-0" />
-								<span>Create organization</span>
-							</Link>
-						</div>
-					</div>
-				</>
-			)}
-		</div>
+					</DropdownMenuItem>
+				))}
+				<DropdownMenuSeparator />
+				<DropdownMenuItem asChild>
+					<Link to="/dashboard/organization">
+						<Settings className="h-3.5 w-3.5 shrink-0" />
+						<span>Manage organization</span>
+					</Link>
+				</DropdownMenuItem>
+				<DropdownMenuItem asChild>
+					<Link to="/dashboard/organization/new">
+						<Plus className="h-3.5 w-3.5 shrink-0" />
+						<span>Create organization</span>
+					</Link>
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }
 
@@ -145,46 +132,46 @@ export function Sidebar() {
 		resolvedTheme === "dark" ? "/logo-light.svg" : "/logo-dark.svg";
 
 	return (
-		<div
-			className={cn(
-				"relative flex h-full shrink-0 flex-col bg-surface border-r border-border z-20 transition-[width] duration-200 ease-in-out",
-				collapsed ? "w-14" : "w-64",
-			)}
-		>
-			<div className="flex items-center border-b border-border">
-				<Link
-					to="/dashboard"
-					className={cn(
-						"flex items-center shrink-0 px-4 h-10",
-						collapsed && "px-3",
-					)}
-				>
-					<img src={logoSrc} alt="Rudel" className="h-5 w-5" />
-				</Link>
-				<div className="flex-1 min-w-0">
-					<OrgSwitcher collapsed={collapsed} />
+		<TooltipProvider>
+			<div
+				className={cn(
+					"relative flex h-full shrink-0 flex-col bg-surface border-r border-border z-20 transition-[width] duration-200 ease-in-out",
+					collapsed ? "w-14" : "w-64",
+				)}
+			>
+				<div className="flex items-center border-b border-border">
+					<Link
+						to="/dashboard"
+						className={cn(
+							"flex items-center shrink-0 px-4 h-10",
+							collapsed && "px-3",
+						)}
+					>
+						<img src={logoSrc} alt="Rudel" className="h-5 w-5" />
+					</Link>
+					<div className="flex-1 min-w-0">
+						<OrgSwitcher collapsed={collapsed} />
+					</div>
+					<button
+						type="button"
+						onClick={() => setCollapsed(!collapsed)}
+						className="p-1 mr-1 rounded-md text-muted hover:text-foreground hover:bg-hover transition-colors shrink-0"
+						title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+					>
+						{collapsed ? (
+							<ChevronsRight className="h-4 w-4" />
+						) : (
+							<ChevronsLeft className="h-4 w-4" />
+						)}
+					</button>
 				</div>
-				<button
-					type="button"
-					onClick={() => setCollapsed(!collapsed)}
-					className="p-1 mr-1 rounded-md text-muted hover:text-foreground hover:bg-hover transition-colors shrink-0"
-					title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-				>
-					{collapsed ? (
-						<ChevronsRight className="h-4 w-4" />
-					) : (
-						<ChevronsLeft className="h-4 w-4" />
-					)}
-				</button>
-			</div>
 
-			<nav className="flex-1 px-2 pt-2 pb-1 flex flex-col gap-[1px]">
-				{navigation.map((item) => {
-					const isActive = pathname === item.href;
-					const Icon = item.icon;
+				<nav className="flex-1 px-2 pt-2 pb-1 flex flex-col gap-[1px]">
+					{navigation.map((item) => {
+						const isActive = pathname === item.href;
+						const Icon = item.icon;
 
-					return (
-						<div key={item.name} className="relative group">
+						const link = (
 							<Link
 								to={item.href}
 								className={cn(
@@ -202,60 +189,89 @@ export function Sidebar() {
 									</span>
 								)}
 							</Link>
+						);
 
-							{collapsed && (
-								<div className="absolute left-full top-1/2 -translate-y-1/2 ml-2 px-2.5 py-1.5 rounded-md bg-heading text-surface text-xs font-medium whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity duration-150 z-50">
-									{item.name}
-								</div>
-							)}
-						</div>
-					);
-				})}
-			</nav>
+						return (
+							<div key={item.name}>
+								{collapsed ? (
+									<Tooltip>
+										<TooltipTrigger asChild>{link}</TooltipTrigger>
+										<TooltipContent side="right">{item.name}</TooltipContent>
+									</Tooltip>
+								) : (
+									link
+								)}
+							</div>
+						);
+					})}
+				</nav>
 
-			{session?.user && (
-				<div
-					className={cn(
-						"border-t border-border p-2 relative group flex items-center gap-2",
-						collapsed ? "justify-center" : "px-2",
-					)}
-				>
-					<Link
-						to="/dashboard/profile"
-						className="flex-1 flex items-center gap-2 min-w-0"
-					>
-						<Avatar size="sm" className="shrink-0">
-							{session.user.image && (
-								<AvatarImage src={session.user.image} alt={session.user.name} />
-							)}
-							<AvatarFallback>{getInitials(session.user.name)}</AvatarFallback>
-						</Avatar>
-						{!collapsed && (
-							<span className="flex-1 truncate text-xs font-medium text-foreground hover:text-heading transition-colors">
-								{session.user.name}
-							</span>
+				{session?.user && (
+					<div
+						className={cn(
+							"border-t border-border p-2 flex items-center gap-2",
+							collapsed ? "justify-center" : "px-2",
 						)}
-					</Link>
-					{!collapsed && (
-						<>
-							<ThemeToggle />
-							<button
-								type="button"
-								onClick={() => signOut()}
-								className="p-1 rounded-md text-muted hover:text-foreground hover:bg-hover transition-colors shrink-0"
-								title="Sign out"
-							>
-								<LogOut className="h-3.5 w-3.5" />
-							</button>
-						</>
-					)}
-					{collapsed && (
-						<div className="absolute left-full top-1/2 -translate-y-1/2 ml-2 px-2.5 py-1.5 rounded-md bg-heading text-surface text-xs font-medium whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity duration-150 z-50">
-							{session.user.name}
-						</div>
-					)}
-				</div>
-			)}
-		</div>
+					>
+						{collapsed ? (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Link
+										to="/dashboard/profile"
+										className="flex items-center gap-2 min-w-0"
+									>
+										<Avatar size="sm" className="shrink-0">
+											{session.user.image && (
+												<AvatarImage
+													src={session.user.image}
+													alt={session.user.name}
+												/>
+											)}
+											<AvatarFallback>
+												{getInitials(session.user.name)}
+											</AvatarFallback>
+										</Avatar>
+									</Link>
+								</TooltipTrigger>
+								<TooltipContent side="right">
+									{session.user.name}
+								</TooltipContent>
+							</Tooltip>
+						) : (
+							<>
+								<Link
+									to="/dashboard/profile"
+									className="flex-1 flex items-center gap-2 min-w-0"
+								>
+									<Avatar size="sm" className="shrink-0">
+										{session.user.image && (
+											<AvatarImage
+												src={session.user.image}
+												alt={session.user.name}
+											/>
+										)}
+										<AvatarFallback>
+											{getInitials(session.user.name)}
+										</AvatarFallback>
+									</Avatar>
+									<span className="flex-1 truncate text-xs font-medium text-foreground hover:text-heading transition-colors">
+										{session.user.name}
+									</span>
+								</Link>
+								<ThemeToggle />
+								<button
+									type="button"
+									onClick={() => signOut()}
+									className="p-1 rounded-md text-muted hover:text-foreground hover:bg-hover transition-colors shrink-0"
+									title="Sign out"
+								>
+									<LogOut className="h-3.5 w-3.5" />
+								</button>
+							</>
+						)}
+					</div>
+				)}
+			</div>
+		</TooltipProvider>
 	);
 }

--- a/apps/web/src/components/charts/ErrorTrendChart.tsx
+++ b/apps/web/src/components/charts/ErrorTrendChart.tsx
@@ -12,6 +12,13 @@ import {
 	XAxis,
 	YAxis,
 } from "recharts";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { useChartTheme } from "@/hooks/useChartTheme";
 
 interface ErrorTrendChartProps {
@@ -135,18 +142,21 @@ export function ErrorTrendChart({
 					>
 						Metric:
 					</label>
-					<select
-						id="error-metric-select"
+					<Select
 						value={metric}
-						onChange={(e) => onMetricChange(e.target.value as typeof metric)}
-						className="px-3 py-2 border border-border rounded-md text-sm bg-input focus:outline-none focus:ring-2 focus:ring-accent w-56"
+						onValueChange={(v) => onMetricChange(v as typeof metric)}
 					>
-						{Object.entries(METRIC_LABELS).map(([key, label]) => (
-							<option key={key} value={key}>
-								{label}
-							</option>
-						))}
-					</select>
+						<SelectTrigger className="w-56">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{Object.entries(METRIC_LABELS).map(([key, label]) => (
+								<SelectItem key={key} value={key}>
+									{label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
 				</div>
 
 				<div className="flex items-center gap-2">
@@ -156,18 +166,21 @@ export function ErrorTrendChart({
 					>
 						Split:
 					</label>
-					<select
-						id="error-split-select"
+					<Select
 						value={splitBy}
-						onChange={(e) => onSplitByChange(e.target.value as typeof splitBy)}
-						className="px-3 py-2 border border-border rounded-md text-sm bg-input focus:outline-none focus:ring-2 focus:ring-accent w-40"
+						onValueChange={(v) => onSplitByChange(v as typeof splitBy)}
 					>
-						{Object.entries(SPLIT_LABELS).map(([key, label]) => (
-							<option key={key} value={key}>
-								{label}
-							</option>
-						))}
-					</select>
+						<SelectTrigger className="w-40">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{Object.entries(SPLIT_LABELS).map(([key, label]) => (
+								<SelectItem key={key} value={key}>
+									{label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
 				</div>
 			</div>
 

--- a/apps/web/src/components/charts/LearningsTrendChart.tsx
+++ b/apps/web/src/components/charts/LearningsTrendChart.tsx
@@ -9,6 +9,14 @@ import {
 	XAxis,
 	YAxis,
 } from "recharts";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { useChartTheme } from "@/hooks/useChartTheme";
 
 interface LearningsTrendChartProps {
@@ -102,16 +110,20 @@ export function LearningsTrendChart({
 		<div className="space-y-4">
 			<div className="flex flex-wrap items-center justify-end gap-4">
 				<div className="flex items-center gap-2">
-					<select
+					<Select
 						value={splitBy}
-						onChange={(e) =>
-							onSplitByChange(e.target.value as "user_id" | "repository")
+						onValueChange={(v) =>
+							onSplitByChange(v as "user_id" | "repository")
 						}
-						className="px-3 py-2 border border-border rounded-md text-sm bg-input focus:outline-none focus:ring-2 focus:ring-accent w-40"
 					>
-						<option value="user_id">by Developer</option>
-						<option value="repository">by Repository</option>
-					</select>
+						<SelectTrigger className="w-40">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="user_id">by Developer</SelectItem>
+							<SelectItem value="repository">by Repository</SelectItem>
+						</SelectContent>
+					</Select>
 				</div>
 
 				<div className="flex items-center gap-2">
@@ -121,24 +133,11 @@ export function LearningsTrendChart({
 					>
 						Cumulative
 					</label>
-					<button
-						type="button"
+					<Switch
 						id="cumulative-toggle"
-						role="switch"
-						aria-checked={isCumulative}
-						onClick={() => setIsCumulative(!isCumulative)}
-						className={`
-							relative inline-flex h-6 w-11 items-center rounded-full transition-colors
-							${isCumulative ? "bg-accent" : "bg-border"}
-						`}
-					>
-						<span
-							className={`
-								inline-block h-4 w-4 transform rounded-full bg-input transition-transform
-								${isCumulative ? "translate-x-6" : "translate-x-1"}
-							`}
-						/>
-					</button>
+						checked={isCumulative}
+						onCheckedChange={setIsCumulative}
+					/>
 				</div>
 			</div>
 

--- a/apps/web/src/components/learnings/LearningsTimeline.tsx
+++ b/apps/web/src/components/learnings/LearningsTimeline.tsx
@@ -1,5 +1,6 @@
 import type { LearningEntry } from "@rudel/api-routes";
 import { BookOpen } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
 import { TimelineItem } from "./TimelineItem";
 
 interface LearningsTimelineProps {
@@ -23,10 +24,10 @@ export function LearningsTimeline({
 						key={i}
 						className="relative pl-8 pb-8 border-l-2 border-border"
 					>
-						<div className="absolute -left-2 top-0 w-4 h-4 rounded-full bg-muted animate-pulse" />
+						<Skeleton className="absolute -left-2 top-0 w-4 h-4 rounded-full" />
 						<div className="space-y-3">
-							<div className="h-4 bg-muted rounded w-32 animate-pulse" />
-							<div className="h-32 bg-muted/50 rounded animate-pulse" />
+							<Skeleton className="h-4 w-32" />
+							<Skeleton className="h-32" />
 						</div>
 					</div>
 				))}

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { CheckIcon } from "lucide-react";
+import { Checkbox as CheckboxPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Checkbox({
+	className,
+	...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+	return (
+		<CheckboxPrimitive.Root
+			data-slot="checkbox"
+			className={cn(
+				"peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+				className,
+			)}
+			{...props}
+		>
+			<CheckboxPrimitive.Indicator
+				data-slot="checkbox-indicator"
+				className="grid place-content-center text-current transition-none"
+			>
+				<CheckIcon className="size-3.5" />
+			</CheckboxPrimitive.Indicator>
+		</CheckboxPrimitive.Root>
+	);
+}
+
+export { Checkbox };

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,255 @@
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function DropdownMenu({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+	return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+	return (
+		<DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+	);
+}
+
+function DropdownMenuTrigger({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+	return (
+		<DropdownMenuPrimitive.Trigger
+			data-slot="dropdown-menu-trigger"
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuContent({
+	className,
+	sideOffset = 4,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+	return (
+		<DropdownMenuPrimitive.Portal>
+			<DropdownMenuPrimitive.Content
+				data-slot="dropdown-menu-content"
+				sideOffset={sideOffset}
+				className={cn(
+					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+					className,
+				)}
+				{...props}
+			/>
+		</DropdownMenuPrimitive.Portal>
+	);
+}
+
+function DropdownMenuGroup({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+	return (
+		<DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+	);
+}
+
+function DropdownMenuItem({
+	className,
+	inset,
+	variant = "default",
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+	inset?: boolean;
+	variant?: "default" | "destructive";
+}) {
+	return (
+		<DropdownMenuPrimitive.Item
+			data-slot="dropdown-menu-item"
+			data-inset={inset}
+			data-variant={variant}
+			className={cn(
+				"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuCheckboxItem({
+	className,
+	children,
+	checked,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+	return (
+		<DropdownMenuPrimitive.CheckboxItem
+			data-slot="dropdown-menu-checkbox-item"
+			className={cn(
+				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className,
+			)}
+			checked={checked}
+			{...props}
+		>
+			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+				<DropdownMenuPrimitive.ItemIndicator>
+					<CheckIcon className="size-4" />
+				</DropdownMenuPrimitive.ItemIndicator>
+			</span>
+			{children}
+		</DropdownMenuPrimitive.CheckboxItem>
+	);
+}
+
+function DropdownMenuRadioGroup({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+	return (
+		<DropdownMenuPrimitive.RadioGroup
+			data-slot="dropdown-menu-radio-group"
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuRadioItem({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+	return (
+		<DropdownMenuPrimitive.RadioItem
+			data-slot="dropdown-menu-radio-item"
+			className={cn(
+				"focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className,
+			)}
+			{...props}
+		>
+			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+				<DropdownMenuPrimitive.ItemIndicator>
+					<CircleIcon className="size-2 fill-current" />
+				</DropdownMenuPrimitive.ItemIndicator>
+			</span>
+			{children}
+		</DropdownMenuPrimitive.RadioItem>
+	);
+}
+
+function DropdownMenuLabel({
+	className,
+	inset,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+	inset?: boolean;
+}) {
+	return (
+		<DropdownMenuPrimitive.Label
+			data-slot="dropdown-menu-label"
+			data-inset={inset}
+			className={cn(
+				"px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuSeparator({
+	className,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+	return (
+		<DropdownMenuPrimitive.Separator
+			data-slot="dropdown-menu-separator"
+			className={cn("bg-border -mx-1 my-1 h-px", className)}
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuShortcut({
+	className,
+	...props
+}: React.ComponentProps<"span">) {
+	return (
+		<span
+			data-slot="dropdown-menu-shortcut"
+			className={cn(
+				"text-muted-foreground ml-auto text-xs tracking-widest",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuSub({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+	return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+	className,
+	inset,
+	children,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+	inset?: boolean;
+}) {
+	return (
+		<DropdownMenuPrimitive.SubTrigger
+			data-slot="dropdown-menu-sub-trigger"
+			data-inset={inset}
+			className={cn(
+				"focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+			<ChevronRightIcon className="ml-auto size-4" />
+		</DropdownMenuPrimitive.SubTrigger>
+	);
+}
+
+function DropdownMenuSubContent({
+	className,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+	return (
+		<DropdownMenuPrimitive.SubContent
+			data-slot="dropdown-menu-sub-content"
+			className={cn(
+				"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	DropdownMenu,
+	DropdownMenuPortal,
+	DropdownMenuTrigger,
+	DropdownMenuContent,
+	DropdownMenuGroup,
+	DropdownMenuLabel,
+	DropdownMenuItem,
+	DropdownMenuCheckboxItem,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuSeparator,
+	DropdownMenuShortcut,
+	DropdownMenuSub,
+	DropdownMenuSubTrigger,
+	DropdownMenuSubContent,
+};

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -1,0 +1,87 @@
+import { Popover as PopoverPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Popover({
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+	return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+	return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+	className,
+	align = "center",
+	sideOffset = 4,
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+	return (
+		<PopoverPrimitive.Portal>
+			<PopoverPrimitive.Content
+				data-slot="popover-content"
+				align={align}
+				sideOffset={sideOffset}
+				className={cn(
+					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+					className,
+				)}
+				{...props}
+			/>
+		</PopoverPrimitive.Portal>
+	);
+}
+
+function PopoverAnchor({
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+	return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="popover-header"
+			className={cn("flex flex-col gap-1 text-sm", className)}
+			{...props}
+		/>
+	);
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+	return (
+		<div
+			data-slot="popover-title"
+			className={cn("font-medium", className)}
+			{...props}
+		/>
+	);
+}
+
+function PopoverDescription({
+	className,
+	...props
+}: React.ComponentProps<"p">) {
+	return (
+		<p
+			data-slot="popover-description"
+			className={cn("text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Popover,
+	PopoverTrigger,
+	PopoverContent,
+	PopoverAnchor,
+	PopoverHeader,
+	PopoverTitle,
+	PopoverDescription,
+};

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,0 +1,188 @@
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { Select as SelectPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Select({
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+	return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+	return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+	return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+	className,
+	size = "default",
+	children,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+	size?: "sm" | "default";
+}) {
+	return (
+		<SelectPrimitive.Trigger
+			data-slot="select-trigger"
+			data-size={size}
+			className={cn(
+				"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+			<SelectPrimitive.Icon asChild>
+				<ChevronDownIcon className="size-4 opacity-50" />
+			</SelectPrimitive.Icon>
+		</SelectPrimitive.Trigger>
+	);
+}
+
+function SelectContent({
+	className,
+	children,
+	position = "item-aligned",
+	align = "center",
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+	return (
+		<SelectPrimitive.Portal>
+			<SelectPrimitive.Content
+				data-slot="select-content"
+				className={cn(
+					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+					position === "popper" &&
+						"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+					className,
+				)}
+				position={position}
+				align={align}
+				{...props}
+			>
+				<SelectScrollUpButton />
+				<SelectPrimitive.Viewport
+					className={cn(
+						"p-1",
+						position === "popper" &&
+							"h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1",
+					)}
+				>
+					{children}
+				</SelectPrimitive.Viewport>
+				<SelectScrollDownButton />
+			</SelectPrimitive.Content>
+		</SelectPrimitive.Portal>
+	);
+}
+
+function SelectLabel({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+	return (
+		<SelectPrimitive.Label
+			data-slot="select-label"
+			className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+			{...props}
+		/>
+	);
+}
+
+function SelectItem({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+	return (
+		<SelectPrimitive.Item
+			data-slot="select-item"
+			className={cn(
+				"focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+				className,
+			)}
+			{...props}
+		>
+			<span
+				data-slot="select-item-indicator"
+				className="absolute right-2 flex size-3.5 items-center justify-center"
+			>
+				<SelectPrimitive.ItemIndicator>
+					<CheckIcon className="size-4" />
+				</SelectPrimitive.ItemIndicator>
+			</span>
+			<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+		</SelectPrimitive.Item>
+	);
+}
+
+function SelectSeparator({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+	return (
+		<SelectPrimitive.Separator
+			data-slot="select-separator"
+			className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+			{...props}
+		/>
+	);
+}
+
+function SelectScrollUpButton({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+	return (
+		<SelectPrimitive.ScrollUpButton
+			data-slot="select-scroll-up-button"
+			className={cn(
+				"flex cursor-default items-center justify-center py-1",
+				className,
+			)}
+			{...props}
+		>
+			<ChevronUpIcon className="size-4" />
+		</SelectPrimitive.ScrollUpButton>
+	);
+}
+
+function SelectScrollDownButton({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+	return (
+		<SelectPrimitive.ScrollDownButton
+			data-slot="select-scroll-down-button"
+			className={cn(
+				"flex cursor-default items-center justify-center py-1",
+				className,
+			)}
+			{...props}
+		>
+			<ChevronDownIcon className="size-4" />
+		</SelectPrimitive.ScrollDownButton>
+	);
+}
+
+export {
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectLabel,
+	SelectScrollDownButton,
+	SelectScrollUpButton,
+	SelectSeparator,
+	SelectTrigger,
+	SelectValue,
+};

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="skeleton"
+			className={cn("bg-accent animate-pulse rounded-md", className)}
+			{...props}
+		/>
+	);
+}
+
+export { Skeleton };

--- a/apps/web/src/components/ui/spinner.tsx
+++ b/apps/web/src/components/ui/spinner.tsx
@@ -1,0 +1,35 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const spinnerVariants = cva(
+	"inline-block animate-spin rounded-full border-4 border-solid border-accent border-r-transparent",
+	{
+		variants: {
+			size: {
+				sm: "h-6 w-6",
+				default: "h-8 w-8",
+				lg: "h-10 w-10",
+			},
+		},
+		defaultVariants: {
+			size: "default",
+		},
+	},
+);
+
+function Spinner({
+	className,
+	size,
+	...props
+}: React.ComponentProps<"div"> & VariantProps<typeof spinnerVariants>) {
+	return (
+		<div
+			data-slot="spinner"
+			className={cn(spinnerVariants({ size, className }))}
+			{...props}
+		/>
+	);
+}
+
+export { Spinner, spinnerVariants };

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+import { Switch as SwitchPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+	className,
+	size = "default",
+	...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+	size?: "sm" | "default";
+}) {
+	return (
+		<SwitchPrimitive.Root
+			data-slot="switch"
+			data-size={size}
+			className={cn(
+				"peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6",
+				className,
+			)}
+			{...props}
+		>
+			<SwitchPrimitive.Thumb
+				data-slot="switch-thumb"
+				className={cn(
+					"bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block rounded-full ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+				)}
+			/>
+		</SwitchPrimitive.Root>
+	);
+}
+
+export { Switch };

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+	return (
+		<div
+			data-slot="table-container"
+			className="relative w-full overflow-x-auto"
+		>
+			<table
+				data-slot="table"
+				className={cn("w-full caption-bottom text-sm", className)}
+				{...props}
+			/>
+		</div>
+	);
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+	return (
+		<thead
+			data-slot="table-header"
+			className={cn("[&_tr]:border-b", className)}
+			{...props}
+		/>
+	);
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+	return (
+		<tbody
+			data-slot="table-body"
+			className={cn("[&_tr:last-child]:border-0", className)}
+			{...props}
+		/>
+	);
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+	return (
+		<tfoot
+			data-slot="table-footer"
+			className={cn(
+				"bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+	return (
+		<tr
+			data-slot="table-row"
+			className={cn(
+				"hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+	return (
+		<th
+			data-slot="table-head"
+			className={cn(
+				"text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+	return (
+		<td
+			data-slot="table-cell"
+			className={cn(
+				"p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableCaption({
+	className,
+	...props
+}: React.ComponentProps<"caption">) {
+	return (
+		<caption
+			data-slot="table-caption"
+			className={cn("text-muted-foreground mt-4 text-sm", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Table,
+	TableHeader,
+	TableBody,
+	TableFooter,
+	TableHead,
+	TableRow,
+	TableCell,
+	TableCaption,
+};

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Tooltip as TooltipPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({
+	delayDuration = 0,
+	...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+	return (
+		<TooltipPrimitive.Provider
+			data-slot="tooltip-provider"
+			delayDuration={delayDuration}
+			{...props}
+		/>
+	);
+}
+
+function Tooltip({
+	...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+	return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({
+	...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+	return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+	className,
+	sideOffset = 0,
+	children,
+	...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+	return (
+		<TooltipPrimitive.Portal>
+			<TooltipPrimitive.Content
+				data-slot="tooltip-content"
+				sideOffset={sideOffset}
+				className={cn(
+					"bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+					className,
+				)}
+				{...props}
+			>
+				{children}
+				<TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+			</TooltipPrimitive.Content>
+		</TooltipPrimitive.Portal>
+	);
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/apps/web/src/pages/dashboard/DeveloperDetailPage.tsx
+++ b/apps/web/src/pages/dashboard/DeveloperDetailPage.tsx
@@ -18,6 +18,22 @@ import { AnalyticsCard } from "@/components/analytics/AnalyticsCard";
 import { DatePicker } from "@/components/analytics/DatePicker";
 import { PageHeader } from "@/components/analytics/PageHeader";
 import { StatCard } from "@/components/analytics/StatCard";
+import { Button } from "@/components/ui/button";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import { useDateRange } from "@/contexts/DateRangeContext";
 import { useChartTheme } from "@/hooks/useChartTheme";
 import {
@@ -162,13 +178,12 @@ export function DeveloperDetailPage() {
 					title="Developer Details"
 					description="Loading developer information..."
 					actions={
-						<Link
-							to="/dashboard/developers"
-							className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-subheading bg-input border border-border rounded-lg hover:bg-hover"
-						>
-							<ArrowLeft className="h-4 w-4" />
-							Back to Developers
-						</Link>
+						<Button variant="outline" size="sm" asChild>
+							<Link to="/dashboard/developers">
+								<ArrowLeft className="h-4 w-4" />
+								Back to Developers
+							</Link>
+						</Button>
 					}
 				/>
 				<AnalyticsCard>
@@ -191,13 +206,12 @@ export function DeveloperDetailPage() {
 							onStartDateChange={setStartDate}
 							onEndDateChange={setEndDate}
 						/>
-						<Link
-							to="/dashboard/developers"
-							className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-subheading bg-input border border-border rounded-lg hover:bg-hover"
-						>
-							<ArrowLeft className="h-4 w-4" />
-							Back
-						</Link>
+						<Button variant="outline" size="sm" asChild>
+							<Link to="/dashboard/developers">
+								<ArrowLeft className="h-4 w-4" />
+								Back
+							</Link>
+						</Button>
 					</div>
 				}
 			/>
@@ -407,42 +421,40 @@ export function DeveloperDetailPage() {
 					<h2 className="text-xl font-bold text-heading mb-6">
 						Errors Encountered
 					</h2>
-					<div className="overflow-x-auto">
-						<table className="min-w-full divide-y divide-border">
-							<thead className="bg-surface">
-								<tr>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
-										Error Type
-									</th>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
-										Occurrences
-									</th>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
-										Last Seen
-									</th>
-								</tr>
-							</thead>
-							<tbody className="bg-input divide-y divide-border">
-								{errors.map((error, idx) => (
-									<tr
-										// biome-ignore lint/suspicious/noArrayIndexKey: static error list
-										key={idx}
-										className="hover:bg-hover"
-									>
-										<td className="px-6 py-4 text-sm font-medium text-foreground">
-											{error.error_pattern}
-										</td>
-										<td className="px-6 py-4 text-sm text-muted">
-											{error.occurrences}
-										</td>
-										<td className="px-6 py-4 text-sm text-muted">
-											{new Date(error.last_seen).toLocaleDateString()}
-										</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
+					<Table>
+						<TableHeader className="bg-surface">
+							<TableRow>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase">
+									Error Type
+								</TableHead>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase">
+									Occurrences
+								</TableHead>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase">
+									Last Seen
+								</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody className="bg-input">
+							{errors.map((error, idx) => (
+								<TableRow
+									// biome-ignore lint/suspicious/noArrayIndexKey: static error list
+									key={idx}
+									className="hover:bg-hover"
+								>
+									<TableCell className="px-6 py-4 text-sm font-medium text-foreground">
+										{error.error_pattern}
+									</TableCell>
+									<TableCell className="px-6 py-4 text-sm text-muted">
+										{error.occurrences}
+									</TableCell>
+									<TableCell className="px-6 py-4 text-sm text-muted">
+										{new Date(error.last_seen).toLocaleDateString()}
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
 				</AnalyticsCard>
 			)}
 
@@ -451,127 +463,139 @@ export function DeveloperDetailPage() {
 				<div className="flex justify-between items-center mb-6">
 					<h2 className="text-xl font-bold text-heading">Session History</h2>
 					<div className="flex gap-3">
-						<select
-							value={projectFilter}
-							onChange={(e) => setProjectFilter(e.target.value)}
-							className="px-3 py-2 text-sm border border-border rounded-lg bg-input text-foreground focus:ring-2 focus:ring-accent"
+						<Select
+							value={projectFilter || "all"}
+							onValueChange={(v) => setProjectFilter(v === "all" ? "" : v)}
 						>
-							<option value="">All Projects</option>
-							{uniqueProjects.map((path) => (
-								<option key={path} value={path}>
-									{path.split("/").pop()}
-								</option>
-							))}
-						</select>
-						<select
+							<SelectTrigger className="w-auto">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All Projects</SelectItem>
+								{uniqueProjects.map((path) => (
+									<SelectItem key={path} value={path}>
+										{path.split("/").pop()}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						<Select
 							value={outcomeFilter}
-							onChange={(e) =>
-								setOutcomeFilter(e.target.value as "all" | "success")
-							}
-							className="px-3 py-2 text-sm border border-border rounded-lg bg-input text-foreground focus:ring-2 focus:ring-accent"
+							onValueChange={(v) => setOutcomeFilter(v as "all" | "success")}
 						>
-							<option value="all">All Outcomes</option>
-							<option value="success">Likely Success</option>
-						</select>
-						<select
+							<SelectTrigger className="w-auto">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All Outcomes</SelectItem>
+								<SelectItem value="success">Likely Success</SelectItem>
+							</SelectContent>
+						</Select>
+						<Select
 							value={`${sortBy}-${sortOrder}`}
-							onChange={(e) => {
-								const [s, o] = e.target.value.split("-");
+							onValueChange={(v) => {
+								const [s, o] = v.split("-");
 								setSortBy(s as "date" | "duration" | "tokens");
 								setSortOrder(o as "asc" | "desc");
 							}}
-							className="px-3 py-2 text-sm border border-border rounded-lg bg-input text-foreground focus:ring-2 focus:ring-accent"
 						>
-							<option value="date-desc">Date (Newest)</option>
-							<option value="date-asc">Date (Oldest)</option>
-							<option value="duration-desc">Duration (Longest)</option>
-							<option value="duration-asc">Duration (Shortest)</option>
-							<option value="tokens-desc">Tokens (Most)</option>
-							<option value="tokens-asc">Tokens (Least)</option>
-						</select>
+							<SelectTrigger className="w-auto">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="date-desc">Date (Newest)</SelectItem>
+								<SelectItem value="date-asc">Date (Oldest)</SelectItem>
+								<SelectItem value="duration-desc">
+									Duration (Longest)
+								</SelectItem>
+								<SelectItem value="duration-asc">
+									Duration (Shortest)
+								</SelectItem>
+								<SelectItem value="tokens-desc">Tokens (Most)</SelectItem>
+								<SelectItem value="tokens-asc">Tokens (Least)</SelectItem>
+							</SelectContent>
+						</Select>
 					</div>
 				</div>
 
-				<div className="overflow-x-auto">
-					<table className="min-w-full divide-y divide-border">
-						<thead className="bg-surface">
-							<tr>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
-									Date
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
-									Project
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
-									Duration
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
-									Tokens
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
-									Features
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
-									Status
-								</th>
-							</tr>
-						</thead>
-						<tbody className="bg-input divide-y divide-border">
-							{sessions?.map((session) => (
-								<tr key={session.session_id} className="hover:bg-hover">
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-										{new Date(session.session_date).toLocaleString()}
-									</td>
-									<td className="px-6 py-4 text-sm">
-										<span className="font-medium text-foreground">
-											{session.project_path.split("/").pop()}
-										</span>
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-										{session.duration_min.toFixed(0)}m
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-										{(session.total_tokens / 1000).toFixed(0)}K
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm">
-										<div className="flex gap-1">
-											{session.has_subagents && (
-												<span className="px-2 py-1 text-xs bg-blue-100 text-blue-800 rounded">
-													SA
-												</span>
-											)}
-											{session.has_skills && (
-												<span className="px-2 py-1 text-xs bg-purple-100 text-purple-800 rounded">
-													SK
-												</span>
-											)}
-											{session.has_slash_commands && (
-												<span className="px-2 py-1 text-xs bg-green-100 text-green-800 rounded">
-													SC
-												</span>
-											)}
-										</div>
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm">
-										{session.likely_success ? (
-											<span className="px-2 py-1 text-xs bg-status-success-bg text-status-success-text rounded-full">
-												Success
-											</span>
-										) : session.has_errors ? (
-											<span className="px-2 py-1 text-xs bg-status-error-bg text-status-error-text rounded-full">
-												Error
-											</span>
-										) : (
-											<span className="px-2 py-1 text-xs bg-surface text-subheading rounded-full">
-												Unknown
+				<Table>
+					<TableHeader className="bg-surface">
+						<TableRow>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase">
+								Date
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase">
+								Project
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase">
+								Duration
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase">
+								Tokens
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase">
+								Features
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase">
+								Status
+							</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody className="bg-input">
+						{sessions?.map((session) => (
+							<TableRow key={session.session_id} className="hover:bg-hover">
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-muted">
+									{new Date(session.session_date).toLocaleString()}
+								</TableCell>
+								<TableCell className="px-6 py-4 text-sm">
+									<span className="font-medium text-foreground">
+										{session.project_path.split("/").pop()}
+									</span>
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-muted">
+									{session.duration_min.toFixed(0)}m
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-muted">
+									{(session.total_tokens / 1000).toFixed(0)}K
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm">
+									<div className="flex gap-1">
+										{session.has_subagents && (
+											<span className="px-2 py-1 text-xs bg-blue-100 text-blue-800 rounded">
+												SA
 											</span>
 										)}
-									</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
-				</div>
+										{session.has_skills && (
+											<span className="px-2 py-1 text-xs bg-purple-100 text-purple-800 rounded">
+												SK
+											</span>
+										)}
+										{session.has_slash_commands && (
+											<span className="px-2 py-1 text-xs bg-green-100 text-green-800 rounded">
+												SC
+											</span>
+										)}
+									</div>
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm">
+									{session.likely_success ? (
+										<span className="px-2 py-1 text-xs bg-status-success-bg text-status-success-text rounded-full">
+											Success
+										</span>
+									) : session.has_errors ? (
+										<span className="px-2 py-1 text-xs bg-status-error-bg text-status-error-text rounded-full">
+											Error
+										</span>
+									) : (
+										<span className="px-2 py-1 text-xs bg-surface text-subheading rounded-full">
+											Unknown
+										</span>
+									)}
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
 			</AnalyticsCard>
 		</div>
 	);

--- a/apps/web/src/pages/dashboard/DevelopersListPage.tsx
+++ b/apps/web/src/pages/dashboard/DevelopersListPage.tsx
@@ -15,6 +15,15 @@ import { DatePicker } from "@/components/analytics/DatePicker";
 import { PageHeader } from "@/components/analytics/PageHeader";
 import { StatCard } from "@/components/analytics/StatCard";
 import { DeveloperTrendChart } from "@/components/charts/DeveloperTrendChart";
+import { Button } from "@/components/ui/button";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import { useDateRange } from "@/contexts/DateRangeContext";
 import { formatUsername } from "@/lib/format";
 import { orpc } from "@/lib/orpc";
@@ -146,15 +155,11 @@ export function DevelopersListPage() {
 						{(
 							["sessions", "tokens", "success_rate", "last_active"] as const
 						).map((key) => (
-							<button
-								type="button"
+							<Button
 								key={key}
+								variant={sortBy === key ? "default" : "secondary"}
+								size="sm"
 								onClick={() => setSortBy(key)}
-								className={`px-3 py-1 text-sm rounded ${
-									sortBy === key
-										? "bg-accent text-accent-foreground"
-										: "bg-surface text-subheading"
-								}`}
 							>
 								{key === "sessions"
 									? "Sessions"
@@ -163,131 +168,127 @@ export function DevelopersListPage() {
 										: key === "success_rate"
 											? "Success Rate"
 											: "Last Active"}
-							</button>
+							</Button>
 						))}
 					</div>
 				</div>
 
-				<div className="overflow-x-auto">
-					<table className="min-w-full divide-y divide-border">
-						<thead className="bg-surface">
-							<tr>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Developer
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Sessions
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Active Days
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Total Tokens
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Success Rate
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Cost
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Trend
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Avg Session
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Last Active
-								</th>
-							</tr>
-						</thead>
-						<tbody className="bg-input divide-y divide-border">
-							{sortedDevelopers.map((dev) => (
-								<tr
-									key={dev.user_id}
-									onClick={() =>
-										navigate(`/dashboard/developers/${dev.user_id}`)
-									}
-									className="hover:bg-hover cursor-pointer"
-								>
-									<td className="px-6 py-4 whitespace-nowrap">
-										<div className="flex items-center">
-											<div className="flex-shrink-0 h-10 w-10 bg-blue-100 rounded-full flex items-center justify-center">
-												<span className="text-blue-600 font-semibold text-sm">
-													{formatUsername(dev.user_id, userMapRecord)
-														.substring(0, 2)
-														.toUpperCase()}
+				<Table>
+					<TableHeader className="bg-surface">
+						<TableRow>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Developer
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Sessions
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Active Days
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Total Tokens
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Success Rate
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Cost
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Trend
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Avg Session
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Last Active
+							</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody className="bg-input">
+						{sortedDevelopers.map((dev) => (
+							<TableRow
+								key={dev.user_id}
+								onClick={() => navigate(`/dashboard/developers/${dev.user_id}`)}
+								className="hover:bg-hover cursor-pointer"
+							>
+								<TableCell className="px-6 py-4 whitespace-nowrap">
+									<div className="flex items-center">
+										<div className="flex-shrink-0 h-10 w-10 bg-blue-100 rounded-full flex items-center justify-center">
+											<span className="text-blue-600 font-semibold text-sm">
+												{formatUsername(dev.user_id, userMapRecord)
+													.substring(0, 2)
+													.toUpperCase()}
+											</span>
+										</div>
+										<div className="ml-4">
+											<div className="text-sm font-medium text-foreground">
+												{formatUsername(dev.user_id, userMapRecord)}
+											</div>
+										</div>
+									</div>
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-muted">
+									{dev.total_sessions}
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-muted">
+									{dev.active_days}
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-muted">
+									{(dev.total_tokens / 1000).toFixed(0)}K
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-muted">
+									<span
+										className={`font-medium ${
+											dev.success_rate >= 70
+												? "text-status-success-icon"
+												: dev.success_rate >= 50
+													? "text-status-warning-icon"
+													: "text-status-error-icon"
+										}`}
+									>
+										{dev.success_rate.toFixed(0)}%
+									</span>
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-muted">
+									${dev.cost.toFixed(2)}
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm">
+									<div className="flex items-center">
+										{dev.success_rate_trend > 0 && (
+											<>
+												<ArrowUp className="w-4 h-4 text-status-success-icon mr-1" />
+												<span className="text-status-success-icon font-medium">
+													+{dev.success_rate_trend.toFixed(0)}%
 												</span>
-											</div>
-											<div className="ml-4">
-												<div className="text-sm font-medium text-foreground">
-													{formatUsername(dev.user_id, userMapRecord)}
-												</div>
-											</div>
-										</div>
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-										{dev.total_sessions}
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-										{dev.active_days}
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-										{(dev.total_tokens / 1000).toFixed(0)}K
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-										<span
-											className={`font-medium ${
-												dev.success_rate >= 70
-													? "text-status-success-icon"
-													: dev.success_rate >= 50
-														? "text-status-warning-icon"
-														: "text-status-error-icon"
-											}`}
-										>
-											{dev.success_rate.toFixed(0)}%
-										</span>
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-										${dev.cost.toFixed(2)}
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm">
-										<div className="flex items-center">
-											{dev.success_rate_trend > 0 && (
-												<>
-													<ArrowUp className="w-4 h-4 text-status-success-icon mr-1" />
-													<span className="text-status-success-icon font-medium">
-														+{dev.success_rate_trend.toFixed(0)}%
-													</span>
-												</>
-											)}
-											{dev.success_rate_trend < 0 && (
-												<>
-													<ArrowDown className="w-4 h-4 text-status-error-icon mr-1" />
-													<span className="text-status-error-icon font-medium">
-														{dev.success_rate_trend.toFixed(0)}%
-													</span>
-												</>
-											)}
-											{dev.success_rate_trend === 0 && (
-												<>
-													<Minus className="w-4 h-4 text-muted mr-1" />
-													<span className="text-muted">0%</span>
-												</>
-											)}
-										</div>
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-										{dev.avg_session_duration_min.toFixed(0)}m
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-										{new Date(dev.last_active_date).toLocaleDateString()}
-									</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
-				</div>
+											</>
+										)}
+										{dev.success_rate_trend < 0 && (
+											<>
+												<ArrowDown className="w-4 h-4 text-status-error-icon mr-1" />
+												<span className="text-status-error-icon font-medium">
+													{dev.success_rate_trend.toFixed(0)}%
+												</span>
+											</>
+										)}
+										{dev.success_rate_trend === 0 && (
+											<>
+												<Minus className="w-4 h-4 text-muted mr-1" />
+												<span className="text-muted">0%</span>
+											</>
+										)}
+									</div>
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-muted">
+									{dev.avg_session_duration_min.toFixed(0)}m
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-muted">
+									{new Date(dev.last_active_date).toLocaleDateString()}
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
 			</AnalyticsCard>
 
 			{/* Developer Trend Chart */}

--- a/apps/web/src/pages/dashboard/OrganizationPage.tsx
+++ b/apps/web/src/pages/dashboard/OrganizationPage.tsx
@@ -16,6 +16,13 @@ import { PageHeader } from "../../components/analytics/PageHeader";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "../../components/ui/select";
 import { useOrganization } from "../../contexts/OrganizationContext";
 import { authClient } from "../../lib/auth-client";
 
@@ -155,14 +162,15 @@ export function OrganizationPage() {
 							}}
 							className="flex-1"
 						/>
-						<select
-							value={inviteRole}
-							onChange={(e) => setInviteRole(e.target.value)}
-							className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-foreground"
-						>
-							<option value="member">Member</option>
-							<option value="admin">Admin</option>
-						</select>
+						<Select value={inviteRole} onValueChange={setInviteRole}>
+							<SelectTrigger className="w-auto">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="member">Member</SelectItem>
+								<SelectItem value="admin">Admin</SelectItem>
+							</SelectContent>
+						</Select>
 						<Button
 							type="submit"
 							size="sm"

--- a/apps/web/src/pages/dashboard/OverviewPage.tsx
+++ b/apps/web/src/pages/dashboard/OverviewPage.tsx
@@ -14,6 +14,7 @@ import { PageHeader } from "@/components/analytics/PageHeader";
 import { StatCard } from "@/components/analytics/StatCard";
 import { ModelTokensChart } from "@/components/charts/ModelTokensChart";
 import { UsageTrendChart } from "@/components/charts/UsageTrendChart";
+import { Spinner } from "@/components/ui/spinner";
 import { useDateRange } from "@/contexts/DateRangeContext";
 import { orpc } from "@/lib/orpc";
 
@@ -58,7 +59,7 @@ export function OverviewPage() {
 			{kpisLoading && (
 				<div className="flex items-center justify-center py-12">
 					<div className="text-center">
-						<div className="inline-block h-10 w-10 animate-spin rounded-full border-4 border-solid border-accent border-r-transparent mb-4" />
+						<Spinner size="lg" className="mb-4" />
 						<p className="text-muted">Loading dashboard data...</p>
 					</div>
 				</div>

--- a/apps/web/src/pages/dashboard/ProjectDetailPage.tsx
+++ b/apps/web/src/pages/dashboard/ProjectDetailPage.tsx
@@ -16,6 +16,15 @@ import { AnalyticsCard } from "@/components/analytics/AnalyticsCard";
 import { DatePicker } from "@/components/analytics/DatePicker";
 import { PageHeader } from "@/components/analytics/PageHeader";
 import { StatCard } from "@/components/analytics/StatCard";
+import { Button } from "@/components/ui/button";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import { useDateRange } from "@/contexts/DateRangeContext";
 import { useChartTheme } from "@/hooks/useChartTheme";
 import { decodeProjectPath, formatUsername } from "@/lib/format";
@@ -85,13 +94,12 @@ export function ProjectDetailPage() {
 					title="Project Details"
 					description="Loading project information..."
 					actions={
-						<Link
-							to="/dashboard/projects"
-							className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-subheading bg-input border border-border rounded-lg hover:bg-hover"
-						>
-							<ArrowLeft className="h-4 w-4" />
-							Back to Projects
-						</Link>
+						<Button variant="outline" size="sm" asChild>
+							<Link to="/dashboard/projects">
+								<ArrowLeft className="h-4 w-4" />
+								Back to Projects
+							</Link>
+						</Button>
 					}
 				/>
 				<AnalyticsCard>
@@ -116,13 +124,12 @@ export function ProjectDetailPage() {
 							onStartDateChange={setStartDate}
 							onEndDateChange={setEndDate}
 						/>
-						<Link
-							to="/dashboard/projects"
-							className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-subheading bg-input border border-border rounded-lg hover:bg-hover"
-						>
-							<ArrowLeft className="h-4 w-4" />
-							Back
-						</Link>
+						<Button variant="outline" size="sm" asChild>
+							<Link to="/dashboard/projects">
+								<ArrowLeft className="h-4 w-4" />
+								Back
+							</Link>
+						</Button>
 					</div>
 				}
 			/>
@@ -237,49 +244,52 @@ export function ProjectDetailPage() {
 						</BarChart>
 					</ResponsiveContainer>
 					{contributors && (
-						<div className="mt-6 overflow-x-auto">
-							<table className="min-w-full divide-y divide-border">
-								<thead className="bg-surface">
-									<tr>
-										<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
+						<div className="mt-6">
+							<Table>
+								<TableHeader className="bg-surface">
+									<TableRow>
+										<TableHead className="px-6 py-3 text-xs text-muted uppercase">
 											Developer
-										</th>
-										<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
+										</TableHead>
+										<TableHead className="px-6 py-3 text-xs text-muted uppercase">
 											Sessions
-										</th>
-										<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
+										</TableHead>
+										<TableHead className="px-6 py-3 text-xs text-muted uppercase">
 											Contribution
-										</th>
-										<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
+										</TableHead>
+										<TableHead className="px-6 py-3 text-xs text-muted uppercase">
 											Total Time
-										</th>
-										<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
+										</TableHead>
+										<TableHead className="px-6 py-3 text-xs text-muted uppercase">
 											Tokens
-										</th>
-									</tr>
-								</thead>
-								<tbody className="bg-input divide-y divide-border">
+										</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody className="bg-input">
 									{contributors.map((contributor) => (
-										<tr key={contributor.user_id} className="hover:bg-hover">
-											<td className="px-6 py-4 text-sm font-medium text-foreground">
+										<TableRow
+											key={contributor.user_id}
+											className="hover:bg-hover"
+										>
+											<TableCell className="px-6 py-4 text-sm font-medium text-foreground">
 												{formatUsername(contributor.user_id, userMapRecord)}
-											</td>
-											<td className="px-6 py-4 text-sm text-muted">
+											</TableCell>
+											<TableCell className="px-6 py-4 text-sm text-muted">
 												{contributor.sessions}
-											</td>
-											<td className="px-6 py-4 text-sm text-muted">
+											</TableCell>
+											<TableCell className="px-6 py-4 text-sm text-muted">
 												{contributor.contribution_percentage.toFixed(0)}%
-											</td>
-											<td className="px-6 py-4 text-sm text-muted">
+											</TableCell>
+											<TableCell className="px-6 py-4 text-sm text-muted">
 												{(contributor.total_duration_min / 60).toFixed(1)}h
-											</td>
-											<td className="px-6 py-4 text-sm text-muted">
+											</TableCell>
+											<TableCell className="px-6 py-4 text-sm text-muted">
 												{(contributor.total_tokens / 1000).toFixed(0)}K
-											</td>
-										</tr>
+											</TableCell>
+										</TableRow>
 									))}
-								</tbody>
-							</table>
+								</TableBody>
+							</Table>
 						</div>
 					)}
 				</AnalyticsCard>
@@ -290,48 +300,46 @@ export function ProjectDetailPage() {
 					<h2 className="text-xl font-bold text-heading mb-6">
 						Errors Encountered
 					</h2>
-					<div className="overflow-x-auto">
-						<table className="min-w-full divide-y divide-border">
-							<thead className="bg-surface">
-								<tr>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
-										Error Type
-									</th>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
-										Occurrences
-									</th>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
-										Affected Users
-									</th>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase">
-										Last Seen
-									</th>
-								</tr>
-							</thead>
-							<tbody className="bg-input divide-y divide-border">
-								{errors.map((error, idx) => (
-									<tr
-										// biome-ignore lint/suspicious/noArrayIndexKey: static error list
-										key={idx}
-										className="hover:bg-hover"
-									>
-										<td className="px-6 py-4 text-sm font-medium text-foreground">
-											{error.error_pattern}
-										</td>
-										<td className="px-6 py-4 text-sm text-muted">
-											{error.occurrences}
-										</td>
-										<td className="px-6 py-4 text-sm text-muted">
-											{error.affected_users}
-										</td>
-										<td className="px-6 py-4 text-sm text-muted">
-											{new Date(error.last_seen).toLocaleDateString()}
-										</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
+					<Table>
+						<TableHeader className="bg-surface">
+							<TableRow>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase">
+									Error Type
+								</TableHead>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase">
+									Occurrences
+								</TableHead>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase">
+									Affected Users
+								</TableHead>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase">
+									Last Seen
+								</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody className="bg-input">
+							{errors.map((error, idx) => (
+								<TableRow
+									// biome-ignore lint/suspicious/noArrayIndexKey: static error list
+									key={idx}
+									className="hover:bg-hover"
+								>
+									<TableCell className="px-6 py-4 text-sm font-medium text-foreground">
+										{error.error_pattern}
+									</TableCell>
+									<TableCell className="px-6 py-4 text-sm text-muted">
+										{error.occurrences}
+									</TableCell>
+									<TableCell className="px-6 py-4 text-sm text-muted">
+										{error.affected_users}
+									</TableCell>
+									<TableCell className="px-6 py-4 text-sm text-muted">
+										{new Date(error.last_seen).toLocaleDateString()}
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
 				</AnalyticsCard>
 			)}
 		</div>

--- a/apps/web/src/pages/dashboard/ProjectsListPage.tsx
+++ b/apps/web/src/pages/dashboard/ProjectsListPage.tsx
@@ -13,6 +13,14 @@ import { DatePicker } from "@/components/analytics/DatePicker";
 import { PageHeader } from "@/components/analytics/PageHeader";
 import { StatCard } from "@/components/analytics/StatCard";
 import { ProjectTrendChart } from "@/components/charts/ProjectTrendChart";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import { useDateRange } from "@/contexts/DateRangeContext";
 import { encodeProjectPath } from "@/lib/format";
 import { orpc } from "@/lib/orpc";
@@ -143,93 +151,91 @@ export function ProjectsListPage() {
 			<AnalyticsCard>
 				<h2 className="text-xl font-bold text-heading mb-4">Project Details</h2>
 				{projects && projects.length > 0 ? (
-					<div className="overflow-x-auto">
-						<table className="min-w-full divide-y divide-border">
-							<thead className="bg-surface">
-								<tr>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-										Project
-									</th>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-										Sessions
-									</th>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-										Time
-									</th>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-										Tokens
-									</th>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-										Success Rate
-									</th>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-										Cost
-									</th>
-									<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-										Trend
-									</th>
-								</tr>
-							</thead>
-							<tbody className="bg-input divide-y divide-border">
-								{projects.map((project, index) => {
-									const encodedPath = encodeProjectPath(project.project_path);
-									const successRate = project.success_rate || 0;
-									const successRateColor =
-										successRate >= 70
-											? "text-status-success-icon"
-											: successRate >= 50
-												? "text-status-warning-icon"
-												: "text-status-error-icon";
-									const trend = project.success_rate_trend || 0;
-									const trendIconStr =
-										trend > 0 ? "\u2191" : trend < 0 ? "\u2193" : "-";
-									const trendColor =
-										trend > 0
-											? "text-status-success-icon"
-											: trend < 0
-												? "text-status-error-icon"
-												: "text-muted";
+					<Table>
+						<TableHeader className="bg-surface">
+							<TableRow>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+									Project
+								</TableHead>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+									Sessions
+								</TableHead>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+									Time
+								</TableHead>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+									Tokens
+								</TableHead>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+									Success Rate
+								</TableHead>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+									Cost
+								</TableHead>
+								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+									Trend
+								</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody className="bg-input">
+							{projects.map((project, index) => {
+								const encodedPath = encodeProjectPath(project.project_path);
+								const successRate = project.success_rate || 0;
+								const successRateColor =
+									successRate >= 70
+										? "text-status-success-icon"
+										: successRate >= 50
+											? "text-status-warning-icon"
+											: "text-status-error-icon";
+								const trend = project.success_rate_trend || 0;
+								const trendIconStr =
+									trend > 0 ? "\u2191" : trend < 0 ? "\u2193" : "-";
+								const trendColor =
+									trend > 0
+										? "text-status-success-icon"
+										: trend < 0
+											? "text-status-error-icon"
+											: "text-muted";
 
-									return (
-										<tr
-											// biome-ignore lint/suspicious/noArrayIndexKey: static project list
-											key={index}
-											onClick={() =>
-												navigate(`/dashboard/projects/${encodedPath}`)
-											}
-											className="hover:bg-hover cursor-pointer"
+								return (
+									<TableRow
+										// biome-ignore lint/suspicious/noArrayIndexKey: static project list
+										key={index}
+										onClick={() =>
+											navigate(`/dashboard/projects/${encodedPath}`)
+										}
+										className="hover:bg-hover cursor-pointer"
+									>
+										<TableCell className="px-6 py-4 text-sm font-medium text-foreground">
+											{project.project_path.split("/").pop()}
+										</TableCell>
+										<TableCell className="px-6 py-4 text-sm text-muted">
+											{project.sessions}
+										</TableCell>
+										<TableCell className="px-6 py-4 text-sm text-muted">
+											{(project.total_duration_min / 60).toFixed(1)}h
+										</TableCell>
+										<TableCell className="px-6 py-4 text-sm text-muted">
+											{formatTokens(project.total_tokens || 0)}
+										</TableCell>
+										<TableCell
+											className={`px-6 py-4 text-sm font-semibold ${successRateColor}`}
 										>
-											<td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-foreground">
-												{project.project_path.split("/").pop()}
-											</td>
-											<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-												{project.sessions}
-											</td>
-											<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-												{(project.total_duration_min / 60).toFixed(1)}h
-											</td>
-											<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-												{formatTokens(project.total_tokens || 0)}
-											</td>
-											<td
-												className={`px-6 py-4 whitespace-nowrap text-sm font-semibold ${successRateColor}`}
-											>
-												{successRate.toFixed(0)}%
-											</td>
-											<td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-												${(project.cost || 0).toFixed(2)}
-											</td>
-											<td
-												className={`px-6 py-4 whitespace-nowrap text-sm font-semibold ${trendColor}`}
-											>
-												{trendIconStr} {Math.abs(trend).toFixed(1)}%
-											</td>
-										</tr>
-									);
-								})}
-							</tbody>
-						</table>
-					</div>
+											{successRate.toFixed(0)}%
+										</TableCell>
+										<TableCell className="px-6 py-4 text-sm text-muted">
+											${(project.cost || 0).toFixed(2)}
+										</TableCell>
+										<TableCell
+											className={`px-6 py-4 text-sm font-semibold ${trendColor}`}
+										>
+											{trendIconStr} {Math.abs(trend).toFixed(1)}%
+										</TableCell>
+									</TableRow>
+								);
+							})}
+						</TableBody>
+					</Table>
 				) : (
 					<p className="text-center text-muted py-8">
 						No project data available

--- a/apps/web/src/pages/dashboard/ROIPage.tsx
+++ b/apps/web/src/pages/dashboard/ROIPage.tsx
@@ -20,6 +20,17 @@ import { AnalyticsCard } from "@/components/analytics/AnalyticsCard";
 import { DatePicker } from "@/components/analytics/DatePicker";
 import { PageHeader } from "@/components/analytics/PageHeader";
 import { StatCard } from "@/components/analytics/StatCard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import { useDateRange } from "@/contexts/DateRangeContext";
 import { useChartTheme } from "@/hooks/useChartTheme";
 import { formatUsername } from "@/lib/format";
@@ -127,7 +138,7 @@ export function ROIPage() {
 			{isLoading && (
 				<div className="flex items-center justify-center py-12">
 					<div className="text-center">
-						<div className="inline-block h-10 w-10 animate-spin rounded-full border-4 border-solid border-accent border-r-transparent mb-4" />
+						<Spinner size="lg" className="mb-4" />
 						<p className="text-muted">Loading ROI data...</p>
 					</div>
 				</div>
@@ -153,7 +164,7 @@ export function ROIPage() {
 								>
 									Code Percentage (%)
 								</label>
-								<input
+								<Input
 									id="codePercentage"
 									type="number"
 									value={roiInputs.codePercentage}
@@ -165,7 +176,6 @@ export function ROIPage() {
 									}
 									min={0}
 									max={100}
-									className="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:ring-accent focus:border-accent"
 								/>
 								<p className="text-xs text-muted mt-1">
 									% of output that is actual code
@@ -178,7 +188,7 @@ export function ROIPage() {
 								>
 									Tokens per LOC
 								</label>
-								<input
+								<Input
 									id="tokensPerLOC"
 									type="number"
 									value={roiInputs.tokensPerLOC}
@@ -189,7 +199,6 @@ export function ROIPage() {
 										})
 									}
 									min={1}
-									className="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:ring-accent focus:border-accent"
 								/>
 								<p className="text-xs text-muted mt-1">
 									Average tokens per line of code
@@ -202,7 +211,7 @@ export function ROIPage() {
 								>
 									LOC per Hour (baseline)
 								</label>
-								<input
+								<Input
 									id="locPerHour"
 									type="number"
 									value={roiInputs.locPerHour}
@@ -213,7 +222,6 @@ export function ROIPage() {
 										})
 									}
 									min={1}
-									className="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:ring-accent focus:border-accent"
 								/>
 								<p className="text-xs text-muted mt-1">
 									Manual coding speed without Claude
@@ -226,7 +234,7 @@ export function ROIPage() {
 								>
 									Developer Rate ($/hr)
 								</label>
-								<input
+								<Input
 									id="devHourlyRate"
 									type="number"
 									value={roiInputs.devHourlyRate}
@@ -237,19 +245,14 @@ export function ROIPage() {
 										})
 									}
 									min={1}
-									className="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:ring-accent focus:border-accent"
 								/>
 								<p className="text-xs text-muted mt-1">Hourly developer cost</p>
 							</div>
 						</div>
 						<div className="mt-4">
-							<button
-								type="button"
-								onClick={resetToDefaults}
-								className="px-4 py-2 text-sm font-medium text-accent bg-accent-light border border-accent-light rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
-							>
+							<Button variant="outline" size="sm" onClick={resetToDefaults}>
 								Reset to Defaults
-							</button>
+							</Button>
 						</div>
 					</AnalyticsCard>
 
@@ -479,38 +482,36 @@ export function ROIPage() {
 									Developer Cost Breakdown
 								</h3>
 							</div>
-							<div className="overflow-x-auto">
-								<table className="min-w-full divide-y divide-border">
-									<thead>
-										<tr className="bg-surface">
-											<th className="px-4 py-3 text-left text-xs font-medium text-muted uppercase">
-												Developer
-											</th>
-											<th className="px-4 py-3 text-right text-xs font-medium text-muted uppercase">
-												Cost
-											</th>
-											<th className="px-4 py-3 text-right text-xs font-medium text-muted uppercase">
-												Sessions
-											</th>
-										</tr>
-									</thead>
-									<tbody className="bg-input divide-y divide-border">
-										{developerCosts?.map((dev) => (
-											<tr key={dev.user_id} className="hover:bg-hover">
-												<td className="px-4 py-3 text-sm font-medium text-foreground">
-													{formatUsername(dev.user_id, userMapRecord)}
-												</td>
-												<td className="px-4 py-3 text-sm text-right text-subheading">
-													{formatCurrency(dev.cost)}
-												</td>
-												<td className="px-4 py-3 text-sm text-right text-subheading">
-													{dev.sessions}
-												</td>
-											</tr>
-										))}
-									</tbody>
-								</table>
-							</div>
+							<Table>
+								<TableHeader className="bg-surface">
+									<TableRow>
+										<TableHead className="px-4 py-3 text-xs text-muted uppercase">
+											Developer
+										</TableHead>
+										<TableHead className="px-4 py-3 text-xs text-muted uppercase text-right">
+											Cost
+										</TableHead>
+										<TableHead className="px-4 py-3 text-xs text-muted uppercase text-right">
+											Sessions
+										</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody className="bg-input">
+									{developerCosts?.map((dev) => (
+										<TableRow key={dev.user_id} className="hover:bg-hover">
+											<TableCell className="px-4 py-3 text-sm font-medium text-foreground">
+												{formatUsername(dev.user_id, userMapRecord)}
+											</TableCell>
+											<TableCell className="px-4 py-3 text-sm text-right text-subheading">
+												{formatCurrency(dev.cost)}
+											</TableCell>
+											<TableCell className="px-4 py-3 text-sm text-right text-subheading">
+												{dev.sessions}
+											</TableCell>
+										</TableRow>
+									))}
+								</TableBody>
+							</Table>
 						</AnalyticsCard>
 
 						<AnalyticsCard>
@@ -519,39 +520,40 @@ export function ROIPage() {
 									Project Cost Breakdown
 								</h3>
 							</div>
-							<div className="overflow-x-auto">
-								<table className="min-w-full divide-y divide-border">
-									<thead>
-										<tr className="bg-surface">
-											<th className="px-4 py-3 text-left text-xs font-medium text-muted uppercase">
-												Project
-											</th>
-											<th className="px-4 py-3 text-right text-xs font-medium text-muted uppercase">
-												Cost
-											</th>
-											<th className="px-4 py-3 text-right text-xs font-medium text-muted uppercase">
-												Sessions
-											</th>
-										</tr>
-									</thead>
-									<tbody className="bg-input divide-y divide-border">
-										{projectCosts?.slice(0, 10).map((proj) => (
-											<tr key={proj.project_path} className="hover:bg-hover">
-												<td className="px-4 py-3 text-sm font-medium text-foreground truncate max-w-xs">
-													{proj.project_path.split("/").pop() ||
-														proj.project_path}
-												</td>
-												<td className="px-4 py-3 text-sm text-right text-subheading">
-													{formatCurrency(proj.cost)}
-												</td>
-												<td className="px-4 py-3 text-sm text-right text-subheading">
-													{proj.sessions}
-												</td>
-											</tr>
-										))}
-									</tbody>
-								</table>
-							</div>
+							<Table>
+								<TableHeader className="bg-surface">
+									<TableRow>
+										<TableHead className="px-4 py-3 text-xs text-muted uppercase">
+											Project
+										</TableHead>
+										<TableHead className="px-4 py-3 text-xs text-muted uppercase text-right">
+											Cost
+										</TableHead>
+										<TableHead className="px-4 py-3 text-xs text-muted uppercase text-right">
+											Sessions
+										</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody className="bg-input">
+									{projectCosts?.slice(0, 10).map((proj) => (
+										<TableRow
+											key={proj.project_path}
+											className="hover:bg-hover"
+										>
+											<TableCell className="px-4 py-3 text-sm font-medium text-foreground truncate max-w-xs">
+												{proj.project_path.split("/").pop() ||
+													proj.project_path}
+											</TableCell>
+											<TableCell className="px-4 py-3 text-sm text-right text-subheading">
+												{formatCurrency(proj.cost)}
+											</TableCell>
+											<TableCell className="px-4 py-3 text-sm text-right text-subheading">
+												{proj.sessions}
+											</TableCell>
+										</TableRow>
+									))}
+								</TableBody>
+							</Table>
 						</AnalyticsCard>
 					</div>
 				</>

--- a/apps/web/src/pages/dashboard/SessionDetailPage.tsx
+++ b/apps/web/src/pages/dashboard/SessionDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { ConversationList } from "@/components/sessions/conversation/ConversationList";
 import { SessionHeader } from "@/components/sessions/SessionHeader";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useSession } from "@/hooks/useSession";
 import { orpc } from "@/lib/orpc";
 
@@ -19,14 +20,14 @@ export function SessionDetailPage() {
 		return (
 			<div className="flex flex-col h-full">
 				<div className="border-b p-4 space-y-3">
-					<div className="h-8 w-48 bg-muted animate-pulse rounded" />
-					<div className="h-4 w-64 bg-muted animate-pulse rounded" />
-					<div className="h-6 w-96 bg-muted animate-pulse rounded" />
+					<Skeleton className="h-8 w-48" />
+					<Skeleton className="h-4 w-64" />
+					<Skeleton className="h-6 w-96" />
 				</div>
 				<div className="flex-1 p-4">
 					<div className="space-y-4">
 						{["sk-1", "sk-2", "sk-3", "sk-4", "sk-5"].map((id) => (
-							<div key={id} className="h-24 bg-muted animate-pulse rounded" />
+							<Skeleton key={id} className="h-24" />
 						))}
 					</div>
 				</div>

--- a/apps/web/src/pages/dashboard/SessionsListPage.tsx
+++ b/apps/web/src/pages/dashboard/SessionsListPage.tsx
@@ -9,6 +9,23 @@ import { MultiSelect } from "@/components/analytics/MultiSelect";
 import { PageHeader } from "@/components/analytics/PageHeader";
 import { StatCard } from "@/components/analytics/StatCard";
 import { DimensionAnalysisChart } from "@/components/charts/DimensionAnalysisChart";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import { useDateRange } from "@/contexts/DateRangeContext";
 import { calculateCost, formatUsername } from "@/lib/format";
 import { orpc } from "@/lib/orpc";
@@ -200,24 +217,29 @@ export function SessionsListPage() {
 						>
 							Measure (Y-Axis)
 						</label>
-						<select
-							id="sessions-metric-select"
+						<Select
 							value={selectedMetric}
-							onChange={(e) =>
-								setSelectedMetric(
-									e.target.value as DimensionAnalysisInput["metric"],
-								)
+							onValueChange={(v) =>
+								setSelectedMetric(v as DimensionAnalysisInput["metric"])
 							}
-							className="w-full px-3 py-2 border border-border rounded-lg bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
 						>
-							<option value="session_count">Session Count</option>
-							<option value="avg_duration">Avg Duration (min)</option>
-							<option value="total_duration">Total Duration (hours)</option>
-							<option value="avg_tokens">Avg Tokens</option>
-							<option value="total_tokens">Total Tokens</option>
-							<option value="avg_success_score">Avg Success Score</option>
-							<option value="total_errors">Total Errors</option>
-						</select>
+							<SelectTrigger className="w-full">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="session_count">Session Count</SelectItem>
+								<SelectItem value="avg_duration">Avg Duration (min)</SelectItem>
+								<SelectItem value="total_duration">
+									Total Duration (hours)
+								</SelectItem>
+								<SelectItem value="avg_tokens">Avg Tokens</SelectItem>
+								<SelectItem value="total_tokens">Total Tokens</SelectItem>
+								<SelectItem value="avg_success_score">
+									Avg Success Score
+								</SelectItem>
+								<SelectItem value="total_errors">Total Errors</SelectItem>
+							</SelectContent>
+						</Select>
 					</div>
 					<div>
 						<label
@@ -226,23 +248,24 @@ export function SessionsListPage() {
 						>
 							Group By (X-Axis)
 						</label>
-						<select
-							id="sessions-dimension-select"
+						<Select
 							value={selectedDimension}
-							onChange={(e) =>
-								setSelectedDimension(
-									e.target.value as DimensionAnalysisInput["dimension"],
-								)
+							onValueChange={(v) =>
+								setSelectedDimension(v as DimensionAnalysisInput["dimension"])
 							}
-							className="w-full px-3 py-2 border border-border rounded-lg bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
 						>
-							<option value="session_archetype">Session Type</option>
-							<option value="model_used">Model Used</option>
-							<option value="user_id">User/Developer</option>
-							<option value="project_path">Project</option>
-							<option value="repository">Repository</option>
-							<option value="has_commit">Has Commit</option>
-						</select>
+							<SelectTrigger className="w-full">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="session_archetype">Session Type</SelectItem>
+								<SelectItem value="model_used">Model Used</SelectItem>
+								<SelectItem value="user_id">User/Developer</SelectItem>
+								<SelectItem value="project_path">Project</SelectItem>
+								<SelectItem value="repository">Repository</SelectItem>
+								<SelectItem value="has_commit">Has Commit</SelectItem>
+							</SelectContent>
+						</Select>
 					</div>
 					<div>
 						<label
@@ -251,23 +274,27 @@ export function SessionsListPage() {
 						>
 							Split By (Optional)
 						</label>
-						<select
-							id="sessions-splitby-select"
-							value={selectedSplitBy}
-							onChange={(e) => {
+						<Select
+							value={selectedSplitBy || "none"}
+							onValueChange={(v) => {
+								const value = v === "none" ? "" : v;
 								setSelectedSplitBy(
-									e.target.value as DimensionAnalysisInput["dimension"] | "",
+									value as DimensionAnalysisInput["dimension"] | "",
 								);
-								if (!e.target.value) setShowPercentage(false);
+								if (!value) setShowPercentage(false);
 							}}
-							className="w-full px-3 py-2 border border-border rounded-lg bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
 						>
-							<option value="">None</option>
-							<option value="session_archetype">Session Type</option>
-							<option value="model_used">Model Used</option>
-							<option value="user_id">User/Developer</option>
-							<option value="repository">Repository</option>
-						</select>
+							<SelectTrigger className="w-full">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="none">None</SelectItem>
+								<SelectItem value="session_archetype">Session Type</SelectItem>
+								<SelectItem value="model_used">Model Used</SelectItem>
+								<SelectItem value="user_id">User/Developer</SelectItem>
+								<SelectItem value="repository">Repository</SelectItem>
+							</SelectContent>
+						</Select>
 					</div>
 				</div>
 
@@ -276,29 +303,17 @@ export function SessionsListPage() {
 						<span className="text-sm text-muted">
 							{showPercentage ? "Showing as %" : "Showing absolute values"}
 						</span>
-						<button
-							type="button"
-							onClick={() => setShowPercentage(!showPercentage)}
-							className="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
-							style={{
-								backgroundColor: showPercentage
-									? "var(--color-accent)"
-									: "var(--color-border)",
-							}}
-						>
-							<span
-								className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-									showPercentage ? "translate-x-6" : "translate-x-1"
-								}`}
-							/>
-						</button>
+						<Switch
+							checked={showPercentage}
+							onCheckedChange={setShowPercentage}
+						/>
 					</div>
 				)}
 
 				{dimensionLoading ? (
 					<div className="flex items-center justify-center h-64">
 						<div className="text-center">
-							<div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-accent border-r-transparent mb-2" />
+							<Spinner className="mb-2" />
 							<p className="text-muted">Loading chart...</p>
 						</div>
 					</div>
@@ -340,95 +355,93 @@ export function SessionsListPage() {
 					</div>
 				</div>
 
-				<div className="overflow-x-auto">
-					<table className="min-w-full divide-y divide-border">
-						<thead className="bg-surface">
-							<tr>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Session ID
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Date
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									User
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Project
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Duration
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Success Score
-								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-									Cost
-								</th>
-							</tr>
-						</thead>
-						<tbody className="bg-input divide-y divide-border">
-							{filteredSessions.map((session) => (
-								<tr
-									key={session.session_id}
-									className="hover:bg-hover cursor-pointer"
-								>
-									<td className="px-6 py-4 whitespace-nowrap text-sm">
-										<Link
-											to={`/dashboard/sessions/${session.session_id}`}
-											className="text-accent hover:text-accent-hover hover:underline font-mono text-xs"
-										>
-											{session.session_id.slice(0, 8)}...
-										</Link>
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
-										{new Date(session.session_date).toLocaleDateString()}
-										<br />
-										<span className="text-xs text-muted">
-											{new Date(session.session_date).toLocaleTimeString()}
-										</span>
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-subheading">
-										{formatUsername(session.user_id, userMapRecord)}
-									</td>
-									<td className="px-6 py-4 text-sm text-foreground">
-										<div
-											className="max-w-xs truncate"
-											title={session.project_path}
-										>
-											{session.project_path.split("/").pop() ||
-												session.project_path}
-										</div>
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
-										{session.duration_min.toFixed(0)} min
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm">
-										<span
-											className={`font-semibold ${
-												session.success_score >= 70
-													? "text-status-success-icon"
-													: session.success_score >= 40
-														? "text-status-warning-icon"
-														: "text-status-error-icon"
-											}`}
-										>
-											{session.success_score.toFixed(0)}
-										</span>
-										<span className="text-xs text-muted"> / 100</span>
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-sm text-foreground font-mono">
-										$
-										{calculateCost(
-											session.input_tokens,
-											session.output_tokens,
-										).toFixed(4)}
-									</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
-				</div>
+				<Table>
+					<TableHeader className="bg-surface">
+						<TableRow>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Session ID
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Date
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								User
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Project
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Duration
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Success Score
+							</TableHead>
+							<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
+								Cost
+							</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody className="bg-input">
+						{filteredSessions.map((session) => (
+							<TableRow
+								key={session.session_id}
+								className="hover:bg-hover cursor-pointer"
+							>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm">
+									<Link
+										to={`/dashboard/sessions/${session.session_id}`}
+										className="text-accent hover:text-accent-hover hover:underline font-mono text-xs"
+									>
+										{session.session_id.slice(0, 8)}...
+									</Link>
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
+									{new Date(session.session_date).toLocaleDateString()}
+									<br />
+									<span className="text-xs text-muted">
+										{new Date(session.session_date).toLocaleTimeString()}
+									</span>
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-subheading">
+									{formatUsername(session.user_id, userMapRecord)}
+								</TableCell>
+								<TableCell className="px-6 py-4 text-sm text-foreground">
+									<div
+										className="max-w-xs truncate"
+										title={session.project_path}
+									>
+										{session.project_path.split("/").pop() ||
+											session.project_path}
+									</div>
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
+									{session.duration_min.toFixed(0)} min
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm">
+									<span
+										className={`font-semibold ${
+											session.success_score >= 70
+												? "text-status-success-icon"
+												: session.success_score >= 40
+													? "text-status-warning-icon"
+													: "text-status-error-icon"
+										}`}
+									>
+										{session.success_score.toFixed(0)}
+									</span>
+									<span className="text-xs text-muted"> / 100</span>
+								</TableCell>
+								<TableCell className="px-6 py-4 whitespace-nowrap text-sm text-foreground font-mono">
+									$
+									{calculateCost(
+										session.input_tokens,
+										session.output_tokens,
+									).toFixed(4)}
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
 			</AnalyticsCard>
 		</div>
 	);

--- a/bun.lock
+++ b/bun.lock
@@ -388,9 +388,9 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
-    "@orpc/client": ["@orpc/client@1.13.5", "", { "dependencies": { "@orpc/shared": "1.13.5", "@orpc/standard-server": "1.13.5", "@orpc/standard-server-fetch": "1.13.5", "@orpc/standard-server-peer": "1.13.5" } }, "sha512-j0VJpiWiFv9Xfan3NOoouHL07nSiHX8haxYaZzHYWSdWh+ABzwa8aRTwQSUpuCfD6i0EtYEZJAB6gVwtAnQoxQ=="],
+    "@orpc/client": ["@orpc/client@1.13.6", "", { "dependencies": { "@orpc/shared": "1.13.6", "@orpc/standard-server": "1.13.6", "@orpc/standard-server-fetch": "1.13.6", "@orpc/standard-server-peer": "1.13.6" } }, "sha512-M6lYM6fJUFp9GR+It/qglYTeXwspb6sGj46xXWHqHS6iDVquqju0bdYuLOfHx8CGJcUSzi0aKUcqMXiGJhBG3w=="],
 
-    "@orpc/contract": ["@orpc/contract@1.13.5", "", { "dependencies": { "@orpc/client": "1.13.5", "@orpc/shared": "1.13.5", "@standard-schema/spec": "^1.1.0", "openapi-types": "^12.1.3" } }, "sha512-JeklRu2kxsRKyaPeKqA40YHsGRLjQdAuEGNCNU6VxA3v4UReh8ZsDG+WvEoHfXIOLRn2VWBzEsbE1G2MwRCGsg=="],
+    "@orpc/contract": ["@orpc/contract@1.13.6", "", { "dependencies": { "@orpc/client": "1.13.6", "@orpc/shared": "1.13.6", "@standard-schema/spec": "^1.1.0", "openapi-types": "^12.1.3" } }, "sha512-wjnpKMsCBbUE7MxdS+9by1BIDTJ4vnfUk9he4GmxKQ8fvK/MRNHUR5jkNhsBCoLnigBrsAedHrr9AIqNgqquyQ=="],
 
     "@orpc/interop": ["@orpc/interop@1.13.5", "", {}, "sha512-l02yMZWJ9hJ2Z0PF14UsP2Hd71jbUbNgvA5/hxzGkx9ci89cgJ3F9yv3clpwz8VElfh2Qp9jta+peKgiRV1a5A=="],
 
@@ -410,7 +410,7 @@
 
     "@orpc/standard-server-peer": ["@orpc/standard-server-peer@1.13.5", "", { "dependencies": { "@orpc/shared": "1.13.5", "@orpc/standard-server": "1.13.5" } }, "sha512-pEvnaYtwXaw2Fjy0VJyvfZTma/AprSUGSJlOcnfBySo0TU3ZfsB54vhTlQCCN+WUCGjInZ75vCjIQnGj3Af3gg=="],
 
-    "@orpc/tanstack-query": ["@orpc/tanstack-query@1.13.5", "", { "dependencies": { "@orpc/shared": "1.13.5" }, "peerDependencies": { "@orpc/client": "1.13.5", "@tanstack/query-core": ">=5.80.2" } }, "sha512-DUgwJ/IiXAf7CFes2eLFKwFS9bBB4y6OZCiiualHiBE8nUumUw1/ErbXJnD52JbbyT9EriITInUM5iz0c1PBjQ=="],
+    "@orpc/tanstack-query": ["@orpc/tanstack-query@1.13.6", "", { "dependencies": { "@orpc/shared": "1.13.6" }, "peerDependencies": { "@orpc/client": "1.13.6", "@tanstack/query-core": ">=5.80.2" } }, "sha512-OBseuArjkAobKtKLVdzpepiS0fhc0TzW0O0Jixt1gkhkCiWG1xK8z0gZ7daQ85UBXRIoI9SXzwXhl+HVP+j14w=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -1634,6 +1634,22 @@
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
+    "@orpc/client/@orpc/shared": ["@orpc/shared@1.13.6", "", { "dependencies": { "radash": "^12.1.1", "type-fest": "^5.4.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-XqpXPgmtkg2tviDXZC13Y4a3B0D5r1yuG4Q2qPG3gM1dargxob6/aSIeKE6rs1tNXOoI+IpJaGV53EWWB+x+iA=="],
+
+    "@orpc/client/@orpc/standard-server": ["@orpc/standard-server@1.13.6", "", { "dependencies": { "@orpc/shared": "1.13.6" } }, "sha512-GNYZXCWxYLVHsxBWR+bg5F12vDCsQghqxbqoFpMnA4goe58dugNWmuxM+aSDbI0D81YxkKDULSqft5S+GWi5ww=="],
+
+    "@orpc/client/@orpc/standard-server-fetch": ["@orpc/standard-server-fetch@1.13.6", "", { "dependencies": { "@orpc/shared": "1.13.6", "@orpc/standard-server": "1.13.6" } }, "sha512-O0bK4crjEOU9H4LzJ2abMjku3dvEhs8tcLXP/W5NXyH+Wm7qjBjDr6psxZ3YuaWdVbfd/P7CHtvw2rQDHJCNfQ=="],
+
+    "@orpc/client/@orpc/standard-server-peer": ["@orpc/standard-server-peer@1.13.6", "", { "dependencies": { "@orpc/shared": "1.13.6", "@orpc/standard-server": "1.13.6" } }, "sha512-WTqjNS6A9sxR4HVxWUb9ZoBHeQiesHeANmVBFdM/QjAaPUZYKn6WACYU6Q2eGmsCUeTQFfMssk0BG2EsgRNEYw=="],
+
+    "@orpc/contract/@orpc/shared": ["@orpc/shared@1.13.6", "", { "dependencies": { "radash": "^12.1.1", "type-fest": "^5.4.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-XqpXPgmtkg2tviDXZC13Y4a3B0D5r1yuG4Q2qPG3gM1dargxob6/aSIeKE6rs1tNXOoI+IpJaGV53EWWB+x+iA=="],
+
+    "@orpc/server/@orpc/client": ["@orpc/client@1.13.5", "", { "dependencies": { "@orpc/shared": "1.13.5", "@orpc/standard-server": "1.13.5", "@orpc/standard-server-fetch": "1.13.5", "@orpc/standard-server-peer": "1.13.5" } }, "sha512-j0VJpiWiFv9Xfan3NOoouHL07nSiHX8haxYaZzHYWSdWh+ABzwa8aRTwQSUpuCfD6i0EtYEZJAB6gVwtAnQoxQ=="],
+
+    "@orpc/server/@orpc/contract": ["@orpc/contract@1.13.5", "", { "dependencies": { "@orpc/client": "1.13.5", "@orpc/shared": "1.13.5", "@standard-schema/spec": "^1.1.0", "openapi-types": "^12.1.3" } }, "sha512-JeklRu2kxsRKyaPeKqA40YHsGRLjQdAuEGNCNU6VxA3v4UReh8ZsDG+WvEoHfXIOLRn2VWBzEsbE1G2MwRCGsg=="],
+
+    "@orpc/tanstack-query/@orpc/shared": ["@orpc/shared@1.13.6", "", { "dependencies": { "radash": "^12.1.1", "type-fest": "^5.4.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-XqpXPgmtkg2tviDXZC13Y4a3B0D5r1yuG4Q2qPG3gM1dargxob6/aSIeKE6rs1tNXOoI+IpJaGV53EWWB+x+iA=="],
+
     "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "@rudel/web/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -1679,6 +1695,10 @@
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
+    "rudel/@orpc/client": ["@orpc/client@1.13.5", "", { "dependencies": { "@orpc/shared": "1.13.5", "@orpc/standard-server": "1.13.5", "@orpc/standard-server-fetch": "1.13.5", "@orpc/standard-server-peer": "1.13.5" } }, "sha512-j0VJpiWiFv9Xfan3NOoouHL07nSiHX8haxYaZzHYWSdWh+ABzwa8aRTwQSUpuCfD6i0EtYEZJAB6gVwtAnQoxQ=="],
+
+    "rudel/@orpc/contract": ["@orpc/contract@1.13.5", "", { "dependencies": { "@orpc/client": "1.13.5", "@orpc/shared": "1.13.5", "@standard-schema/spec": "^1.1.0", "openapi-types": "^12.1.3" } }, "sha512-JeklRu2kxsRKyaPeKqA40YHsGRLjQdAuEGNCNU6VxA3v4UReh8ZsDG+WvEoHfXIOLRn2VWBzEsbE1G2MwRCGsg=="],
 
     "vite/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 


### PR DESCRIPTION
## Summary

Systematically replace hand-rolled dropdowns, tables, selects, toggles, loading states, and tooltips with shadcn/ui components across the web app. Installs 8 new shadcn components (popover, checkbox, dropdown-menu, tooltip, select, table, skeleton, switch) and creates a shared Spinner component.

## What Changed

- **Phase 0**: Install 8 shadcn components via CLI
- **Phases 1-8**: Replace inline spinners, tables, selects, inputs, buttons, skeletons, and switches across 6 dashboard pages and 3 chart components
- **Phases 9-12**: Refactor complex components (MultiSelect, DatePicker, OrgSwitcher, Sidebar tooltips) to use Popover, DropdownMenu, and Tooltip primitives

16 files modified/created. Removes 900+ lines of manual click-outside detection, custom styling, and state management code. All UI elements now use consistent Radix primitives with proper keyboard navigation and accessibility support.

## Files Modified

- 8 new shadcn component files in `apps/web/src/components/ui/`
- 1 new shared Spinner component
- 6 dashboard page files (ROI, Projects, Developers, Sessions, DeveloperDetail, ProjectDetail, Organization, SessionDetail, Overview)
- 2 chart component files (LearningsTrendChart, ErrorTrendChart)
- 3 analytics component files (MultiSelect, DatePicker, Sidebar)
- 1 learnings component file (LearningsTimeline)

## Verification

- ✅ `bun run verify` passes (type check, lint, tests, build)
- ✅ All tables render correctly with shadcn styling
- ✅ All selects function correctly with Radix primitives
- ✅ Popover-based dropdowns handle click-outside and Escape automatically
- ✅ Tooltip accessibility improved with keyboard support and screen reader announcements

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>