### PR TITLE
test: add 36 analytics endpoint integration tests + seeding script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,6 +9,7 @@
 		"check-types": "tsc --noEmit",
 		"test": "bun test",
 		"test:integration": "bun test src/__tests__/ingest-clickhouse.integration.ts",
+		"test:analytics": "bun test src/__tests__/analytics.integration.ts",
 		"test:migrate": "bun test src/__tests__/migrate-sessions.integration.ts"
 	},
 	"dependencies": {

--- a/apps/api/src/__tests__/analytics.integration.ts
+++ b/apps/api/src/__tests__/analytics.integration.ts
@@ -1,0 +1,568 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+import { resolve } from "node:path";
+import {
+	DeveloperCostBreakdownSchema,
+	DeveloperDetailsSchema,
+	DeveloperErrorSchema,
+	DeveloperFeatureUsageSchema,
+	DeveloperProjectSchema,
+	DeveloperSessionSchema,
+	DeveloperSummarySchema,
+	DeveloperTimelineSchema,
+	DeveloperTrendDataPointSchema,
+	DimensionAnalysisDataPointSchema,
+	ErrorTrendDataPointSchema,
+	InsightSchema,
+	LearningEntrySchema,
+	LearningsFeedStatsSchema,
+	LearningsTrendDataPointSchema,
+	ModelTokensTrendDataSchema,
+	OverviewKPIsSchema,
+	ProjectContributorSchema,
+	ProjectCostBreakdownSchema,
+	ProjectErrorSchema,
+	ProjectFeatureUsageSchema,
+	RecurringErrorSchema,
+	ROIMetricsSchema,
+	ROITrendSchema,
+	SessionAnalyticsSchema,
+	SessionAnalyticsSummaryComparisonSchema,
+	SessionAnalyticsSummarySchema,
+	SessionDetailSchema,
+	SuccessRateSchema,
+	UsageTrendDataSchema,
+} from "@rudel/api-routes";
+
+// ── Inline test server helper (avoids cross-package TS rootDir issue) ──
+
+const MONOREPO_ROOT = resolve(import.meta.dir, "..", "..", "..", "..");
+
+interface TestServer {
+	port: number;
+	baseUrl: string;
+	stop: () => Promise<void>;
+	ensureAlive: () => Promise<void>;
+}
+
+function spawnServer(env: Record<string, string | undefined>) {
+	const proc = Bun.spawn(["bun", "apps/api/src/index.ts"], {
+		cwd: MONOREPO_ROOT,
+		stdout: "pipe",
+		stderr: "pipe",
+		env,
+	});
+	proc.unref();
+	return proc;
+}
+
+function drainStreams(proc: ReturnType<typeof Bun.spawn>) {
+	if (proc.stdout instanceof ReadableStream)
+		proc.stdout.pipeTo(new WritableStream()).catch(() => {});
+	if (proc.stderr instanceof ReadableStream)
+		proc.stderr.pipeTo(new WritableStream()).catch(() => {});
+}
+
+async function parseReadyPort(
+	proc: ReturnType<typeof Bun.spawn>,
+): Promise<number> {
+	const stdout = proc.stdout;
+	if (!stdout || !(stdout instanceof ReadableStream))
+		throw new Error("Server process has no readable stdout");
+	const reader = stdout.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	const deadline = Date.now() + 30_000;
+	try {
+		while (Date.now() < deadline) {
+			const { value, done } = await reader.read();
+			if (done) break;
+			buffer += decoder.decode(value, { stream: true });
+			const match = buffer.match(/listening on https?:\/\/localhost:(\d+)/i);
+			if (match?.[1]) {
+				reader.releaseLock();
+				return Number.parseInt(match[1], 10);
+			}
+		}
+	} catch {
+		// fall through
+	}
+	proc.kill();
+	throw new Error(`Server did not become ready within 30s`);
+}
+
+async function waitForReady(baseUrl: string): Promise<void> {
+	const deadline = Date.now() + 10_000;
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(`${baseUrl}/health`, {
+				signal: AbortSignal.timeout(2000),
+			});
+			if (res.ok) return;
+		} catch {
+			// retry
+		}
+		await Bun.sleep(200);
+	}
+	throw new Error(`Server at ${baseUrl} did not respond within 10s`);
+}
+
+async function startTestServer(): Promise<TestServer> {
+	const env = {
+		...process.env,
+		PORT: "0",
+		APP_URL: "http://localhost",
+		BETTER_AUTH_SECRET: "test-secret-for-integration-tests",
+		ALLOWED_ORIGIN: "http://localhost",
+	};
+	let proc = spawnServer(env);
+	let port = await parseReadyPort(proc);
+	drainStreams(proc);
+	await waitForReady(`http://localhost:${port}`);
+
+	return {
+		get port() {
+			return port;
+		},
+		get baseUrl() {
+			return `http://localhost:${port}`;
+		},
+		async stop() {
+			proc.kill();
+			await proc.exited;
+		},
+		async ensureAlive() {
+			try {
+				const res = await fetch(`http://localhost:${port}/health`, {
+					signal: AbortSignal.timeout(2000),
+				});
+				if (res.ok) return;
+			} catch {
+				// restart
+			}
+			proc = spawnServer(env);
+			port = await parseReadyPort(proc);
+			drainStreams(proc);
+			await waitForReady(`http://localhost:${port}`);
+		},
+	};
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function parseArray<T>(
+	schema: { parse: (v: unknown) => T },
+	data: unknown,
+): T[] {
+	if (!Array.isArray(data))
+		throw new Error(`Expected array, got ${typeof data}`);
+	return data.map((item: unknown) => schema.parse(item));
+}
+
+// ── Constants ───────────────────────────────────────────────────────
+
+const TEST_EMAIL = "analytics-test@rudel.ai";
+const TEST_PASSWORD = "analytics-test-password-42";
+const START_DATE = "2026-02-01";
+const END_DATE = "2026-03-15";
+const DAYS = 90;
+
+// ── Shared state ────────────────────────────────────────────────────
+
+let server: TestServer;
+let token: string;
+let userId: string;
+let sessionList: Array<{ session_id: string; project_path: string }>;
+
+// ── RPC helper ──────────────────────────────────────────────────────
+
+async function rpc(
+	path: string,
+	input?: Record<string, unknown>,
+): Promise<unknown> {
+	const res = await fetch(`${server.baseUrl}/rpc/${path}`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${token}`,
+		},
+		body: JSON.stringify(input ? { json: input } : {}),
+	});
+	const data = await res.json();
+	if (!res.ok)
+		throw new Error(`RPC ${path}: ${res.status} ${JSON.stringify(data)}`);
+	return (data as { json: unknown }).json;
+}
+
+// ── Setup / teardown ────────────────────────────────────────────────
+
+beforeAll(async () => {
+	if (!process.env.CLICKHOUSE_URL) {
+		throw new Error(
+			"CLICKHOUSE_URL not set — skipping analytics integration tests",
+		);
+	}
+
+	server = await startTestServer();
+
+	// Sign in as the pre-seeded test user
+	const signInRes = await fetch(`${server.baseUrl}/api/auth/sign-in/email`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD }),
+	});
+	if (!signInRes.ok) {
+		const body = await signInRes.text();
+		throw new Error(
+			`Sign-in failed (${signInRes.status}): ${body}. ` +
+				"Run: doppler run --project rudel --config ci -- bun scripts/seed-analytics-test-data.ts",
+		);
+	}
+
+	// Extract token
+	const signInData = (await signInRes.json()) as { token?: string };
+	if (signInData.token) {
+		token = signInData.token;
+	} else {
+		const cookies = signInRes.headers.getSetCookie();
+		const sessionCookie = cookies
+			.find((c) => c.startsWith("better-auth.session_token="))
+			?.split("=")[1]
+			?.split(";")[0];
+		if (!sessionCookie)
+			throw new Error("Could not extract token from sign-in response");
+		token = sessionCookie;
+	}
+
+	// Get user ID
+	const me = (await rpc("me")) as { id: string };
+	userId = me.id;
+
+	// Sanity check: verify analytics data exists
+	const kpis = (await rpc("analytics/overview/kpis", {
+		startDate: START_DATE,
+		endDate: END_DATE,
+	})) as { distinct_sessions: number };
+
+	if (kpis.distinct_sessions < 5) {
+		throw new Error(
+			`Expected >= 5 sessions in analytics, got ${kpis.distinct_sessions}. ` +
+				"Run: doppler run --project rudel --config ci -- bun scripts/seed-analytics-test-data.ts",
+		);
+	}
+
+	// Cache session list for tests that need a session ID / project path
+	sessionList = (await rpc("analytics/sessions/list", {
+		days: DAYS,
+	})) as Array<{
+		session_id: string;
+		project_path: string;
+	}>;
+}, 120_000);
+
+beforeEach(async () => {
+	await server.ensureAlive();
+});
+
+afterAll(async () => {
+	if (server) await server.stop();
+});
+
+// ── Overview ────────────────────────────────────────────────────────
+
+describe("analytics/overview", () => {
+	const dateRange = { startDate: START_DATE, endDate: END_DATE };
+
+	test("kpis", async () => {
+		const result = await rpc("analytics/overview/kpis", dateRange);
+		const parsed = OverviewKPIsSchema.parse(result);
+		expect(parsed.distinct_sessions).toBeGreaterThanOrEqual(5);
+		expect(parsed.total_sessions).toBeGreaterThanOrEqual(5);
+	}, 30_000);
+
+	test("usageTrend", async () => {
+		const result = await rpc("analytics/overview/usageTrend", dateRange);
+		const parsed = parseArray(UsageTrendDataSchema, result);
+		expect(parsed.length).toBeGreaterThan(0);
+	}, 30_000);
+
+	test("modelTokensTrend", async () => {
+		const result = await rpc("analytics/overview/modelTokensTrend", dateRange);
+		const parsed = parseArray(ModelTokensTrendDataSchema, result);
+		expect(parsed.length).toBeGreaterThan(0);
+	}, 30_000);
+
+	test("insights", async () => {
+		const result = await rpc("analytics/overview/insights", dateRange);
+		const parsed = parseArray(InsightSchema, result);
+		expect(Array.isArray(parsed)).toBe(true);
+	}, 30_000);
+
+	// Known bug: ClickHouse AVG returns null on empty comparison period, failing output validation
+	test.todo("teamSummaryComparison", () => {});
+
+	test("successRate", async () => {
+		const result = await rpc("analytics/overview/successRate", dateRange);
+		const parsed = SuccessRateSchema.parse(result);
+		expect(parsed.current.total_sessions).toBeGreaterThanOrEqual(5);
+	}, 30_000);
+});
+
+// ── Developers ──────────────────────────────────────────────────────
+
+describe("analytics/developers", () => {
+	test("list", async () => {
+		const result = await rpc("analytics/developers/list", { days: DAYS });
+		const parsed = parseArray(DeveloperSummarySchema, result);
+		expect(parsed.length).toBeGreaterThanOrEqual(1);
+	}, 30_000);
+
+	test("details", async () => {
+		const result = await rpc("analytics/developers/details", {
+			days: DAYS,
+			userId,
+		});
+		const parsed = DeveloperDetailsSchema.parse(result);
+		expect(parsed.user_id).toBe(userId);
+		expect(parsed.total_sessions).toBeGreaterThanOrEqual(5);
+	}, 30_000);
+
+	test("sessions", async () => {
+		const result = await rpc("analytics/developers/sessions", {
+			days: DAYS,
+			userId,
+		});
+		const parsed = parseArray(DeveloperSessionSchema, result);
+		expect(parsed.length).toBeGreaterThanOrEqual(5);
+	}, 30_000);
+
+	test("projects", async () => {
+		const result = await rpc("analytics/developers/projects", {
+			days: DAYS,
+			userId,
+		});
+		const parsed = parseArray(DeveloperProjectSchema, result);
+		expect(parsed.length).toBeGreaterThanOrEqual(1);
+	}, 30_000);
+
+	test("timeline", async () => {
+		const result = await rpc("analytics/developers/timeline", {
+			days: DAYS,
+			userId,
+		});
+		const parsed = parseArray(DeveloperTimelineSchema, result);
+		expect(parsed.length).toBeGreaterThan(0);
+	}, 30_000);
+
+	test("features", async () => {
+		const result = await rpc("analytics/developers/features", {
+			days: DAYS,
+			userId,
+		});
+		const parsed = DeveloperFeatureUsageSchema.parse(result);
+		expect(parsed).toBeDefined();
+	}, 30_000);
+
+	test("errors", async () => {
+		const result = await rpc("analytics/developers/errors", {
+			days: DAYS,
+			userId,
+		});
+		const parsed = parseArray(DeveloperErrorSchema, result);
+		expect(Array.isArray(parsed)).toBe(true);
+	}, 30_000);
+
+	test("trends", async () => {
+		const result = await rpc("analytics/developers/trends", {
+			days: DAYS,
+		});
+		const parsed = parseArray(DeveloperTrendDataPointSchema, result);
+		expect(parsed.length).toBeGreaterThan(0);
+	}, 30_000);
+});
+
+// ── Projects ────────────────────────────────────────────────────────
+
+describe("analytics/projects", () => {
+	// Known bug: ClickHouse query error on projects/investment
+	test.todo("investment", () => {});
+
+	// Known bug: ClickHouse query error on projects/trends
+	test.todo("trends", () => {});
+
+	// Known bug: Internal server error from ClickHouse query on projects/details
+	test.todo("details", () => {});
+
+	test("contributors", async () => {
+		const projectPath = sessionList[0]?.project_path;
+		expect(projectPath).toBeDefined();
+		const result = await rpc("analytics/projects/contributors", {
+			days: DAYS,
+			projectPath,
+		});
+		const parsed = parseArray(ProjectContributorSchema, result);
+		expect(parsed.length).toBeGreaterThanOrEqual(1);
+	}, 30_000);
+
+	test("features", async () => {
+		const projectPath = sessionList[0]?.project_path;
+		expect(projectPath).toBeDefined();
+		const result = await rpc("analytics/projects/features", {
+			days: DAYS,
+			projectPath,
+		});
+		const parsed = ProjectFeatureUsageSchema.parse(result);
+		expect(parsed).toBeDefined();
+	}, 30_000);
+
+	test("errors", async () => {
+		const projectPath = sessionList[0]?.project_path;
+		expect(projectPath).toBeDefined();
+		const result = await rpc("analytics/projects/errors", {
+			days: DAYS,
+			projectPath,
+		});
+		const parsed = parseArray(ProjectErrorSchema, result);
+		expect(Array.isArray(parsed)).toBe(true);
+	}, 30_000);
+});
+
+// ── Sessions ────────────────────────────────────────────────────────
+
+describe("analytics/sessions", () => {
+	test("list", async () => {
+		const result = await rpc("analytics/sessions/list", { days: DAYS });
+		const parsed = parseArray(SessionAnalyticsSchema, result);
+		expect(parsed.length).toBeGreaterThanOrEqual(5);
+	}, 30_000);
+
+	test("summary", async () => {
+		const result = await rpc("analytics/sessions/summary", { days: DAYS });
+		const parsed = SessionAnalyticsSummarySchema.parse(result);
+		expect(parsed.total_sessions).toBeGreaterThanOrEqual(5);
+	}, 30_000);
+
+	test("summaryComparison", async () => {
+		const result = await rpc("analytics/sessions/summaryComparison", {
+			days: DAYS,
+		});
+		const parsed = SessionAnalyticsSummaryComparisonSchema.parse(result);
+		expect(parsed.current.total_sessions).toBeGreaterThanOrEqual(5);
+	}, 30_000);
+
+	test("dimensionAnalysis", async () => {
+		const result = await rpc("analytics/sessions/dimensionAnalysis", {
+			days: DAYS,
+			dimension: "project_path",
+			metric: "session_count",
+		});
+		const parsed = parseArray(DimensionAnalysisDataPointSchema, result);
+		expect(parsed.length).toBeGreaterThan(0);
+	}, 30_000);
+
+	test("detail", async () => {
+		const sessionId = sessionList[0]?.session_id;
+		expect(sessionId).toBeDefined();
+		const result = await rpc("analytics/sessions/detail", {
+			sessionId: sessionId as string,
+		});
+		const parsed = SessionDetailSchema.parse(result);
+		expect(parsed.session_id).toBe(sessionId as string);
+	}, 30_000);
+});
+
+// ── ROI ─────────────────────────────────────────────────────────────
+
+describe("analytics/roi", () => {
+	test("metrics", async () => {
+		const result = await rpc("analytics/roi/metrics", { days: DAYS });
+		const parsed = ROIMetricsSchema.parse(result);
+		expect(parsed.total_sessions).toBeGreaterThanOrEqual(5);
+	}, 30_000);
+
+	test("trends", async () => {
+		const result = await rpc("analytics/roi/trends", { days: DAYS });
+		const parsed = parseArray(ROITrendSchema, result);
+		expect(parsed.length).toBeGreaterThan(0);
+	}, 30_000);
+
+	test("breakdownDevelopers", async () => {
+		const result = await rpc("analytics/roi/breakdownDevelopers", {
+			days: DAYS,
+		});
+		const parsed = parseArray(DeveloperCostBreakdownSchema, result);
+		expect(parsed.length).toBeGreaterThanOrEqual(1);
+	}, 30_000);
+
+	test("breakdownProjects", async () => {
+		const result = await rpc("analytics/roi/breakdownProjects", {
+			days: DAYS,
+		});
+		const parsed = parseArray(ProjectCostBreakdownSchema, result);
+		expect(parsed.length).toBeGreaterThanOrEqual(1);
+	}, 30_000);
+});
+
+// ── Errors ──────────────────────────────────────────────────────────
+
+describe("analytics/errors", () => {
+	test("topRecurring", async () => {
+		const result = await rpc("analytics/errors/topRecurring", {
+			days: DAYS,
+			minOccurrences: 1,
+		});
+		const parsed = parseArray(RecurringErrorSchema, result);
+		expect(Array.isArray(parsed)).toBe(true);
+	}, 30_000);
+
+	test("trends", async () => {
+		const result = await rpc("analytics/errors/trends", {
+			startDate: START_DATE,
+			endDate: END_DATE,
+			splitBy: "repository",
+		});
+		const parsed = parseArray(ErrorTrendDataPointSchema, result);
+		expect(Array.isArray(parsed)).toBe(true);
+	}, 30_000);
+});
+
+// ── Learnings ───────────────────────────────────────────────────────
+
+describe("analytics/learnings", () => {
+	test("list", async () => {
+		const result = await rpc("analytics/learnings/list", { days: DAYS });
+		const parsed = parseArray(LearningEntrySchema, result);
+		expect(Array.isArray(parsed)).toBe(true);
+	}, 30_000);
+
+	test("stats", async () => {
+		const result = await rpc("analytics/learnings/stats", { days: DAYS });
+		const parsed = LearningsFeedStatsSchema.parse(result);
+		expect(parsed).toBeDefined();
+	}, 30_000);
+
+	test("users", async () => {
+		const result = await rpc("analytics/learnings/users");
+		expect(Array.isArray(result)).toBe(true);
+	}, 30_000);
+
+	test("projects", async () => {
+		const result = await rpc("analytics/learnings/projects");
+		expect(Array.isArray(result)).toBe(true);
+	}, 30_000);
+
+	test("trend", async () => {
+		const result = await rpc("analytics/learnings/trend", {
+			days: DAYS,
+			splitBy: "user_id",
+		});
+		const parsed = parseArray(LearningsTrendDataPointSchema, result);
+		expect(Array.isArray(parsed)).toBe(true);
+	}, 30_000);
+});

--- a/scripts/seed-analytics-test-data.ts
+++ b/scripts/seed-analytics-test-data.ts
@@ -1,0 +1,262 @@
+/**
+ * One-time setup script: seed CI ClickHouse with real session data for analytics integration tests.
+ *
+ * Usage:
+ *   doppler run --project rudel --config ci -- bun scripts/seed-analytics-test-data.ts
+ *
+ * This script:
+ * 1. Starts an API server (uses CI Postgres + ClickHouse from env)
+ * 2. Signs up a dedicated test user (analytics-test@rudel.ai)
+ * 3. Reads 5 local session .jsonl files
+ * 4. POSTs each to /rpc/ingestSession with a bearer token
+ * 5. Polls session_analytics until all 5 rows are visible
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+
+const TEST_EMAIL = "analytics-test@rudel.ai";
+const TEST_PASSWORD = "analytics-test-password-42";
+
+const SESSION_FILES = [
+	{
+		file: "-Users-marc-Workspace-chkit/e1731008-549e-4aef-b905-b1379a55ff4a.jsonl",
+		projectPath: "/Users/marc/Workspace/chkit",
+	},
+	{
+		file: "-Users-marc-Workspace-gazed-apps-api/1935809e-16bb-4e24-894b-d91ee0e230a9.jsonl",
+		projectPath: "/Users/marc/Workspace/gazed-apps-api",
+	},
+	{
+		file: "-Users-marc-conductor-workspaces-rudel-kinshasa-v1/401b4b86-47df-4b57-90f8-aebfeb639585.jsonl",
+		projectPath: "/Users/marc/conductor/workspaces/rudel/kinshasa-v1",
+	},
+	{
+		file: "-Users-marc-conductor-workspaces-ob-db-calgary-v1/b9f16e91-8d9a-48f9-9dac-acc3924f80a8.jsonl",
+		projectPath: "/Users/marc/conductor/workspaces/ob-db/calgary-v1",
+	},
+	{
+		file: "-Users-marc-conductor-workspaces-rudel-cancun/a4a33bab-e533-4a10-b181-ab1346a18625.jsonl",
+		projectPath: "/Users/marc/conductor/workspaces/rudel/cancun",
+	},
+];
+
+const MONOREPO_ROOT = resolve(import.meta.dir, "..");
+
+// ── Server lifecycle ────────────────────────────────────────────────
+
+function spawnServer() {
+	const proc = Bun.spawn(["bun", "apps/api/src/index.ts"], {
+		cwd: MONOREPO_ROOT,
+		stdout: "pipe",
+		stderr: "pipe",
+		env: {
+			...process.env,
+			PORT: "0",
+			APP_URL: "http://localhost",
+			BETTER_AUTH_SECRET: "test-secret-for-integration-tests",
+			ALLOWED_ORIGIN: "http://localhost",
+		},
+	});
+	return proc;
+}
+
+async function parseReadyPort(proc: ReturnType<typeof Bun.spawn>): Promise<number> {
+	const stdout = proc.stdout;
+	if (!stdout || !(stdout instanceof ReadableStream)) {
+		throw new Error("Server process has no readable stdout");
+	}
+	const reader = stdout.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	const deadline = Date.now() + 30_000;
+	try {
+		while (Date.now() < deadline) {
+			const { value, done } = await reader.read();
+			if (done) break;
+			buffer += decoder.decode(value, { stream: true });
+			const match = buffer.match(/listening on https?:\/\/localhost:(\d+)/i);
+			if (match?.[1]) {
+				reader.releaseLock();
+				return Number.parseInt(match[1], 10);
+			}
+		}
+	} catch {
+		// fall through
+	}
+	proc.kill();
+	throw new Error(`Server did not become ready within 30s.\nstdout: ${buffer}`);
+}
+
+async function waitForReady(baseUrl: string): Promise<void> {
+	const deadline = Date.now() + 10_000;
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(2000) });
+			if (res.ok) return;
+		} catch {
+			// retry
+		}
+		await Bun.sleep(200);
+	}
+	throw new Error(`Server at ${baseUrl} did not respond within 10s`);
+}
+
+// ── Auth helpers ────────────────────────────────────────────────────
+
+async function signUp(baseUrl: string): Promise<string> {
+	const res = await fetch(`${baseUrl}/api/auth/sign-up/email`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD, name: "Analytics Test User" }),
+	});
+	if (!res.ok) {
+		const body = await res.text();
+		// If user already exists, sign in instead
+		if (body.includes("already") || res.status === 422 || res.status === 409) {
+			return signIn(baseUrl);
+		}
+		throw new Error(`Sign-up failed (${res.status}): ${body}`);
+	}
+	return extractToken(res);
+}
+
+async function signIn(baseUrl: string): Promise<string> {
+	const res = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD }),
+	});
+	if (!res.ok) {
+		const body = await res.text();
+		throw new Error(`Sign-in failed (${res.status}): ${body}`);
+	}
+	return extractToken(res);
+}
+
+async function extractToken(res: Response): Promise<string> {
+	const data = (await res.json()) as { token?: string };
+	if (data.token) return data.token;
+	const cookies = res.headers.getSetCookie();
+	const sessionCookie = cookies
+		.find((c) => c.startsWith("better-auth.session_token="))
+		?.split("=")[1]
+		?.split(";")[0];
+	if (sessionCookie) return sessionCookie;
+	throw new Error("Could not extract token from auth response");
+}
+
+// ── RPC helper ──────────────────────────────────────────────────────
+
+async function rpc(baseUrl: string, token: string, path: string, input?: Record<string, unknown>) {
+	const res = await fetch(`${baseUrl}/rpc/${path}`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+		body: JSON.stringify(input ? { json: input } : {}),
+	});
+	const data = await res.json();
+	if (!res.ok) throw new Error(`RPC ${path}: ${res.status} ${JSON.stringify(data)}`);
+	return (data as { json: unknown }).json;
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+async function main() {
+	console.log("Starting API server...");
+	const proc = spawnServer();
+	const port = await parseReadyPort(proc);
+
+	// Drain remaining streams
+	if (proc.stdout instanceof ReadableStream) proc.stdout.pipeTo(new WritableStream()).catch(() => {});
+	if (proc.stderr instanceof ReadableStream) proc.stderr.pipeTo(new WritableStream()).catch(() => {});
+
+	const baseUrl = `http://localhost:${port}`;
+	await waitForReady(baseUrl);
+	console.log(`Server ready at ${baseUrl}`);
+
+	// Sign up or sign in
+	console.log(`Authenticating as ${TEST_EMAIL}...`);
+	const token = await signUp(baseUrl);
+
+	// Get user ID
+	const me = (await rpc(baseUrl, token, "me")) as { id: string; email: string };
+	console.log(`User ID: ${me.id} (${me.email})`);
+
+	// Read and ingest sessions
+	const claudeProjectsDir = resolve(homedir(), ".claude", "projects");
+	let ingested = 0;
+
+	for (const session of SESSION_FILES) {
+		const filePath = resolve(claudeProjectsDir, session.file);
+		const sessionId = session.file.split("/")[1]!.replace(".jsonl", "");
+
+		console.log(`\nIngesting session ${sessionId}...`);
+		console.log(`  File: ${filePath}`);
+
+		let content: string;
+		try {
+			content = readFileSync(filePath, "utf-8");
+		} catch (err) {
+			console.error(`  SKIP: Could not read file: ${(err as Error).message}`);
+			continue;
+		}
+
+		try {
+			await rpc(baseUrl, token, "ingestSession", {
+				sessionId,
+				projectPath: session.projectPath,
+				content,
+			});
+			ingested++;
+			console.log(`  OK (${content.length} bytes)`);
+		} catch (err) {
+			console.error(`  FAIL: ${(err as Error).message}`);
+		}
+	}
+
+	console.log(`\nIngested ${ingested}/${SESSION_FILES.length} sessions.`);
+
+	// Poll session_analytics for propagation (MV computes analytics async)
+	console.log("\nWaiting for session_analytics MV propagation...");
+	const deadline = Date.now() + 60_000;
+	let analyticsCount = 0;
+
+	while (Date.now() < deadline) {
+		try {
+			const result = (await rpc(baseUrl, token, "analytics/overview/kpis", {
+				startDate: "2026-01-01",
+				endDate: "2026-12-31",
+			})) as { distinct_sessions: number };
+			analyticsCount = result.distinct_sessions;
+			if (analyticsCount >= ingested) break;
+		} catch {
+			// MV not ready yet
+		}
+		await Bun.sleep(2000);
+	}
+
+	console.log(`\nsession_analytics has ${analyticsCount} distinct sessions (expected >= ${ingested})`);
+
+	if (analyticsCount < ingested) {
+		console.warn("WARNING: Not all sessions propagated to session_analytics within 60s.");
+		console.warn("The MV may need more time, or session timestamps may be rejected.");
+	}
+
+	// Summary
+	console.log("\n── Summary ──");
+	console.log(`User ID:    ${me.id}`);
+	console.log(`Email:      ${me.email}`);
+	console.log(`Sessions:   ${ingested} ingested, ${analyticsCount} in analytics`);
+	console.log(`Test email: ${TEST_EMAIL}`);
+	console.log(`Password:   ${TEST_PASSWORD}`);
+
+	proc.kill();
+	await proc.exited;
+	console.log("\nDone.");
+}
+
+main().catch((err) => {
+	console.error("Fatal:", err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds comprehensive integration tests for all 36 analytics RPC endpoints with a dedicated test data seeding script. Tests verify each endpoint executes without error and returns correctly-typed responses via Zod schemas.

## Changes

- **scripts/seed-analytics-test-data.ts**: One-time setup script that:
  - Starts API server with CI credentials
  - Signs up dedicated test user (analytics-test@rudel.ai)  
  - Ingests 5 real session JSONL files into CI ClickHouse
  - Polls until analytics data propagates
  
- **apps/api/src/__tests__/analytics.integration.ts**: 36 tests across 7 categories:
  - 32 passing tests for overview, developers, projects, sessions, ROI, errors, learnings
  - 4 known-failing todos for server-side bugs (teamSummaryComparison, projects/investment, projects/trends, projects/details)
  - Inlined test server helpers to avoid cross-package TypeScript issues
  - Uses .integration.ts suffix (not .test.ts) to avoid auto-discovery; run via `bun run --cwd apps/api test:analytics`

## Test Plan

- [x] All 32 tests pass against CI ClickHouse with seeded data
- [x] Lint, type-check, and verify pass
- [x] Data persists across CI runs via ClickHouse ReplacingMergeTree

🤖 Generated with [Claude Code](https://claude.com/claude-code)