### PR TITLE
fix: optimize dashboard loading by caching active org in localStorage

### DIFF
--- a/apps/api/src/services/overview.service.ts
+++ b/apps/api/src/services/overview.service.ts
@@ -33,7 +33,8 @@ export async function getOverviewKPIs(
       uniq(if(git_remote != '', git_remote, if(repository != '', repository, project_path))) as distinct_projects,
       (SELECT uniqExact(val) FROM rudel.session_analytics ARRAY JOIN subagent_types as val WHERE ${buildDateFilter(days)} AND organization_id = '${org}' AND val != '') as distinct_subagents,
       (SELECT uniqExact(val) FROM rudel.session_analytics ARRAY JOIN skills as val WHERE ${buildDateFilter(days)} AND organization_id = '${org}' AND val != '') as distinct_skills,
-      (SELECT uniqExact(val) FROM rudel.session_analytics ARRAY JOIN slash_commands as val WHERE ${buildDateFilter(days)} AND organization_id = '${org}' AND val != '') as distinct_slash_commands
+      (SELECT uniqExact(val) FROM rudel.session_analytics ARRAY JOIN slash_commands as val WHERE ${buildDateFilter(days)} AND organization_id = '${org}' AND val != '') as distinct_slash_commands,
+      (SELECT count() FROM rudel.session_analytics WHERE organization_id = '${org}') as total_sessions
     FROM rudel.session_analytics
     WHERE ${dateFilter}
       AND organization_id = '${org}'
@@ -49,6 +50,7 @@ export async function getOverviewKPIs(
 			distinct_subagents: 0,
 			distinct_skills: 0,
 			distinct_slash_commands: 0,
+			total_sessions: 0,
 		};
 	}
 	// ClickHouse returns UInt64 as strings when output_format_json_quote_64bit_integers is true (the default)
@@ -59,6 +61,7 @@ export async function getOverviewKPIs(
 		distinct_subagents: Number(row.distinct_subagents),
 		distinct_skills: Number(row.distinct_skills),
 		distinct_slash_commands: Number(row.distinct_slash_commands),
+		total_sessions: Number(row.total_sessions),
 	};
 }
 

--- a/apps/web/src/components/analytics/NoSessionsInRange.tsx
+++ b/apps/web/src/components/analytics/NoSessionsInRange.tsx
@@ -1,0 +1,36 @@
+import { CalendarX } from "lucide-react";
+import { useDateRange } from "@/contexts/DateRangeContext";
+import { AnalyticsCard } from "./AnalyticsCard";
+
+export function NoSessionsInRange() {
+	const { setStartDate, setEndDate } = useDateRange();
+
+	const handleViewAllTime = () => {
+		setStartDate("2024-01-01");
+		setEndDate(new Date().toISOString().split("T")[0]);
+	};
+
+	return (
+		<AnalyticsCard className="mt-4">
+			<div className="flex flex-col items-center justify-center py-20 px-4 text-center">
+				<div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mb-6">
+					<CalendarX className="w-8 h-8 text-muted-foreground" />
+				</div>
+				<h3 className="text-lg font-semibold text-foreground mb-3">
+					No sessions in this time range
+				</h3>
+				<p className="text-sm text-muted-foreground max-w-lg mb-6">
+					There are no sessions matching the selected dates. Try expanding the
+					date range or view all sessions.
+				</p>
+				<button
+					type="button"
+					onClick={handleViewAllTime}
+					className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 transition-colors"
+				>
+					View all time
+				</button>
+			</div>
+		</AnalyticsCard>
+	);
+}

--- a/apps/web/src/contexts/OrganizationContext.tsx
+++ b/apps/web/src/contexts/OrganizationContext.tsx
@@ -21,6 +21,32 @@ interface OrganizationContextType {
 	isLoading: boolean;
 }
 
+const ACTIVE_ORG_CACHE_KEY = "rudel:activeOrg";
+
+function getCachedOrg(): Organization | null {
+	try {
+		const raw = localStorage.getItem(ACTIVE_ORG_CACHE_KEY);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw);
+		if (parsed && typeof parsed.id === "string") return parsed;
+	} catch {
+		// Corrupted cache, ignore
+	}
+	return null;
+}
+
+function setCachedOrg(org: Organization | null) {
+	try {
+		if (org) {
+			localStorage.setItem(ACTIVE_ORG_CACHE_KEY, JSON.stringify(org));
+		} else {
+			localStorage.removeItem(ACTIVE_ORG_CACHE_KEY);
+		}
+	} catch {
+		// Storage full or unavailable, ignore
+	}
+}
+
 const OrganizationContext = createContext<OrganizationContextType | undefined>(
 	undefined,
 );
@@ -31,6 +57,19 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
 	const { data: orgs, isPending: listLoading } =
 		authClient.useListOrganizations();
 	const [switching, setSwitching] = useState(false);
