### PR TITLE
feat: optimize data fetching with org-scoped cache keys

### DIFF
--- a/apps/web/src/components/DeleteOrganizationDialog.tsx
+++ b/apps/web/src/components/DeleteOrganizationDialog.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { AlertTriangle, Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { client } from "../lib/orpc";
@@ -27,8 +28,17 @@ export function DeleteOrganizationDialog({
 	otherOrganizations,
 	onDeleted,
 }: DeleteOrganizationDialogProps) {
-	const [sessionCount, setSessionCount] = useState<number | null>(null);
-	const [loading, setLoading] = useState(true);
+	const { data: sessionCountData, isLoading: loading } = useQuery({
+		queryKey: ["org-session-count", organization.id],
+		queryFn: async () => {
+			const res = await client.getOrganizationSessionCount({
+				organizationId: organization.id,
+			});
+			return res.count;
+		},
+		enabled: open,
+	});
+	const sessionCount = sessionCountData ?? null;
 	const [sessionAction, setSessionAction] = useState<
 		"migrate" | "delete" | null
 	>(null);
@@ -39,22 +49,13 @@ export function DeleteOrganizationDialog({
 
 	useEffect(() => {
 		if (!open) {
-			setSessionCount(null);
-			setLoading(true);
 			setSessionAction(null);
 			setMigrateTarget("");
 			setConfirmName("");
 			setDeleting(false);
 			setError(null);
-			return;
 		}
-
-		client
-			.getOrganizationSessionCount({ organizationId: organization.id })
-			.then((res) => setSessionCount(res.count))
-			.catch(() => setSessionCount(0))
-			.finally(() => setLoading(false));
-	}, [open, organization.id]);
+	}, [open]);
 
 	const nameMatches =
 		confirmName.toLowerCase() === organization.name.toLowerCase();

--- a/apps/web/src/contexts/OrganizationContext.tsx
+++ b/apps/web/src/contexts/OrganizationContext.tsx
@@ -1,4 +1,3 @@
-import { useQueryClient } from "@tanstack/react-query";
 import {
 	createContext,
 	type ReactNode,
@@ -31,7 +30,6 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
 		authClient.useActiveOrganization();
 	const { data: orgs, isPending: listLoading } =
 		authClient.useListOrganizations();
-	const queryClient = useQueryClient();
 	const [switching, setSwitching] = useState(false);
 
 	// Auto-set active org if none is set but user has orgs
@@ -47,16 +45,14 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
 			setSwitching(true);
 			authClient.organization
 				.setActive({ organizationId: orgs[0].id })
-				.then(() => queryClient.invalidateQueries())
 				.finally(() => setSwitching(false));
 		}
-	}, [activeOrg, orgs, activeLoading, listLoading, switching, queryClient]);
+	}, [activeOrg, orgs, activeLoading, listLoading, switching]);
 
 	const switchOrg = async (orgId: string) => {
 		setSwitching(true);
 		try {
 			await authClient.organization.setActive({ organizationId: orgId });
-			await queryClient.invalidateQueries();
 		} finally {
 			setSwitching(false);
 		}

--- a/apps/web/src/hooks/useAccounts.ts
+++ b/apps/web/src/hooks/useAccounts.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { authClient } from "@/lib/auth-client";
+
+interface Account {
+	id: string;
+	providerId: string;
+}
+
+const ACCOUNTS_KEY = ["accounts"] as const;
+
+export function useAccounts() {
+	const { data, isLoading } = useQuery({
+		queryKey: ACCOUNTS_KEY,
+		queryFn: async () => {
+			const res = await authClient.listAccounts();
+			return (res.data as readonly Account[]) ?? [];
+		},
+	});
+
+	return { accounts: data ?? [], isLoading };
+}

--- a/apps/web/src/hooks/useAnalyticsQuery.ts
+++ b/apps/web/src/hooks/useAnalyticsQuery.ts
@@ -1,0 +1,16 @@
+import {
+	type UseQueryOptions,
+	type UseQueryResult,
+	useQuery,
+} from "@tanstack/react-query";
+import { useOrganization } from "@/contexts/OrganizationContext";
+
+export function useAnalyticsQuery<TData>(
+	options: UseQueryOptions<TData>,
+): UseQueryResult<TData> {
+	const { activeOrg } = useOrganization();
+	return useQuery({
+		...options,
+		queryKey: ["org", activeOrg?.id, ...(options.queryKey ?? [])],
+	});
+}

--- a/apps/web/src/hooks/useFullOrganization.ts
+++ b/apps/web/src/hooks/useFullOrganization.ts
@@ -1,0 +1,43 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { authClient } from "@/lib/auth-client";
+
+interface FullOrg {
+	id: string;
+	name: string;
+	slug: string;
+	members: readonly {
+		id: string;
+		userId: string;
+		role: string;
+		user: { id: string; name: string; email: string; image: string | null };
+	}[];
+	invitations: readonly {
+		id: string;
+		email: string;
+		role: string | null;
+		status: string;
+	}[];
+}
+
+export function useFullOrganization(orgId: string | undefined) {
+	const queryClient = useQueryClient();
+	const queryKey = ["full-organization", orgId] as const;
+
+	const { data, isLoading } = useQuery({
+		queryKey,
+		queryFn: async () => {
+			const res = await authClient.organization.getFullOrganization({
+				query: { organizationId: orgId as string },
+			});
+			return (res.data as unknown as FullOrg) ?? null;
+		},
+		enabled: !!orgId,
+	});
+
+	const invalidate = useCallback(() => {
+		queryClient.invalidateQueries({ queryKey });
+	}, [queryClient, queryKey]);
+
+	return { data: data ?? null, isLoading, invalidate };
+}

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -1,3 +1,12 @@
 import { QueryClient } from "@tanstack/react-query";
 
-export const queryClient = new QueryClient();
+export const queryClient = new QueryClient({
+	defaultOptions: {
+		queries: {
+			staleTime: 0,
+			gcTime: 10 * 60 * 1000,
+			refetchOnWindowFocus: false,
+			retry: 1,
+		},
+	},
+});

--- a/apps/web/src/pages/dashboard/DeveloperDetailPage.tsx
+++ b/apps/web/src/pages/dashboard/DeveloperDetailPage.tsx
@@ -1,5 +1,4 @@
 import type { DeveloperError, DeveloperSession } from "@rudel/api-routes";
-import { useQuery } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Activity, ArrowLeft, Calendar, Clock, Code, Zap } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -30,6 +29,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { useDateRange } from "@/contexts/DateRangeContext";
+import { useAnalyticsQuery } from "@/hooks/useAnalyticsQuery";
 import { useChartTheme } from "@/hooks/useChartTheme";
 import {
 	calculateRollingAverage,
@@ -52,13 +52,13 @@ export function DeveloperDetailPage() {
 	const [projectFilter, setProjectFilter] = useState<string>("");
 	const [outcomeFilter, setOutcomeFilter] = useState<"all" | "success">("all");
 
-	const { data: details, isLoading: detailsLoading } = useQuery(
+	const { data: details, isLoading: detailsLoading } = useAnalyticsQuery(
 		orpc.analytics.developers.details.queryOptions({
 			input: { userId: userId as string, days },
 		}),
 	);
 
-	const { data: sessions } = useQuery(
+	const { data: sessions } = useAnalyticsQuery(
 		orpc.analytics.developers.sessions.queryOptions({
 			input: {
 				userId: userId as string,
@@ -72,31 +72,31 @@ export function DeveloperDetailPage() {
 		}),
 	);
 
-	const { data: projects } = useQuery(
+	const { data: projects } = useAnalyticsQuery(
 		orpc.analytics.developers.projects.queryOptions({
 			input: { userId: userId as string, days },
 		}),
 	);
 
-	const { data: timeline } = useQuery(
+	const { data: timeline } = useAnalyticsQuery(
 		orpc.analytics.developers.timeline.queryOptions({
 			input: { userId: userId as string, days },
 		}),
 	);
 
-	const { data: features } = useQuery(
+	const { data: features } = useAnalyticsQuery(
 		orpc.analytics.developers.features.queryOptions({
 			input: { userId: userId as string, days },
 		}),
 	);
 
-	const { data: errors } = useQuery(
+	const { data: errors } = useAnalyticsQuery(
 		orpc.analytics.developers.errors.queryOptions({
 			input: { userId: userId as string, days },
 		}),
 	);
 
-	const { data: userMappings } = useQuery(
+	const { data: userMappings } = useAnalyticsQuery(
 		orpc.analytics.users.mappings.queryOptions({ input: { days: 30 } }),
 	);
 

--- a/apps/web/src/pages/dashboard/DevelopersListPage.tsx
+++ b/apps/web/src/pages/dashboard/DevelopersListPage.tsx
@@ -1,5 +1,4 @@
 import type { DeveloperSummary } from "@rudel/api-routes";
-import { useQuery } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import {
 	Activity,
@@ -11,7 +10,7 @@ import {
 	UserCheck,
 	Users,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { AnalyticsCard } from "@/components/analytics/AnalyticsCard";
 import { DatePicker } from "@/components/analytics/DatePicker";
@@ -21,7 +20,8 @@ import { DeveloperTrendChart } from "@/components/charts/DeveloperTrendChart";
 import { DataTable } from "@/components/ui/data-table";
 import { useDateRange } from "@/contexts/DateRangeContext";
 import { useOrganization } from "@/contexts/OrganizationContext";
-import { authClient } from "@/lib/auth-client";
+import { useAnalyticsQuery } from "@/hooks/useAnalyticsQuery";
+import { useFullOrganization } from "@/hooks/useFullOrganization";
 import { formatUsername } from "@/lib/format";
 import { orpc } from "@/lib/orpc";
 
@@ -32,31 +32,18 @@ export function DevelopersListPage() {
 	const days = calculateDays();
 
 	const { activeOrg } = useOrganization();
-	const [memberCount, setMemberCount] = useState<number | null>(null);
+	const { data: fullOrg } = useFullOrganization(activeOrg?.id);
+	const memberCount = fullOrg?.members.length ?? null;
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: refetch when org changes
-	useEffect(() => {
-		if (!activeOrg) return;
-		authClient.organization
-			.getFullOrganization({ query: { organizationId: activeOrg.id } })
-			.then((res) => {
-				if (res.data) {
-					setMemberCount(
-						(res.data as { members: readonly unknown[] }).members.length,
-					);
-				}
-			});
-	}, [activeOrg?.id]);
-
-	const { data: developers, isLoading } = useQuery(
+	const { data: developers, isLoading } = useAnalyticsQuery(
 		orpc.analytics.developers.list.queryOptions({ input: { days } }),
 	);
 
-	const { data: trendsData } = useQuery(
+	const { data: trendsData } = useAnalyticsQuery(
 		orpc.analytics.developers.trends.queryOptions({ input: { days } }),
 	);
 
-	const { data: userMappings } = useQuery(
+	const { data: userMappings } = useAnalyticsQuery(
 		orpc.analytics.users.mappings.queryOptions({ input: { days: 30 } }),
 	);
 

--- a/apps/web/src/pages/dashboard/ErrorsPage.tsx
+++ b/apps/web/src/pages/dashboard/ErrorsPage.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import { AlertCircle, AlertTriangle, Clock, Users } from "lucide-react";
 import { useMemo, useState } from "react";
 import { AnalyticsCard } from "@/components/analytics/AnalyticsCard";
@@ -7,6 +6,7 @@ import { PageHeader } from "@/components/analytics/PageHeader";
 import { StatCard } from "@/components/analytics/StatCard";
 import { ErrorTrendChart } from "@/components/charts/ErrorTrendChart";
 import { useDateRange } from "@/contexts/DateRangeContext";
+import { useAnalyticsQuery } from "@/hooks/useAnalyticsQuery";
 import { orpc } from "@/lib/orpc";
 
 const severityColors = {
@@ -34,19 +34,19 @@ export function ErrorsPage() {
 		"repository" | "user_id" | "model"
 	>("repository");
 
-	const { data: errors, isLoading } = useQuery(
+	const { data: errors, isLoading } = useAnalyticsQuery(
 		orpc.analytics.errors.topRecurring.queryOptions({
 			input: { days, minOccurrences: 2, limit: 15 },
 		}),
 	);
 
-	const { data: trendData, isLoading: trendLoading } = useQuery(
+	const { data: trendData, isLoading: trendLoading } = useAnalyticsQuery(
 		orpc.analytics.errors.trends.queryOptions({
 			input: { startDate, endDate, splitBy: trendSplitBy },
 		}),
 	);
 
-	const { data: userMappings } = useQuery(
+	const { data: userMappings } = useAnalyticsQuery(
 		orpc.analytics.users.mappings.queryOptions({ input: { days: 30 } }),
 	);
 

--- a/apps/web/src/pages/dashboard/LearningsPage.tsx
+++ b/apps/web/src/pages/dashboard/LearningsPage.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import { BookOpen, FolderKanban, Lightbulb, Users } from "lucide-react";
 import { useMemo, useState } from "react";
 import { AnalyticsCard } from "@/components/analytics/AnalyticsCard";
@@ -9,6 +8,7 @@ import { StatCard } from "@/components/analytics/StatCard";
 import { LearningsTrendChart } from "@/components/charts/LearningsTrendChart";
 import { LearningsTimeline } from "@/components/learnings/LearningsTimeline";
 import { useDateRange } from "@/contexts/DateRangeContext";
+import { useAnalyticsQuery } from "@/hooks/useAnalyticsQuery";
 import { orpc } from "@/lib/orpc";
 
 export function LearningsPage() {
@@ -20,31 +20,31 @@ export function LearningsPage() {
 	const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
 	const [selectedProjects, setSelectedProjects] = useState<string[]>([]);
 
-	const { data: learnings, isLoading } = useQuery(
+	const { data: learnings, isLoading } = useAnalyticsQuery(
 		orpc.analytics.learnings.list.queryOptions({
 			input: { days, limit: 100, offset: 0 },
 		}),
 	);
 
-	const { data: stats } = useQuery(
+	const { data: stats } = useAnalyticsQuery(
 		orpc.analytics.learnings.stats.queryOptions({ input: { days } }),
 	);
 
-	const { data: trendData } = useQuery(
+	const { data: trendData } = useAnalyticsQuery(
 		orpc.analytics.learnings.trend.queryOptions({
 			input: { days, splitBy },
 		}),
 	);
 
-	const { data: availableUsers } = useQuery(
+	const { data: availableUsers } = useAnalyticsQuery(
 		orpc.analytics.learnings.users.queryOptions({}),
 	);
 
-	const { data: availableProjects } = useQuery(
+	const { data: availableProjects } = useAnalyticsQuery(
 		orpc.analytics.learnings.projects.queryOptions({}),
 	);
 
-	const { data: userMappings } = useQuery(
+	const { data: userMappings } = useAnalyticsQuery(
 		orpc.analytics.users.mappings.queryOptions({ input: { days: 30 } }),
 	);
 

--- a/apps/web/src/pages/dashboard/OrganizationPage.tsx
+++ b/apps/web/src/pages/dashboard/OrganizationPage.tsx
@@ -11,7 +11,7 @@ import {
 	UserPlus,
 	X,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { AnalyticsCard } from "../../components/analytics/AnalyticsCard";
 import { PageHeader } from "../../components/analytics/PageHeader";
@@ -28,32 +28,18 @@ import {
 	SelectValue,
 } from "../../components/ui/select";
 import { useOrganization } from "../../contexts/OrganizationContext";
+import { useFullOrganization } from "../../hooks/useFullOrganization";
 import { authClient } from "../../lib/auth-client";
-
-interface FullOrg {
-	id: string;
-	name: string;
-	slug: string;
-	members: readonly {
-		id: string;
-		userId: string;
-		role: string;
-		user: { id: string; name: string; email: string; image: string | null };
-	}[];
-	invitations: readonly {
-		id: string;
-		email: string;
-		role: string | null;
-		status: string;
-	}[];
-}
 
 export function OrganizationPage() {
 	const { activeOrg, organizations, switchOrg } = useOrganization();
 	const { data: session } = authClient.useSession();
 	const navigate = useNavigate();
-	const [fullOrg, setFullOrg] = useState<FullOrg | null>(null);
-	const [loading, setLoading] = useState(true);
+	const {
+		data: fullOrg,
+		isLoading: loading,
+		invalidate,
+	} = useFullOrganization(activeOrg?.id);
 	const [inviteEmail, setInviteEmail] = useState("");
 	const [inviteRole, setInviteRole] = useState("member");
 	const [inviting, setInviting] = useState(false);
@@ -107,25 +93,8 @@ export function OrganizationPage() {
 
 		setEditing(false);
 		setSaving(false);
-		await fetchOrg();
+		invalidate();
 	};
-
-	const fetchOrg = async () => {
-		if (!activeOrg) return;
-		setLoading(true);
-		const res = await authClient.organization.getFullOrganization({
-			query: { organizationId: activeOrg.id },
-		});
-		if (res.data) {
-			setFullOrg(res.data as unknown as FullOrg);
-		}
-		setLoading(false);
-	};
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: refetch when org changes
-	useEffect(() => {
-		fetchOrg();
-	}, [activeOrg?.id]);
 
 	const handleInvite = async (e: React.FormEvent) => {
 		e.preventDefault();
@@ -139,7 +108,7 @@ export function OrganizationPage() {
 			const link = `${window.location.origin}/invitation/${res.data.id}`;
 			setInviteLink(link);
 			setInviteEmail("");
-			await fetchOrg();
+			invalidate();
 		}
 		setInviting(false);
 	};
@@ -153,12 +122,12 @@ export function OrganizationPage() {
 
 	const handleRemoveMember = async (memberIdOrEmail: string) => {
 		await authClient.organization.removeMember({ memberIdOrEmail });
-		await fetchOrg();
+		invalidate();
 	};
 
 	const handleCancelInvitation = async (invitationId: string) => {
 		await authClient.organization.cancelInvitation({ invitationId });
-		await fetchOrg();
+		invalidate();
 	};
 
 	if (!activeOrg) {

--- a/apps/web/src/pages/dashboard/OverviewPage.tsx
+++ b/apps/web/src/pages/dashboard/OverviewPage.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import {
 	Activity,
 	Bot,
@@ -17,6 +16,7 @@ import { ModelTokensChart } from "@/components/charts/ModelTokensChart";
 import { UsageTrendChart } from "@/components/charts/UsageTrendChart";
 import { Spinner } from "@/components/ui/spinner";
 import { useDateRange } from "@/contexts/DateRangeContext";
+import { useAnalyticsQuery } from "@/hooks/useAnalyticsQuery";
 import { orpc } from "@/lib/orpc";
 
 export function OverviewPage() {
@@ -24,21 +24,21 @@ export function OverviewPage() {
 		useDateRange();
 	const days = calculateDays();
 
-	const { data: kpis, isLoading: kpisLoading } = useQuery(
+	const { data: kpis, isLoading: kpisLoading } = useAnalyticsQuery(
 		orpc.analytics.overview.kpis.queryOptions({ input: { days } }),
 	);
 
-	const { data: usageTrendData } = useQuery(
+	const { data: usageTrendData } = useAnalyticsQuery(
 		orpc.analytics.overview.usageTrend.queryOptions({ input: { days } }),
 	);
 
-	const { data: modelTokensData } = useQuery(
+	const { data: modelTokensData } = useAnalyticsQuery(
 		orpc.analytics.overview.modelTokensTrend.queryOptions({
 			input: { days },
 		}),
 	);
 
-	const { data: insights } = useQuery(
+	const { data: insights } = useAnalyticsQuery(
 		orpc.analytics.overview.insights.queryOptions({ input: { days } }),
 	);
 

--- a/apps/web/src/pages/dashboard/ProfilePage.tsx
+++ b/apps/web/src/pages/dashboard/ProfilePage.tsx
@@ -1,14 +1,10 @@
 import { Github, Loader2, LogOut, Mail, User } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { AnalyticsCard } from "../../components/analytics/AnalyticsCard";
 import { PageHeader } from "../../components/analytics/PageHeader";
 import { Button } from "../../components/ui/button";
+import { useAccounts } from "../../hooks/useAccounts";
 import { authClient, signOut } from "../../lib/auth-client";
-
-interface Account {
-	id: string;
-	providerId: string;
-}
 
 const providers = [
 	{ id: "google", label: "Google", icon: Mail },
@@ -17,20 +13,8 @@ const providers = [
 
 export function ProfilePage() {
 	const { data: session } = authClient.useSession();
-	const [accounts, setAccounts] = useState<readonly Account[]>([]);
-	const [loading, setLoading] = useState(true);
+	const { accounts, isLoading: loading } = useAccounts();
 	const [linkingProvider, setLinkingProvider] = useState<string | null>(null);
-
-	useEffect(() => {
-		authClient
-			.listAccounts()
-			.then((res) => {
-				if (res.data) {
-					setAccounts(res.data);
-				}
-			})
-			.finally(() => setLoading(false));
-	}, []);
 
 	const linkedProviders = new Set(accounts.map((a) => a.providerId));
 

--- a/apps/web/src/pages/dashboard/ProjectDetailPage.tsx
+++ b/apps/web/src/pages/dashboard/ProjectDetailPage.tsx
@@ -1,5 +1,4 @@
 import type { ProjectContributor, ProjectError } from "@rudel/api-routes";
-import { useQuery } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Activity, ArrowLeft, Clock, Code, Users, Zap } from "lucide-react";
 import { useMemo } from "react";
@@ -21,6 +20,7 @@ import { StatCard } from "@/components/analytics/StatCard";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import { useDateRange } from "@/contexts/DateRangeContext";
+import { useAnalyticsQuery } from "@/hooks/useAnalyticsQuery";
 import { useChartTheme } from "@/hooks/useChartTheme";
 import { decodeProjectPath, formatUsername } from "@/lib/format";
 import { orpc } from "@/lib/orpc";
@@ -35,31 +35,31 @@ export function ProjectDetailPage() {
 	const chartTheme = useChartTheme();
 	const days = calculateDays();
 
-	const { data: details, isLoading } = useQuery(
+	const { data: details, isLoading } = useAnalyticsQuery(
 		orpc.analytics.projects.details.queryOptions({
 			input: { projectPath, days },
 		}),
 	);
 
-	const { data: contributors } = useQuery(
+	const { data: contributors } = useAnalyticsQuery(
 		orpc.analytics.projects.contributors.queryOptions({
 			input: { projectPath, days },
 		}),
 	);
 
-	const { data: features } = useQuery(
+	const { data: features } = useAnalyticsQuery(
 		orpc.analytics.projects.features.queryOptions({
 			input: { projectPath, days },
 		}),
 	);
 
-	const { data: errors } = useQuery(
+	const { data: errors } = useAnalyticsQuery(
 		orpc.analytics.projects.errors.queryOptions({
 			input: { projectPath, days },
 		}),
 	);
 
-	const { data: userMappings } = useQuery(
+	const { data: userMappings } = useAnalyticsQuery(
 		orpc.analytics.users.mappings.queryOptions({ input: { days: 30 } }),
 	);
 

--- a/apps/web/src/pages/dashboard/ProjectsListPage.tsx
+++ b/apps/web/src/pages/dashboard/ProjectsListPage.tsx
@@ -1,5 +1,4 @@
 import type { ProjectInvestment } from "@rudel/api-routes";
-import { useQuery } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import {
 	Clock,
@@ -18,6 +17,7 @@ import { StatCard } from "@/components/analytics/StatCard";
 import { ProjectTrendChart } from "@/components/charts/ProjectTrendChart";
 import { DataTable } from "@/components/ui/data-table";
 import { useDateRange } from "@/contexts/DateRangeContext";
+import { useAnalyticsQuery } from "@/hooks/useAnalyticsQuery";
 import { encodeProjectPath } from "@/lib/format";
 import { orpc } from "@/lib/orpc";
 
@@ -115,11 +115,11 @@ export function ProjectsListPage() {
 		useDateRange();
 	const days = calculateDays();
 
-	const { data: projects, isLoading } = useQuery(
+	const { data: projects, isLoading } = useAnalyticsQuery(
 		orpc.analytics.projects.investment.queryOptions({ input: { days } }),
 	);
 
-	const { data: trendData } = useQuery(
+	const { data: trendData } = useAnalyticsQuery(
 		orpc.analytics.projects.trends.queryOptions({ input: { days } }),
 	);
 

--- a/apps/web/src/pages/dashboard/ROIPage.tsx
+++ b/apps/web/src/pages/dashboard/ROIPage.tsx
@@ -2,7 +2,6 @@ import type {
 	DeveloperCostBreakdown,
 	ProjectCostBreakdown,
 } from "@rudel/api-routes";
-import { useQuery } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import {
 	Activity,
@@ -30,6 +29,7 @@ import { DataTable } from "@/components/ui/data-table";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { useDateRange } from "@/contexts/DateRangeContext";
+import { useAnalyticsQuery } from "@/hooks/useAnalyticsQuery";
 import { useChartTheme } from "@/hooks/useChartTheme";
 import { formatUsername } from "@/lib/format";
 import { orpc } from "@/lib/orpc";
@@ -47,23 +47,23 @@ export function ROIPage() {
 		devHourlyRate: 100,
 	});
 
-	const { data: metrics, isLoading } = useQuery(
+	const { data: metrics, isLoading } = useAnalyticsQuery(
 		orpc.analytics.roi.metrics.queryOptions({ input: { days } }),
 	);
 
-	const { data: trends } = useQuery(
+	const { data: trends } = useAnalyticsQuery(
 		orpc.analytics.roi.trends.queryOptions({ input: { days: 56 } }),
 	);
 
-	const { data: developerCosts } = useQuery(
+	const { data: developerCosts } = useAnalyticsQuery(
 		orpc.analytics.roi.breakdownDevelopers.queryOptions({ input: { days } }),
 	);
 
-	const { data: projectCosts } = useQuery(
+	const { data: projectCosts } = useAnalyticsQuery(
 		orpc.analytics.roi.breakdownProjects.queryOptions({ input: { days } }),
 	);
 
-	const { data: userMappings } = useQuery(
+	const { data: userMappings } = useAnalyticsQuery(
 		orpc.analytics.users.mappings.queryOptions({ input: { days: 90 } }),
 	);
 

--- a/apps/web/src/pages/dashboard/SessionDetailPage.tsx
+++ b/apps/web/src/pages/dashboard/SessionDetailPage.tsx
@@ -1,16 +1,16 @@
-import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 import { ConversationList } from "@/components/sessions/conversation/ConversationList";
 import { SessionHeader } from "@/components/sessions/SessionHeader";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useAnalyticsQuery } from "@/hooks/useAnalyticsQuery";
 import { useSession } from "@/hooks/useSession";
 import { orpc } from "@/lib/orpc";
 
 export function SessionDetailPage() {
 	const { sessionId } = useParams<{ sessionId: string }>();
 
-	const { data, isLoading, error } = useQuery(
+	const { data, isLoading, error } = useAnalyticsQuery(
 		orpc.analytics.sessions.detail.queryOptions({
 			input: { sessionId: sessionId as string },
 		}),

--- a/apps/web/src/pages/dashboard/SessionsListPage.tsx
+++ b/apps/web/src/pages/dashboard/SessionsListPage.tsx
@@ -2,7 +2,6 @@ import type {
 	DimensionAnalysisInput,
 	SessionAnalytics,
 } from "@rudel/api-routes";
-import { useQuery } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Activity, Clock, Timer } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -24,6 +23,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { useDateRange } from "@/contexts/DateRangeContext";
+import { useAnalyticsQuery } from "@/hooks/useAnalyticsQuery";
 import { calculateCost, formatUsername } from "@/lib/format";
 import { orpc } from "@/lib/orpc";
 
@@ -64,37 +64,38 @@ export function SessionsListPage() {
 		return () => clearTimeout(timer);
 	}, [selectedDimension, selectedMetric, selectedSplitBy]);
 
-	const { data: summary } = useQuery(
+	const { data: summary } = useAnalyticsQuery(
 		orpc.analytics.sessions.summary.queryOptions({ input: { days } }),
 	);
 
-	const { data: comparison } = useQuery(
+	const { data: comparison } = useAnalyticsQuery(
 		orpc.analytics.sessions.summaryComparison.queryOptions({
 			input: { days },
 		}),
 	);
 
-	const { data: sessions, isLoading } = useQuery(
+	const { data: sessions, isLoading } = useAnalyticsQuery(
 		orpc.analytics.sessions.list.queryOptions({
 			input: { days, limit: 100, sortBy: "session_date", sortOrder: "desc" },
 		}),
 	);
 
-	const { data: userMappings } = useQuery(
+	const { data: userMappings } = useAnalyticsQuery(
 		orpc.analytics.users.mappings.queryOptions({ input: { days: 30 } }),
 	);
 
-	const { data: dimensionData, isLoading: dimensionLoading } = useQuery(
-		orpc.analytics.sessions.dimensionAnalysis.queryOptions({
-			input: {
-				days,
-				dimension: debouncedDimension,
-				metric: debouncedMetric,
-				splitBy: debouncedSplitBy || undefined,
-				limit: 10,
-			},
-		}),
-	);
+	const { data: dimensionData, isLoading: dimensionLoading } =
+		useAnalyticsQuery(
+			orpc.analytics.sessions.dimensionAnalysis.queryOptions({
+				input: {
+					days,
+					dimension: debouncedDimension,
+					metric: debouncedMetric,
+					splitBy: debouncedSplitBy || undefined,
+					limit: 10,
+				},
+			}),
+		);
 
 	const userMap = useMemo(() => {
 		const map = new Map<string, string>();


### PR DESCRIPTION
## Summary

Optimized web app performance by implementing org-scoped query cache keys and SWR (stale-while-revalidate) behavior. Switching orgs no longer invalidates the entire React Query cache, allowing instant restoration of cached data when returning to previously viewed organizations. Wrapped auth API calls in dedicated React Query hooks for consistent data management across the app.

## Changes

- **QueryClient**: Configure with SWR defaults (staleTime: 0, gcTime: 10min, refetchOnWindowFocus: false)
- **useAnalyticsQuery**: New hook prepending org ID to all analytics query keys for org-scoped caching
- **useFullOrganization & useAccounts**: New hooks wrapping auth API calls in React Query with invalidate callbacks
- **OrganizationContext**: Remove queryClient.invalidateQueries() on org switches (no longer needed with org-scoped keys)
- **10 analytics pages**: Migrate from useQuery to useAnalyticsQuery for instant org-switching UX
- **3 auth pages**: Replace useEffect/useState patterns with new query hooks

## Test plan

- [ ] Switch between organizations → verify cached analytics data loads instantly on return
- [ ] Navigate through analytics pages → confirm no loading spinners on cached data
- [ ] OrganizationPage: invite/remove members → verify member list refreshes via invalidate()
- [ ] ProfilePage: linked accounts → load via React Query (cached on return)
- [ ] DeleteOrganizationDialog: open/close → verify session count query only runs when dialog is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)