### PR TITLE
fix: make org deletion non-blocking by deferring ClickHouse mutations

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -163,11 +163,8 @@ const deleteOrganization = os.deleteOrganization
 		}
 
 		try {
-			console.log(
-				`[deleteOrganization] deleting ClickHouse sessions for org=${orgId}`,
-			);
-			await deleteOrgSessions(orgId);
-			console.log(`[deleteOrganization] ClickHouse session deletion complete`);
+			// Fire-and-forget: ClickHouse mutations are slow, don't block on them
+			deleteOrgSessions(orgId);
 
 			// Delete the organization from Postgres (cascade handles member + invitation)
 			console.log(`[deleteOrganization] deleting org=${orgId} from Postgres`);

--- a/apps/api/src/services/org-session.service.ts
+++ b/apps/api/src/services/org-session.service.ts
@@ -15,16 +15,21 @@ export async function getOrgSessionCount(orgId: string): Promise<number> {
 	return results.reduce((sum, rows) => sum + Number(rows[0]?.count ?? 0), 0);
 }
 
-export async function deleteOrgSessions(orgId: string): Promise<void> {
+export function deleteOrgSessions(orgId: string): void {
 	const ch = getClickhouse();
 	const escaped = escapeString(orgId);
 	const tables = getAllAdapters().map((a) => a.rawTableName);
-	await Promise.all([
+	Promise.all([
 		...tables.map((table) =>
 			ch.execute(`DELETE FROM ${table} WHERE organization_id = '${escaped}'`),
 		),
 		ch.execute(
 			`DELETE FROM rudel.session_analytics WHERE organization_id = '${escaped}'`,
 		),
-	]);
+	]).catch((error) => {
+		console.error(
+			`[deleteOrgSessions] async ClickHouse deletion failed for org=${orgId}:`,
+			error,
+		);
+	});
 }

--- a/apps/web/src/pages/dashboard/OrganizationPage.tsx
+++ b/apps/web/src/pages/dashboard/OrganizationPage.tsx
@@ -411,6 +411,11 @@ export function OrganizationPage() {
 						if (other) {
 							await switchOrg(other.id);
 						}
+						for (const key of Object.keys(authClient.$store.atoms)) {
+							if (key.startsWith("$")) {
+								authClient.$store.notify(key);
+							}
+						}
 						navigate("/dashboard");
 					}}
 				/>


### PR DESCRIPTION
## Summary
- Made `deleteOrgSessions()` fire-and-forget so ClickHouse mutations run async in the background
- Postgres org deletion now happens immediately, so users see the deleted org removed from the list instantly
- Added error logging for any background ClickHouse mutations that fail
- Refresh better-auth store atoms after deletion to ensure the org list query refetches

## Test plan
- [ ] Delete an organization with multiple sessions and verify it disappears from the UI without delay
- [ ] Verify the Postgres org is deleted even if ClickHouse mutations fail
- [ ] Check API logs for any ClickHouse deletion errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)