### PR TITLE
chore: add migration to drop repository column

### DIFF
--- a/packages/ch-schema/chx/meta/snapshot.json
+++ b/packages/ch-schema/chx/meta/snapshot.json
@@ -1,6 +1,6 @@
 {
 	"version": 1,
-	"generatedAt": "2026-03-03T16:02:52.394Z",
+	"generatedAt": "2026-03-03T18:10:35.114Z",
 	"definitions": [
 		{
 			"database": "rudel",
@@ -28,11 +28,6 @@
 				{
 					"name": "project_path",
 					"type": "String"
-				},
-				{
-					"name": "repository",
-					"type": "String",
-					"nullable": true
 				},
 				{
 					"name": "git_remote",
@@ -121,11 +116,6 @@
 					"type": "String"
 				},
 				{
-					"name": "repository",
-					"type": "String",
-					"nullable": true
-				},
-				{
 					"name": "git_remote",
 					"type": "String",
 					"default": "''"
@@ -205,11 +195,6 @@
 				{
 					"name": "project_path",
 					"type": "String"
-				},
-				{
-					"name": "repository",
-					"type": "String",
-					"nullable": true
 				},
 				{
 					"name": "git_remote",
@@ -402,12 +387,6 @@
 				{
 					"name": "idx_project_path",
 					"expression": "project_path",
-					"type": "set",
-					"granularity": 4
-				},
-				{
-					"name": "idx_repository",
-					"expression": "repository",
 					"type": "set",
 					"granularity": 4
 				},

--- a/packages/ch-schema/chx/migrations/20260303181035_auto.sql
+++ b/packages/ch-schema/chx/migrations/20260303181035_auto.sql
@@ -1,0 +1,19 @@
+-- chkit-migration-format: v1
+-- generated-at: 2026-03-03T18:10:35.114Z
+-- cli-version: 0.1.0-beta.15
+-- definition-count: 5
+-- operation-count: 4
+-- rename-suggestion-count: 0
+-- risk-summary: safe=0, caution=1, danger=3
+
+-- operation: alter_table_drop_column key=table:rudel.claude_sessions:column:repository risk=danger
+ALTER TABLE rudel.claude_sessions DROP COLUMN IF EXISTS `repository`;
+
+-- operation: alter_table_drop_column key=table:rudel.codex_sessions:column:repository risk=danger
+ALTER TABLE rudel.codex_sessions DROP COLUMN IF EXISTS `repository`;
+
+-- operation: alter_table_drop_column key=table:rudel.session_analytics:column:repository risk=danger
+ALTER TABLE rudel.session_analytics DROP COLUMN IF EXISTS `repository`;
+
+-- operation: alter_table_drop_index key=table:rudel.session_analytics:index:idx_repository risk=caution
+ALTER TABLE rudel.session_analytics DROP INDEX IF EXISTS `idx_repository`;


### PR DESCRIPTION
## Summary
- Adds ClickHouse migration to drop the `repository` column and `idx_repository` index, following #114

## Migration operations
- `ALTER TABLE rudel.claude_sessions DROP COLUMN IF EXISTS repository`
- `ALTER TABLE rudel.codex_sessions DROP COLUMN IF EXISTS repository`
- `ALTER TABLE rudel.session_analytics DROP COLUMN IF EXISTS repository`
- `ALTER TABLE rudel.session_analytics DROP INDEX IF EXISTS idx_repository`

## Test plan
- [ ] Run `ch:migrate` against CI after merge
- [ ] Run `ch:migrate:prd` against production after CI verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)