### PR TITLE
ci: disable automerge on release PR to allow manual batching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,3 @@ jobs:
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable automerge on release PR
-        if: steps.release.outputs.pr
-        run: gh pr merge --auto --squash ${{ fromJSON(steps.release.outputs.pr).number }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Remove automerge step from release workflow to allow release PR to accumulate changes from multiple merged PRs before manual merge
- Release PR will now be created/updated but require explicit manual merge by reviewer

## Test plan
- [x] Verification passed (type check, lint, tests)
- [ ] Verify that release PR is created on next main push but does not auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)