### PR TITLE
feat: make agent source type-safe with enum

### DIFF
--- a/apps/cli/src/commands/hooks/claude/session-end.ts
+++ b/apps/cli/src/commands/hooks/claude/session-end.ts
@@ -85,7 +85,7 @@ async function runSessionEnd(): Promise<void> {
 				sessionId: input.session_id,
 				transcriptPath: input.transcript_path,
 				projectPath: input.cwd,
-				source: "claude-code",
+				source: claudeCodeAdapter.source,
 				organizationId,
 				error: result.error ?? "Unknown error",
 			});

--- a/apps/cli/src/commands/hooks/codex/turn-complete.ts
+++ b/apps/cli/src/commands/hooks/codex/turn-complete.ts
@@ -72,7 +72,7 @@ async function runTurnComplete(): Promise<void> {
 				sessionId: input.thread_id,
 				transcriptPath,
 				projectPath: input.cwd,
-				source: "codex",
+				source: codexAdapter.source,
 				organizationId,
 				error: result.error ?? "Unknown error",
 			});

--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -7,6 +7,7 @@ import {
 	type ScannedProject,
 	type SessionFile,
 } from "@rudel/agent-adapters";
+import type { Source } from "@rudel/api-routes";
 import { buildCommand } from "@stricli/core";
 import type { BatchUploadItem } from "../lib/batch-upload.js";
 import { renderBatchSummary, runBatchUpload } from "../lib/batch-upload-ui.js";
@@ -199,12 +200,8 @@ async function runInteractiveUpload(flags: UploadFlags): Promise<void> {
 	}
 }
 
