### PR TITLE
ci: remove redundant lockfile verification step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Check for local overrides
         run: bun scripts/check-overrides.ts
 
-      - name: Verify lockfile unchanged
-        run: git diff --exit-code bun.lock
-
       - name: Verify
         run: bunx turbo run lint check-types test build
         env:


### PR DESCRIPTION
## Summary
Removes the redundant `git diff --exit-code bun.lock` check in CI. The setup action already runs `bun install --frozen-lockfile`, which fails the build if the lockfile would change. This makes the explicit git diff check unnecessary.

## Test plan
- [x] Verification passed (lint, type-check, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)