### PR TITLE
♻️ Refactor: Use package.json for CLI version and remove extra-files from release-please config

### DIFF
--- a/apps/cli/src/app.ts
+++ b/apps/cli/src/app.ts
@@ -1,4 +1,5 @@
 import { buildApplication, buildRouteMap } from "@stricli/core";
+import pkg from "../package.json";
 import { disableCommand } from "./commands/disable.js";
 import { enableCommand } from "./commands/enable.js";
 import { hooksRouteMap } from "./commands/hooks/index.js";
@@ -28,7 +29,7 @@ const routes = buildRouteMap({
 export const app = buildApplication(routes, {
 	name: "rudel",
 	versionInfo: {
-		currentVersion: "0.1.4", // x-release-please-version
+		currentVersion: pkg.version,
 	},
 	scanner: {
 		caseStyle: "allow-kebab-for-camel",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,8 +8,7 @@
 		"apps/cli": {
 			"release-type": "node",
 			"component": "rudel",
-			"changelog-path": "CHANGELOG.md",
-			"extra-files": [{ "type": "generic", "path": "src/app.ts" }]
+			"changelog-path": "CHANGELOG.md"
 		}
 	}
 }


### PR DESCRIPTION
Uses the version from package.json instead of hardcoding it in app.ts. Removes the extra-files entry from release-please-config.json as it's no longer needed.

Entire-Checkpoint: 31249f538387
