### PR TITLE
fix: move agent-adapters to devDependencies

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -41,11 +41,11 @@
 		"@logtape/logtape": "^2.0.4",
 		"@orpc/client": "^1.13.5",
 		"@orpc/contract": "^1.13.5",
-		"@rudel/agent-adapters": "workspace:*",
 		"@stricli/core": "^1.2.5",
 		"p-map": "^7.0.4"
 	},
 	"devDependencies": {
+		"@rudel/agent-adapters": "workspace:*",
 		"@rudel/api-routes": "workspace:*",
 		"@rudel/typescript-config": "workspace:*",
 		"bun-types": "latest",

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/cli": {
       "name": "rudel",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "bin": {
         "rudel": "./dist/cli.js",
       },
@@ -46,11 +46,11 @@
         "@logtape/logtape": "^2.0.4",
         "@orpc/client": "^1.13.5",
         "@orpc/contract": "^1.13.5",
-        "@rudel/agent-adapters": "workspace:*",
         "@stricli/core": "^1.2.5",
         "p-map": "^7.0.4",
       },
       "devDependencies": {
+        "@rudel/agent-adapters": "workspace:*",
         "@rudel/api-routes": "workspace:*",
         "@rudel/typescript-config": "workspace:*",
         "bun-types": "latest",


### PR DESCRIPTION
## Summary

Moves `@rudel/agent-adapters` from `dependencies` to `devDependencies` in the CLI package. Since the package is a private workspace-only package that gets bundled into the CLI with `bun build`, it doesn't need to be a runtime dependency. This fixes the `EUNSUPPORTEDPROTOCOL` error npm users encountered when installing the published package.

## Test plan

- [x] Verification passed: type check, lint, tests, build all succeed
- [x] CLI still builds correctly with bundled code
- [x] All 35 CLI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)