### PR TITLE
test: add --no-browser flag to prevent login test from opening browser

### DIFF
--- a/apps/cli/src/__tests__/auth.e2e.test.ts
+++ b/apps/cli/src/__tests__/auth.e2e.test.ts
@@ -50,7 +50,7 @@ describe("auth e2e", () => {
 			[
 				"bash",
 				"-c",
-				`bun "${cliPath}" login --api-base="${server.baseUrl}" --web-url=http://localhost:9999 2>&1 | tee "${stdoutLogPath}"`,
+				`bun "${cliPath}" login --api-base="${server.baseUrl}" --web-url=http://localhost:9999 --no-browser 2>&1 | tee "${stdoutLogPath}"`,
 			],
 			{
 				env: {

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -10,6 +10,7 @@ const CALLBACK_TIMEOUT_MS = 120_000;
 async function runLogin(flags: {
 	apiBase: string;
 	webUrl: string;
+	noBrowser: boolean;
 }): Promise<void> {
 	p.intro("rudel login");
 
@@ -71,14 +72,16 @@ async function runLogin(flags: {
 	p.log.info(`If the browser doesn't open, visit:\n${loginUrl}`);
 
 	// Open browser
-	if (process.platform === "win32") {
-		Bun.spawn(["cmd", "/c", "start", "", loginUrl], {
-			stdout: "ignore",
-			stderr: "ignore",
-		});
-	} else {
-		const opener = process.platform === "darwin" ? "open" : "xdg-open";
-		Bun.spawn([opener, loginUrl], { stdout: "ignore", stderr: "ignore" });
+	if (!flags.noBrowser) {
+		if (process.platform === "win32") {
+			Bun.spawn(["cmd", "/c", "start", "", loginUrl], {
+				stdout: "ignore",
+				stderr: "ignore",
+			});
+		} else {
+			const opener = process.platform === "darwin" ? "open" : "xdg-open";
+			Bun.spawn([opener, loginUrl], { stdout: "ignore", stderr: "ignore" });
+		}
 	}
 
 	// Wait for callback with timeout
@@ -147,6 +150,11 @@ export const loginCommand = buildCommand({
 				parse: String,
 				brief: "Web app URL for authentication",
 				default: DEFAULT_WEB_URL,
+			},
+			noBrowser: {
+				kind: "boolean",
+				brief: "Skip opening the browser automatically",
+				default: false,
 			},
 		},
 	},


### PR DESCRIPTION
## Summary
- Added `--no-browser` flag to the login command to skip browser opening
- Updated the auth.e2e test to use this flag, preventing the test from popping open a browser window
- The login URL is still printed to stdout so users can manually visit it if needed

## Test plan
- [x] All existing tests pass (34 tests)
- [x] Manual testing: login command still opens browser by default
- [x] Manual testing: login with --no-browser flag skips browser opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)