### PR TITLE
fix: add missing agent-adapters package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY package.json bun.lock ./
 COPY apps/api/package.json apps/api/package.json
 COPY apps/cli/package.json apps/cli/package.json
 COPY apps/web/package.json apps/web/package.json
+COPY packages/agent-adapters/package.json packages/agent-adapters/package.json
 COPY packages/api-routes/package.json packages/api-routes/package.json
 COPY packages/ch-schema/package.json packages/ch-schema/package.json
 COPY packages/sql-schema/package.json packages/sql-schema/package.json


### PR DESCRIPTION
## Summary
- Fixed Docker build failure caused by missing workspace dependency
- Added `COPY packages/agent-adapters/package.json` to Dockerfile so `bun install` can resolve `@rudel/agent-adapters`
- This was blocking all main branch deploys for the last 5+ commits

## Test plan
- [x] Verification passed (lint, type check, tests)
- [x] Dockerfile now includes all workspace packages needed by lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)