### PR TITLE
feat: add CLI setup hint to empty overview dashboard

### DIFF
--- a/apps/web/src/components/analytics/CliSetupHint.tsx
+++ b/apps/web/src/components/analytics/CliSetupHint.tsx
@@ -1,0 +1,51 @@
+import { Terminal } from "lucide-react";
+import { AnalyticsCard } from "./AnalyticsCard";
+
+export function CliSetupHint() {
+	return (
+		<AnalyticsCard className="mt-4">
+			<div className="flex flex-col items-center justify-center py-20 px-4 text-center">
+				<div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mb-6">
+					<Terminal className="w-8 h-8 text-muted-foreground" />
+				</div>
+				<h3 className="text-lg font-semibold text-foreground mb-3">
+					No sessions yet
+				</h3>
+				<p className="text-sm text-muted-foreground max-w-lg mb-6">
+					Install the Rudel CLI and enable automatic uploads to start tracking
+					your team's Claude Code sessions.
+				</p>
+				<div className="w-full max-w-md text-left space-y-4">
+					<div>
+						<p className="text-xs font-medium text-muted-foreground mb-2">
+							1. Install the CLI globally
+						</p>
+						<pre className="bg-background rounded-md border border-border px-4 py-3 text-sm font-mono text-foreground">
+							npm install -g rudel
+						</pre>
+					</div>
+					<div>
+						<p className="text-xs font-medium text-muted-foreground mb-2">
+							2. Log in to your account
+						</p>
+						<pre className="bg-background rounded-md border border-border px-4 py-3 text-sm font-mono text-foreground">
+							rudel login
+						</pre>
+					</div>
+					<div>
+						<p className="text-xs font-medium text-muted-foreground mb-2">
+							3. Enable auto-upload in your repository
+						</p>
+						<pre className="bg-background rounded-md border border-border px-4 py-3 text-sm font-mono text-foreground">
+							rudel enable
+						</pre>
+					</div>
+				</div>
+				<p className="text-xs text-muted-foreground/60 max-w-md mt-6">
+					Sessions will appear here automatically after your next Claude Code
+					session ends.
+				</p>
+			</div>
+		</AnalyticsCard>
+	);
+}

--- a/apps/web/src/pages/dashboard/OverviewPage.tsx
+++ b/apps/web/src/pages/dashboard/OverviewPage.tsx
@@ -8,6 +8,7 @@ import {
 	Users,
 } from "lucide-react";
 import { AnalyticsCard } from "@/components/analytics/AnalyticsCard";
+import { CliSetupHint } from "@/components/analytics/CliSetupHint";
 import { DatePicker } from "@/components/analytics/DatePicker";
 import { InsightCard } from "@/components/analytics/InsightCard";
 import { PageHeader } from "@/components/analytics/PageHeader";
@@ -41,18 +42,22 @@ export function OverviewPage() {
 		orpc.analytics.overview.insights.queryOptions({ input: { days } }),
 	);
 
+	const hasData = !kpisLoading && kpis && kpis.distinct_sessions > 0;
+
 	return (
 		<div className="px-8 py-6">
 			<PageHeader
 				title="Dashboard Overview"
 				description="Track your team's Claude Code usage and metrics"
 				actions={
-					<DatePicker
-						startDate={startDate}
-						endDate={endDate}
-						onStartDateChange={setStartDate}
-						onEndDateChange={setEndDate}
-					/>
+					hasData ? (
+						<DatePicker
+							startDate={startDate}
+							endDate={endDate}
+							onStartDateChange={setStartDate}
+							onEndDateChange={setEndDate}
+						/>
+					) : undefined
 				}
 			/>
 
@@ -65,7 +70,9 @@ export function OverviewPage() {
 				</div>
 			)}
 
-			{!kpisLoading && kpis && (
+			{!kpisLoading && kpis && kpis.distinct_sessions === 0 && <CliSetupHint />}
+
+			{hasData && (
 				<>
 					<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
 						<StatCard


### PR DESCRIPTION
## Summary
- Added `CliSetupHint` component to show onboarding instructions when no sessions exist
- Users are guided through three steps: install CLI globally, login, and enable auto-upload in their repo
- Date picker is hidden until data is available for cleaner empty state UX
- Extracted hint into a reusable component for potential reuse across other empty states

## Test plan
- [ ] Verify empty overview shows the setup hint with correct formatting
- [ ] Confirm instructions match README (npm install -g, rudel login, rudel enable)
- [ ] Check that dashboard displays normally once sessions are uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)