### PR TITLE
feat: add git_remote and package_name as primary project identity

### DIFF
--- a/apps/api/src/ingest.ts
+++ b/apps/api/src/ingest.ts
@@ -70,6 +70,8 @@ export function buildSessionRow(
 		organization_id: context.organizationId,
 		project_path: input.projectPath,
 		repository: input.repository ?? null,
+		git_remote: input.gitRemote ?? "",
+		package_name: input.packageName ?? "",
 		content: input.content,
 		subagents,
 		ingested_at: now,

--- a/apps/api/src/services/overview.service.ts
+++ b/apps/api/src/services/overview.service.ts
@@ -30,7 +30,7 @@ export async function getOverviewKPIs(
     SELECT
       uniq(user_id) as distinct_users,
       count() as distinct_sessions,
-      uniq(project_path) as distinct_projects,
+      uniq(if(git_remote != '', git_remote, if(repository != '', repository, project_path))) as distinct_projects,
       (SELECT uniqExact(val) FROM rudel.session_analytics ARRAY JOIN subagent_types as val WHERE ${buildDateFilter(days)} AND organization_id = '${org}' AND val != '') as distinct_subagents,
       (SELECT uniqExact(val) FROM rudel.session_analytics ARRAY JOIN skills as val WHERE ${buildDateFilter(days)} AND organization_id = '${org}' AND val != '') as distinct_skills,
       (SELECT uniqExact(val) FROM rudel.session_analytics ARRAY JOIN slash_commands as val WHERE ${buildDateFilter(days)} AND organization_id = '${org}' AND val != '') as distinct_slash_commands

--- a/apps/api/src/services/project.service.ts
+++ b/apps/api/src/services/project.service.ts
@@ -104,7 +104,9 @@ export async function getProjectInvestment(
 	const query = `
     WITH current_period AS (
       SELECT
-        repository,
+        if(git_remote != '', git_remote, repository) as project_key,
+        any(git_remote) as git_remote,
+        any(repository) as repository,
         any(project_path) as project_path,
         COUNT(*) as sessions,
         COUNT(DISTINCT user_id) as unique_users,
@@ -117,24 +119,25 @@ export async function getProjectInvestment(
       FROM rudel.session_analytics
       WHERE ${buildDateFilter(d)}
         AND organization_id = '${org}'
-        AND repository != ''
+        AND (git_remote != '' OR repository != '')
         ${projectFilter}
-      GROUP BY repository
+      GROUP BY project_key
     ),
     previous_period AS (
       SELECT
-        repository,
+        if(git_remote != '', git_remote, repository) as project_key,
         round(AVG(success_score), 2) as prev_success_rate
       FROM rudel.session_analytics
       WHERE session_date >= now64(3) - INTERVAL ${d * 2} DAY
         AND session_date < now64(3) - INTERVAL ${d} DAY
         AND organization_id = '${org}'
-        AND repository != ''
+        AND (git_remote != '' OR repository != '')
         ${projectFilter}
-      GROUP BY repository
+      GROUP BY project_key
     )
     SELECT
       c.repository,
+      c.git_remote,
       c.project_path,
       c.sessions,
       c.unique_users,
@@ -147,17 +150,20 @@ export async function getProjectInvestment(
       round((c.output_tokens_sum / 1000000.0) * 15.0 + (c.input_tokens_sum / 1000000.0) * 3.0, 4) as cost,
       round(c.success_rate - ifNull(p.prev_success_rate, c.success_rate), 2) as success_rate_trend
     FROM current_period c
-    LEFT JOIN previous_period p ON c.repository = p.repository
+    LEFT JOIN previous_period p ON c.project_key = p.project_key
     ORDER BY c.total_duration_min DESC
     LIMIT ${lim}
     OFFSET ${off}
   `;
 
-	const results = await queryClickhouse<ProjectInvestment>(query);
+	const results = await queryClickhouse<
+		ProjectInvestment & { git_remote?: string }
+	>(query);
 
 	return results.map((project) => ({
 		...project,
 		repository: project.repository || null,
+		git_remote: project.git_remote || undefined,
 	}));
 }
 
@@ -223,24 +229,24 @@ export async function getProjectActivity(
 	}
 
 	const query = `
-    WITH project_repository AS (
-      SELECT repository, any(project_path) as project_path
+    WITH project_key AS (
+      SELECT if(git_remote != '', git_remote, repository) as pk, any(project_path) as project_path
       FROM rudel.session_analytics
       WHERE project_path = '${pp}'
-        AND repository != ''
+        AND (git_remote != '' OR repository != '')
         AND organization_id = '${org}'
       LIMIT 1
     )
     SELECT
       toString(${dateGrouping}) as date,
-      pr.project_path,
+      pk.project_path,
       COUNT(*) as sessions,
       COUNT(DISTINCT s.user_id) as unique_users
-    FROM project_repository pr
-    INNER JOIN rudel.session_analytics s ON s.repository = pr.repository
+    FROM project_key pk
+    INNER JOIN rudel.session_analytics s ON if(s.git_remote != '', s.git_remote, s.repository) = pk.pk
     WHERE s.${buildDateFilter(d)}
       AND s.organization_id = '${org}'
-    GROUP BY ${dateGrouping}, pr.project_path
+    GROUP BY ${dateGrouping}, pk.project_path
     ORDER BY date ASC
   `;
 
@@ -303,6 +309,14 @@ export async function getProjectDetails(
 	const d = Number(days);
 
 	const query = `
+    WITH project_key AS (
+      SELECT if(git_remote != '', git_remote, repository) as pk
+      FROM rudel.session_analytics
+      WHERE project_path = '${pp}'
+        AND (git_remote != '' OR repository != '')
+        AND organization_id = '${org}'
+      LIMIT 1
+    )
     SELECT
       any(project_path) as project_path,
       COUNT(*) as total_sessions,
@@ -315,14 +329,7 @@ export async function getProjectDetails(
       round(AVG(success_score), 2) as success_rate,
       round(SUM(actual_duration_min), 2) as total_duration_min
     FROM rudel.session_analytics
-    WHERE repository = (
-      SELECT repository
-      FROM rudel.session_analytics
-      WHERE project_path = '${pp}'
-        AND repository != ''
-        AND organization_id = '${org}'
-      LIMIT 1
-    )
+    WHERE if(git_remote != '', git_remote, repository) = (SELECT pk FROM project_key)
     AND ${buildDateFilter(d)}
     AND organization_id = '${org}'
   `;
@@ -364,18 +371,18 @@ export async function getProjectContributors(
 	const d = Number(days);
 
 	const query = `
-    WITH project_repository AS (
-      SELECT repository
+    WITH project_key AS (
+      SELECT if(git_remote != '', git_remote, repository) as pk
       FROM rudel.session_analytics
       WHERE project_path = '${pp}'
-        AND repository != ''
+        AND (git_remote != '' OR repository != '')
         AND organization_id = '${org}'
       LIMIT 1
     ),
     project_totals AS (
       SELECT COUNT(*) as total_sessions
       FROM rudel.session_analytics
-      WHERE repository = (SELECT repository FROM project_repository)
+      WHERE if(git_remote != '', git_remote, repository) = (SELECT pk FROM project_key)
         AND ${buildDateFilter(d)}
         AND organization_id = '${org}'
     )
@@ -388,7 +395,7 @@ export async function getProjectContributors(
       toString(max(session_date)) as last_session,
       round(COUNT(*) * 100.0 / (SELECT total_sessions FROM project_totals), 2) as contribution_percentage
     FROM rudel.session_analytics
-    WHERE repository = (SELECT repository FROM project_repository)
+    WHERE if(git_remote != '', git_remote, repository) = (SELECT pk FROM project_key)
       AND ${buildDateFilter(d)}
       AND organization_id = '${org}'
     GROUP BY user_id
@@ -410,11 +417,11 @@ export async function getProjectFeatureUsage(
 	const pp = escapeString(projectPath);
 	const d = Number(days);
 
-	const repoSubquery = `(
-    SELECT repository
+	const pkSubquery = `(
+    SELECT if(git_remote != '', git_remote, repository) as pk
     FROM rudel.session_analytics
     WHERE project_path = '${pp}'
-      AND repository != ''
+      AND (git_remote != '' OR repository != '')
       AND organization_id = '${org}'
     LIMIT 1
   )`;
@@ -426,7 +433,7 @@ export async function getProjectFeatureUsage(
       countIf(length(skills) > 0) as skills_sessions,
       countIf(length(slash_commands) > 0) as slash_commands_sessions
     FROM rudel.session_analytics
-    WHERE repository = ${repoSubquery}
+    WHERE if(git_remote != '', git_remote, repository) = ${pkSubquery}
     AND ${buildDateFilter(d)}
     AND organization_id = '${org}'
   `;
@@ -435,7 +442,7 @@ export async function getProjectFeatureUsage(
     SELECT val as name, count() as count
     FROM rudel.session_analytics
     ARRAY JOIN subagent_types as val
-    WHERE repository = ${repoSubquery}
+    WHERE if(git_remote != '', git_remote, repository) = ${pkSubquery}
       AND ${buildDateFilter(d)}
       AND organization_id = '${org}'
       AND val != ''
@@ -448,7 +455,7 @@ export async function getProjectFeatureUsage(
     SELECT val as name, count() as count
     FROM rudel.session_analytics
     ARRAY JOIN skills as val
-    WHERE repository = ${repoSubquery}
+    WHERE if(git_remote != '', git_remote, repository) = ${pkSubquery}
       AND ${buildDateFilter(d)}
       AND organization_id = '${org}'
       AND val != ''
@@ -461,7 +468,7 @@ export async function getProjectFeatureUsage(
     SELECT val as name, count() as count
     FROM rudel.session_analytics
     ARRAY JOIN slash_commands as val
-    WHERE repository = ${repoSubquery}
+    WHERE if(git_remote != '', git_remote, repository) = ${pkSubquery}
       AND ${buildDateFilter(d)}
       AND organization_id = '${org}'
       AND val != ''
@@ -536,11 +543,11 @@ export async function getProjectErrors(
 	const d = Number(days);
 
 	const query = `
-    WITH project_repository AS (
-      SELECT repository
+    WITH project_key AS (
+      SELECT if(git_remote != '', git_remote, repository) as pk
       FROM rudel.session_analytics
       WHERE project_path = '${pp}'
-        AND repository != ''
+        AND (git_remote != '' OR repository != '')
         AND organization_id = '${org}'
       LIMIT 1
     ),
@@ -560,7 +567,7 @@ export async function getProjectErrors(
           ELSE NULL
         END as error_pattern
       FROM rudel.session_analytics
-      WHERE repository = (SELECT repository FROM project_repository)
+      WHERE if(git_remote != '', git_remote, repository) = (SELECT pk FROM project_key)
         AND ${buildDateFilter(d)}
         AND organization_id = '${org}'
         AND (content LIKE '%Error:%' OR content LIKE '%error:%')
@@ -600,7 +607,7 @@ export async function getProjectTrends(
 	const query = `
     SELECT
       toString(${dateFunc}) as date,
-      repository,
+      if(git_remote != '', git_remote, repository) as project_key,
       any(project_path) as project_path,
       COUNT(*) as sessions,
       round(SUM(actual_duration_min) / 60, 2) as total_hours,
@@ -609,19 +616,19 @@ export async function getProjectTrends(
     FROM rudel.session_analytics
     WHERE ${buildDateFilter(d)}
       AND organization_id = '${org}'
-      AND repository != ''
-    GROUP BY date, repository
-    ORDER BY date ASC, repository ASC
+      AND (git_remote != '' OR repository != '')
+    GROUP BY date, project_key
+    ORDER BY date ASC, project_key ASC
   `;
 
 	const results = await queryClickhouse<
-		ProjectTrendDataPoint & { repository: string }
+		ProjectTrendDataPoint & { project_key: string }
 	>(query);
 
 	return results.map((item) => ({
 		date: item.date,
 		project_path: item.project_path,
-		project_name: item.repository,
+		project_name: item.project_key,
 		sessions: item.sessions,
 		total_hours: item.total_hours,
 		total_tokens: item.total_tokens,

--- a/apps/api/src/services/session-analytics.service.ts
+++ b/apps/api/src/services/session-analytics.service.ts
@@ -17,6 +17,7 @@ export interface SessionAnalyticsRaw {
 	project_path: string;
 	organization_id: string;
 	repository: string;
+	git_remote: string;
 
 	// Interaction timing metrics
 	total_interactions: number;
@@ -103,7 +104,8 @@ export async function getSessionAnalytics(
 		filters += ` AND project_path = '${escapeString(project_path)}'`;
 	}
 	if (repository) {
-		filters += ` AND repository = '${escapeString(repository)}'`;
+		const escapedRepo = escapeString(repository);
+		filters += ` AND (repository = '${escapedRepo}' OR git_remote = '${escapedRepo}')`;
 	}
 
 	const sortColumn =
@@ -122,6 +124,7 @@ export async function getSessionAnalytics(
       project_path,
       organization_id,
       repository,
+      git_remote,
       total_interactions,
       avg_period_sec,
       median_period_sec,
@@ -162,6 +165,7 @@ export async function getSessionAnalytics(
 			session_date: row.session_date,
 			project_path: row.project_path,
 			repository: row.repository || null,
+			git_remote: row.git_remote || undefined,
 			duration_min: row.actual_duration_min,
 			total_tokens: row.total_tokens,
 			input_tokens: row.input_tokens,
@@ -491,6 +495,7 @@ export async function getSessionDimensionAnalysis(
 
 	// Map dimension to SQL expression (for computed dimensions)
 	const dimensionExpressions: Record<string, string> = {
+		repository: "if(git_remote != '', git_remote, repository)",
 		used_skills: "if(length(skills) > 0, 1, 0)",
 		used_slash_commands: "if(length(slash_commands) > 0, 1, 0)",
 		used_subagents: "if(length(subagent_types) > 0, 1, 0)",

--- a/apps/cli/src/__tests__/upload.integration.test.ts
+++ b/apps/cli/src/__tests__/upload.integration.test.ts
@@ -249,7 +249,8 @@ describe("git info", () => {
 	test("returns empty info for non-git directory", async () => {
 		const info = await getGitInfo(tempDir);
 
-		expect(info.repository).toBeUndefined();
+		// repository falls back to directory name for non-git dirs
+		expect(info.gitRemote).toBeUndefined();
 		expect(info.branch).toBeUndefined();
 		expect(info.sha).toBeUndefined();
 	});

--- a/apps/cli/src/commands/hooks/claude/session-end.ts
+++ b/apps/cli/src/commands/hooks/claude/session-end.ts
@@ -52,6 +52,8 @@ async function runSessionEnd(): Promise<void> {
 			sessionId: input.session_id,
 			projectPath: input.cwd,
 			repository: gitInfo.repository,
+			gitRemote: gitInfo.gitRemote,
+			packageName: gitInfo.packageName,
 			gitBranch: gitInfo.branch,
 			gitSha: gitInfo.sha,
 			content,

--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -225,6 +225,8 @@ async function runSingleUpload(
 		sessionId: sessionInfo.sessionId,
 		projectPath: sessionInfo.projectPath,
 		repository: gitInfo.repository,
+		gitRemote: gitInfo.gitRemote,
+		packageName: gitInfo.packageName,
 		gitBranch: gitInfo.branch,
 		gitSha: gitInfo.sha,
 		tag,

--- a/apps/cli/src/lib/batch-uploader.ts
+++ b/apps/cli/src/lib/batch-uploader.ts
@@ -58,6 +58,8 @@ export async function uploadOneSession(
 		sessionId,
 		projectPath,
 		repository: gitInfo.repository,
+		gitRemote: gitInfo.gitRemote,
+		packageName: gitInfo.packageName,
 		gitBranch: gitInfo.branch,
 		gitSha: gitInfo.sha,
 		tag,

--- a/apps/cli/src/lib/git-info.ts
+++ b/apps/cli/src/lib/git-info.ts
@@ -3,36 +3,74 @@ import { $ } from "bun";
 
 export interface GitInfo {
 	repository?: string;
+	gitRemote?: string;
+	packageName?: string;
 	branch?: string;
 	sha?: string;
+}
+
+/**
+ * Normalize a git remote URL to a canonical form: "github.com/owner/repo"
+ */
+export function normalizeRemoteUrl(url: string): string {
+	return url
+		.replace(/^(https?:\/\/|git@|ssh:\/\/)/, "")
+		.replace(/:/, "/")
+		.replace(/\.git$/, "");
 }
 
 /**
  * Extract git metadata for a given project directory.
  */
 export async function getGitInfo(cwd: string): Promise<GitInfo> {
-	const [repository, branch, sha] = await Promise.all([
-		getRepositoryName(cwd),
+	const [remoteUrl, branch, sha, packageName] = await Promise.all([
+		getGitRemoteUrl(cwd),
 		getGitBranch(cwd),
 		getGitSha(cwd),
+		getPackageName(cwd),
 	]);
 
+	const gitRemote = remoteUrl ? normalizeRemoteUrl(remoteUrl) : undefined;
+	const repository = getRepositoryName(gitRemote, packageName, cwd);
+
 	return {
-		repository: repository ?? undefined,
+		repository,
+		gitRemote,
+		packageName: packageName ?? undefined,
 		branch: branch ?? undefined,
 		sha: sha ?? undefined,
 	};
 }
 
-async function getRepositoryName(cwd: string): Promise<string | null> {
+/**
+ * Extract a display name for the repository.
+ * Prefers owner/repo from git remote, falls back to package name, then dir name.
+ */
+function getRepositoryName(
+	gitRemote: string | undefined,
+	packageName: string | null,
+	cwd: string,
+): string | undefined {
+	if (gitRemote) {
+		// "github.com/owner/repo" → "owner/repo"
+		const parts = gitRemote.split("/");
+		if (parts.length >= 3) {
+			return parts.slice(1).join("/");
+		}
+		return gitRemote;
+	}
+	if (packageName) return packageName;
+	const dirName = cwd.split("/").pop();
+	return dirName ?? undefined;
+}
+
+async function getPackageName(cwd: string): Promise<string | null> {
 	try {
 		const gitRootResult =
 			await $`git -C ${cwd} rev-parse --show-toplevel`.quiet();
-		if (gitRootResult.exitCode !== 0) return null;
+		const gitRoot =
+			gitRootResult.exitCode === 0 ? gitRootResult.text().trim() : cwd;
 
-		const gitRoot = gitRootResult.text().trim();
-
-		// Try package.json name first
 		const packageJsonPath = join(gitRoot, "package.json");
 		const packageFile = Bun.file(packageJsonPath);
 		if (await packageFile.exists()) {
@@ -40,22 +78,10 @@ async function getRepositoryName(cwd: string): Promise<string | null> {
 				const packageJson = await packageFile.json();
 				if (packageJson.name) return packageJson.name;
 			} catch {
-				// Invalid JSON, continue to git remote
+				// Invalid JSON
 			}
 		}
-
-		// Fall back to git remote origin URL
-		const remoteResult =
-			await $`git -C ${gitRoot} remote get-url origin`.quiet();
-		if (remoteResult.exitCode === 0) {
-			const remoteUrl = remoteResult.text().trim();
-			const match = remoteUrl.match(/[/:]([^/]+?)(?:\.git)?$/);
-			if (match?.[1]) return match[1];
-		}
-
-		// Fall back to directory name
-		const dirName = gitRoot.split("/").pop();
-		return dirName ?? null;
+		return null;
 	} catch {
 		return null;
 	}

--- a/apps/cli/src/lib/project-scanner.ts
+++ b/apps/cli/src/lib/project-scanner.ts
@@ -1,6 +1,12 @@
 import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
-import { getGitRemoteUrl } from "./git-info.js";
+import { getGitRemoteUrl, normalizeRemoteUrl } from "./git-info.js";
+import {
+	cacheRemote,
+	cacheRemotes,
+	getCachedRemote,
+	getRemoteCache,
+} from "./remote-cache.js";
 import { decodeProjectPath, SESSIONS_BASE_DIR } from "./session-resolver.js";
 
 export interface ScannedProject {
@@ -91,13 +97,6 @@ export interface ProjectGroup {
 	containsCwd: boolean;
 }
 
-function normalizeRemoteUrl(url: string): string {
-	return url
-		.replace(/^(https?:\/\/|git@|ssh:\/\/)/, "")
-		.replace(/:/, "/")
-		.replace(/\.git$/, "");
-}
-
 function extractDisplayName(normalized: string): string {
 	// "github.com/owner/repo" → "owner/repo"
 	const parts = normalized.split("/");
@@ -111,6 +110,9 @@ export async function groupProjectsByRemote(
 	projects: ScannedProject[],
 	cwd: string,
 ): Promise<ProjectGroup[]> {
+	const cache = await getRemoteCache();
+	let cacheUpdated = false;
+
 	const remotes = await Promise.all(
 		projects.map((p) => getGitRemoteUrl(p.decodedPath)),
 	);
@@ -125,17 +127,32 @@ export async function groupProjectsByRemote(
 		const project = projects[i] as ScannedProject;
 		const remote = remotes[i];
 
-		if (!remote) {
-			ungrouped.push(project);
-			continue;
-		}
-
-		const normalized = normalizeRemoteUrl(remote);
-		const existing = grouped.get(normalized);
-		if (existing) {
-			existing.projects.push(project);
+		if (remote) {
+			const normalized = normalizeRemoteUrl(remote);
+			// Cache newly resolved remotes
+			if (getCachedRemote(cache, project.encodedDir) !== normalized) {
+				cacheRemote(cache, project.encodedDir, normalized);
+				cacheUpdated = true;
+			}
+			const existing = grouped.get(normalized);
+			if (existing) {
+				existing.projects.push(project);
+			} else {
+				grouped.set(normalized, { remote: normalized, projects: [project] });
+			}
 		} else {
-			grouped.set(normalized, { remote: normalized, projects: [project] });
+			// Try cache for ungrouped projects
+			const cached = getCachedRemote(cache, project.encodedDir);
+			if (cached) {
+				const existing = grouped.get(cached);
+				if (existing) {
+					existing.projects.push(project);
+				} else {
+					grouped.set(cached, { remote: cached, projects: [project] });
+				}
+			} else {
+				ungrouped.push(project);
+			}
 		}
 	}
 
@@ -195,6 +212,11 @@ export async function groupProjectsByRemote(
 		if (aHasRemote !== bHasRemote) return aHasRemote ? -1 : 1;
 		return a.displayName.localeCompare(b.displayName);
 	});
+
+	// Fire-and-forget cache write
+	if (cacheUpdated) {
+		cacheRemotes(cache);
+	}
 
 	return groups;
 }

--- a/apps/cli/src/lib/remote-cache.ts
+++ b/apps/cli/src/lib/remote-cache.ts
@@ -1,0 +1,42 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const CACHE_PATH = join(homedir(), ".rudel", "remote-cache.json");
+
+type RemoteCacheData = Record<string, string>;
+
+export async function getRemoteCache(): Promise<RemoteCacheData> {
+	try {
+		const file = Bun.file(CACHE_PATH);
+		if (!(await file.exists())) return {};
+		return (await file.json()) as RemoteCacheData;
+	} catch {
+		return {};
+	}
+}
+
+export function getCachedRemote(
+	cache: RemoteCacheData,
+	encodedDir: string,
+): string | null {
+	return cache[encodedDir] ?? null;
+}
+
+export function cacheRemote(
+	cache: RemoteCacheData,
+	encodedDir: string,
+	normalizedRemote: string,
+): void {
+	cache[encodedDir] = normalizedRemote;
+}
+
+export async function cacheRemotes(cache: RemoteCacheData): Promise<void> {
+	try {
+		const { mkdir } = await import("node:fs/promises");
+		const { dirname } = await import("node:path");
+		await mkdir(dirname(CACHE_PATH), { recursive: true });
+		await Bun.write(CACHE_PATH, JSON.stringify(cache));
+	} catch {
+		// Fire-and-forget — cache is best-effort
+	}
+}

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -26,6 +26,8 @@ export interface IngestRequest {
 	sessionId: string;
 	projectPath: string;
 	repository?: string;
+	gitRemote?: string;
+	packageName?: string;
 	gitBranch?: string;
 	gitSha?: string;
 	tag?: SessionTag;

--- a/apps/web/src/pages/dashboard/ProjectsListPage.tsx
+++ b/apps/web/src/pages/dashboard/ProjectsListPage.tsx
@@ -31,11 +31,13 @@ const columns: ColumnDef<ProjectInvestment>[] = [
 	{
 		accessorKey: "project_path",
 		header: "Project",
-		cell: ({ row }) => (
-			<span className="font-medium text-foreground">
-				{row.original.project_path.split("/").pop()}
-			</span>
-		),
+		cell: ({ row }) => {
+			const remote = row.original.git_remote;
+			const name = remote
+				? remote.split("/").pop()
+				: row.original.project_path.split("/").pop();
+			return <span className="font-medium text-foreground">{name}</span>;
+		},
 	},
 	{
 		accessorKey: "sessions",

--- a/apps/web/src/pages/dashboard/SessionsListPage.tsx
+++ b/apps/web/src/pages/dashboard/SessionsListPage.tsx
@@ -149,9 +149,14 @@ export function SessionsListPage() {
 				accessorKey: "project_path",
 				header: "Project",
 				cell: ({ row }) => (
-					<div className="max-w-xs truncate" title={row.original.project_path}>
-						{row.original.project_path.split("/").pop() ||
-							row.original.project_path}
+					<div
+						className="max-w-xs truncate"
+						title={row.original.git_remote || row.original.project_path}
+					>
+						{row.original.git_remote
+							? row.original.git_remote.split("/").pop()
+							: row.original.project_path.split("/").pop() ||
+								row.original.project_path}
 					</div>
 				),
 			},

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -90,6 +90,8 @@ export const IngestSessionInputSchema = z.object({
 	sessionId: z.string(),
 	projectPath: z.string(),
 	repository: z.string().optional(),
+	gitRemote: z.string().optional(),
+	packageName: z.string().optional(),
 	gitBranch: z.string().optional(),
 	gitSha: z.string().optional(),
 	tag: SessionTagSchema.optional(),

--- a/packages/api-routes/src/schemas/analytics.ts
+++ b/packages/api-routes/src/schemas/analytics.ts
@@ -184,6 +184,7 @@ export const DeveloperSessionsInputSchema = DaysInputSchema.extend({
 
 export const ProjectInvestmentSchema = z.object({
 	repository: z.string().nullable(),
+	git_remote: z.string().optional(),
 	project_path: z.string(),
 	sessions: z.number(),
 	unique_users: z.number(),
@@ -253,6 +254,7 @@ export const SessionAnalyticsSchema = z.object({
 	session_date: z.string(),
 	project_path: z.string(),
 	repository: z.string().nullable(),
+	git_remote: z.string().optional(),
 	duration_min: z.number(),
 	total_tokens: z.number(),
 	input_tokens: z.number(),

--- a/packages/ch-schema/chx/meta/snapshot.json
+++ b/packages/ch-schema/chx/meta/snapshot.json
@@ -1,6 +1,6 @@
 {
 	"version": 1,
-	"generatedAt": "2026-03-01T14:59:16.239Z",
+	"generatedAt": "2026-03-02T05:18:14.696Z",
 	"definitions": [
 		{
 			"database": "rudel",
@@ -33,6 +33,16 @@
 					"name": "repository",
 					"type": "String",
 					"nullable": true
+				},
+				{
+					"name": "git_remote",
+					"type": "String",
+					"default": "''"
+				},
+				{
+					"name": "package_name",
+					"type": "String",
+					"default": "''"
 				},
 				{
 					"name": "content",
@@ -109,6 +119,16 @@
 					"name": "repository",
 					"type": "String",
 					"nullable": true
+				},
+				{
+					"name": "git_remote",
+					"type": "String",
+					"default": "''"
+				},
+				{
+					"name": "package_name",
+					"type": "String",
+					"default": "''"
 				},
 				{
 					"name": "content",
@@ -266,6 +286,12 @@
 				"index_granularity": "8192"
 			},
 			"indexes": [
+				{
+					"name": "idx_git_remote",
+					"expression": "git_remote",
+					"type": "set",
+					"granularity": 4
+				},
 				{
 					"name": "idx_model_used",
 					"expression": "model_used",

--- a/packages/ch-schema/chx/migrations/20260302051814_auto.sql
+++ b/packages/ch-schema/chx/migrations/20260302051814_auto.sql
@@ -1,0 +1,22 @@
+-- chkit-migration-format: v1
+-- generated-at: 2026-03-02T05:18:14.696Z
+-- cli-version: 0.1.0-beta.15
+-- definition-count: 3
+-- operation-count: 5
+-- rename-suggestion-count: 0
+-- risk-summary: safe=4, caution=1, danger=0
+
+-- operation: alter_table_add_column key=table:rudel.claude_sessions:column:git_remote risk=safe
+ALTER TABLE rudel.claude_sessions ADD COLUMN IF NOT EXISTS `git_remote` String DEFAULT '''''';
+
+-- operation: alter_table_add_column key=table:rudel.claude_sessions:column:package_name risk=safe
+ALTER TABLE rudel.claude_sessions ADD COLUMN IF NOT EXISTS `package_name` String DEFAULT '''''';
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:git_remote risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `git_remote` String DEFAULT '''''';
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:package_name risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `package_name` String DEFAULT '''''';
+
+-- operation: alter_table_add_index key=table:rudel.session_analytics:index:idx_git_remote risk=caution
+ALTER TABLE rudel.session_analytics ADD INDEX IF NOT EXISTS `idx_git_remote` (git_remote) TYPE set GRANULARITY 4;

--- a/packages/ch-schema/src/__tests__/ingest-clickhouse.integration.ts
+++ b/packages/ch-schema/src/__tests__/ingest-clickhouse.integration.ts
@@ -91,6 +91,8 @@ describe("ingestRudelClaudeSessions", () => {
 		organization_id: "org_test",
 		project_path: "/test/project",
 		repository: null,
+		git_remote: "",
+		package_name: "",
 		content: "test session content",
 		subagents: {},
 		ingested_at: now,

--- a/packages/ch-schema/src/__tests__/schemas.test.ts
+++ b/packages/ch-schema/src/__tests__/schemas.test.ts
@@ -9,6 +9,8 @@ describe("RudelClaudeSessionsRowSchema", () => {
 		organization_id: "org_xyz",
 		project_path: "/Users/dev/project",
 		repository: "github.com/org/repo",
+		git_remote: "github.com/org/repo",
+		package_name: "my-project",
 		content: "session transcript content",
 		subagents: { agent1: "result1" },
 		ingested_at: "2026-02-13T09:24:27.180Z",

--- a/packages/ch-schema/src/db/schema/claude-sessions.ts
+++ b/packages/ch-schema/src/db/schema/claude-sessions.ts
@@ -19,6 +19,8 @@ const rudel_claude_sessions = table({
 		{ name: "organization_id", type: "String" },
 		{ name: "project_path", type: "String" },
 		{ name: "repository", type: "String", nullable: true },
+		{ name: "git_remote", type: "String", default: "''" },
+		{ name: "package_name", type: "String", default: "''" },
 		{ name: "content", type: "String" },
 		{ name: "subagents", type: "Map(String, String)", default: "fn:map()" },
 		{

--- a/packages/ch-schema/src/db/schema/session-analytics.ts
+++ b/packages/ch-schema/src/db/schema/session-analytics.ts
@@ -20,6 +20,8 @@ const rudel_session_analytics = table({
 		{ name: "organization_id", type: "String" },
 		{ name: "project_path", type: "String" },
 		{ name: "repository", type: "String", nullable: true },
+		{ name: "git_remote", type: "String", default: "''" },
+		{ name: "package_name", type: "String", default: "''" },
 		{ name: "content", type: "String" },
 		{ name: "subagents", type: "Map(String, String)", default: "fn:map()" },
 		{ name: "skills", type: "Array(String)", default: "fn:[]" },
@@ -85,6 +87,12 @@ const rudel_session_analytics = table({
 		{
 			name: "idx_model_used",
 			expression: "model_used",
+			type: "set",
+			granularity: 4,
+		},
+		{
+			name: "idx_git_remote",
+			expression: "git_remote",
 			type: "set",
 			granularity: 4,
 		},

--- a/packages/ch-schema/src/generated/chkit-types.ts
+++ b/packages/ch-schema/src/generated/chkit-types.ts
@@ -10,6 +10,8 @@ export interface RudelClaudeSessionsRow {
   organization_id: string
   project_path: string
   repository: string | null
+  git_remote: string
+  package_name: string
   content: string
   subagents: Record<string, string>
   ingested_at: string
@@ -26,6 +28,8 @@ export const RudelClaudeSessionsRowSchema = z.object({
   organization_id: z.string(),
   project_path: z.string(),
   repository: z.string().nullable(),
+  git_remote: z.string(),
+  package_name: z.string(),
   content: z.string(),
   subagents: z.record(z.string(), z.string()),
   ingested_at: z.string(),
@@ -45,6 +49,8 @@ export interface RudelSessionAnalyticsRow {
   organization_id: string
   project_path: string
   repository: string | null
+  git_remote: string
+  package_name: string
   content: string
   subagents: Record<string, string>
   skills: string[]
@@ -84,6 +90,8 @@ export const RudelSessionAnalyticsRowSchema = z.object({
   organization_id: z.string(),
   project_path: z.string(),
   repository: z.string().nullable(),
+  git_remote: z.string(),
+  package_name: z.string(),
   content: z.string(),
   subagents: z.record(z.string(), z.string()),
   skills: z.array(z.string()),


### PR DESCRIPTION
## Summary

Implements `git_remote` and `package_name` as the primary project identification signals to fix the session grouping issue where ~81% of sessions were orphaned.

- **ClickHouse**: Added columns to `claude_sessions` and `session_analytics` with `idx_git_remote` index
- **API contract**: Added fields to ingest and output schemas 
- **Backend**: All project queries now group by `git_remote` with fallback to `repository` for backward compatibility
- **CLI**: Resolves git remote URL (normalized to `github.com/owner/repo`) and reads `package_name` from package.json; caches remotes at `~/.rudel/remote-cache.json`
- **Web UI**: Displays repo name from git_remote in project and session lists

## Test Plan

- [x] Type checking passes across all packages
- [x] Linting clean with Biome
- [x] All tests pass (CLI integration, API ingest, ch-schema, auth, upload)
- [x] Build succeeds for CLI and web
- [x] ClickHouse migration reviewed (4 safe column adds, 1 index addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)