### PR TITLE
feat: add invitations page and notification indicator

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,7 @@ import { CreateOrgPage } from "./pages/dashboard/CreateOrgPage";
 import { DeveloperDetailPage } from "./pages/dashboard/DeveloperDetailPage";
 import { DevelopersListPage } from "./pages/dashboard/DevelopersListPage";
 import { ErrorsPage } from "./pages/dashboard/ErrorsPage";
+import { InvitationsPage } from "./pages/dashboard/InvitationsPage";
 import { LearningsPage } from "./pages/dashboard/LearningsPage";
 import { OrganizationPage } from "./pages/dashboard/OrganizationPage";
 import { OverviewPage } from "./pages/dashboard/OverviewPage";
@@ -116,6 +117,7 @@ function App() {
 				<Route path="errors" element={<ErrorsPage />} />
 				<Route path="learnings" element={<LearningsPage />} />
 				<Route path="profile" element={<ProfilePage />} />
+				<Route path="invitations" element={<InvitationsPage />} />
 				<Route path="organization" element={<OrganizationPage />} />
 				<Route path="organization/new" element={<CreateOrgPage />} />
 			</Route>

--- a/apps/web/src/components/analytics/Breadcrumb.tsx
+++ b/apps/web/src/components/analytics/Breadcrumb.tsx
@@ -9,6 +9,7 @@ const segmentLabels: Record<string, string> = {
 	sessions: "Sessions",
 	learnings: "Learnings",
 	errors: "Errors",
+	invitations: "Invitations",
 	profile: "Profile",
 };
 

--- a/apps/web/src/components/analytics/Sidebar.tsx
+++ b/apps/web/src/components/analytics/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
 	FolderKanban,
 	LayoutDashboard,
 	LogOut,
+	Mail,
 	Plus,
 	Settings,
 	UserCircle,
@@ -19,6 +20,7 @@ import { useTheme } from "next-themes";
 import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useOrganization } from "../../contexts/OrganizationContext";
+import { useUserInvitations } from "../../hooks/useUserInvitations";
 import { authClient, signOut } from "../../lib/auth-client";
 import { cn } from "../../lib/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
@@ -127,6 +129,7 @@ export function Sidebar() {
 	const { data: session } = authClient.useSession();
 	const [collapsed, setCollapsed] = useState(false);
 	const { resolvedTheme } = useTheme();
+	const { count: invitationCount } = useUserInvitations();
 
 	const logoSrc =
 		resolvedTheme === "dark" ? "/logo-light.svg" : "/logo-dark.svg";
@@ -204,6 +207,49 @@ export function Sidebar() {
 							</div>
 						);
 					})}
