### PR TITLE
fix(api): resolve 500 errors on open-source project details

### DIFF
--- a/apps/api/src/services/project.service.ts
+++ b/apps/api/src/services/project.service.ts
@@ -342,8 +342,8 @@ export async function getProjectDetails(
       SUM(ifNull(output_tokens, 0)) as output_tokens_sum,
       COUNT(DISTINCT user_id) as contributors_count,
       countIf(success_score < 40) as errors_count,
-      round(AVG(actual_duration_min), 2) as avg_session_duration_min,
-      round(AVG(success_score), 2) as success_rate,
+      ifNull(round(avgOrNull(actual_duration_min), 2), 0) as avg_session_duration_min,
+      ifNull(round(avgOrNull(success_score), 2), 0) as success_rate,
       round(SUM(actual_duration_min), 2) as total_duration_min
     FROM rudel.session_analytics
     WHERE ${PROJECT_DISPLAY_EXPR} = ${projectDisplaySubquery}
@@ -360,7 +360,7 @@ export async function getProjectDetails(
 	>(query);
 
 	const [row] = results;
-	if (!row) return null;
+	if (!row || row.total_sessions === 0) return null;
 	const cost =
 		row.output_tokens_sum * 0.000015 + row.input_tokens_sum * 0.000003;
 	return {

--- a/apps/web/src/pages/dashboard/ProjectsListPage.tsx
+++ b/apps/web/src/pages/dashboard/ProjectsListPage.tsx
@@ -147,7 +147,8 @@ export function ProjectsListPage() {
 			: "0";
 
 	const handleRowClick = (row: ProjectInvestment) => {
-		const encodedPath = encodeProjectPath(row.project_path);
+		const key = row.git_remote || row.project_path;
+		const encodedPath = encodeProjectPath(key);
 		navigate(`/dashboard/projects/${encodedPath}`);
 	};
 


### PR DESCRIPTION
## Summary

- **API 500**: `getProjectDetails` used `AVG()` in an aggregate query without `GROUP BY`. When 0 rows matched the WHERE clause, ClickHouse returned `nan` for those columns — which is not valid JSON — causing a parse error and a 500 response. Fixed by using `avgOrNull()` + `ifNull(..., 0)` so ClickHouse returns `0` instead of `nan`. Also added a `total_sessions === 0` guard to return `NOT_FOUND` cleanly instead of all-zero data.
- **Navigation bug**: For open-source projects where sessions have `git_remote` set but `project_path` is empty, `ProjectsListPage` was navigating with an empty key, routing back to the projects list instead of the detail page. Fixed by using `git_remote || project_path` as the navigation key (the detail API's `buildProjectDisplaySubquery` already handles git remote URLs in its lookup).

## Test plan

- [ ] Navigate to a project detail page for a project with a `git_remote` set — should load without 500
- [ ] Navigate to a project detail page and switch to a date range with no sessions — should return 404/not found rather than 500
- [ ] Open-source projects (multiple contributors, same git remote, different local paths) load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)