### PR TITLE
feat: add retry and failed upload tracking to CLI uploads

### DIFF
--- a/apps/cli/src/commands/enable.ts
+++ b/apps/cli/src/commands/enable.ts
@@ -3,6 +3,10 @@ import { type AgentAdapter, getAvailableAdapters } from "@rudel/agent-adapters";
 import { buildCommand } from "@stricli/core";
 import { createApiClient } from "../lib/api-client.js";
 import { verifyAuth } from "../lib/auth.js";
+import {
+	recordFailedUpload,
+	removeFailedUpload,
+} from "../lib/failed-uploads.js";
 import { getGitInfo } from "../lib/git-info.js";
 import { getProjectOrgId, setProjectOrgId } from "../lib/project-config.js";
 import { uploadSession } from "../lib/uploader.js";
@@ -134,12 +138,15 @@ async function runEnable(): Promise<void> {
 		if (p.isCancel(shouldUpload) || !shouldUpload) continue;
 
 		const gitInfo = await getGitInfo(cwd);
+		let succeeded = 0;
 		let failed = 0;
+		const errors: Array<{ sessionId: string; error: string }> = [];
 
 		await p.tasks(
 			sessions.map((session, i) => ({
 				title: `[${i + 1}/${sessions.length}] ${session.sessionId}`,
 				task: async (message: (msg: string) => void) => {
+					const prefix = `[${i + 1}/${sessions.length}]`;
 					try {
 						message("Building upload request...");
 						const request = await adapter.buildUploadRequest(session, {
@@ -151,23 +158,70 @@ async function runEnable(): Promise<void> {
 						const result = await uploadSession(request, {
 							endpoint,
 							token: credentials.token,
+							onRetry: (attempt, maxAttempts, error) => {
+								message(
+									`${prefix} Retrying (${attempt}/${maxAttempts}) after ${error}...`,
+								);
+							},
 						});
 
-						if (result.success) return "Uploaded";
+						if (result.success) {
+							succeeded++;
+							await removeFailedUpload(session.sessionId);
+							const retryNote =
+								result.attempts && result.attempts > 1
+									? ` (after ${result.attempts} attempts)`
+									: "";
+							return `Uploaded${retryNote}`;
+						}
 						failed++;
+						const uploadError = result.error ?? "Unknown error";
+						errors.push({ sessionId: session.sessionId, error: uploadError });
+						await recordFailedUpload({
+							sessionId: session.sessionId,
+							transcriptPath: session.transcriptPath,
+							projectPath: session.projectPath,
+							source: adapter.source,
+							organizationId: selectedOrgId,
+							error: uploadError,
+						});
 						return `Failed: ${result.error}`;
 					} catch (error) {
 						failed++;
-						return `Error: ${error instanceof Error ? error.message : String(error)}`;
+						const errorMessage =
+							error instanceof Error ? error.message : String(error);
+						errors.push({ sessionId: session.sessionId, error: errorMessage });
+						await recordFailedUpload({
+							sessionId: session.sessionId,
+							transcriptPath: session.transcriptPath,
+							projectPath: session.projectPath,
+							source: adapter.source,
+							organizationId: selectedOrgId,
+							error: errorMessage,
+						});
+						return `Error: ${errorMessage}`;
 					}
 				},
 			})),
 		);
 
+		if (succeeded > 0) {
+			p.log.success(`${succeeded} ${adapter.name} session(s) uploaded`);
+		}
 		if (failed > 0) {
 			p.log.error(`${failed} ${adapter.name} session(s) failed`);
-			totalFailed += failed;
+			for (const err of errors.slice(0, 5)) {
+				p.log.warn(`  ${err.sessionId}: ${err.error}`);
+			}
+			if (errors.length > 5) {
+				p.log.warn(`  ...and ${errors.length - 5} more`);
+			}
 		}
+		totalFailed += failed;
+	}
+
+	if (totalFailed > 0) {
+		p.log.info("Run `rudel upload --retry` to retry failed uploads.");
 	}
 
 	p.outro("Done!");

--- a/apps/cli/src/commands/hooks/claude/session-end.ts
+++ b/apps/cli/src/commands/hooks/claude/session-end.ts
@@ -2,6 +2,10 @@ import { getLogger } from "@logtape/logtape";
 import { claudeCodeAdapter, type SessionFile } from "@rudel/agent-adapters";
 import { buildCommand } from "@stricli/core";
 import { loadCredentials } from "../../../lib/credentials.js";
+import {
+	recordFailedUpload,
+	removeFailedUpload,
+} from "../../../lib/failed-uploads.js";
 import { getGitInfo } from "../../../lib/git-info.js";
 import { getProjectOrgId } from "../../../lib/project-config.js";
 import { uploadSession } from "../../../lib/uploader.js";
@@ -55,11 +59,37 @@ async function runSessionEnd(): Promise<void> {
 
 		const apiBase = process.env.RUDEL_API_BASE ?? credentials.apiBaseUrl;
 		const endpoint = `${apiBase}/rpc`;
-		await uploadSession(request, { endpoint, token: credentials.token });
-
-		logger.info("Upload successful for session {sessionId}", {
-			sessionId: input.session_id,
+		const result = await uploadSession(request, {
+			endpoint,
+			token: credentials.token,
+			onRetry: (attempt, maxAttempts, error) => {
+				logger.warn(
+					"Retrying upload for {sessionId} ({attempt}/{maxAttempts}): {error}",
+					{ sessionId: input.session_id, attempt, maxAttempts, error },
+				);
+			},
 		});
+
+		if (result.success) {
+			logger.info(
+				"Upload successful for session {sessionId} (attempts: {attempts})",
+				{ sessionId: input.session_id, attempts: result.attempts },
+			);
+			await removeFailedUpload(input.session_id);
+		} else {
+			logger.error("Upload failed for session {sessionId}: {error}", {
+				sessionId: input.session_id,
+				error: result.error,
+			});
+			await recordFailedUpload({
+				sessionId: input.session_id,
+				transcriptPath: input.transcript_path,
+				projectPath: input.cwd,
+				source: "claude-code",
+				organizationId,
+				error: result.error ?? "Unknown error",
+			});
+		}
 	} catch (error) {
 		logger.error("Session end hook failed: {error}", { error });
 	} finally {

--- a/apps/cli/src/commands/hooks/codex/turn-complete.ts
+++ b/apps/cli/src/commands/hooks/codex/turn-complete.ts
@@ -5,6 +5,10 @@ import {
 } from "@rudel/agent-adapters";
 import { buildCommand } from "@stricli/core";
 import { loadCredentials } from "../../../lib/credentials.js";
+import {
+	recordFailedUpload,
+	removeFailedUpload,
+} from "../../../lib/failed-uploads.js";
 import { getGitInfo } from "../../../lib/git-info.js";
 import { getProjectOrgId } from "../../../lib/project-config.js";
 import { uploadSession } from "../../../lib/uploader.js";
@@ -56,7 +60,23 @@ async function runTurnComplete(): Promise<void> {
 
 		const apiBase = process.env.RUDEL_API_BASE ?? credentials.apiBaseUrl;
 		const endpoint = `${apiBase}/rpc`;
-		await uploadSession(request, { endpoint, token: credentials.token });
+		const result = await uploadSession(request, {
+			endpoint,
+			token: credentials.token,
+		});
+
+		if (result.success) {
+			await removeFailedUpload(input.thread_id);
+		} else {
+			await recordFailedUpload({
+				sessionId: input.thread_id,
+				transcriptPath,
+				projectPath: input.cwd,
+				source: "codex",
+				organizationId,
+				error: result.error ?? "Unknown error",
+			});
+		}
 	} catch {
 		// Swallow all errors — this runs async in the background
 	}

--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -10,6 +10,11 @@ import {
 import { buildCommand } from "@stricli/core";
 import { classifySession } from "../lib/classifier.js";
 import { loadCredentials } from "../lib/credentials.js";
+import {
+	loadFailedUploads,
+	recordFailedUpload,
+	removeFailedUpload,
+} from "../lib/failed-uploads.js";
 import { getGitInfo } from "../lib/git-info.js";
 import { getProjectOrgId } from "../lib/project-config.js";
 import { resolveSession } from "../lib/session-resolver.js";
@@ -26,6 +31,7 @@ interface UploadFlags {
 	classify: boolean;
 	dryRun: boolean;
 	org?: string;
+	retry: boolean;
 }
 
 async function runInteractiveUpload(flags: UploadFlags): Promise<void> {
@@ -156,23 +162,50 @@ async function runInteractiveUpload(flags: UploadFlags): Promise<void> {
 					continue;
 				}
 
-				const result = await uploadSession(request, uploadConfig);
+				const result = await uploadSession(request, {
+					...uploadConfig,
+					onRetry: (attempt, maxAttempts, error) => {
+						uploadSpin.message(
+							`[${completed}/${totalSessions}] Retrying (${attempt}/${maxAttempts}) after ${error}`,
+						);
+					},
+				});
 				if (result.success) {
 					succeeded++;
+					await removeFailedUpload(session.sessionId);
 				} else {
 					failed++;
+					const error = result.error ?? "Unknown error";
 					errors.push({
 						sessionId: session.sessionId,
 						project: project.displayPath,
-						error: result.error ?? "Unknown error",
+						error,
+					});
+					await recordFailedUpload({
+						sessionId: session.sessionId,
+						transcriptPath: session.transcriptPath,
+						projectPath: session.projectPath,
+						source: project.source,
+						organizationId,
+						error,
 					});
 				}
 			} catch (error) {
 				failed++;
+				const errorMessage =
+					error instanceof Error ? error.message : String(error);
 				errors.push({
 					sessionId: session.sessionId,
 					project: project.displayPath,
-					error: error instanceof Error ? error.message : String(error),
+					error: errorMessage,
+				});
+				await recordFailedUpload({
+					sessionId: session.sessionId,
+					transcriptPath: session.transcriptPath,
+					projectPath: session.projectPath,
+					source: project.source,
+					organizationId,
+					error: errorMessage,
 				});
 			}
 		}
@@ -191,6 +224,7 @@ async function runInteractiveUpload(flags: UploadFlags): Promise<void> {
 		if (errors.length > 5) {
 			p.log.warn(`  ...and ${errors.length - 5} more`);
 		}
+		p.log.info("Run `rudel upload --retry` to retry failed uploads.");
 	}
 
 	if (flags.dryRun) {
@@ -311,10 +345,129 @@ async function runSingleUpload(
 	}
 }
 
+async function runRetryUpload(flags: UploadFlags): Promise<void> {
+	const credentials = loadCredentials();
+	if (!credentials) {
+		p.log.error("Not authenticated. Run `rudel login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	p.intro("rudel upload --retry");
+
+	const failures = await loadFailedUploads();
+	if (failures.length === 0) {
+		p.outro("No failed uploads to retry.");
+		return;
+	}
+
+	p.log.info(`Found ${failures.length} failed upload(s):`);
+	for (const f of failures.slice(0, 10)) {
+		p.log.warn(`  ${f.sessionId}: ${f.error} (${f.failedAt})`);
+	}
+	if (failures.length > 10) {
+		p.log.warn(`  ...and ${failures.length - 10} more`);
+	}
+
+	const shouldRetry = await p.confirm({
+		message: `Retry all ${failures.length} failed upload(s)?`,
+		initialValue: true,
+	});
+
+	if (p.isCancel(shouldRetry) || !shouldRetry) {
+		p.cancel("Retry cancelled.");
+		return;
+	}
+
+	const endpoint = flags.endpoint;
+	let succeeded = 0;
+	let failed = 0;
+
+	await p.tasks(
+		failures.map((failure, i) => ({
+			title: `[${i + 1}/${failures.length}] ${failure.sessionId}`,
+			task: async (message: (msg: string) => void) => {
+				const prefix = `[${i + 1}/${failures.length}]`;
+				try {
+					message("Building upload request...");
+					const adapter = failure.source
+						? getAdapter(failure.source)
+						: claudeCodeAdapter;
+					const sessionFile: SessionFile = {
+						sessionId: failure.sessionId,
+						transcriptPath: failure.transcriptPath,
+						projectPath: failure.projectPath,
+					};
+					const gitInfo = await getGitInfo(failure.projectPath);
+					const organizationId =
+						flags.org ??
+						failure.organizationId ??
+						(await getProjectOrgId(failure.projectPath));
+
+					const request = await adapter.buildUploadRequest(sessionFile, {
+						tag: flags.tag,
+						gitInfo,
+						organizationId,
+					});
+
+					message("Uploading...");
+					const result = await uploadSession(request, {
+						endpoint,
+						token: credentials.token,
+						onRetry: (attempt, maxAttempts, error) => {
+							message(
+								`${prefix} Retrying (${attempt}/${maxAttempts}) after ${error}...`,
+							);
+						},
+					});
+
+					if (result.success) {
+						succeeded++;
+						await removeFailedUpload(failure.sessionId);
+						const retryNote =
+							result.attempts && result.attempts > 1
+								? ` (after ${result.attempts} attempts)`
+								: "";
+						return `Uploaded${retryNote}`;
+					}
+					failed++;
+					await recordFailedUpload({
+						...failure,
+						error: result.error ?? "Unknown error",
+					});
+					return `Failed: ${result.error}`;
+				} catch (error) {
+					failed++;
+					const errorMessage =
+						error instanceof Error ? error.message : String(error);
+					await recordFailedUpload({ ...failure, error: errorMessage });
+					return `Error: ${errorMessage}`;
+				}
+			},
+		})),
+	);
+
+	if (succeeded > 0) {
+		p.log.success(`${succeeded} session(s) uploaded`);
+	}
+	if (failed > 0) {
+		p.log.error(`${failed} session(s) still failing`);
+	}
+
+	p.outro("Done!");
+
+	if (failed > 0) {
+		process.exitCode = 1;
+	}
+}
+
 async function runUpload(
 	flags: UploadFlags,
 	...sessions: string[]
 ): Promise<void> {
+	if (flags.retry) {
+		return runRetryUpload(flags);
+	}
 	if (sessions.length === 0) {
 		return runInteractiveUpload(flags);
 	}
@@ -361,12 +514,18 @@ export const uploadCommand = buildCommand({
 				brief: "Override the organization ID to upload to",
 				optional: true,
 			},
+			retry: {
+				kind: "boolean",
+				brief: "Retry previously failed uploads",
+				default: false,
+			},
 		},
 		aliases: {
 			t: "tag",
 			c: "classify",
 			n: "dryRun",
 			o: "org",
+			r: "retry",
 		},
 	},
 	docs: {

--- a/apps/cli/src/lib/failed-uploads.ts
+++ b/apps/cli/src/lib/failed-uploads.ts
@@ -1,0 +1,67 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const FAILED_UPLOADS_PATH = join(homedir(), ".rudel", "failed-uploads.json");
+
+export interface FailedUpload {
+	sessionId: string;
+	transcriptPath: string;
+	projectPath: string;
+	/** Agent adapter source (e.g. "claude-code", "codex") */
+	source?: string;
+	organizationId?: string;
+	error: string;
+	failedAt: string;
+}
+
+interface FailedUploadsData {
+	failures: FailedUpload[];
+}
+
+export async function loadFailedUploads(): Promise<FailedUpload[]> {
+	try {
+		const file = Bun.file(FAILED_UPLOADS_PATH);
+		if (!(await file.exists())) return [];
+		const data = (await file.json()) as FailedUploadsData;
+		return data.failures;
+	} catch {
+		return [];
+	}
+}
+
+async function saveFailedUploads(failures: FailedUpload[]): Promise<void> {
+	try {
+		const { mkdir } = await import("node:fs/promises");
+		const { dirname } = await import("node:path");
+		await mkdir(dirname(FAILED_UPLOADS_PATH), { recursive: true });
+		const data: FailedUploadsData = { failures };
+		await Bun.write(FAILED_UPLOADS_PATH, JSON.stringify(data, null, 2));
+	} catch {
+		// Best-effort — don't break the upload flow
+	}
+}
+
+export async function recordFailedUpload(
+	failure: Omit<FailedUpload, "failedAt">,
+): Promise<void> {
+	const failures = await loadFailedUploads();
+	const existing = failures.findIndex((f) => f.sessionId === failure.sessionId);
+	const entry: FailedUpload = {
+		...failure,
+		failedAt: new Date().toISOString(),
+	};
+	if (existing >= 0) {
+		failures[existing] = entry;
+	} else {
+		failures.push(entry);
+	}
+	await saveFailedUploads(failures);
+}
+
+export async function removeFailedUpload(sessionId: string): Promise<void> {
+	const failures = await loadFailedUploads();
+	const filtered = failures.filter((f) => f.sessionId !== sessionId);
+	if (filtered.length !== failures.length) {
+		await saveFailedUploads(filtered);
+	}
+}

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -21,6 +21,7 @@ export interface UploadResult {
 	success: boolean;
 	status?: number;
 	error?: string;
+	attempts?: number;
 }
 
 export const DEFAULT_ENDPOINT = "https://app.rudel.ai/rpc";

--- a/apps/cli/src/lib/uploader.ts
+++ b/apps/cli/src/lib/uploader.ts
@@ -1,4 +1,4 @@
-import { createORPCClient } from "@orpc/client";
+import { createORPCClient, ORPCError } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
 import type { ContractRouterClient } from "@orpc/contract";
 import type { contract, IngestSessionInput } from "@rudel/api-routes";
@@ -7,8 +7,37 @@ import type { UploadResult } from "./types.js";
 export interface UploadConfig {
 	endpoint: string;
 	token: string;
+	onRetry?: (attempt: number, maxAttempts: number, error: string) => void;
 }
 
+const RETRYABLE_STATUS_CODES = new Set([502, 503, 429]);
+const MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 1_000;
+
+function isRetryable(error: unknown): boolean {
+	if (error instanceof ORPCError) {
+		return RETRYABLE_STATUS_CODES.has(error.status);
+	}
+	if (error instanceof TypeError) {
+		return true; // network errors (fetch failures)
+	}
+	return false;
+}
+
+function formatError(error: unknown): string {
+	if (error instanceof ORPCError) {
+		return `${error.status} ${error.message}`;
+	}
+	if (error instanceof Error) {
+		return error.message;
+	}
+	return String(error);
+}
+
+/**
+ * Upload a session transcript to the backend via oRPC.
+ * Retries on transient errors (502, 503, 429) with exponential backoff.
+ */
 export async function uploadSession(
 	request: IngestSessionInput,
 	config: UploadConfig,
@@ -22,10 +51,31 @@ export async function uploadSession(
 
 	const client: ContractRouterClient<typeof contract> = createORPCClient(link);
 
-	try {
-		await client.ingestSession(request);
-		return { success: true, status: 200 };
-	} catch (error) {
-		return { success: false, error: String(error) };
+	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+		try {
+			await client.ingestSession(request);
+			return { success: true, status: 200, attempts: attempt };
+		} catch (error) {
+			const errorMessage = formatError(error);
+
+			if (isRetryable(error) && attempt < MAX_ATTEMPTS) {
+				config.onRetry?.(attempt, MAX_ATTEMPTS, errorMessage);
+				const delay = BASE_DELAY_MS * 2 ** (attempt - 1);
+				await new Promise((resolve) => setTimeout(resolve, delay));
+				continue;
+			}
+
+			return {
+				success: false,
+				error: errorMessage,
+				attempts: attempt,
+			};
+		}
 	}
+
+	return {
+		success: false,
+		error: "Max retries exceeded",
+		attempts: MAX_ATTEMPTS,
+	};
 }


### PR DESCRIPTION
## Summary
- Automatic retries with exponential backoff (1s/2s delays) on transient errors (502, 503, 429, network errors)
- Explicit progress visibility during retries in CLI spinners
- Failed upload tracking to `~/.rudel/failed-uploads.json` with `rudel upload --retry` to retry later
- Better error reporting: HTTP status codes + messages instead of opaque error strings
- Improved summaries: session IDs, error details, timestamps, and hints to users

## Test plan
- [x] All 11 turbo tasks pass (lint, type-check, test, build)
- [x] All 35 tests pass (including upload integration tests)
- [x] Code verified on refactored main branch with multi-agent support (Claude Code + Codex)
- [x] Spans all upload paths: interactive, single-session, `enable` bulk, and async hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)