### PR TITLE
fix(web): resolve SessionDetail CI lint failures and text wrapping

### DIFF
--- a/apps/web/src/components/conversation/ConversationMessage.tsx
+++ b/apps/web/src/components/conversation/ConversationMessage.tsx
@@ -7,7 +7,10 @@ import {
 	Wrench,
 } from "lucide-react";
 import { useState } from "react";
-import type { Conversation, ToolResultContent } from "@/lib/conversation-schema";
+import type {
+	Conversation,
+	ToolResultContent,
+} from "@/lib/conversation-schema";
 import {
 	isSlashCommandMessage,
 	parseSlashCommand,
@@ -250,7 +253,9 @@ export function ConversationMessage({
 			</div>
 			<div className="flex-1 min-w-0 bg-card border border-border rounded-lg p-4 shadow-sm">
 				<div className="flex items-center gap-2 mb-3">
-					<span className="text-sm font-semibold text-foreground">Assistant</span>
+					<span className="text-sm font-semibold text-foreground">
+						Assistant
+					</span>
 					<span className="text-xs text-muted-foreground">
 						{new Date(entry.timestamp).toLocaleTimeString()}
 					</span>

--- a/apps/web/src/components/conversation/ConversationView.tsx
+++ b/apps/web/src/components/conversation/ConversationView.tsx
@@ -55,9 +55,7 @@ function extractTokenData(content: string): TokenDataPoint[] {
 }
 
 /** Extract tool, skill, and subagent activity from parsed conversations */
-function extractToolActivity(
-	entries: Conversation[],
-): ToolActivityPoint[] {
+function extractToolActivity(entries: Conversation[]): ToolActivityPoint[] {
 	const points: ToolActivityPoint[] = [];
 
 	for (let i = 0; i < entries.length; i++) {
@@ -155,11 +153,11 @@ export function ConversationView({
 
 			setConversations(parsed);
 
-				if (parsed.length > 0) {
-					if (onTokenDataReady) {
-						const tokenData = extractTokenData(content);
-						onTokenDataReady(tokenData, parsed.length);
-					}
+			if (parsed.length > 0) {
+				if (onTokenDataReady) {
+					const tokenData = extractTokenData(content);
+					onTokenDataReady(tokenData, parsed.length);
+				}
 				if (onToolActivityReady) {
 					const activityData = extractToolActivity(parsed);
 					onToolActivityReady(activityData);

--- a/apps/web/src/components/conversation/MessageContent.tsx
+++ b/apps/web/src/components/conversation/MessageContent.tsx
@@ -67,11 +67,7 @@ function parseTextContent(
 function renderPlainText(text: string, key: number) {
 	const parts = parseTextContent(text);
 	return (
-		<div
-			// biome-ignore lint/suspicious/noArrayIndexKey: static parsed content blocks
-			key={key}
-			className="space-y-3"
-		>
+		<div key={key} className="space-y-3">
 			{parts.map((part, partIdx) =>
 				part.type === "code" ? (
 					<CodeBlock
@@ -86,7 +82,7 @@ function renderPlainText(text: string, key: number) {
 						key={partIdx}
 						className="prose prose-sm max-w-none"
 					>
-						<p className="whitespace-pre-wrap text-foreground leading-relaxed">
+						<p className="whitespace-pre-wrap text-foreground leading-relaxed break-words [overflow-wrap:anywhere]">
 							{part.content}
 						</p>
 					</div>
@@ -106,7 +102,11 @@ export function MessageContent({ content, className }: MessageContentProps) {
 	}
 
 	if (typeof content === "string") {
-		return <div className={cn("space-y-3", className)}>{renderPlainText(content, 0)}</div>;
+		return (
+			<div className={cn("space-y-3", className)}>
+				{renderPlainText(content, 0)}
+			</div>
+		);
 	}
 
 	if (!Array.isArray(content)) {


### PR DESCRIPTION
## Summary
- fix Biome formatting/lint violations introduced by the SessionDetail rollback
- remove an unused Biome suppression in MessageContent
- make long user message text wrap with  to avoid horizontal overflow

## Verification
- bun run lint
- bun run check-types
- bunx turbo run lint check-types test build