### PR TITLE
ci: tighten PR title lint to validate single-commit messages

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -31,3 +31,9 @@ jobs:
             ci
             chore
             revert
+          # If there's only one commit, also validate its message matches
+          # the PR title. This prevents squash merges from using a
+          # non-conventional commit message (e.g. with emoji prefixes)
+          # when GitHub's COMMIT_OR_PR_TITLE setting picks the commit.
+          validateSingleCommit: true
+          validateSingleCommitMatchesPrTitle: true


### PR DESCRIPTION
## Summary
- Added validateSingleCommit and validateSingleCommitMatchesPrTitle checks to PR title lint workflow
- For single-commit PRs, the lint now validates the commit message itself follows conventional format and matches the PR title
- Updated repo squash merge setting to always use PR title instead of COMMIT_OR_PR_TITLE
- This prevents non-conventional commit messages with emoji prefixes from landing on main and breaking release-please

## Test plan
- [x] Ran bun run verify (all checks pass)
- [x] CI will validate with new PR title lint on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)