-function getAdapterName(source: string): string {
-	try {
-		return getAdapter(source).name;
-	} catch {
-		return source;
-	}
+function getAdapterName(source: Source): string {
+	return getAdapter(source).name;
 }
 
 function sessionCountHint(count: number): string {

--- a/apps/cli/src/lib/batch-upload.ts
+++ b/apps/cli/src/lib/batch-upload.ts
@@ -1,3 +1,4 @@
+import type { Source } from "@rudel/api-routes";
 import pMap from "p-map";
 import { recordFailedUpload, removeFailedUpload } from "./failed-uploads.js";
 import type { UploadResult } from "./types.js";
@@ -7,7 +8,7 @@ export interface BatchUploadItem {
 	label: string;
 	transcriptPath: string;
 	projectPath: string;
-	source?: string;
+	source?: Source;
 	organizationId?: string;
 }
 

--- a/apps/cli/src/lib/failed-uploads.ts
+++ b/apps/cli/src/lib/failed-uploads.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { type Source, SourceSchema } from "@rudel/api-routes";
 
 const FAILED_UPLOADS_PATH = join(homedir(), ".rudel", "failed-uploads.json");
 
@@ -7,8 +8,7 @@ export interface FailedUpload {
 	sessionId: string;
 	transcriptPath: string;
 	projectPath: string;
-	/** Agent adapter source (e.g. "claude-code", "codex") */
-	source?: string;
+	source?: Source;
 	organizationId?: string;
 	error: string;
 	failedAt: string;
@@ -18,12 +18,22 @@ interface FailedUploadsData {
 	failures: FailedUpload[];
 }
 
+function normalizeSource(raw: unknown): Source | undefined {
+	if (typeof raw !== "string") return undefined;
+	const normalized = raw.replace(/-/g, "_");
+	const parsed = SourceSchema.safeParse(normalized);
+	return parsed.success ? parsed.data : undefined;
+}
+
 export async function loadFailedUploads(): Promise<FailedUpload[]> {
 	try {
 		const file = Bun.file(FAILED_UPLOADS_PATH);
 		if (!(await file.exists())) return [];
 		const data = (await file.json()) as FailedUploadsData;
-		return data.failures;
+		return data.failures.map((f) => ({
+			...f,
+			source: normalizeSource(f.source),
+		}));
 	} catch {
 		return [];
 	}

--- a/packages/agent-adapters/src/adapters/claude-code/index.ts
+++ b/packages/agent-adapters/src/adapters/claude-code/index.ts
@@ -138,7 +138,7 @@ export async function readSubagentFiles(
 
 class ClaudeCodeAdapter implements AgentAdapter {
 	name = "Claude Code";
-	source = "claude_code";
+	source = "claude_code" as const;
 	rawTableName = "rudel.claude_sessions";
 
 	getSessionsBaseDir(): string {

--- a/packages/agent-adapters/src/adapters/codex/index.ts
+++ b/packages/agent-adapters/src/adapters/codex/index.ts
@@ -87,7 +87,7 @@ export async function findActiveRolloutFile(
 
 class CodexAdapter implements AgentAdapter {
 	name = "OpenAI Codex";
-	source = "codex";
+	source = "codex" as const;
 	rawTableName = "rudel.codex_sessions";
 
 	getSessionsBaseDir(): string {

--- a/packages/agent-adapters/src/registry.ts
+++ b/packages/agent-adapters/src/registry.ts
@@ -1,13 +1,14 @@
 import { existsSync } from "node:fs";
+import type { Source } from "@rudel/api-routes";
 import type { AgentAdapter } from "./types.js";
 
-const adapters = new Map<string, AgentAdapter>();
+const adapters = new Map<Source, AgentAdapter>();
 
 export function registerAdapter(adapter: AgentAdapter): void {
 	adapters.set(adapter.source, adapter);
 }
 
-export function getAdapter(source: string): AgentAdapter {
+export function getAdapter(source: Source): AgentAdapter {
 	const adapter = adapters.get(source);
 	if (!adapter) {
 		throw new Error(`No adapter registered for source: ${source}`);

--- a/packages/agent-adapters/src/types.ts
+++ b/packages/agent-adapters/src/types.ts
@@ -1,4 +1,4 @@
-import type { IngestSessionInput } from "@rudel/api-routes";
+import type { IngestSessionInput, Source } from "@rudel/api-routes";
 import type { Ingestor } from "@rudel/ch-schema/generated";
 
 export interface SessionFile {
@@ -10,7 +10,7 @@ export interface SessionFile {
 }
 
 export interface ScannedProject {
-	source: string;
+	source: Source;
 	projectPath: string;
 	displayPath: string;
 	sessions: SessionFile[];
@@ -44,7 +44,7 @@ export interface IngestContext {
 
 export interface AgentAdapter {
 	name: string;
-	source: string;
+	source: Source;
 	rawTableName: string;
 
 	// Session Discovery (CLI)

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -81,13 +81,18 @@ export const SessionTagSchema = z.enum([
 	"other",
 ]);
 
+export type { Source } from "./schemas/source.js";
+export { SourceSchema } from "./schemas/source.js";
+
+import { SourceSchema } from "./schemas/source.js";
+
 export const SubagentFileSchema = z.object({
 	agentId: z.string(),
 	content: z.string(),
 });
 
 export const IngestSessionInputSchema = z.object({
-	source: z.string().default("claude_code"),
+	source: SourceSchema.default("claude_code"),
 	sessionId: z.string(),
 	projectPath: z.string(),
 	repository: z.string().optional(),

--- a/packages/api-routes/src/schemas/analytics.ts
+++ b/packages/api-routes/src/schemas/analytics.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { SourceSchema } from "./source.js";
 
 // ── Common inputs ──────────────────────────────────────────────────
 
@@ -269,7 +270,7 @@ export const SessionAnalyticsSchema = z.object({
 	session_archetype: z.string(),
 	model_used: z.string(),
 	used_plan_mode: z.boolean(),
-	source: z.string().optional(),
+	source: SourceSchema.optional(),
 });
 
 export const SessionAnalyticsSummarySchema = z.object({
@@ -295,7 +296,7 @@ export const SessionListInputSchema = DaysInputSchema.extend({
 	userId: z.string().optional(),
 	projectPath: z.string().optional(),
 	repository: z.string().optional(),
-	source: z.string().optional(),
+	source: SourceSchema.optional(),
 	limit: z.number().int().positive().default(100),
 	offset: z.number().int().nonnegative().default(0),
 	sortBy: z
@@ -368,7 +369,7 @@ export const SessionDetailSchema = z.object({
 	total_interactions: z.number().optional(),
 	session_archetype: z.string().optional(),
 	model_used: z.string().optional(),
-	source: z.string().optional(),
+	source: SourceSchema.optional(),
 });
 
 export const SessionDetailInputSchema = z.object({

--- a/packages/api-routes/src/schemas/source.ts
+++ b/packages/api-routes/src/schemas/source.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+
+export const SourceSchema = z.enum(["claude_code", "codex"]);
+export type Source = z.infer<typeof SourceSchema>;


### PR DESCRIPTION
## Summary
- Added `Source` enum type for agent adapters (`claude_code`, `codex`) to replace loose string types
- Made source field type-safe across adapters, CLI, and API schemas with single source of truth in `SourceSchema`
- Fixed retry upload bug where old failure records with hyphenated `"claude-code"` couldn't resolve to adapters
- Added backward-compatible normalization of source values on load from failed-uploads.json
- Replaced hardcoded source strings in hooks with adapter property references

## Test plan
- [x] All type checks pass
- [x] All linting passes  
- [x] All tests pass
- [x] Verify script passes (lint, check-types, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)