### PR TITLE
fix: resolve session migration error by reading and re-inserting

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,8 @@
 		"dev:env": "doppler run --project rudel --config prd_local -- bun --watch src/index.ts",
 		"check-types": "tsc --noEmit",
 		"test": "bun test",
-		"test:integration": "bun test src/__tests__/ingest-clickhouse.integration.ts"
+		"test:integration": "bun test src/__tests__/ingest-clickhouse.integration.ts",
+		"test:migrate": "bun test src/__tests__/migrate-sessions.integration.ts"
 	},
 	"dependencies": {
 		"@clickhouse/client-web": "^1.11.0",

--- a/apps/api/src/__tests__/migrate-sessions.integration.ts
+++ b/apps/api/src/__tests__/migrate-sessions.integration.ts
@@ -1,0 +1,122 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { getAdapter } from "@rudel/agent-adapters";
+import type { IngestSessionInput } from "@rudel/api-routes";
+import {
+	type ClickHouseExecutor,
+	createClickHouseExecutor,
+} from "../clickhouse.js";
+import { migrateOrgSessions } from "../services/org-session.service.js";
+
+const testId = `migrate_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+const orgA = `test_org_A_${testId}`;
+const orgB = `test_org_B_${testId}`;
+
+const baseExecutor = createClickHouseExecutor({
+	url: process.env.CLICKHOUSE_URL || "http://localhost:8123",
+	username:
+		process.env.CLICKHOUSE_USERNAME || process.env.CLICKHOUSE_USER || "default",
+	password: process.env.CLICKHOUSE_PASSWORD || "",
+	database: "default",
+});
+
+const executor: ClickHouseExecutor = {
+	...baseExecutor,
+	async insert(params) {
+		const rows = params.values.map((r) => JSON.stringify(r)).join("\n");
+		// Retry on race condition (code 236) — same as getClickhouse() wrapper
+		for (let attempt = 0; attempt < 3; attempt++) {
+			try {
+				await baseExecutor.execute(
+					`INSERT INTO ${params.table} SETTINGS async_insert=0 FORMAT JSONEachRow ${rows}`,
+				);
+				return;
+			} catch (error) {
+				if (attempt === 2) throw error;
+				await new Promise((r) => setTimeout(r, 200 * (attempt + 1)));
+			}
+		}
+	},
+};
+
+afterAll(async () => {
+	// Fire-and-forget: ClickHouse Cloud DELETE mutations are slow
+	for (const org of [orgA, orgB]) {
+		executor
+			.execute(
+				`DELETE FROM rudel.claude_sessions WHERE organization_id = '${org}'`,
+			)
+			.catch(() => {});
+		executor
+			.execute(
+				`DELETE FROM rudel.session_analytics WHERE organization_id = '${org}'`,
+			)
+			.catch(() => {});
+	}
+});
+
+async function waitForRow(
+	table: string,
+	orgId: string,
+	sessionId: string,
+	timeoutMs = 30_000,
+	intervalMs = 2_000,
+): Promise<Array<{ session_id: string; organization_id: string }>> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		const results = await executor.query<{
+			session_id: string;
+			organization_id: string;
+		}>(
+			`SELECT session_id, organization_id FROM ${table} WHERE session_id = '${sessionId}' AND organization_id = '${orgId}' LIMIT 1`,
+		);
+		if (results.length > 0) return results;
+		await new Promise((r) => setTimeout(r, intervalMs));
+	}
+	return [];
+}
+
+describe("migrateOrgSessions", () => {
+	const sessionId = `sess_${testId}`;
+
+	test("migrates sessions from one org to another via temp table", async () => {
+		const input: IngestSessionInput = {
+			source: "claude_code",
+			sessionId,
+			projectPath: "/test/migrate",
+			repository: "test-repo",
+			gitBranch: "main",
+			gitSha: "abc123",
+			tag: "tests",
+			content: "migrate integration test content",
+		};
+
+		// Ingest a row under orgA
+		const adapter = getAdapter(input.source);
+		let ingested = false;
+		for (let attempt = 0; attempt < 5; attempt++) {
+			try {
+				await adapter.ingest(executor, input, {
+					userId: "test_user",
+					organizationId: orgA,
+				});
+				ingested = true;
+				break;
+			} catch {
+				await new Promise((r) => setTimeout(r, 2000 * 2 ** attempt));
+			}
+		}
+		expect(ingested).toBe(true);
+
+		const before = await waitForRow("rudel.claude_sessions", orgA, sessionId);
+		expect(before).toHaveLength(1);
+
+		// Migrate from orgA → orgB (DELETEs may 504 on ClickHouse Cloud but
+		// the mutations still run server-side — migrateOrgSessions handles this)
+		await migrateOrgSessions(orgA, orgB, executor);
+
+		// New org should have the migrated row
+		const newRows = await waitForRow("rudel.claude_sessions", orgB, sessionId);
+		expect(newRows).toHaveLength(1);
+		expect(newRows[0]?.organization_id).toBe(orgB);
+	}, 180_000);
+});

--- a/apps/api/src/services/org-session.service.ts
+++ b/apps/api/src/services/org-session.service.ts
@@ -1,5 +1,9 @@
 import { getAllAdapters } from "@rudel/agent-adapters";
-import { escapeString, getClickhouse } from "../clickhouse.js";
+import {
+	type ClickHouseExecutor,
+	escapeString,
+	getClickhouse,
+} from "../clickhouse.js";
 
 export async function getOrgSessionCount(orgId: string): Promise<number> {
 	const ch = getClickhouse();
@@ -32,19 +36,48 @@ export async function deleteOrgSessions(orgId: string): Promise<void> {
 export async function migrateOrgSessions(
 	fromOrgId: string,
 	toOrgId: string,
+	ch: ClickHouseExecutor = getClickhouse(),
 ): Promise<void> {
-	const ch = getClickhouse();
 	const from = escapeString(fromOrgId);
-	const to = escapeString(toOrgId);
 	const tables = getAllAdapters().map((a) => a.rawTableName);
-	await Promise.all([
+
+	// Can't use ALTER TABLE UPDATE — organization_id is an ORDER BY key and
+	// ingested_at is the ReplacingMergeTree version column.
+	// Can't use CREATE TABLE ... AS SELECT — ClickHouse Cloud has eventual
+	// consistency across replicas, so the SELECT may read stale data.
+	// Instead, read rows into the app, swap the org_id, and re-insert.
+	await Promise.all(
+		tables.map(async (table) => {
+			const rows = await ch.query<Record<string, unknown>>(
+				`SELECT * FROM ${table} WHERE organization_id = '${from}'`,
+			);
+			if (rows.length === 0) return;
+			const migrated = rows.map((row) => ({
+				...row,
+				organization_id: toOrgId,
+			}));
+			await ch.insert({ table, values: migrated });
+		}),
+	);
+
+	// Delete old rows. On ClickHouse Cloud, DELETE mutations may outlast the
+	// HTTP gateway timeout (504) but still run to completion server-side.
+	// Fire all deletes in parallel and don't let a gateway timeout abort the
+	// migration — the INSERT above already succeeded.
+	const deletions = [
 		...tables.map((table) =>
-			ch.execute(
-				`ALTER TABLE ${table} UPDATE organization_id = '${to}', ingested_at = now64(3) WHERE organization_id = '${from}'`,
-			),
+			ch.execute(`DELETE FROM ${table} WHERE organization_id = '${from}'`),
 		),
 		ch.execute(
-			`ALTER TABLE rudel.session_analytics UPDATE organization_id = '${to}', ingested_at = now64(3) WHERE organization_id = '${from}'`,
+			`DELETE FROM rudel.session_analytics WHERE organization_id = '${from}'`,
 		),
-	]);
+	];
+	const results = await Promise.allSettled(deletions);
+	for (const r of results) {
+		if (r.status === "rejected") {
+			console.warn(
+				`[migrateOrgSessions] DELETE mutation may still be running: ${r.reason}`,
+			);
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Fixed `migrateOrgSessions` that was failing with "Cannot UPDATE key column" error
- Replaced `ALTER TABLE UPDATE` with app-level read-modify-reinsert approach (SELECT old rows → modify org_id in JS → INSERT back)
- Made DELETE mutations resilient to ClickHouse Cloud gateway timeouts via `Promise.allSettled`
- Added integration test verifying session migration against real ClickHouse

## Test plan
- [x] Verification passed: all 11 tasks (lint, type-check, tests, build)
- [x] New integration test `migrateOrgSessions` passes against CI ClickHouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)