### PR TITLE
feat: add table controls to projects list

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
 		"@orpc/tanstack-query": "latest",
 		"@rudel/api-routes": "workspace:*",
 		"@tanstack/react-query": "^5.80.0",
+		"@tanstack/react-table": "^8.21.3",
 		"better-auth": "^1.4.18",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",

--- a/apps/web/src/components/ui/data-table.tsx
+++ b/apps/web/src/components/ui/data-table.tsx
@@ -1,0 +1,183 @@
+import {
+	type ColumnDef,
+	flexRender,
+	getCoreRowModel,
+	getPaginationRowModel,
+	getSortedRowModel,
+	type SortingState,
+	useReactTable,
+} from "@tanstack/react-table";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+
+interface DataTableProps<TData, TValue> {
+	columns: ColumnDef<TData, TValue>[];
+	data: TData[];
+	defaultSorting?: SortingState;
+	defaultPageSize?: number;
+	pageSizeOptions?: number[];
+	onRowClick?: (row: TData) => void;
+}
+
+function DataTable<TData, TValue>({
+	columns,
+	data,
+	defaultSorting = [],
+	defaultPageSize = 10,
+	pageSizeOptions = [10, 20, 50],
+	onRowClick,
+}: DataTableProps<TData, TValue>) {
+	const [sorting, setSorting] = useState<SortingState>(defaultSorting);
+
+	const table = useReactTable({
+		data,
+		columns,
+		state: { sorting },
+		onSortingChange: setSorting,
+		getCoreRowModel: getCoreRowModel(),
+		getSortedRowModel: getSortedRowModel(),
+		getPaginationRowModel: getPaginationRowModel(),
+		initialState: {
+			pagination: { pageSize: defaultPageSize },
+		},
+	});
+
+	return (
+		<div>
+			<Table>
+				<TableHeader className="bg-surface">
+					{table.getHeaderGroups().map((headerGroup) => (
+						<TableRow key={headerGroup.id}>
+							{headerGroup.headers.map((header) => (
+								<TableHead
+									key={header.id}
+									className="px-6 py-3 text-xs text-muted uppercase tracking-wider"
+								>
+									{header.isPlaceholder ? null : header.column.getCanSort() ? (
+										<button
+											type="button"
+											className="inline-flex items-center gap-1 cursor-pointer select-none hover:text-foreground transition-colors"
+											onClick={header.column.getToggleSortingHandler()}
+										>
+											{flexRender(
+												header.column.columnDef.header,
+												header.getContext(),
+											)}
+											{header.column.getIsSorted() === "asc" ? (
+												<ArrowUp className="size-3" />
+											) : header.column.getIsSorted() === "desc" ? (
+												<ArrowDown className="size-3" />
+											) : (
+												<ArrowUpDown className="size-3 opacity-40" />
+											)}
+										</button>
+									) : (
+										flexRender(
+											header.column.columnDef.header,
+											header.getContext(),
+										)
+									)}
+								</TableHead>
+							))}
+						</TableRow>
+					))}
+				</TableHeader>
+				<TableBody className="bg-input">
+					{table.getRowModel().rows.length > 0 ? (
+						table.getRowModel().rows.map((row) => (
+							<TableRow
+								key={row.id}
+								onClick={
+									onRowClick ? () => onRowClick(row.original) : undefined
+								}
+								className={onRowClick ? "hover:bg-hover cursor-pointer" : ""}
+							>
+								{row.getVisibleCells().map((cell) => (
+									<TableCell key={cell.id} className="px-6 py-4 text-sm">
+										{flexRender(cell.column.columnDef.cell, cell.getContext())}
+									</TableCell>
+								))}
+							</TableRow>
+						))
+					) : (
+						<TableRow>
+							<TableCell
+								colSpan={columns.length}
+								className="h-24 text-center text-muted"
+							>
+								No results.
+							</TableCell>
+						</TableRow>
+					)}
+				</TableBody>
+			</Table>
+
+			<div className="flex items-center justify-between pt-4 px-2">
+				<div className="flex items-center gap-2 text-sm text-muted">
+					<span>Rows per page</span>
+					<Select
+						value={String(table.getState().pagination.pageSize)}
+						onValueChange={(value) => table.setPageSize(Number(value))}
+					>
+						<SelectTrigger size="sm" className="w-[70px]">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{pageSizeOptions.map((size) => (
+								<SelectItem key={size} value={String(size)}>
+									{size}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
+				<div className="flex items-center gap-4">
+					<span className="text-sm text-muted">
+						Page {table.getState().pagination.pageIndex + 1} of{" "}
+						{table.getPageCount()}
+					</span>
+					<div className="flex items-center gap-1">
+						<Button
+							variant="outline"
+							size="icon-sm"
+							onClick={() => table.previousPage()}
+							disabled={!table.getCanPreviousPage()}
+						>
+							<span className="sr-only">Previous page</span>
+							&#8249;
+						</Button>
+						<Button
+							variant="outline"
+							size="icon-sm"
+							onClick={() => table.nextPage()}
+							disabled={!table.getCanNextPage()}
+						>
+							<span className="sr-only">Next page</span>
+							&#8250;
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export { DataTable };
+export type { DataTableProps };

--- a/apps/web/src/pages/dashboard/ProjectsListPage.tsx
+++ b/apps/web/src/pages/dashboard/ProjectsListPage.tsx
@@ -1,4 +1,6 @@
+import type { ProjectInvestment } from "@rudel/api-routes";
 import { useQuery } from "@tanstack/react-query";
+import type { ColumnDef } from "@tanstack/react-table";
 import {
 	Clock,
 	DollarSign,
@@ -7,23 +9,103 @@ import {
 	Users,
 	Zap,
 } from "lucide-react";
+import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { AnalyticsCard } from "@/components/analytics/AnalyticsCard";
 import { DatePicker } from "@/components/analytics/DatePicker";
 import { PageHeader } from "@/components/analytics/PageHeader";
 import { StatCard } from "@/components/analytics/StatCard";
 import { ProjectTrendChart } from "@/components/charts/ProjectTrendChart";
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
-} from "@/components/ui/table";
+import { DataTable } from "@/components/ui/data-table";
 import { useDateRange } from "@/contexts/DateRangeContext";
 import { encodeProjectPath } from "@/lib/format";
 import { orpc } from "@/lib/orpc";
+
+function formatTokens(tokens: number) {
+	if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+	if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}K`;
+	return tokens.toString();
+}
+
+const columns: ColumnDef<ProjectInvestment>[] = [
+	{
+		accessorKey: "project_path",
+		header: "Project",
+		cell: ({ row }) => (
+			<span className="font-medium text-foreground">
+				{row.original.project_path.split("/").pop()}
+			</span>
+		),
+	},
+	{
+		accessorKey: "sessions",
+		header: "Sessions",
+		cell: ({ row }) => (
+			<span className="text-muted">{row.original.sessions}</span>
+		),
+	},
+	{
+		accessorFn: (row) => row.total_duration_min,
+		id: "time",
+		header: "Time",
+		cell: ({ row }) => (
+			<span className="text-muted">
+				{(row.original.total_duration_min / 60).toFixed(1)}h
+			</span>
+		),
+	},
+	{
+		accessorKey: "total_tokens",
+		header: "Tokens",
+		cell: ({ row }) => (
+			<span className="text-muted">
+				{formatTokens(row.original.total_tokens || 0)}
+			</span>
+		),
+	},
+	{
+		accessorKey: "success_rate",
+		header: "Success Rate",
+		cell: ({ row }) => {
+			const rate = row.original.success_rate || 0;
+			const color =
+				rate >= 70
+					? "text-status-success-icon"
+					: rate >= 50
+						? "text-status-warning-icon"
+						: "text-status-error-icon";
+			return (
+				<span className={`font-semibold ${color}`}>{rate.toFixed(0)}%</span>
+			);
+		},
+	},
+	{
+		accessorKey: "cost",
+		header: "Cost",
+		cell: ({ row }) => (
+			<span className="text-muted">${(row.original.cost || 0).toFixed(2)}</span>
+		),
+	},
+	{
+		accessorKey: "success_rate_trend",
+		header: "Trend",
+		cell: ({ row }) => {
+			const trend = row.original.success_rate_trend || 0;
+			const icon = trend > 0 ? "\u2191" : trend < 0 ? "\u2193" : "-";
+			const color =
+				trend > 0
+					? "text-status-success-icon"
+					: trend < 0
+						? "text-status-error-icon"
+						: "text-muted";
+			return (
+				<span className={`font-semibold ${color}`}>
+					{icon} {Math.abs(trend).toFixed(1)}%
+				</span>
+			);
+		},
+	},
+];
 
 export function ProjectsListPage() {
 	const navigate = useNavigate();
@@ -38,6 +120,8 @@ export function ProjectsListPage() {
 	const { data: trendData } = useQuery(
 		orpc.analytics.projects.trends.queryOptions({ input: { days } }),
 	);
+
+	const sortedProjects = useMemo(() => projects ?? [], [projects]);
 
 	const totalProjects = projects?.length ?? 0;
 	const totalSessions = projects?.reduce((sum, p) => sum + p.sessions, 0) ?? 0;
@@ -54,10 +138,9 @@ export function ProjectsListPage() {
 				).toFixed(1)
 			: "0";
 
-	const formatTokens = (tokens: number) => {
-		if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
-		if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}K`;
-		return tokens.toString();
+	const handleRowClick = (row: ProjectInvestment) => {
+		const encodedPath = encodeProjectPath(row.project_path);
+		navigate(`/dashboard/projects/${encodedPath}`);
 	};
 
 	if (isLoading) {
@@ -150,97 +233,12 @@ export function ProjectsListPage() {
 
 			<AnalyticsCard>
 				<h2 className="text-xl font-bold text-heading mb-4">Project Details</h2>
-				{projects && projects.length > 0 ? (
-					<Table>
-						<TableHeader className="bg-surface">
-							<TableRow>
-								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
-									Project
-								</TableHead>
-								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
-									Sessions
-								</TableHead>
-								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
-									Time
-								</TableHead>
-								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
-									Tokens
-								</TableHead>
-								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
-									Success Rate
-								</TableHead>
-								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
-									Cost
-								</TableHead>
-								<TableHead className="px-6 py-3 text-xs text-muted uppercase tracking-wider">
-									Trend
-								</TableHead>
-							</TableRow>
-						</TableHeader>
-						<TableBody className="bg-input">
-							{projects.map((project, index) => {
-								const encodedPath = encodeProjectPath(project.project_path);
-								const successRate = project.success_rate || 0;
-								const successRateColor =
-									successRate >= 70
-										? "text-status-success-icon"
-										: successRate >= 50
-											? "text-status-warning-icon"
-											: "text-status-error-icon";
-								const trend = project.success_rate_trend || 0;
-								const trendIconStr =
-									trend > 0 ? "\u2191" : trend < 0 ? "\u2193" : "-";
-								const trendColor =
-									trend > 0
-										? "text-status-success-icon"
-										: trend < 0
-											? "text-status-error-icon"
-											: "text-muted";
-
-								return (
-									<TableRow
-										// biome-ignore lint/suspicious/noArrayIndexKey: static project list
-										key={index}
-										onClick={() =>
-											navigate(`/dashboard/projects/${encodedPath}`)
-										}
-										className="hover:bg-hover cursor-pointer"
-									>
-										<TableCell className="px-6 py-4 text-sm font-medium text-foreground">
-											{project.project_path.split("/").pop()}
-										</TableCell>
-										<TableCell className="px-6 py-4 text-sm text-muted">
-											{project.sessions}
-										</TableCell>
-										<TableCell className="px-6 py-4 text-sm text-muted">
-											{(project.total_duration_min / 60).toFixed(1)}h
-										</TableCell>
-										<TableCell className="px-6 py-4 text-sm text-muted">
-											{formatTokens(project.total_tokens || 0)}
-										</TableCell>
-										<TableCell
-											className={`px-6 py-4 text-sm font-semibold ${successRateColor}`}
-										>
-											{successRate.toFixed(0)}%
-										</TableCell>
-										<TableCell className="px-6 py-4 text-sm text-muted">
-											${(project.cost || 0).toFixed(2)}
-										</TableCell>
-										<TableCell
-											className={`px-6 py-4 text-sm font-semibold ${trendColor}`}
-										>
-											{trendIconStr} {Math.abs(trend).toFixed(1)}%
-										</TableCell>
-									</TableRow>
-								);
-							})}
-						</TableBody>
-					</Table>
-				) : (
-					<p className="text-center text-muted py-8">
-						No project data available
-					</p>
-				)}
+				<DataTable
+					columns={columns}
+					data={sortedProjects}
+					defaultSorting={[{ id: "sessions", desc: true }]}
+					onRowClick={handleRowClick}
+				/>
 			</AnalyticsCard>
 		</div>
 	);

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
     },
     "apps/cli": {
       "name": "rudel",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "bin": {
         "rudel": "./dist/cli.js",
       },
@@ -60,6 +60,7 @@
         "@orpc/tanstack-query": "latest",
         "@rudel/api-routes": "workspace:*",
         "@tanstack/react-query": "^5.80.0",
+        "@tanstack/react-table": "^8.21.3",
         "better-auth": "^1.4.18",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -641,6 +642,10 @@
     "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
+
+    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 


### PR DESCRIPTION
## Summary
- Install @tanstack/react-table for advanced table management
- Create reusable DataTable component with column sorting, pagination, and customizable page sizes
- Refactor ProjectsListPage to use DataTable with column definitions
- Default sort by sessions (descending) to show most active projects first
- All 7 columns (Project, Sessions, Time, Tokens, Success Rate, Cost, Trend) are now sortable
- Add rows-per-page dropdown (10, 20, 50 options) with pagination controls

## Test plan
- [x] Type checking passes (tsc -b)
- [x] All linting passes (biome check)
- [x] All tests pass (bun run verify)
- [x] Web app builds successfully (vite build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)