### PR TITLE
🐛 Fix: Handle UInt64 values and loading states in overview KPIs

### DIFF
--- a/apps/api/src/services/overview.service.ts
+++ b/apps/api/src/services/overview.service.ts
@@ -40,16 +40,26 @@ export async function getOverviewKPIs(
   `;
 
 	const result = await queryClickhouse<OverviewKPIs>(query);
-	return (
-		result[0] || {
+	const row = result[0];
+	if (!row) {
+		return {
 			distinct_users: 0,
 			distinct_sessions: 0,
 			distinct_projects: 0,
 			distinct_subagents: 0,
 			distinct_skills: 0,
 			distinct_slash_commands: 0,
-		}
-	);
+		};
+	}
+	// ClickHouse returns UInt64 as strings when output_format_json_quote_64bit_integers is true (the default)
+	return {
+		distinct_users: Number(row.distinct_users),
+		distinct_sessions: Number(row.distinct_sessions),
+		distinct_projects: Number(row.distinct_projects),
+		distinct_subagents: Number(row.distinct_subagents),
+		distinct_skills: Number(row.distinct_skills),
+		distinct_slash_commands: Number(row.distinct_slash_commands),
+	};
 }
 
 /**

--- a/apps/web/src/pages/dashboard/OverviewPage.tsx
+++ b/apps/web/src/pages/dashboard/OverviewPage.tsx
@@ -24,7 +24,11 @@ export function OverviewPage() {
 		useDateRange();
 	const days = calculateDays();
 
-	const { data: kpis, isLoading: kpisLoading } = useAnalyticsQuery(
+	const {
+		data: kpis,
+		isLoading: kpisLoading,
+		isError: kpisError,
+	} = useAnalyticsQuery(
 		orpc.analytics.overview.kpis.queryOptions({ input: { days } }),
 	);
 
@@ -70,7 +74,10 @@ export function OverviewPage() {
 				</div>
 			)}
 
-			{!kpisLoading && kpis && kpis.distinct_sessions === 0 && <CliSetupHint />}
+			{!kpisLoading &&
+				(kpisError || (kpis && kpis.distinct_sessions === 0)) && (
+					<CliSetupHint />
+				)}
 
 			{hasData && (
 				<>


### PR DESCRIPTION
This commit addresses an issue where UInt64 values from ClickHouse were not being correctly handled, causing errors in the overview KPIs. It also improves the handling of loading states to display the CLI setup hint when there are errors or no sessions.

Entire-Checkpoint: f747d61932ff
