### PR TITLE
fix: verify org membership in middleware and session ingestion

### DIFF
--- a/apps/api/src/middleware.ts
+++ b/apps/api/src/middleware.ts
@@ -1,6 +1,9 @@
 import { implement, ORPCError } from "@orpc/server";
 import { contract } from "@rudel/api-routes";
+import { member } from "@rudel/sql-schema";
+import { and, eq } from "drizzle-orm";
 import type { Session } from "./auth.js";
+import { db } from "./db.js";
 
 export interface AppContext {
 	user: Session["user"] | null;
@@ -33,6 +36,27 @@ export const orgMiddleware = os.middleware(async ({ context, next }) => {
 			message: "No active organization",
 		});
 	}
+
+	// When the active org is not the user's personal workspace, verify membership
+	if (organizationId !== context.user.id) {
+		const membership = await db
+			.select({ id: member.id })
+			.from(member)
+			.where(
+				and(
+					eq(member.organizationId, organizationId),
+					eq(member.userId, context.user.id),
+				),
+			)
+			.limit(1);
+
+		if (membership.length === 0) {
+			throw new ORPCError("FORBIDDEN", {
+				message: "Not a member of the active organization",
+			});
+		}
+	}
+
 	return next({
 		context: {
 			user: context.user,

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -63,13 +63,14 @@ const ingestSessionHandler = os.ingestSession
 				| null) ??
 			context.user.id;
 
-		if (input.organizationId) {
+		// Verify membership for any org that isn't the user's personal workspace
+		if (orgId !== context.user.id) {
 			const membership = await db
 				.select({ id: member.id })
 				.from(member)
 				.where(
 					and(
-						eq(member.organizationId, input.organizationId),
+						eq(member.organizationId, orgId),
 						eq(member.userId, context.user.id),
 					),
 				)


### PR DESCRIPTION
## Summary
- Add membership verification to `orgMiddleware` to prevent removed members from accessing org analytics via stale `activeOrganizationId` in their session
- Verify membership in `ingestSessionHandler` when falling back to `activeOrganizationId` instead of only checking explicit `organizationId` parameter
- Removed members with old browser sessions or CLI tokens can no longer retain read/write access to organization data

## Test plan
- [x] Type checking and linting pass
- [x] All existing tests pass
- [x] Verification includes API and web builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)