### PR TITLE
feat(web): restore legacy SessionDetail screen layout

### DIFF
--- a/apps/web/src/components/conversation/CodeBlock.tsx
+++ b/apps/web/src/components/conversation/CodeBlock.tsx
@@ -1,0 +1,43 @@
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { cn } from "@/lib/utils";
+
+interface CodeBlockProps {
+	code: string;
+	language?: string;
+	className?: string;
+}
+
+export function CodeBlock({
+	code,
+	language = "text",
+	className,
+}: CodeBlockProps) {
+	return (
+		<div className={cn("relative rounded-lg overflow-hidden", className)}>
+			{language && language !== "text" && (
+				<div className="absolute top-0 right-0 px-3 py-1 text-xs font-mono text-gray-400 bg-gray-800 rounded-bl z-10">
+					{language.toUpperCase()}
+				</div>
+			)}
+			<div className="overflow-x-auto max-w-full">
+				<SyntaxHighlighter
+					language={language}
+					style={vscDarkPlus}
+					customStyle={{
+						margin: 0,
+						padding: "1.5rem",
+						fontSize: "0.875rem",
+						lineHeight: "1.5",
+						borderRadius: "0.5rem",
+					}}
+					showLineNumbers={language !== "text"}
+					wrapLines={false}
+					wrapLongLines={false}
+				>
+					{code.trim()}
+				</SyntaxHighlighter>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/conversation/ConversationMessage.tsx
+++ b/apps/web/src/components/conversation/ConversationMessage.tsx
@@ -1,0 +1,262 @@
+import {
+	Bot,
+	ChevronRight,
+	FileText,
+	Settings,
+	User,
+	Wrench,
+} from "lucide-react";
+import { useState } from "react";
+import type { Conversation, ToolResultContent } from "@/lib/conversation-schema";
+import {
+	isSlashCommandMessage,
+	parseSlashCommand,
+} from "@/lib/parse-slash-command";
+import { cn } from "@/lib/utils";
+import { MessageContent } from "./MessageContent";
+
+interface ConversationMessageProps {
+	entry: Conversation;
+	messageIndex?: number;
+	className?: string;
+}
+
+const variantStyles = {
+	default: {
+		row: "text-muted",
+		icon: "w-3.5 h-3.5 shrink-0",
+		border: "border-border",
+	},
+	error: {
+		row: "text-red-400",
+		icon: "w-3.5 h-3.5 shrink-0 text-red-400",
+		border: "border-red-300",
+	},
+	success: {
+		row: "text-green-500",
+		icon: "w-3.5 h-3.5 shrink-0 text-green-500",
+		border: "border-green-300",
+	},
+} as const;
+
+function CollapsedEntry({
+	icon: Icon,
+	label,
+	summary,
+	children,
+	anchorId,
+	className,
+	variant = "default",
+}: {
+	icon: React.ComponentType<{ className?: string }>;
+	label: string;
+	summary: string;
+	children: React.ReactNode;
+	anchorId?: string;
+	className?: string;
+	variant?: "default" | "error" | "success";
+}) {
+	const [open, setOpen] = useState(false);
+	const styles = variantStyles[variant];
+
+	return (
+		<div id={anchorId} className={cn("scroll-mt-6", className)}>
+			<button
+				type="button"
+				onClick={() => setOpen(!open)}
+				className={cn(
+					"flex items-center gap-2 w-full text-left px-3 py-1.5 rounded-md hover:bg-hover transition-colors text-xs",
+					styles.row,
+				)}
+			>
+				<Icon className={styles.icon} />
+				<span className="font-medium">{label}</span>
+				<span className="truncate opacity-60">{summary}</span>
+				<ChevronRight
+					className={cn(
+						"w-3 h-3 ml-auto shrink-0 transition-transform",
+						open && "rotate-90",
+					)}
+				/>
+			</button>
+			{open && (
+				<div className={cn("mt-1 ml-5 pl-3 border-l-2", styles.border)}>
+					{children}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function contentSummary(content: unknown): string {
+	if (typeof content === "string") {
+		return content.slice(0, 100);
+	}
+
+	if (Array.isArray(content)) {
+		const first = content[0];
+		if (typeof first === "object" && first) {
+			if (first.type === "tool_result") {
+				const text =
+					typeof first.content === "string"
+						? first.content
+						: JSON.stringify(first.content);
+				return `tool_result: ${text.slice(0, 80)}`;
+			}
+			if (first.type === "text" && "text" in first) {
+				return String(first.text).slice(0, 100);
+			}
+		}
+	}
+
+	return "";
+}
+
+export function ConversationMessage({
+	entry,
+	messageIndex,
+	className,
+}: ConversationMessageProps) {
+	const anchorId =
+		messageIndex !== undefined ? `message-${messageIndex}` : undefined;
+
+	if (entry.type === "summary") {
+		return (
+			<div
+				id={anchorId}
+				className={cn(
+					"border-l-4 border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-950 p-4 rounded-r scroll-mt-6",
+					className,
+				)}
+			>
+				<div className="flex items-start gap-3">
+					<FileText className="w-5 h-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
+					<div className="flex-1">
+						<p className="text-xs font-semibold text-blue-700 dark:text-blue-300 mb-2">
+							Session Summary
+						</p>
+						<p className="text-sm text-blue-900 dark:text-blue-100 whitespace-pre-wrap leading-relaxed">
+							{entry.summary}
+						</p>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	if (entry.type === "system") {
+		return (
+			<CollapsedEntry
+				icon={Settings}
+				label="System"
+				summary={entry.message.content.slice(0, 100)}
+				anchorId={anchorId}
+				className={className}
+			>
+				<p className="text-sm text-foreground whitespace-pre-wrap leading-relaxed font-mono py-2">
+					{entry.message.content}
+				</p>
+			</CollapsedEntry>
+		);
+	}
+
+	if (entry.type === "user") {
+		const { content } = entry.message;
+
+		if (Array.isArray(content)) {
+			const toolResults = content.filter(
+				(item): item is ToolResultContent =>
+					typeof item === "object" &&
+					item !== null &&
+					item.type === "tool_result",
+			);
+			if (toolResults.length === content.length && content.length > 0) {
+				return (
+					<CollapsedEntry
+						icon={Wrench}
+						label={`Tool Results (${content.length})`}
+						summary={contentSummary(content)}
+						variant={
+							toolResults.some((item) => item.is_error) ? "error" : "success"
+						}
+						anchorId={anchorId}
+						className={className}
+					>
+						<div className="py-2">
+							<MessageContent content={content} />
+						</div>
+					</CollapsedEntry>
+				);
+			}
+		}
+
+		const isSlashCommand =
+			typeof content === "string" && isSlashCommandMessage(content);
+		const slashCommandInfo = isSlashCommand ? parseSlashCommand(content) : null;
+
+		return (
+			<div id={anchorId} className={cn("flex gap-4 scroll-mt-6", className)}>
+				<div className="flex-shrink-0">
+					<div className="w-8 h-8 rounded-full bg-blue-600 flex items-center justify-center">
+						<User className="w-5 h-5 text-white" />
+					</div>
+				</div>
+				<div className="flex-1 min-w-0 bg-card border border-border rounded-lg p-4 shadow-sm">
+					<div className="flex items-center gap-2 mb-3">
+						<span className="text-sm font-semibold text-foreground">User</span>
+						<span className="text-xs text-muted-foreground">
+							{new Date(entry.timestamp).toLocaleTimeString()}
+						</span>
+					</div>
+
+					{isSlashCommand && slashCommandInfo ? (
+						<div className="space-y-2">
+							{slashCommandInfo.commandMessage && (
+								<div className="inline-block px-3 py-1 bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 rounded-md text-sm font-mono">
+									{slashCommandInfo.commandMessage}
+								</div>
+							)}
+							{slashCommandInfo.commandName && (
+								<div className="text-sm text-muted-foreground">
+									<span className="font-semibold">Command:</span>{" "}
+									<code className="bg-muted px-2 py-0.5 rounded">
+										{slashCommandInfo.commandName}
+									</code>
+								</div>
+							)}
+							{slashCommandInfo.commandArgs && (
+								<div className="text-sm text-muted-foreground">
+									<span className="font-semibold">Args:</span>{" "}
+									<code className="bg-muted px-2 py-0.5 rounded">
+										{slashCommandInfo.commandArgs}
+									</code>
+								</div>
+							)}
+						</div>
+					) : (
+						<MessageContent content={content} />
+					)}
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div id={anchorId} className={cn("flex gap-4 scroll-mt-6", className)}>
+			<div className="flex-shrink-0">
+				<div className="w-8 h-8 rounded-full bg-gradient-to-br from-purple-600 to-blue-600 flex items-center justify-center">
+					<Bot className="w-5 h-5 text-white" />
+				</div>
+			</div>
+			<div className="flex-1 min-w-0 bg-card border border-border rounded-lg p-4 shadow-sm">
+				<div className="flex items-center gap-2 mb-3">
+					<span className="text-sm font-semibold text-foreground">Assistant</span>
+					<span className="text-xs text-muted-foreground">
+						{new Date(entry.timestamp).toLocaleTimeString()}
+					</span>
+				</div>
+				<MessageContent content={entry.message.content} />
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/conversation/ConversationView.tsx
+++ b/apps/web/src/components/conversation/ConversationView.tsx
@@ -1,0 +1,282 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Conversation } from "@/lib/conversation-schema";
+import { parseConversations } from "@/lib/conversation-schema";
+import { isSlashCommandMessage } from "@/lib/parse-slash-command";
+import { cn } from "@/lib/utils";
+import { ConversationMessage } from "./ConversationMessage";
+import type { TokenDataPoint } from "./TokenUsageChart";
+import type { ToolActivityPoint } from "./ToolActivityChart";
+
+interface ConversationViewProps {
+	content: string;
+	className?: string;
+	scrollContainerRef?: React.RefObject<HTMLElement | null>;
+	onActiveMessageChange?: (messageIndex: number) => void;
+	onTokenDataReady?: (data: TokenDataPoint[], totalMessages: number) => void;
+	onToolActivityReady?: (data: ToolActivityPoint[]) => void;
+	scrollToMessageIndex?: number | null;
+}
+
+/** Extract token usage data from parsed conversations */
+function extractTokenData(content: string): TokenDataPoint[] {
+	const points: TokenDataPoint[] = [];
+	const lines = content.split("\n").filter((line) => line.trim() !== "");
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		if (!line) continue;
+
+		try {
+			const parsed = JSON.parse(line) as {
+				type?: string;
+				message?: {
+					usage?: {
+						input_tokens?: number;
+						output_tokens?: number;
+					};
+				};
+			};
+
+			if (parsed.type !== "assistant") continue;
+			const usage = parsed.message?.usage;
+			if (!usage) continue;
+
+			points.push({
+				messageIndex: i,
+				inputTokens: usage.input_tokens ?? 0,
+				outputTokens: usage.output_tokens ?? 0,
+			});
+		} catch {
+			// Skip malformed JSON lines.
+		}
+	}
+
+	return points;
+}
+
+/** Extract tool, skill, and subagent activity from parsed conversations */
+function extractToolActivity(
+	entries: Conversation[],
+): ToolActivityPoint[] {
+	const points: ToolActivityPoint[] = [];
+
+	for (let i = 0; i < entries.length; i++) {
+		const entry = entries[i];
+
+		if (entry.type === "user") {
+			const { content } = entry.message;
+			if (typeof content === "string" && isSlashCommandMessage(content)) {
+				points.push({
+					messageIndex: i,
+					category: "skill",
+					name: "slash-command",
+					isError: false,
+				});
+			}
+			if (Array.isArray(content)) {
+				for (const block of content) {
+					if (typeof block === "object" && block.type === "tool_result") {
+						points.push({
+							messageIndex: i,
+							category: "tool",
+							name: "tool_result",
+							isError: block.is_error === true,
+						});
+					}
+				}
+			}
+		}
+
+		if (entry.type === "assistant") {
+			for (const block of entry.message.content) {
+				if (block.type !== "tool_use") continue;
+				if (block.name === "Task") {
+					const subagentType =
+						typeof block.input.subagent_type === "string"
+							? block.input.subagent_type
+							: "Task";
+					points.push({
+						messageIndex: i,
+						category: "subagent",
+						name: subagentType,
+						isError: false,
+					});
+					continue;
+				}
+				points.push({
+					messageIndex: i,
+					category: "tool",
+					name: block.name,
+					isError: false,
+				});
+			}
+		}
+	}
+
+	return points;
+}
+
+export function ConversationView({
+	content,
+	className,
+	scrollContainerRef,
+	onActiveMessageChange,
+	onTokenDataReady,
+	onToolActivityReady,
+	scrollToMessageIndex,
+}: ConversationViewProps) {
+	const [conversations, setConversations] = useState<Conversation[]>([]);
+	const [parseError, setParseError] = useState<string | null>(null);
+	const messageRefsMap = useRef<Map<number, HTMLDivElement>>(new Map());
+	const observerRef = useRef<IntersectionObserver | null>(null);
+
+	// Parse content
+	useEffect(() => {
+		if (!content || content.trim() === "") {
+			setConversations([]);
+			return;
+		}
+
+		try {
+			const lines = content.split("\n").filter((line) => line.trim() !== "");
+
+			const parsed = parseConversations(content);
+
+			if (parsed.length === 0 && lines.length > 0) {
+				try {
+					JSON.parse(lines[0] as string);
+					setParseError(
+						`Failed to parse ${lines.length} conversation entries. Check console for details.`,
+					);
+				} catch {
+					setParseError("Content is not valid JSONL format");
+				}
+			}
+
+			setConversations(parsed);
+
+				if (parsed.length > 0) {
+					if (onTokenDataReady) {
+						const tokenData = extractTokenData(content);
+						onTokenDataReady(tokenData, parsed.length);
+					}
+				if (onToolActivityReady) {
+					const activityData = extractToolActivity(parsed);
+					onToolActivityReady(activityData);
+				}
+			}
+		} catch (error) {
+			console.error("[ConversationView] Error parsing conversations:", error);
+			setParseError(error instanceof Error ? error.message : "Unknown error");
+		}
+	}, [content, onTokenDataReady, onToolActivityReady]);
+
+	// Set up IntersectionObserver for scroll tracking
+	useEffect(() => {
+		if (!onActiveMessageChange) return;
+
+		const root = scrollContainerRef?.current || null;
+
+		observerRef.current = new IntersectionObserver(
+			(entries) => {
+				let topmostIndex = -1;
+				let topmostTop = Infinity;
+
+				for (const ioEntry of entries) {
+					if (ioEntry.isIntersecting) {
+						const idx = Number(
+							ioEntry.target.getAttribute("data-message-index"),
+						);
+						if (
+							!Number.isNaN(idx) &&
+							ioEntry.boundingClientRect.top < topmostTop
+						) {
+							topmostTop = ioEntry.boundingClientRect.top;
+							topmostIndex = idx;
+						}
+					}
+				}
+
+				if (topmostIndex >= 0) {
+					onActiveMessageChange(topmostIndex);
+				}
+			},
+			{
+				root,
+				rootMargin: "0px 0px -80% 0px",
+				threshold: 0,
+			},
+		);
+
+		for (const [, el] of messageRefsMap.current) {
+			observerRef.current.observe(el);
+		}
+
+		return () => {
+			observerRef.current?.disconnect();
+		};
+	}, [onActiveMessageChange, scrollContainerRef]);
+
+	// Scroll to message when scrollToMessageIndex changes
+	useEffect(() => {
+		if (scrollToMessageIndex == null) return;
+
+		const el = messageRefsMap.current.get(scrollToMessageIndex);
+		if (el) {
+			el.scrollIntoView({ behavior: "smooth", block: "center" });
+		}
+	}, [scrollToMessageIndex]);
+
+	const registerMessageRef = useCallback(
+		(index: number, el: HTMLDivElement | null) => {
+			if (el) {
+				messageRefsMap.current.set(index, el);
+				observerRef.current?.observe(el);
+			} else {
+				const existing = messageRefsMap.current.get(index);
+				if (existing) {
+					observerRef.current?.unobserve(existing);
+				}
+				messageRefsMap.current.delete(index);
+			}
+		},
+		[],
+	);
+
+	if (parseError) {
+		return (
+			<div className={cn("py-8 text-center", className)}>
+				<p className="text-red-600 dark:text-red-400 font-semibold mb-2">
+					Error parsing conversation data
+				</p>
+				<p className="text-muted-foreground text-sm">{parseError}</p>
+			</div>
+		);
+	}
+
+	if (conversations.length === 0) {
+		return (
+			<div className={cn("py-8 text-center", className)}>
+				<p className="text-muted-foreground">No conversation data available</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className={cn("space-y-6", className)}>
+			<div className="text-xs text-muted-foreground mb-4">
+				Showing {conversations.length} messages
+			</div>
+			{conversations.map((entry, idx) => (
+				<div
+					// biome-ignore lint/suspicious/noArrayIndexKey: stable conversation order
+					key={idx}
+					ref={(el) => registerMessageRef(idx, el)}
+					data-message-index={idx}
+				>
+					<ConversationMessage entry={entry} messageIndex={idx} />
+				</div>
+			))}
+		</div>
+	);
+}

--- a/apps/web/src/components/conversation/MessageContent.tsx
+++ b/apps/web/src/components/conversation/MessageContent.tsx
@@ -1,0 +1,227 @@
+import type {
+	TextContent,
+	ThinkingContent,
+	ToolResultContent,
+	ToolUseContent,
+} from "@/lib/conversation-schema";
+import { cn } from "@/lib/utils";
+import { CodeBlock } from "./CodeBlock";
+import { ToolInvocation } from "./ToolInvocation";
+
+type MessageBlock =
+	| string
+	| TextContent
+	| ThinkingContent
+	| ToolUseContent
+	| ToolResultContent;
+
+interface MessageContentProps {
+	content: string | MessageBlock[];
+	className?: string;
+}
+
+// Parse code blocks from text content
+function parseTextContent(
+	text: string,
+): Array<{ type: "text" | "code"; content: string; language?: string }> {
+	const parts: Array<{
+		type: "text" | "code";
+		content: string;
+		language?: string;
+	}> = [];
+
+	const codeBlockRegex = /```(\w+)?\n([\s\S]*?)```/g;
+	let lastIndex = 0;
+	let match: RegExpExecArray | null = codeBlockRegex.exec(text);
+
+	while (match !== null) {
+		if (match.index > lastIndex) {
+			const textContent = text.slice(lastIndex, match.index).trim();
+			if (textContent) {
+				parts.push({ type: "text", content: textContent });
+			}
+		}
+
+		const language = match[1] || "text";
+		const code = match[2] as string;
+		parts.push({ type: "code", content: code, language });
+
+		lastIndex = match.index + match[0].length;
+		match = codeBlockRegex.exec(text);
+	}
+
+	if (lastIndex < text.length) {
+		const textContent = text.slice(lastIndex).trim();
+		if (textContent) {
+			parts.push({ type: "text", content: textContent });
+		}
+	}
+
+	if (parts.length === 0 && text.trim()) {
+		parts.push({ type: "text", content: text.trim() });
+	}
+
+	return parts;
+}
+
+function renderPlainText(text: string, key: number) {
+	const parts = parseTextContent(text);
+	return (
+		<div
+			// biome-ignore lint/suspicious/noArrayIndexKey: static parsed content blocks
+			key={key}
+			className="space-y-3"
+		>
+			{parts.map((part, partIdx) =>
+				part.type === "code" ? (
+					<CodeBlock
+						// biome-ignore lint/suspicious/noArrayIndexKey: static parsed content blocks
+						key={partIdx}
+						code={part.content}
+						language={part.language}
+					/>
+				) : (
+					<div
+						// biome-ignore lint/suspicious/noArrayIndexKey: static parsed content blocks
+						key={partIdx}
+						className="prose prose-sm max-w-none"
+					>
+						<p className="whitespace-pre-wrap text-foreground leading-relaxed">
+							{part.content}
+						</p>
+					</div>
+				),
+			)}
+		</div>
+	);
+}
+
+export function MessageContent({ content, className }: MessageContentProps) {
+	if (!content) {
+		return (
+			<div className={cn("text-muted-foreground text-sm italic", className)}>
+				(No content)
+			</div>
+		);
+	}
+
+	if (typeof content === "string") {
+		return <div className={cn("space-y-3", className)}>{renderPlainText(content, 0)}</div>;
+	}
+
+	if (!Array.isArray(content)) {
+		return (
+			<div className={cn("text-muted-foreground text-sm italic", className)}>
+				(Invalid content format: {typeof content})
+			</div>
+		);
+	}
+
+	const toolUses = new Map<string, ToolUseContent>();
+	const toolResults = new Map<string, ToolResultContent>();
+
+	for (const block of content) {
+		if (typeof block === "string") continue;
+		if (block.type === "tool_use") {
+			toolUses.set(block.id, block);
+		} else if (block.type === "tool_result") {
+			toolResults.set(block.tool_use_id, block);
+		}
+	}
+
+	return (
+		<div className={cn("space-y-3", className)}>
+			{content.map((block, idx) => {
+				if (typeof block === "string") {
+					return renderPlainText(block, idx);
+				}
+
+				switch (block.type) {
+					case "text":
+						return renderPlainText(block.text, idx);
+
+					case "thinking":
+						return (
+							<div
+								// biome-ignore lint/suspicious/noArrayIndexKey: content blocks have no stable id
+								key={idx}
+								className="border-l-4 border-purple-300 dark:border-purple-800 bg-purple-50 dark:bg-purple-950 p-4 rounded-r"
+							>
+								<p className="text-xs font-semibold text-purple-700 dark:text-purple-300 mb-2">
+									Internal Thinking
+								</p>
+								<p className="text-sm text-purple-900 dark:text-purple-100 whitespace-pre-wrap leading-relaxed italic">
+									{block.thinking}
+								</p>
+							</div>
+						);
+
+					case "tool_use": {
+						const toolResult = toolResults.get(block.id);
+						return (
+							<ToolInvocation
+								// biome-ignore lint/suspicious/noArrayIndexKey: content blocks have no stable id
+								key={idx}
+								toolName={block.name}
+								input={block.input}
+								result={
+									toolResult
+										? {
+												content: toolResult.content,
+												is_error: toolResult.is_error,
+											}
+										: undefined
+								}
+							/>
+						);
+					}
+
+					case "tool_result": {
+						if (toolUses.has(block.tool_use_id)) {
+							return null;
+						}
+
+						const resultContent =
+							typeof block.content === "string"
+								? block.content
+								: block.content
+										.map((item) =>
+											item.type === "text" && "text" in item
+												? item.text
+												: JSON.stringify(item),
+										)
+										.join("\n");
+
+						return (
+							<div
+								// biome-ignore lint/suspicious/noArrayIndexKey: content blocks have no stable id
+								key={idx}
+								className={cn(
+									"border rounded-lg p-4",
+									block.is_error
+										? "border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-950"
+										: "border-border bg-muted/30",
+								)}
+							>
+								<p
+									className={cn(
+										"text-xs font-semibold mb-2",
+										block.is_error
+											? "text-red-700 dark:text-red-300"
+											: "text-muted-foreground",
+									)}
+								>
+									{block.is_error ? "Tool Error" : "Tool Result"}
+								</p>
+								<CodeBlock code={resultContent} language="text" />
+							</div>
+						);
+					}
+
+					default:
+						return null;
+				}
+			})}
+		</div>
+	);
+}

--- a/apps/web/src/components/conversation/TokenUsageChart.tsx
+++ b/apps/web/src/components/conversation/TokenUsageChart.tsx
@@ -1,0 +1,236 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export interface TokenDataPoint {
+	messageIndex: number;
+	inputTokens: number;
+	outputTokens: number;
+}
+
+interface TokenUsageChartProps {
+	data: TokenDataPoint[];
+	totalMessages: number;
+	activeMessageIndex: number;
+	onClickMessage: (messageIndex: number) => void;
+	className?: string;
+}
+
+const CHART_HEIGHT = 160;
+const AXIS_Y = CHART_HEIGHT / 2;
+const BAR_HALF_HEIGHT = AXIS_Y - 4;
+const LEFT_MARGIN = 40; // pixels for Y-axis labels
+
+function formatTokenCount(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
+	return String(n);
+}
+
+export function TokenUsageChart({
+	data,
+	totalMessages,
+	activeMessageIndex,
+	onClickMessage,
+	className,
+}: TokenUsageChartProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [chartWidth, setChartWidth] = useState(400);
+
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		const observer = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (entry) setChartWidth(entry.contentRect.width);
+		});
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, []);
+
+	const drawWidth = chartWidth - LEFT_MARGIN;
+
+	const { maxInput, maxOutput } = useMemo(() => {
+		let maxIn = 0;
+		let maxOut = 0;
+		for (const d of data) {
+			if (d.inputTokens > maxIn) maxIn = d.inputTokens;
+			if (d.outputTokens > maxOut) maxOut = d.outputTokens;
+		}
+		return { maxInput: maxIn || 1, maxOutput: maxOut || 1 };
+	}, [data]);
+
+	const totalInput = useMemo(
+		() => data.reduce((sum, d) => sum + d.inputTokens, 0),
+		[data],
+	);
+	const totalOutput = useMemo(
+		() => data.reduce((sum, d) => sum + d.outputTokens, 0),
+		[data],
+	);
+
+	const handleClick = useCallback(
+		(e: React.MouseEvent<SVGSVGElement>) => {
+			if (totalMessages === 0) return;
+
+			const svg = e.currentTarget;
+			const rect = svg.getBoundingClientRect();
+			const px = e.clientX - rect.left - LEFT_MARGIN;
+			const fraction = px / drawWidth;
+
+			let closest = data[0];
+			let closestDist = Infinity;
+			for (const d of data) {
+				const dx = Math.abs(d.messageIndex / totalMessages - fraction);
+				if (dx < closestDist) {
+					closestDist = dx;
+					closest = d;
+				}
+			}
+			if (closest) {
+				onClickMessage(closest.messageIndex);
+			}
+		},
+		[data, totalMessages, drawWidth, onClickMessage],
+	);
+
+	if (data.length === 0) {
+		return (
+			<div className={cn("text-xs text-muted text-center py-4", className)}>
+				No token data
+			</div>
+		);
+	}
+
+	const cursorX =
+		LEFT_MARGIN +
+		(totalMessages > 0 ? activeMessageIndex / totalMessages : 0) * drawWidth;
+
+	const barWidth = Math.max(2, (drawWidth / totalMessages) * 0.8);
+
+	return (
+		<div className={className}>
+			<div className="text-xs font-medium text-muted mb-2">Token Usage</div>
+
+			<div className="flex justify-between text-[10px] text-muted mb-1">
+				<span>In: {totalInput.toLocaleString()}</span>
+				<span>Out: {totalOutput.toLocaleString()}</span>
+			</div>
+
+			<div ref={containerRef}>
+				{/* biome-ignore lint/a11y/useKeyWithClickEvents: chart click navigation */}
+				<svg
+					viewBox={`0 0 ${chartWidth} ${CHART_HEIGHT}`}
+					className="w-full cursor-pointer"
+					style={{ height: `${CHART_HEIGHT}px` }}
+					onClick={handleClick}
+					role="img"
+					aria-label="Token usage chart showing input and output tokens per message"
+				>
+					{/* Y-axis labels */}
+					<text
+						x={LEFT_MARGIN - 4}
+						y={10}
+						textAnchor="end"
+						className="fill-muted"
+						fontSize="9"
+					>
+						{formatTokenCount(maxInput)}
+					</text>
+					<text
+						x={LEFT_MARGIN - 4}
+						y={AXIS_Y + 3}
+						textAnchor="end"
+						className="fill-muted"
+						fontSize="9"
+					>
+						0
+					</text>
+					<text
+						x={LEFT_MARGIN - 4}
+						y={CHART_HEIGHT - 4}
+						textAnchor="end"
+						className="fill-muted"
+						fontSize="9"
+					>
+						{formatTokenCount(maxOutput)}
+					</text>
+
+					{/* Axis line */}
+					<line
+						x1={LEFT_MARGIN}
+						y1={AXIS_Y}
+						x2={chartWidth}
+						y2={AXIS_Y}
+						stroke="currentColor"
+						strokeWidth="1"
+						className="text-border"
+					/>
+
+					{/* Input bars (above axis) */}
+					{data.map((d, i) => {
+						const x =
+							LEFT_MARGIN + (d.messageIndex / totalMessages) * drawWidth;
+						const barH = (d.inputTokens / maxInput) * BAR_HALF_HEIGHT;
+
+						return (
+							<rect
+								// biome-ignore lint/suspicious/noArrayIndexKey: static chart bar data
+								key={`in-${i}`}
+								x={x - barWidth / 2}
+								y={AXIS_Y - barH}
+								width={barWidth}
+								height={barH}
+								className="fill-blue-400/70 hover:fill-blue-500"
+								rx="1"
+							/>
+						);
+					})}
+
+					{/* Output bars (below axis) */}
+					{data.map((d, i) => {
+						const x =
+							LEFT_MARGIN + (d.messageIndex / totalMessages) * drawWidth;
+						const barH = (d.outputTokens / maxOutput) * BAR_HALF_HEIGHT;
+
+						return (
+							<rect
+								// biome-ignore lint/suspicious/noArrayIndexKey: static chart bar data
+								key={`out-${i}`}
+								x={x - barWidth / 2}
+								y={AXIS_Y}
+								width={barWidth}
+								height={barH}
+								className="fill-purple-400/70 hover:fill-purple-500"
+								rx="1"
+							/>
+						);
+					})}
+
+					{/* Cursor line */}
+					<line
+						x1={cursorX}
+						y1="0"
+						x2={cursorX}
+						y2={CHART_HEIGHT}
+						stroke="currentColor"
+						strokeWidth="1"
+						className="text-foreground"
+						strokeDasharray="4,2"
+					/>
+				</svg>
+			</div>
+
+			{/* Legend */}
+			<div className="flex items-center gap-3 mt-1.5 text-[10px] text-muted">
+				<div className="flex items-center gap-1">
+					<div className="w-2 h-2 rounded-sm bg-blue-400" />
+					<span>Input</span>
+				</div>
+				<div className="flex items-center gap-1">
+					<div className="w-2 h-2 rounded-sm bg-purple-400" />
+					<span>Output</span>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/conversation/ToolActivityChart.tsx
+++ b/apps/web/src/components/conversation/ToolActivityChart.tsx
@@ -1,0 +1,226 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ToolActivityPoint {
+	messageIndex: number;
+	category: "tool" | "skill" | "subagent";
+	name: string;
+	isError: boolean;
+}
+
+interface ToolActivityChartProps {
+	data: ToolActivityPoint[];
+	totalMessages: number;
+	activeMessageIndex: number;
+	onClickMessage: (messageIndex: number) => void;
+	className?: string;
+}
+
+const CHART_HEIGHT = 100;
+const LANE_HEIGHT = 28;
+const LANE_TOP_PAD = 8;
+const DOT_RADIUS = 4;
+const LEFT_MARGIN = 40; // match token chart
+
+const lanes: {
+	category: ToolActivityPoint["category"];
+	label: string;
+	y: number;
+}[] = [
+	{ category: "tool", label: "Tools", y: LANE_TOP_PAD + LANE_HEIGHT * 0.5 },
+	{ category: "skill", label: "Skills", y: LANE_TOP_PAD + LANE_HEIGHT * 1.5 },
+	{
+		category: "subagent",
+		label: "Agents",
+		y: LANE_TOP_PAD + LANE_HEIGHT * 2.5,
+	},
+];
+
+export function ToolActivityChart({
+	data,
+	totalMessages,
+	activeMessageIndex,
+	onClickMessage,
+	className,
+}: ToolActivityChartProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [chartWidth, setChartWidth] = useState(400);
+
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		const observer = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (entry) setChartWidth(entry.contentRect.width);
+		});
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, []);
+
+	const drawWidth = chartWidth - LEFT_MARGIN;
+
+	const counts = useMemo(() => {
+		const tools = data.filter((d) => d.category === "tool").length;
+		const skills = data.filter((d) => d.category === "skill").length;
+		const subagents = data.filter((d) => d.category === "subagent").length;
+		const errors = data.filter((d) => d.isError).length;
+		return { tools, skills, subagents, errors };
+	}, [data]);
+
+	const handleClick = useCallback(
+		(e: React.MouseEvent<SVGSVGElement>) => {
+			if (totalMessages === 0 || data.length === 0) return;
+
+			const svg = e.currentTarget;
+			const rect = svg.getBoundingClientRect();
+			const px = e.clientX - rect.left - LEFT_MARGIN;
+			const fraction = px / drawWidth;
+
+			let closest = data[0];
+			let closestDist = Infinity;
+			for (const d of data) {
+				const dx = Math.abs(d.messageIndex / totalMessages - fraction);
+				if (dx < closestDist) {
+					closestDist = dx;
+					closest = d;
+				}
+			}
+			if (closest) {
+				onClickMessage(closest.messageIndex);
+			}
+		},
+		[data, totalMessages, drawWidth, onClickMessage],
+	);
+
+	if (data.length === 0) {
+		return (
+			<div className={cn("text-xs text-muted text-center py-4", className)}>
+				No tool activity
+			</div>
+		);
+	}
+
+	const cursorX =
+		LEFT_MARGIN +
+		(totalMessages > 0 ? activeMessageIndex / totalMessages : 0) * drawWidth;
+
+	return (
+		<div className={className}>
+			<div className="text-xs font-medium text-muted mb-2">Tool Activity</div>
+
+			<div className="flex gap-3 text-[10px] text-muted mb-1">
+				<span>{counts.tools} tools</span>
+				<span>{counts.skills} skills</span>
+				<span>{counts.subagents} subagents</span>
+				{counts.errors > 0 && (
+					<span className="text-red-400">{counts.errors} errors</span>
+				)}
+			</div>
+
+			<div ref={containerRef}>
+				{/* biome-ignore lint/a11y/useKeyWithClickEvents: chart click navigation */}
+				<svg
+					viewBox={`0 0 ${chartWidth} ${CHART_HEIGHT}`}
+					className="w-full cursor-pointer"
+					style={{ height: `${CHART_HEIGHT}px` }}
+					onClick={handleClick}
+					role="img"
+					aria-label="Tool activity chart showing tool, skill, and subagent usage"
+				>
+					{/* Lane labels + separators */}
+					{lanes.map((lane, idx) => (
+						<g key={lane.category}>
+							<line
+								x1={LEFT_MARGIN}
+								y1={LANE_TOP_PAD + idx * LANE_HEIGHT}
+								x2={chartWidth}
+								y2={LANE_TOP_PAD + idx * LANE_HEIGHT}
+								stroke="currentColor"
+								strokeWidth="0.5"
+								className="text-border"
+							/>
+							<text
+								x={LEFT_MARGIN - 4}
+								y={lane.y + 3}
+								textAnchor="end"
+								className="fill-muted"
+								fontSize="9"
+							>
+								{lane.label}
+							</text>
+						</g>
+					))}
+					{/* Bottom border */}
+					<line
+						x1={LEFT_MARGIN}
+						y1={LANE_TOP_PAD + lanes.length * LANE_HEIGHT}
+						x2={chartWidth}
+						y2={LANE_TOP_PAD + lanes.length * LANE_HEIGHT}
+						stroke="currentColor"
+						strokeWidth="0.5"
+						className="text-border"
+					/>
+
+					{/* Activity dots */}
+					{data.map((d, i) => {
+						const x =
+							LEFT_MARGIN + (d.messageIndex / totalMessages) * drawWidth;
+						const lane = lanes.find((l) => l.category === d.category);
+						if (!lane) return null;
+
+						return (
+							<circle
+								// biome-ignore lint/suspicious/noArrayIndexKey: static chart dot data
+								key={i}
+								cx={x}
+								cy={lane.y}
+								r={DOT_RADIUS}
+								className={
+									d.isError
+										? "fill-red-400/80 hover:fill-red-500"
+										: d.category === "tool"
+											? "fill-green-400/80 hover:fill-green-500"
+											: d.category === "skill"
+												? "fill-purple-400/80 hover:fill-purple-500"
+												: "fill-orange-400/80 hover:fill-orange-500"
+								}
+							/>
+						);
+					})}
+
+					{/* Cursor line */}
+					<line
+						x1={cursorX}
+						y1="0"
+						x2={cursorX}
+						y2={CHART_HEIGHT}
+						stroke="currentColor"
+						strokeWidth="1"
+						className="text-foreground"
+						strokeDasharray="4,2"
+					/>
+				</svg>
+			</div>
+
+			{/* Legend */}
+			<div className="flex items-center gap-3 mt-1.5 text-[10px] text-muted">
+				<div className="flex items-center gap-1">
+					<div className="w-2 h-2 rounded-full bg-green-400" />
+					<span>Tools</span>
+				</div>
+				<div className="flex items-center gap-1">
+					<div className="w-2 h-2 rounded-full bg-purple-400" />
+					<span>Skills</span>
+				</div>
+				<div className="flex items-center gap-1">
+					<div className="w-2 h-2 rounded-full bg-orange-400" />
+					<span>Subagents</span>
+				</div>
+				<div className="flex items-center gap-1">
+					<div className="w-2 h-2 rounded-full bg-red-400" />
+					<span>Error</span>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/conversation/ToolInvocation.tsx
+++ b/apps/web/src/components/conversation/ToolInvocation.tsx
@@ -1,0 +1,142 @@
+import { AlertCircle, ChevronDown, ChevronRight, Terminal } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { CodeBlock } from "./CodeBlock";
+
+interface ToolInvocationProps {
+	toolName: string;
+	input: Record<string, unknown>;
+	result?: {
+		content: string | Array<{ type: string; text?: string; source?: unknown }>;
+		is_error?: boolean;
+	};
+	className?: string;
+}
+
+export function ToolInvocation({
+	toolName,
+	input,
+	result,
+	className,
+}: ToolInvocationProps) {
+	const [isExpanded, setIsExpanded] = useState(false);
+
+	// Format input for display
+	const formatInput = () => {
+		const keys = Object.keys(input);
+		if (keys.length === 0) return "No parameters";
+
+		const important = keys.slice(0, 2);
+		const summary = important
+			.map((key) => {
+				const value = input[key];
+				if (typeof value === "string" && value.length > 50) {
+					return `${key}: "${value.slice(0, 50)}..."`;
+				}
+				if (typeof value === "string") {
+					return `${key}: "${value}"`;
+				}
+				return `${key}: ${JSON.stringify(value)}`;
+			})
+			.join(", ");
+
+		return keys.length > 2 ? `${summary}, +${keys.length - 2} more` : summary;
+	};
+
+	// Format result content
+	const getResultContent = (): string => {
+		if (!result) return "";
+
+		if (typeof result.content === "string") {
+			return result.content;
+		}
+
+		if (Array.isArray(result.content)) {
+			return result.content
+				.map((item) => item.text || JSON.stringify(item))
+				.join("\n");
+		}
+
+		return JSON.stringify(result.content, null, 2);
+	};
+
+	const hasResult = result?.content;
+	const isError = result?.is_error;
+
+	return (
+		<div
+			className={cn(
+				"border rounded-lg overflow-hidden",
+				isError
+					? "border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-950"
+					: "border-border bg-muted/30",
+				className,
+			)}
+		>
+			<button
+				type="button"
+				onClick={() => setIsExpanded(!isExpanded)}
+				className="w-full px-4 py-3 flex items-center gap-2 text-left hover:bg-muted/50 transition-colors min-w-0"
+			>
+				{isExpanded ? (
+					<ChevronDown className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+				) : (
+					<ChevronRight className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+				)}
+				{isError ? (
+					<AlertCircle className="w-4 h-4 text-red-500 flex-shrink-0" />
+				) : (
+					<Terminal className="w-4 h-4 text-blue-500 flex-shrink-0" />
+				)}
+				<span
+					className={cn(
+						"font-mono text-sm font-semibold",
+						isError ? "text-red-700 dark:text-red-300" : "text-foreground",
+					)}
+				>
+					{toolName}
+				</span>
+				<span className="text-xs text-muted-foreground truncate flex-1">
+					{formatInput()}
+				</span>
+			</button>
+
+			{isExpanded && (
+				<div className="px-4 pb-4 space-y-3">
+					{/* Tool Input */}
+					<div>
+						<h4 className="text-xs font-semibold text-muted-foreground mb-2">
+							Input Parameters
+						</h4>
+						<CodeBlock code={JSON.stringify(input, null, 2)} language="json" />
+					</div>
+
+					{/* Tool Result */}
+					{hasResult && (
+						<div>
+							<h4
+								className={cn(
+									"text-xs font-semibold mb-2",
+									isError
+										? "text-red-700 dark:text-red-300"
+										: "text-muted-foreground",
+								)}
+							>
+								{isError ? "Error Output" : "Output"}
+							</h4>
+							<CodeBlock
+								code={getResultContent()}
+								language="text"
+								className={
+									isError
+										? "border-2 border-red-300 dark:border-red-800"
+										: undefined
+								}
+							/>
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/pages/dashboard/SessionDetailPage.tsx
+++ b/apps/web/src/pages/dashboard/SessionDetailPage.tsx
@@ -1,98 +1,354 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+	CheckCircle2,
+	ChevronDown,
+	Clock,
+	Copy,
+	GitBranch,
+	GitCommitHorizontal,
+	User,
+} from "lucide-react";
+import { useCallback, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
-import { ConversationList } from "@/components/sessions/conversation/ConversationList";
-import { SessionHeader } from "@/components/sessions/SessionHeader";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-import { useAnalyticsQuery } from "@/hooks/useAnalyticsQuery";
-import { useSession } from "@/hooks/useSession";
+import { ConversationView } from "@/components/conversation/ConversationView";
+import {
+	type TokenDataPoint,
+	TokenUsageChart,
+} from "@/components/conversation/TokenUsageChart";
+import {
+	ToolActivityChart,
+	type ToolActivityPoint,
+} from "@/components/conversation/ToolActivityChart";
+import { useUserMap } from "@/hooks/useUserMap";
+import { calculateCost, formatUsername } from "@/lib/format";
 import { orpc } from "@/lib/orpc";
+import { formatRelativeTime } from "@/lib/time-utils";
+
+const archetypeStyles: Record<
+	string,
+	{ bg: string; text: string; label: string }
+> = {
+	quick_win: { bg: "bg-green-100", text: "text-green-800", label: "Quick Win" },
+	deep_work: { bg: "bg-blue-100", text: "text-blue-800", label: "Deep Work" },
+	struggle: { bg: "bg-red-100", text: "text-red-800", label: "Struggle" },
+	exploration: {
+		bg: "bg-purple-100",
+		text: "text-purple-800",
+		label: "Exploration",
+	},
+	abandoned: { bg: "bg-gray-100", text: "text-gray-600", label: "Abandoned" },
+	standard: { bg: "bg-surface", text: "text-subheading", label: "Standard" },
+};
 
 export function SessionDetailPage() {
 	const { sessionId } = useParams<{ sessionId: string }>();
+	const { userMap } = useUserMap();
+	const [copied, setCopied] = useState(false);
+	const [tokenData, setTokenData] = useState<TokenDataPoint[]>([]);
+	const [toolActivityData, setToolActivityData] = useState<ToolActivityPoint[]>(
+		[],
+	);
+	const [totalMessages, setTotalMessages] = useState(0);
+	const [activeMessageIndex, setActiveMessageIndex] = useState(0);
+	const [scrollToIndex, setScrollToIndex] = useState<number | null>(null);
+	const scrollContainerRef = useRef<HTMLDivElement>(null);
 
-	const { data, isLoading, error } = useAnalyticsQuery(
+	const handleTokenDataReady = useCallback(
+		(data: TokenDataPoint[], total: number) => {
+			setTokenData(data);
+			setTotalMessages(total);
+		},
+		[],
+	);
+
+	const handleToolActivityReady = useCallback((data: ToolActivityPoint[]) => {
+		setToolActivityData(data);
+	}, []);
+
+	const handleClickMessage = useCallback((messageIndex: number) => {
+		setScrollToIndex(messageIndex);
+		// Reset after triggering scroll so it can be re-triggered
+		setTimeout(() => setScrollToIndex(null), 100);
+	}, []);
+
+	const { data: session, isLoading } = useQuery(
 		orpc.analytics.sessions.detail.queryOptions({
 			input: { sessionId: sessionId as string },
 		}),
 	);
 
+	const copySessionId = () => {
+		if (session) {
+			navigator.clipboard.writeText(session.session_id);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		}
+	};
+
 	if (isLoading) {
 		return (
-			<div className="flex flex-col h-full">
-				<div className="border-b p-4 space-y-3">
-					<Skeleton className="h-8 w-48" />
-					<Skeleton className="h-4 w-64" />
-					<Skeleton className="h-6 w-96" />
+			<div className="flex items-center justify-center h-full">
+				<div className="animate-pulse space-y-4 w-full max-w-md">
+					<div className="h-8 bg-hover rounded w-1/3" />
+					<div className="h-4 bg-hover rounded w-1/2" />
+					<div className="h-4 bg-hover rounded w-2/3" />
 				</div>
-				<div className="flex-1 p-4">
-					<div className="space-y-4">
-						{["sk-1", "sk-2", "sk-3", "sk-4", "sk-5"].map((id) => (
-							<Skeleton key={id} className="h-24" />
+			</div>
+		);
+	}
+
+	if (!session) {
+		return (
+			<div className="flex items-center justify-center h-full">
+				<div className="text-center">
+					<p className="text-status-error-icon text-lg font-semibold mb-2">
+						Session Not Found
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col h-full">
+			{/* Session Header — pinned, never scrolls */}
+			<div className="shrink-0 bg-input px-8 py-4">
+				<div className="flex items-start justify-between">
+					<div>
+						<div className="flex items-center gap-3 mb-2">
+							<h1 className="text-2xl font-bold text-heading">
+								Session Details
+							</h1>
+							{session.session_archetype &&
+								(() => {
+									const style =
+										archetypeStyles[session.session_archetype] ??
+										archetypeStyles.standard;
+									return (
+										<span
+											className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${style.bg} ${style.text}`}
+										>
+											{style.label}
+										</span>
+									);
+								})()}
+						</div>
+						<div className="flex items-center gap-4 text-sm text-muted">
+							<div className="flex items-center gap-2">
+								<span className="font-mono text-xs bg-surface px-2 py-1 rounded">
+									{session.session_id.slice(0, 8)}...
+								</span>
+								<button
+									type="button"
+									onClick={copySessionId}
+									className="p-1 hover:bg-hover rounded"
+									title="Copy session ID"
+								>
+									{copied ? (
+										<CheckCircle2 className="w-4 h-4 text-status-success-icon" />
+									) : (
+										<Copy className="w-4 h-4 text-muted" />
+									)}
+								</button>
+							</div>
+							<div className="flex items-center gap-1">
+								<Clock className="w-4 h-4" />
+								{formatRelativeTime(session.session_date)}
+							</div>
+							<div className="flex items-center gap-1">
+								<User className="w-4 h-4" />
+								{formatUsername(session.user_id, userMap)}
+							</div>
+						</div>
+					</div>
+
+					{/* KPIs — right side of header */}
+					<div className="flex items-center gap-6 text-xs">
+						<div className="text-right">
+							<p className="text-muted">Duration</p>
+							<p className="text-foreground font-medium">
+								{session.duration_min !== undefined
+									? `${session.duration_min} min`
+									: "—"}
+							</p>
+						</div>
+						<div className="text-right">
+							<p className="text-muted">Interactions</p>
+							<p className="text-foreground font-medium">
+								{session.total_interactions ?? "—"}
+							</p>
+						</div>
+						<div className="text-right">
+							<p className="text-muted">Tokens</p>
+							<p className="text-foreground font-medium">
+								{session.input_tokens.toLocaleString()} /{" "}
+								{session.output_tokens.toLocaleString()}
+							</p>
+						</div>
+						<div className="text-right">
+							<p className="text-muted">Cost</p>
+							<p className="text-foreground font-mono font-medium">
+								$
+								{calculateCost(
+									session.input_tokens,
+									session.output_tokens,
+								).toFixed(4)}
+							</p>
+						</div>
+						{session.success_score !== undefined && (
+							<div className="text-right">
+								<p className="text-muted">Score</p>
+								<p
+									className={`font-semibold ${
+										session.success_score >= 70
+											? "text-status-success-icon"
+											: session.success_score >= 40
+												? "text-status-warning-icon"
+												: "text-status-error-icon"
+									}`}
+								>
+									{session.success_score.toFixed(0)}/100
+								</p>
+							</div>
+						)}
+						{Object.keys(session.subagents).length > 0 && (
+							<div className="text-right">
+								<p className="text-muted">Subagents</p>
+								<p className="text-foreground font-medium">
+									{Object.keys(session.subagents).length}
+								</p>
+							</div>
+						)}
+					</div>
+				</div>
+
+				<div className="mt-3 flex flex-wrap items-center gap-4 text-sm">
+					{session.repository && (
+						<div className="flex items-center gap-2 px-3 py-1 bg-status-info-bg rounded-lg">
+							<GitBranch className="w-4 h-4 text-accent" />
+							<span className="text-status-info-text font-medium">
+								{session.repository}
+							</span>
+						</div>
+					)}
+					{session.git_branch && (
+						<div className="flex items-center gap-2 px-3 py-1 bg-status-info-bg rounded-lg">
+							<GitBranch className="w-4 h-4 text-accent" />
+							<span className="text-status-info-text font-medium">
+								{session.git_branch}
+							</span>
+						</div>
+					)}
+					{session.git_sha && (
+						<div className="group relative">
+							<div className="flex items-center gap-2 px-3 py-1 bg-status-info-bg rounded-lg cursor-default">
+								<GitCommitHorizontal className="w-4 h-4 text-accent" />
+								<span className="text-status-info-text font-medium">
+									{session.git_sha.slice(0, 8)}
+								</span>
+								<ChevronDown className="w-3 h-3 text-accent transition-transform group-hover:rotate-180" />
+							</div>
+							<div className="absolute top-full left-0 mt-1 bg-input border border-border rounded-lg shadow-lg z-20 p-2 min-w-[280px] hidden group-hover:block">
+								<div className="flex items-center justify-between gap-2 px-2 py-1">
+									<span className="text-xs font-mono text-foreground select-all">
+										{session.git_sha}
+									</span>
+									<button
+										type="button"
+										onClick={() =>
+											navigator.clipboard.writeText(session.git_sha as string)
+										}
+										className="p-1 hover:bg-hover rounded"
+										title="Copy commit SHA"
+									>
+										<Copy className="w-3 h-3 text-muted" />
+									</button>
+								</div>
+							</div>
+						</div>
+					)}
+					{session.model_used && (
+						<div className="px-3 py-1 bg-surface rounded-lg">
+							<span className="text-subheading text-xs font-mono">
+								{session.model_used}
+							</span>
+						</div>
+					)}
+
+					<div className="flex flex-wrap gap-2 ml-auto">
+						{[...new Set(session.skills)].map((skill) => (
+							<span
+								key={skill}
+								className="px-2 py-1 text-xs bg-purple-100 text-purple-800 rounded"
+							>
+								skill:{skill}
+							</span>
+						))}
+						{[...new Set(session.slash_commands)].map((cmd) => (
+							<span
+								key={cmd}
+								className="px-2 py-1 text-xs bg-green-100 text-green-800 rounded"
+							>
+								/{cmd}
+							</span>
+						))}
+						{Object.keys(session.subagents).map((agent) => (
+							<span
+								key={agent}
+								className="px-2 py-1 text-xs bg-orange-100 text-orange-800 rounded"
+							>
+								agent:{agent}
+							</span>
 						))}
 					</div>
 				</div>
 			</div>
-		);
-	}
 
-	if (error || !data) {
-		return (
-			<div className="flex items-center justify-center h-96">
-				<Card className="max-w-md w-full">
-					<CardHeader>
-						<CardTitle className="text-destructive">
-							Error Loading Session
-						</CardTitle>
-					</CardHeader>
-					<CardContent>
-						<p className="text-sm text-muted-foreground">
-							Failed to load session data. The session may not exist.
-						</p>
-					</CardContent>
-				</Card>
+			{/* Tab subheader */}
+			<div className="shrink-0 bg-surface border-y border-border px-8 flex">
+				<button
+					type="button"
+					className="px-4 py-2 text-sm font-medium text-foreground border-b-2 border-foreground"
+				>
+					Conversation
+				</button>
 			</div>
-		);
-	}
 
-	return <SessionDetailContent session={data} />;
-}
+			{/* Scrollable content — two-column layout */}
+			<div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
+				<div className="flex">
+					{/* Conversation — left */}
+					<div className="flex-1 min-w-0 py-6 px-8">
+						<ConversationView
+							content={session.content}
+							scrollContainerRef={scrollContainerRef}
+							onActiveMessageChange={setActiveMessageIndex}
+							onTokenDataReady={handleTokenDataReady}
+							onToolActivityReady={handleToolActivityReady}
+							scrollToMessageIndex={scrollToIndex}
+						/>
+					</div>
 
-interface SessionDetailContentProps {
-	session: {
-		session_id: string;
-		user_id: string;
-		session_date: string;
-		project_path: string;
-		repository: string | null;
-		content: string;
-		subagents: Record<string, string>;
-		skills: Array<string>;
-		slash_commands: Array<string>;
-		git_branch: string | null;
-		git_sha: string | null;
-		total_tokens: number;
-		input_tokens: number;
-		output_tokens: number;
-		success_score?: number;
-		duration_min?: number;
-		total_interactions?: number;
-		session_archetype?: string;
-		model_used?: string;
-	};
-}
-
-function SessionDetailContent({ session }: SessionDetailContentProps) {
-	const { conversations, getToolResult, subagents } = useSession(session);
-
-	return (
-		<div className="flex flex-col h-full">
-			<SessionHeader session={session} />
-			<div className="flex-1 overflow-auto p-4">
-				<ConversationList
-					conversations={conversations}
-					getToolResult={getToolResult}
-					subagents={subagents}
-				/>
+					{/* Stats panel — right */}
+					<div className="w-[36rem] shrink-0 border-l border-border">
+						<div className="sticky top-0 px-6 py-4">
+							<TokenUsageChart
+								data={tokenData}
+								totalMessages={totalMessages}
+								activeMessageIndex={activeMessageIndex}
+								onClickMessage={handleClickMessage}
+							/>
+							<div className="border-t border-border my-4 pt-4">
+								<ToolActivityChart
+									data={toolActivityData}
+									totalMessages={totalMessages}
+									activeMessageIndex={activeMessageIndex}
+									onClickMessage={handleClickMessage}
+								/>
+							</div>
+						</div>
+					</div>
+				</div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Summary\n- restore the previous SessionDetail experience (the two-column "cool Lucas" screen)\n- bring back the conversation rendering components used by that version\n- adapt the restored screen/components to current contracts and username resolution via \n\n## Verification\n- bun run check-types (apps/web)