### PR TITLE
test: fix flaky API upload integration tests

### DIFF
--- a/apps/cli/src/__tests__/api-upload.integration.test.ts
+++ b/apps/cli/src/__tests__/api-upload.integration.test.ts
@@ -56,17 +56,28 @@ describe("CLI upload to local API", () => {
 			subagents: [{ agentId: "sub-1", content: "subagent content" }],
 		};
 
-		// Retry up to 3 times — ClickHouse can be slow to accept
-		// the first request after startup.
+		// Retry up to 3 times — Bun may kill the server as a "dangling process"
+		// and the restarted server's ClickHouse connection can be slow to warm up.
+		// Each attempt has a per-call timeout so a hanging request doesn't
+		// consume the entire test timeout and block retries.
 		let result = { success: false, error: "not attempted" } as Awaited<
 			ReturnType<typeof uploadSession>
 		>;
 		for (let attempt = 0; attempt < 3; attempt++) {
-			result = await uploadSession(request, {
-				endpoint: server.rpcUrl,
-				token: bearerToken,
-			});
+			result = await Promise.race([
+				uploadSession(request, {
+					endpoint: server.rpcUrl,
+					token: bearerToken,
+				}),
+				Bun.sleep(8000).then(
+					() =>
+						({ success: false, error: "attempt timed out" }) as Awaited<
+							ReturnType<typeof uploadSession>
+						>,
+				),
+			]);
 			if (result.success) break;
+			await server.ensureAlive();
 			await Bun.sleep(1000);
 		}
 
@@ -108,8 +119,9 @@ describe("CLI upload to local API", () => {
 
 		const cliPath = join(import.meta.dir, "..", "bin", "cli.ts");
 
-		// Retry up to 3 times — the server may need a moment after restart
-		// before ClickHouse accepts inserts (same pattern as the direct-call test).
+		// Retry up to 3 times — same dangling-process issue as the direct-call test.
+		// Each subprocess gets a per-attempt timeout so a hanging process
+		// doesn't consume the entire test timeout.
 		let lastStdout = "";
 		let lastStderr = "";
 		let lastExitCode = -1;
@@ -127,17 +139,20 @@ describe("CLI upload to local API", () => {
 				},
 			);
 
+			const timeout = setTimeout(() => proc.kill(), 15_000);
 			const [exitCode, stdout, stderr] = await Promise.all([
 				proc.exited,
 				new Response(proc.stdout).text(),
 				new Response(proc.stderr).text(),
 			]);
+			clearTimeout(timeout);
 
 			lastStdout = stdout;
 			lastStderr = stderr;
 			lastExitCode = exitCode;
 
 			if (stdout.includes("Upload successful!")) break;
+			await server.ensureAlive();
 			await Bun.sleep(1000);
 		}
 


### PR DESCRIPTION
## Summary

Fixed flaky failures in CLI API upload integration tests that were caused by Bun's test runner killing spawned server processes between tests. Added per-attempt timeouts to both the direct oRPC call and subprocess invocations, allowing the retry logic to properly function when the server restarts.

- Direct upload test: 8s timeout per attempt via `Promise.race`
- Subprocess test: 15s timeout per attempt via `setTimeout`
- Both tests now call `ensureAlive()` between retries to verify server health

## Test plan

- [x] All existing tests pass (`bun run verify`)
- [x] Integration tests no longer hang on retries
- [x] Flaky failures should no longer rotate between test 1 and test 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)