+	const [cachedOrg] = useState(getCachedOrg);
+
+	// Persist active org to localStorage whenever it changes
+	useEffect(() => {
+		if (activeOrg) {
+			setCachedOrg({
+				id: activeOrg.id,
+				name: activeOrg.name,
+				slug: activeOrg.slug,
+				logo: activeOrg.logo,
+			});
+		}
+	}, [activeOrg]);
 
 	// Auto-set active org if none is set but user has orgs
 	useEffect(() => {
@@ -58,10 +97,13 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
 		}
 	};
 
+	// Use cached org as optimistic value while better-auth is still loading
+	const resolvedOrg = activeOrg ?? (activeLoading ? cachedOrg : null);
+
 	return (
 		<OrganizationContext.Provider
 			value={{
-				activeOrg: activeOrg ?? null,
+				activeOrg: resolvedOrg,
 				organizations: orgs ?? [],
 				switchOrg,
 				isLoading: activeLoading || listLoading || switching,

--- a/apps/web/src/hooks/useAnalyticsQuery.ts
+++ b/apps/web/src/hooks/useAnalyticsQuery.ts
@@ -12,5 +12,6 @@ export function useAnalyticsQuery<TData>(
 	return useQuery({
 		...options,
 		queryKey: ["org", activeOrg?.id, ...(options.queryKey ?? [])],
+		enabled: !!activeOrg?.id && options.enabled !== false,
 	});
 }

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -12,6 +12,7 @@ export async function signOut() {
 	queryClient.clear();
 	localStorage.removeItem("dateRange");
 	localStorage.removeItem("globalFilters");
+	localStorage.removeItem("rudel:activeOrg");
 	// Notify all better-auth signal atoms to trigger refetches,
 	// clearing stale org data that /sign-out doesn't reset
 	for (const key of Object.keys(authClient.$store.atoms)) {

--- a/apps/web/src/pages/dashboard/OverviewPage.tsx
+++ b/apps/web/src/pages/dashboard/OverviewPage.tsx
@@ -10,6 +10,7 @@ import { AnalyticsCard } from "@/components/analytics/AnalyticsCard";
 import { CliSetupHint } from "@/components/analytics/CliSetupHint";
 import { DatePicker } from "@/components/analytics/DatePicker";
 import { InsightCard } from "@/components/analytics/InsightCard";
+import { NoSessionsInRange } from "@/components/analytics/NoSessionsInRange";
 import { PageHeader } from "@/components/analytics/PageHeader";
 import { StatCard } from "@/components/analytics/StatCard";
 import { ModelTokensChart } from "@/components/charts/ModelTokensChart";
@@ -26,7 +27,7 @@ export function OverviewPage() {
 
 	const {
 		data: kpis,
-		isLoading: kpisLoading,
+		isPending: kpisLoading,
 		isError: kpisError,
 	} = useAnalyticsQuery(
 		orpc.analytics.overview.kpis.queryOptions({ input: { days } }),
@@ -47,6 +48,8 @@ export function OverviewPage() {
 	);
 
 	const hasData = !kpisLoading && kpis && kpis.distinct_sessions > 0;
+	const hasAnySessions = kpis && kpis.total_sessions > 0;
+	const showDatePicker = hasData || (!kpisLoading && hasAnySessions);
 
 	return (
 		<div className="px-8 py-6">
@@ -54,7 +57,7 @@ export function OverviewPage() {
 				title="Dashboard Overview"
 				description="Track your team's Claude Code usage and metrics"
 				actions={
-					hasData ? (
+					showDatePicker ? (
 						<DatePicker
 							startDate={startDate}
 							endDate={endDate}
@@ -74,10 +77,11 @@ export function OverviewPage() {
 				</div>
 			)}
 
-			{!kpisLoading &&
-				(kpisError || (kpis && kpis.distinct_sessions === 0)) && (
-					<CliSetupHint />
-				)}
+			{!kpisLoading && !hasData && hasAnySessions && <NoSessionsInRange />}
+
+			{!kpisLoading && (kpisError || (kpis && kpis.total_sessions === 0)) && (
+				<CliSetupHint />
+			)}
 
 			{hasData && (
 				<>

--- a/packages/api-routes/src/schemas/analytics.ts
+++ b/packages/api-routes/src/schemas/analytics.ts
@@ -26,6 +26,7 @@ export const OverviewKPIsSchema = z.object({
 	distinct_subagents: z.number(),
 	distinct_skills: z.number(),
 	distinct_slash_commands: z.number(),
+	total_sessions: z.number(),
 });
 
 export const UsageTrendDataSchema = z.object({


### PR DESCRIPTION
Gate analytics queries on activeOrg being available and cache the active
org in localStorage for instant availability on return visits. This
eliminates the empty state flash caused by queries firing before the org
was resolved through better-auth's multi-request flow.

Also distinguish between "no sessions at all" (show CLI setup hint) and
"no sessions in date range" (show date range hint) using a new
total_sessions KPI.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Entire-Checkpoint: fa25698cc77a
