### PR TITLE
refactor: modernize CLI UX with @clack/prompts

### DIFF
--- a/apps/cli/src/commands/disable.ts
+++ b/apps/cli/src/commands/disable.ts
@@ -1,17 +1,17 @@
+import * as p from "@clack/prompts";
 import { buildCommand } from "@stricli/core";
 import { getDefaultAgent } from "../lib/agents/index.js";
 
 async function runDisable(): Promise<void> {
-	const write = (msg: string) => process.stdout.write(`${msg}\n`);
 	const agent = getDefaultAgent();
 
 	if (!agent.isHookInstalled()) {
-		write("Auto-upload hook is not enabled.");
+		p.log.info("Auto-upload hook is not enabled.");
 		return;
 	}
 
 	agent.removeHook();
-	write(`Auto-upload hook removed from ${agent.getHookSettingsPath()}`);
+	p.log.success(`Auto-upload hook removed from ${agent.getHookSettingsPath()}`);
 }
 
 export const disableCommand = buildCommand({

--- a/apps/cli/src/commands/enable.ts
+++ b/apps/cli/src/commands/enable.ts
@@ -1,5 +1,5 @@
 import { dirname } from "node:path";
-import { createInterface } from "node:readline";
+import * as p from "@clack/prompts";
 import { buildCommand } from "@stricli/core";
 import { getDefaultAgent } from "../lib/agents/index.js";
 import { createApiClient } from "../lib/api-client.js";
@@ -11,39 +11,14 @@ import { extractAgentIds, readTranscript } from "../lib/transcript-reader.js";
 import type { IngestRequest } from "../lib/types.js";
 import { uploadSession } from "../lib/uploader.js";
 
-async function promptChoice(question: string, max: number): Promise<number> {
-	const rl = createInterface({ input: process.stdin, output: process.stdout });
-	return new Promise((resolve) => {
-		rl.question(question, (answer) => {
-			rl.close();
-			const num = Number.parseInt(answer.trim(), 10);
-			if (Number.isNaN(num) || num < 1 || num > max) {
-				resolve(1);
-			} else {
-				resolve(num);
-			}
-		});
-	});
-}
-
-async function promptYesNo(question: string): Promise<boolean> {
-	const rl = createInterface({ input: process.stdin, output: process.stdout });
-	return new Promise((resolve) => {
-		rl.question(question, (answer) => {
-			rl.close();
-			resolve(answer.trim().toLowerCase() === "y");
-		});
-	});
-}
-
 async function runEnable(): Promise<void> {
-	const write = (msg: string) => process.stdout.write(`${msg}\n`);
-	const writeError = (msg: string) => process.stderr.write(`${msg}\n`);
+	p.intro("rudel enable");
 
 	// Verify auth (loads credentials + pings API)
 	const auth = await verifyAuth();
 	if (!auth.authenticated) {
-		writeError(`Error: ${auth.message}`);
+		p.log.error(auth.message);
+		p.outro("Run `rudel login` to authenticate.");
 		process.exitCode = 1;
 		return;
 	}
@@ -56,15 +31,14 @@ async function runEnable(): Promise<void> {
 	try {
 		orgs = await client.listMyOrganizations();
 	} catch {
-		writeError("Error: Failed to fetch organizations. Check your connection.");
+		p.log.error("Failed to fetch organizations. Check your connection.");
 		process.exitCode = 1;
 		return;
 	}
 
 	if (orgs.length === 0) {
-		writeError(
-			"Error: No organizations found. Create one at app.rudel.ai first.",
-		);
+		p.log.error("No organizations found.");
+		p.outro("Create one at app.rudel.ai first.");
 		process.exitCode = 1;
 		return;
 	}
@@ -81,23 +55,30 @@ async function runEnable(): Promise<void> {
 	const [firstOrg] = orgs;
 	if (orgs.length === 1 && firstOrg) {
 		selectedOrgId = firstOrg.id;
-		write(`Using organization: ${firstOrg.name}`);
+		p.log.info(`Using organization: ${firstOrg.name}`);
 	} else if (existingOrg) {
-		write(`Currently configured for: ${existingOrg.name}`);
+		p.log.info(`Currently configured for: ${existingOrg.name}`);
 		selectedOrgId = existingOrg.id;
 	} else {
-		write("Select an organization for this repository:");
-		for (const [i, org] of orgs.entries()) {
-			write(`  ${i + 1}. ${org.name} (${org.slug})`);
+		const selected = await p.select({
+			message: "Select an organization for this repository",
+			options: orgs.map((org) => ({
+				value: org.id,
+				label: org.name,
+				hint: org.slug,
+			})),
+		});
+
+		if (p.isCancel(selected)) {
+			p.cancel("Setup cancelled.");
+			return;
 		}
-		const choice = await promptChoice(
-			`Choice [1-${orgs.length}]: `,
-			orgs.length,
-		);
-		const selected = orgs[choice - 1] ?? orgs[0];
-		if (!selected) return;
-		selectedOrgId = selected.id;
-		write(`Selected: ${selected.name}`);
+
+		selectedOrgId = selected;
+		const selectedOrg = orgs.find((o) => o.id === selected);
+		if (selectedOrg) {
+			p.log.success(`Selected: ${selectedOrg.name}`);
+		}
 	}
 
 	await setProjectOrgId(cwd, selectedOrgId);
@@ -106,62 +87,84 @@ async function runEnable(): Promise<void> {
 	const agent = getDefaultAgent();
 
 	if (agent.isHookInstalled()) {
-		write("Auto-upload hook is already enabled. Organization updated.");
+		p.log.info("Auto-upload hook is already enabled. Organization updated.");
 	} else {
 		agent.installHook();
-		write(`Auto-upload hook enabled in ${agent.getHookSettingsPath()}`);
+		p.log.success(`Auto-upload hook enabled in ${agent.getHookSettingsPath()}`);
 	}
 
 	// Check for existing sessions to upload
 	const sessions = await agent.findProjectSessions(cwd);
-	if (sessions.length === 0) return;
+	if (sessions.length === 0) {
+		p.outro("Done!");
+		return;
+	}
 
-	const shouldUpload = await promptYesNo(
-		`Found ${sessions.length} previous session(s). Upload them now? [y/N] `,
-	);
-	if (!shouldUpload) return;
+	const shouldUpload = await p.confirm({
+		message: `Found ${sessions.length} previous session(s). Upload them now?`,
+		initialValue: false,
+	});
+
+	if (p.isCancel(shouldUpload) || !shouldUpload) {
+		p.outro("Done!");
+		return;
+	}
 
 	const endpoint = `${credentials.apiBaseUrl}/rpc`;
+	let failed = 0;
 
-	for (const [i, session] of sessions.entries()) {
-		const label = `[${i + 1}/${sessions.length}]`;
-		try {
-			const content = await readTranscript(session.transcriptPath);
-			const agentIds = extractAgentIds(content);
-			const sessionDir = dirname(session.transcriptPath);
-			const subagents =
-				agentIds.length > 0
-					? await readSubagentFiles(sessionDir, agentIds, session.sessionId)
-					: [];
-			const gitInfo = await getGitInfo(session.projectPath);
+	await p.tasks(
+		sessions.map((session, i) => ({
+			title: `[${i + 1}/${sessions.length}] ${session.sessionId}`,
+			task: async (message) => {
+				message("Reading transcript...");
+				try {
+					const content = await readTranscript(session.transcriptPath);
+					const agentIds = extractAgentIds(content);
+					const sessionDir = dirname(session.transcriptPath);
+					const subagents =
+						agentIds.length > 0
+							? await readSubagentFiles(sessionDir, agentIds, session.sessionId)
+							: [];
 
-			const request: IngestRequest = {
-				sessionId: session.sessionId,
-				projectPath: session.projectPath,
-				repository: gitInfo.repository,
-				gitBranch: gitInfo.branch,
-				gitSha: gitInfo.sha,
-				content,
-				subagents: subagents.length > 0 ? subagents : undefined,
-				organizationId: selectedOrgId,
-			};
+					message("Resolving git info...");
+					const gitInfo = await getGitInfo(session.projectPath);
 
-			const result = await uploadSession(request, {
-				endpoint,
-				token: credentials.token,
-			});
+					const request: IngestRequest = {
+						sessionId: session.sessionId,
+						projectPath: session.projectPath,
+						repository: gitInfo.repository,
+						gitBranch: gitInfo.branch,
+						gitSha: gitInfo.sha,
+						content,
+						subagents: subagents.length > 0 ? subagents : undefined,
+						organizationId: selectedOrgId,
+					};
 
-			if (result.success) {
-				write(`${label} Uploaded ${session.sessionId}`);
-			} else {
-				writeError(`${label} Failed ${session.sessionId}: ${result.error}`);
-			}
-		} catch (error) {
-			writeError(
-				`${label} Error ${session.sessionId}: ${error instanceof Error ? error.message : String(error)}`,
-			);
-		}
+					message("Uploading...");
+					const result = await uploadSession(request, {
+						endpoint,
+						token: credentials.token,
+					});
+
+					if (result.success) {
+						return "Uploaded";
+					}
+					failed++;
+					return `Failed: ${result.error}`;
+				} catch (error) {
+					failed++;
+					return `Error: ${error instanceof Error ? error.message : String(error)}`;
+				}
+			},
+		})),
+	);
+
+	if (failed > 0) {
+		p.log.error(`${failed} session(s) failed`);
 	}
+
+	p.outro("Done!");
 }
 
 export const enableCommand = buildCommand({

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import * as p from "@clack/prompts";
 import { buildCommand } from "@stricli/core";
 import { loadCredentials, saveCredentials } from "../lib/credentials.js";
 
@@ -10,12 +11,12 @@ async function runLogin(flags: {
 	apiBase: string;
 	webUrl: string;
 }): Promise<void> {
-	const write = (msg: string) => process.stdout.write(`${msg}\n`);
-	const writeError = (msg: string) => process.stderr.write(`${msg}\n`);
+	p.intro("rudel login");
 
 	const existing = loadCredentials();
 	if (existing) {
-		write("Already logged in. Run `rudel logout` first to switch accounts.");
+		p.log.warn("Already logged in.");
+		p.outro("Run `rudel logout` first to switch accounts.");
 		return;
 	}
 
@@ -67,8 +68,7 @@ async function runLogin(flags: {
 	const callbackUrl = `http://127.0.0.1:${server.port}/callback`;
 	const loginUrl = `${flags.webUrl}?cli_callback=${encodeURIComponent(callbackUrl)}&state=${state}`;
 
-	write("Opening browser for authentication...");
-	write(`If the browser doesn't open, visit: ${loginUrl}`);
+	p.log.info(`If the browser doesn't open, visit:\n${loginUrl}`);
 
 	// Open browser
 	if (process.platform === "win32") {
@@ -86,23 +86,26 @@ async function runLogin(flags: {
 		rejectCallback(new Error("Login timed out after 120 seconds"));
 	}, CALLBACK_TIMEOUT_MS);
 
+	const spin = p.spinner();
+	spin.start("Waiting for browser authentication...");
+
 	let token: string;
 	try {
 		token = await tokenPromise;
 	} catch (error) {
 		clearTimeout(timeout);
 		server.stop();
-		writeError(
-			`Login failed: ${error instanceof Error ? error.message : String(error)}`,
-		);
+		spin.stop("Authentication failed");
+		p.log.error(error instanceof Error ? error.message : String(error));
 		process.exitCode = 1;
 		return;
 	}
 	clearTimeout(timeout);
 	server.stop();
 
+	spin.message("Validating token...");
+
 	// Validate token via /rpc/me
-	write("Validating token...");
 	const meResponse = await fetch(`${flags.apiBase}/rpc/me`, {
 		method: "POST",
 		headers: {
@@ -113,7 +116,8 @@ async function runLogin(flags: {
 	});
 
 	if (!meResponse.ok) {
-		writeError("Login failed: token validation failed");
+		spin.stop("Token validation failed");
+		p.log.error("Login failed: token validation failed");
 		process.exitCode = 1;
 		return;
 	}
@@ -123,7 +127,9 @@ async function runLogin(flags: {
 	};
 
 	saveCredentials(token, flags.apiBase);
-	write(`Logged in as ${body.json.name} (${body.json.email})`);
+	spin.stop("Authenticated");
+	p.log.success(`Logged in as ${body.json.name} (${body.json.email})`);
+	p.outro("Done!");
 }
 
 export const loginCommand = buildCommand({

--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -1,17 +1,16 @@
+import * as p from "@clack/prompts";
 import { buildCommand } from "@stricli/core";
 import { clearCredentials, loadCredentials } from "../lib/credentials.js";
 
 async function runLogout(): Promise<void> {
-	const write = (msg: string) => process.stdout.write(`${msg}\n`);
-
 	const credentials = loadCredentials();
 	if (!credentials) {
-		write("Not logged in.");
+		p.log.info("Not logged in.");
 		return;
 	}
 
 	clearCredentials();
-	write("Logged out successfully.");
+	p.log.success("Logged out successfully.");
 }
 
 export const logoutCommand = buildCommand({

--- a/apps/cli/src/commands/set-org.ts
+++ b/apps/cli/src/commands/set-org.ts
@@ -1,31 +1,16 @@
-import { createInterface } from "node:readline";
+import * as p from "@clack/prompts";
 import { buildCommand } from "@stricli/core";
 import { createApiClient } from "../lib/api-client.js";
 import { loadCredentials } from "../lib/credentials.js";
 import { getProjectOrgId, setProjectOrgId } from "../lib/project-config.js";
 
-async function promptChoice(question: string, max: number): Promise<number> {
-	const rl = createInterface({ input: process.stdin, output: process.stdout });
-	return new Promise((resolve) => {
-		rl.question(question, (answer) => {
-			rl.close();
-			const num = Number.parseInt(answer.trim(), 10);
-			if (Number.isNaN(num) || num < 1 || num > max) {
-				resolve(1);
-			} else {
-				resolve(num);
-			}
-		});
-	});
-}
-
 async function runSetOrg(): Promise<void> {
-	const write = (msg: string) => process.stdout.write(`${msg}\n`);
-	const writeError = (msg: string) => process.stderr.write(`${msg}\n`);
+	p.intro("rudel set-org");
 
 	const credentials = loadCredentials();
 	if (!credentials) {
-		writeError("Error: Not authenticated. Run `rudel login` first.");
+		p.log.error("Not authenticated.");
+		p.outro("Run `rudel login` first.");
 		process.exitCode = 1;
 		return;
 	}
@@ -35,40 +20,40 @@ async function runSetOrg(): Promise<void> {
 	try {
 		orgs = await client.listMyOrganizations();
 	} catch {
-		writeError("Error: Failed to fetch organizations. Check your connection.");
+		p.log.error("Failed to fetch organizations. Check your connection.");
 		process.exitCode = 1;
 		return;
 	}
 
 	if (orgs.length === 0) {
-		writeError(
-			"Error: No organizations found. Create one at app.rudel.ai first.",
-		);
+		p.log.error("No organizations found.");
+		p.outro("Create one at app.rudel.ai first.");
 		process.exitCode = 1;
 		return;
 	}
 
 	const cwd = process.cwd();
 	const currentOrgId = await getProjectOrgId(cwd);
-	const currentOrg = currentOrgId
-		? orgs.find((o) => o.id === currentOrgId)
-		: undefined;
 
-	if (currentOrg) {
-		write(`Current organization: ${currentOrg.name} (${currentOrg.slug})`);
+	const selected = await p.select({
+		message: "Select an organization for this repository",
+		options: orgs.map((org) => ({
+			value: org.id,
+			label: org.name,
+			hint: org.id === currentOrgId ? `${org.slug} (current)` : org.slug,
+		})),
+		initialValue: currentOrgId ?? undefined,
+	});
+
+	if (p.isCancel(selected)) {
+		p.cancel("Cancelled.");
+		return;
 	}
 
-	write("Select an organization for this repository:");
-	for (const [i, org] of orgs.entries()) {
-		const marker = org.id === currentOrgId ? " (current)" : "";
-		write(`  ${i + 1}. ${org.name} (${org.slug})${marker}`);
-	}
-
-	const choice = await promptChoice(`Choice [1-${orgs.length}]: `, orgs.length);
-	const selected = orgs[choice - 1] ?? orgs[0];
-	if (!selected) return;
-	await setProjectOrgId(cwd, selected.id);
-	write(`Organization set to: ${selected.name}`);
+	await setProjectOrgId(cwd, selected);
+	const selectedOrg = orgs.find((o) => o.id === selected);
+	p.log.success(`Organization set to: ${selectedOrg?.name}`);
+	p.outro("Done!");
 }
 
 export const setOrgCommand = buildCommand({

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -1,22 +1,20 @@
+import * as p from "@clack/prompts";
 import { buildCommand } from "@stricli/core";
 import { verifyAuth } from "../lib/auth.js";
 
 async function runWhoami(): Promise<void> {
-	const write = (msg: string) => process.stdout.write(`${msg}\n`);
-	const writeError = (msg: string) => process.stderr.write(`${msg}\n`);
-
 	const result = await verifyAuth();
 	if (!result.authenticated) {
 		if (result.reason === "no_credentials") {
-			write("Not logged in. Run `rudel login` to authenticate.");
+			p.log.info("Not logged in. Run `rudel login` to authenticate.");
 		} else {
-			writeError(`Error: ${result.message}`);
+			p.log.error(result.message);
 			process.exitCode = 1;
 		}
 		return;
 	}
 
-	write(`Logged in as ${result.user.name} (${result.user.email})`);
+	p.log.info(`Logged in as ${result.user.name} (${result.user.email})`);
 }
 
 export const whoamiCommand = buildCommand({


### PR DESCRIPTION
## Summary

Replace raw `process.stdout.write` and `node:readline` prompts with `@clack/prompts` for consistent, styled terminal UI across all CLI commands.

- **enable**: `p.select()` for org selection with hints, `p.confirm()` for upload prompt, `p.tasks()` for per-session upload progress with live status updates
- **set-org**: `p.select()` with initialValue and current org hint
- **login**: `p.spinner()` while waiting for browser auth callback instead of static message
- **logout, whoami, disable**: Switch to `p.log.*` for consistent styling
- **All commands**: Use `p.intro/outro` for framing, remove duplicated readline helpers

Also fixes TypeScript error in `app.ts` by adding `with { type: "json" }` to package.json import.

## Benefits

- Consistent, styled output with color/icons across all commands
- Better progress reporting during session uploads (each session shows spinner with status messages)
- Arrow-key navigable selection menus instead of raw numbered input
- Eliminated code duplication (`promptChoice` was defined twice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)