### PR TITLE
fix: unify session discovery between enable and upload

### DIFF
--- a/apps/cli/src/commands/enable.ts
+++ b/apps/cli/src/commands/enable.ts
@@ -6,6 +6,7 @@ import { createApiClient } from "../lib/api-client.js";
 import { verifyAuth } from "../lib/auth.js";
 import { getGitInfo } from "../lib/git-info.js";
 import { getProjectOrgId, setProjectOrgId } from "../lib/project-config.js";
+import { findSessionsForCwd } from "../lib/project-scanner.js";
 import { readSubagentFiles } from "../lib/subagent-reader.js";
 import { extractAgentIds, readTranscript } from "../lib/transcript-reader.js";
 import type { IngestRequest } from "../lib/types.js";
@@ -93,8 +94,8 @@ async function runEnable(): Promise<void> {
 		p.log.success(`Auto-upload hook enabled in ${agent.getHookSettingsPath()}`);
 	}
 
-	// Check for existing sessions to upload
-	const sessions = await agent.findProjectSessions(cwd);
+	// Check for existing sessions to upload (uses same scan logic as `upload`)
+	const sessions = await findSessionsForCwd(cwd);
 	if (sessions.length === 0) {
 		p.outro("Done!");
 		return;

--- a/apps/cli/src/lib/project-scanner.ts
+++ b/apps/cli/src/lib/project-scanner.ts
@@ -1,5 +1,6 @@
 import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
+import type { SessionFile } from "./agents/types.js";
 import { getGitRemoteUrl, normalizeRemoteUrl } from "./git-info.js";
 import {
 	cacheRemote,
@@ -219,6 +220,31 @@ export async function groupProjectsByRemote(
 	}
 
 	return groups;
+}
+
+export function toSessionFiles(projects: ScannedProject[]): SessionFile[] {
+	return projects.flatMap((project) =>
+		project.sessionIds.map((sessionId) => ({
+			sessionId,
+			transcriptPath: `${project.sessionDir}/${sessionId}.jsonl`,
+			projectPath: project.decodedPath,
+		})),
+	);
+}
+
+/**
+ * Find all sessions belonging to the same repository as `cwd`.
+ * Uses the same scan + group-by-remote logic as the upload command.
+ */
+export async function findSessionsForCwd(cwd: string): Promise<SessionFile[]> {
+	const projects = await scanProjects();
+	if (projects.length === 0) return [];
+
+	const groups = await groupProjectsByRemote(projects, cwd);
+	const cwdGroup = groups.find((g) => g.containsCwd);
+	if (!cwdGroup) return [];
+
+	return toSessionFiles(cwdGroup.projects);
 }
 
 function commonPrefixLength(a: string, b: string): number {


### PR DESCRIPTION
## Summary
- `rudel enable` and `rudel upload` used completely different codepaths to discover sessions
- `enable` only found sessions matching the exact encoded CWD (~14), while `upload` found all sessions grouped by git remote (~114)
- Both commands now use the same `scanProjects()` + `groupProjectsByRemote()` pipeline via the new `findSessionsForCwd()` function

## Test plan
- [x] All existing tests pass (type checking, linting, unit tests)
- [x] Session discovery now matches between both commands for the same repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)