### PR TITLE
🔧 Add session-end hook in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -88,6 +88,16 @@
             "async": true
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rudel hooks claude session-end",
+            "async": true
+          }
+        ]
       }
     ],
     "SessionStart": [


### PR DESCRIPTION
This commit introduces a new session-end hook in .claude/settings.json to trigger a command when a Claude session ends.
