### PR TITLE
fix: normalize Windows backslash paths in project display and ingestion

### DIFF
--- a/apps/api/src/services/project.service.ts
+++ b/apps/api/src/services/project.service.ts
@@ -16,7 +16,7 @@ import {
 const logger = getLogger(["rudel", "api", "project-service"]);
 
 const PROJECT_KEY_EXPR = `if(git_remote != '', git_remote, if(package_name != '', package_name, project_path))`;
-const PROJECT_DISPLAY_EXPR = `if(git_remote != '', arrayElement(splitByChar('/', git_remote), -1), arrayElement(splitByChar('/', project_path), -1))`;
+const PROJECT_DISPLAY_EXPR = `if(git_remote != '', arrayElement(splitByChar('/', git_remote), -1), arrayElement(splitByChar('/', replaceAll(project_path, '\\\\', '/')), -1))`;
 
 function buildProjectDisplaySubquery(
 	org: string,
@@ -27,7 +27,7 @@ function buildProjectDisplaySubquery(
       if(
         count() > 0,
         any(${PROJECT_DISPLAY_EXPR}),
-        if(position('${escapedProjectPath}', '/') > 0, arrayElement(splitByChar('/', '${escapedProjectPath}'), -1), '${escapedProjectPath}')
+        arrayElement(splitByChar('/', replaceAll('${escapedProjectPath}', '\\\\', '/')), -1)
       ) as project_display
     FROM rudel.session_analytics
     WHERE organization_id = '${org}'

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -94,7 +94,7 @@ export const SubagentFileSchema = z.object({
 export const IngestSessionInputSchema = z.object({
 	source: SourceSchema.default("claude_code"),
 	sessionId: z.string(),
-	projectPath: z.string(),
+	projectPath: z.string().transform((p) => p.replace(/\\/g, "/")),
 	gitRemote: z.string().optional(),
 	packageName: z.string().optional(),
 	packageType: z.string().optional(),


### PR DESCRIPTION
## Summary
- Add `.transform()` to `IngestSessionInputSchema.projectPath` to convert backslashes to forward slashes at the API boundary — fixes Windows paths going forward
- Update `PROJECT_DISPLAY_EXPR` to use `replaceAll(project_path, '\\', '/')` before `splitByChar` so existing Windows paths in ClickHouse (e.g. `c:\Personal\Numia\zeus`) correctly display just the last folder name (`zeus`)
- Simplify `buildProjectDisplaySubquery` fallback to always normalize with `replaceAll` instead of checking for `/` position first

## Test plan
- [ ] Upload a session with a Windows-style `projectPath` (e.g. `C:\Users\foo\myproject`) and verify it's stored as `C:/Users/foo/myproject`
- [ ] Check the Projects table — existing Windows paths should show just the last folder name instead of the full path

🤖 Generated with [Claude Code](https://claude.com/claude-code)