+					{invitationCount > 0 &&
+						(() => {
+							const isActive = pathname === "/dashboard/invitations";
+							const link = (
+								<Link
+									to="/dashboard/invitations"
+									className={cn(
+										"relative flex items-center gap-2 rounded-lg px-2 py-2 text-[0.8125rem] font-medium transition-colors duration-150",
+										collapsed && "justify-center",
+										isActive
+											? "bg-hover text-heading"
+											: "text-muted hover:bg-hover hover:text-foreground",
+									)}
+								>
+									<span className="relative">
+										<Mail className="h-4 w-4 shrink-0" />
+										<span className="absolute -top-1.5 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-500 text-[0.5625rem] font-bold leading-none text-white">
+											{invitationCount}
+										</span>
+									</span>
+									{!collapsed && (
+										<span className="whitespace-nowrap overflow-hidden">
+											Invitations
+										</span>
+									)}
+								</Link>
+							);
+
+							return (
+								<div>
+									{collapsed ? (
+										<Tooltip>
+											<TooltipTrigger asChild>{link}</TooltipTrigger>
+											<TooltipContent side="right">
+												Invitations ({invitationCount})
+											</TooltipContent>
+										</Tooltip>
+									) : (
+										link
+									)}
+								</div>
+							);
+						})()}
 				</nav>
 
 				{session?.user && (

--- a/apps/web/src/hooks/useUserInvitations.ts
+++ b/apps/web/src/hooks/useUserInvitations.ts
@@ -1,0 +1,25 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { authClient } from "../lib/auth-client";
+
+export const USER_INVITATIONS_KEY = ["user-invitations"] as const;
+
+export function useUserInvitations() {
+	const queryClient = useQueryClient();
+
+	const { data, isLoading } = useQuery({
+		queryKey: USER_INVITATIONS_KEY,
+		queryFn: async () => {
+			const res = await authClient.organization.listUserInvitations();
+			return res.data ?? [];
+		},
+	});
+
+	const invitations = data ?? [];
+
+	const invalidate = useCallback(() => {
+		queryClient.invalidateQueries({ queryKey: USER_INVITATIONS_KEY });
+	}, [queryClient]);
+
+	return { invitations, count: invitations.length, isLoading, invalidate };
+}

--- a/apps/web/src/pages/AcceptInvitationPage.tsx
+++ b/apps/web/src/pages/AcceptInvitationPage.tsx
@@ -1,12 +1,15 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { Building2, Check, Loader2, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "../components/ui/button";
+import { USER_INVITATIONS_KEY } from "../hooks/useUserInvitations";
 import { authClient } from "../lib/auth-client";
 
 export function AcceptInvitationPage() {
 	const { invitationId } = useParams<{ invitationId: string }>();
 	const navigate = useNavigate();
+	const queryClient = useQueryClient();
 	const { data: session, isPending: sessionLoading } = authClient.useSession();
 	const [status, setStatus] = useState<
 		"loading" | "accepting" | "accepted" | "error"
@@ -47,6 +50,7 @@ export function AcceptInvitationPage() {
 		}
 
 		setStatus("accepted");
+		queryClient.invalidateQueries({ queryKey: USER_INVITATIONS_KEY });
 		setTimeout(() => navigate("/dashboard"), 1500);
 	};
 

--- a/apps/web/src/pages/dashboard/InvitationsPage.tsx
+++ b/apps/web/src/pages/dashboard/InvitationsPage.tsx
@@ -1,0 +1,133 @@
+import { Building2, Check, Loader2, Mail, X } from "lucide-react";
+import { useState } from "react";
+import { AnalyticsCard } from "@/components/analytics/AnalyticsCard";
+import { PageHeader } from "@/components/analytics/PageHeader";
+import { Button } from "@/components/ui/button";
+import { useOrganization } from "@/contexts/OrganizationContext";
+import { useUserInvitations } from "@/hooks/useUserInvitations";
+import { authClient } from "@/lib/auth-client";
+
+export function InvitationsPage() {
+	const { invitations, isLoading, invalidate } = useUserInvitations();
+	const { switchOrg } = useOrganization();
+	const [processingId, setProcessingId] = useState<string | null>(null);
+
+	const handleAccept = async (invitationId: string) => {
+		setProcessingId(invitationId);
+		const res = await authClient.organization.acceptInvitation({
+			invitationId,
+		});
+		if (res.data) {
+			await switchOrg(res.data.member.organizationId);
+		}
+		invalidate();
+		setProcessingId(null);
+	};
+
+	const handleDecline = async (invitationId: string) => {
+		setProcessingId(invitationId);
+		await authClient.organization.rejectInvitation({ invitationId });
+		invalidate();
+		setProcessingId(null);
+	};
+
+	if (isLoading) {
+		return (
+			<div className="px-8 py-6">
+				<PageHeader
+					title="Invitations"
+					description="Pending invitations to join organizations"
+				/>
+				<AnalyticsCard>
+					<div className="flex items-center justify-center py-12 text-muted gap-2">
+						<Loader2 className="h-4 w-4 animate-spin" />
+						<span>Loading invitations...</span>
+					</div>
+				</AnalyticsCard>
+			</div>
+		);
+	}
+
+	return (
+		<div className="px-8 py-6">
+			<PageHeader
+				title="Invitations"
+				description="Pending invitations to join organizations"
+			/>
+
+			{invitations.length === 0 ? (
+				<AnalyticsCard>
+					<div className="text-center py-12">
+						<div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-hover">
+							<Mail className="h-6 w-6 text-muted" />
+						</div>
+						<p className="text-lg font-medium text-foreground mb-1">
+							No pending invitations
+						</p>
+						<p className="text-sm text-muted">
+							When someone invites you to an organization, it will appear here.
+						</p>
+					</div>
+				</AnalyticsCard>
+			) : (
+				<div className="space-y-4">
+					{invitations.map((invitation) => {
+						const isProcessing = processingId === invitation.id;
+						return (
+							<AnalyticsCard key={invitation.id}>
+								<div className="flex items-center justify-between">
+									<div className="flex items-center gap-4">
+										<div className="flex h-10 w-10 items-center justify-center rounded-full bg-hover">
+											<Building2 className="h-5 w-5 text-accent" />
+										</div>
+										<div>
+											<p className="text-sm font-semibold text-heading">
+												{invitation.organizationName}
+											</p>
+											<div className="flex items-center gap-2 mt-0.5">
+												<span className="inline-flex items-center rounded-full bg-hover px-2 py-0.5 text-xs font-medium text-subheading">
+													{invitation.role}
+												</span>
+												<span className="text-xs text-muted">
+													Invited{" "}
+													{new Date(invitation.createdAt).toLocaleDateString()}
+												</span>
+											</div>
+										</div>
+									</div>
+									<div className="flex items-center gap-2">
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => handleDecline(invitation.id)}
+											disabled={isProcessing}
+										>
+											{isProcessing ? (
+												<Loader2 className="h-4 w-4 mr-1 animate-spin" />
+											) : (
+												<X className="h-4 w-4 mr-1" />
+											)}
+											Decline
+										</Button>
+										<Button
+											size="sm"
+											onClick={() => handleAccept(invitation.id)}
+											disabled={isProcessing}
+										>
+											{isProcessing ? (
+												<Loader2 className="h-4 w-4 mr-1 animate-spin" />
+											) : (
+												<Check className="h-4 w-4 mr-1" />
+											)}
+											Accept
+										</Button>
+									</div>
+								</div>
+							</AnalyticsCard>
+						);
+					})}
+				</div>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

- Add a new `/dashboard/invitations` page listing all pending invitations with accept/decline actions
- Display a Mail icon with count badge in the sidebar when invitations exist
- Create a shared `useUserInvitations` hook backed by react-query to deduplicate API calls and keep state in sync
- Invalidate invitation cache when accepting via direct link to keep sidebar count up to date

The implementation follows existing patterns: the Sidebar and InvitationsPage both call the same hook, and react-query deduplicates the request and shares the cached data automatically.

## Test plan

1. Run `bun run verify` — all types, lint, and tests pass
2. Run `bun run dev:local` and test the feature:
   - With no pending invitations: "Invitations" nav item is hidden
   - Invite a user from org settings, log in as that user: "Invitations" nav item appears with badge
   - Click nav item: invitations page shows the pending invite
   - Accept: user joins org, org switcher updates, invite disappears from page
   - Test collapsed sidebar: Mail icon displays with count badge and tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)