### PR TITLE
feat(api): add ingest rate limiting, request body size limits, and metadata field length validation

### DIFF
--- a/apps/api/src/__tests__/rate-limit.test.ts
+++ b/apps/api/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { IngestSessionInputSchema } from "@rudel/api-routes";
+
+describe("IngestSessionInputSchema metadata field limits", () => {
+	const validBase = {
+		source: "claude_code" as const,
+		sessionId: "abc-123",
+		projectPath: "/home/user/project",
+		content: '{"type":"user","timestamp":"2026-01-01T00:00:00Z"}',
+	};
+
+	test("accepts metadata fields within 200 char limit", () => {
+		const result = IngestSessionInputSchema.safeParse({
+			...validBase,
+			sessionId: "a".repeat(200),
+			projectPath: "b".repeat(200),
+			gitRemote: "c".repeat(200),
+			gitBranch: "d".repeat(200),
+			gitSha: "e".repeat(200),
+			packageName: "f".repeat(200),
+			packageType: "g".repeat(200),
+			organizationId: "h".repeat(200),
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects sessionId over 200 chars", () => {
+		const result = IngestSessionInputSchema.safeParse({
+			...validBase,
+			sessionId: "a".repeat(201),
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects projectPath over 200 chars", () => {
+		const result = IngestSessionInputSchema.safeParse({
+			...validBase,
+			projectPath: "a".repeat(201),
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects gitRemote over 200 chars", () => {
+		const result = IngestSessionInputSchema.safeParse({
+			...validBase,
+			gitRemote: "a".repeat(201),
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects gitBranch over 200 chars", () => {
+		const result = IngestSessionInputSchema.safeParse({
+			...validBase,
+			gitBranch: "a".repeat(201),
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects organizationId over 200 chars", () => {
+		const result = IngestSessionInputSchema.safeParse({
+			...validBase,
+			organizationId: "a".repeat(201),
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("does not limit content field length", () => {
+		const result = IngestSessionInputSchema.safeParse({
+			...validBase,
+			content: "x".repeat(10_000_000),
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("does not limit subagent content field length", () => {
+		const result = IngestSessionInputSchema.safeParse({
+			...validBase,
+			subagents: [{ agentId: "agent-1", content: "y".repeat(1_000_000) }],
+		});
+		expect(result.success).toBe(true);
+	});
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -70,6 +70,9 @@ function corsHeaders(origin: string | null): Record<string, string> {
 }
 
 const port = process.env.PORT ?? 4010;
+const MAX_REQUEST_BODY_BYTES = Number(
+	process.env.MAX_REQUEST_BODY_BYTES ?? 500 * 1024 * 1024, // 500 MB
+);
 
 const server = Bun.serve({
 	port,
@@ -79,6 +82,19 @@ const server = Bun.serve({
 
 		if (request.method === "OPTIONS") {
 			return new Response(null, { status: 204, headers: cors });
+		}
+
+		const contentLength = request.headers.get("Content-Length");
+		if (contentLength && Number(contentLength) > MAX_REQUEST_BODY_BYTES) {
+			return new Response(
+				JSON.stringify({
+					error: `Request body too large. Maximum size is ${Math.round(MAX_REQUEST_BODY_BYTES / (1024 * 1024))} MB.`,
+				}),
+				{
+					status: 413,
+					headers: { ...cors, "Content-Type": "application/json" },
+				},
+			);
 		}
 
 		const url = new URL(request.url);

--- a/apps/api/src/rate-limit.ts
+++ b/apps/api/src/rate-limit.ts
@@ -1,0 +1,59 @@
+import { getLogger } from "@logtape/logtape";
+import { ORPCError } from "@orpc/server";
+import { escapeString, queryClickhouse } from "./clickhouse.js";
+
+const logger = getLogger(["rudel", "api", "rate-limit"]);
+
+export interface RateLimitConfig {
+	maxRequests: number;
+	windowSeconds: number;
+	countQuery: (userId: string, windowSeconds: number) => string;
+}
+
+const ingestCountQuery = (userId: string, windowSeconds: number) =>
+	`SELECT sum(c) AS count FROM (` +
+	`SELECT count() AS c FROM rudel.claude_sessions WHERE user_id = '${userId}' AND ingested_at >= now64(3) - INTERVAL ${windowSeconds} SECOND ` +
+	`UNION ALL ` +
+	`SELECT count() AS c FROM rudel.codex_sessions WHERE user_id = '${userId}' AND ingested_at >= now64(3) - INTERVAL ${windowSeconds} SECOND` +
+	`)`;
+
+export const INGEST_RATE_LIMIT: RateLimitConfig = {
+	maxRequests: Number(process.env.RATE_LIMIT_INGEST_MAX ?? 120),
+	windowSeconds: Number(process.env.RATE_LIMIT_INGEST_WINDOW ?? 3600),
+	countQuery: ingestCountQuery,
+};
+
+/**
+ * Checks if a user has exceeded their rate limit.
+ * Returns the current count, or null if the check failed (ClickHouse down).
+ */
+export async function checkIngestRateLimit(
+	userId: string,
+	config: RateLimitConfig = INGEST_RATE_LIMIT,
+): Promise<void> {
+	const { maxRequests, windowSeconds, countQuery } = config;
+
+	try {
+		const rows = await queryClickhouse<{ count: number }>(
+			countQuery(escapeString(userId), windowSeconds),
+		);
+		const count = rows[0]?.count ?? 0;
+
+		if (count >= maxRequests) {
+			logger.warn(
+				"Rate limit exceeded for user {userId}: {count}/{maxRequests} in {windowSeconds}s",
+				{ userId, count, maxRequests, windowSeconds },
+			);
+			throw new ORPCError("TOO_MANY_REQUESTS", {
+				message: `Rate limit exceeded. Maximum ${maxRequests} requests per ${Math.round(windowSeconds / 60)} minutes.`,
+			});
+		}
+	} catch (error) {
+		if (error instanceof ORPCError) throw error;
+		// If ClickHouse is down, log and allow the request through.
+		// Availability > rate limiting.
+		logger.error("Rate limit check failed, allowing request: {error}", {
+			error,
+		});
+	}
+}

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -6,6 +6,7 @@ import { getClickhouse } from "./clickhouse.js";
 import { db } from "./db.js";
 import { analyticsRouter } from "./handlers/analytics/index.js";
 import { authMiddleware, os } from "./middleware.js";
+import { checkIngestRateLimit } from "./rate-limit.js";
 import {
 	deleteOrgSessions,
 	getOrgSessionCount,
@@ -56,6 +57,8 @@ const listMyOrganizations = os.listMyOrganizations
 const ingestSessionHandler = os.ingestSession
 	.use(authMiddleware)
 	.handler(async ({ input, context }) => {
+		await checkIngestRateLimit(context.user.id);
+
 		const orgId =
 			input.organizationId ??
 			((context.session as Record<string, unknown>).activeOrganizationId as

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -93,17 +93,20 @@ export const SubagentFileSchema = z.object({
 
 export const IngestSessionInputSchema = z.object({
 	source: SourceSchema.default("claude_code"),
-	sessionId: z.string(),
-	projectPath: z.string().transform((p) => p.replace(/\\/g, "/")),
-	gitRemote: z.string().optional(),
-	packageName: z.string().optional(),
-	packageType: z.string().optional(),
-	gitBranch: z.string().optional(),
-	gitSha: z.string().optional(),
+	sessionId: z.string().max(200),
+	projectPath: z
+		.string()
+		.max(200)
+		.transform((p) => p.replace(/\\/g, "/")),
+	gitRemote: z.string().max(200).optional(),
+	packageName: z.string().max(200).optional(),
+	packageType: z.string().max(200).optional(),
+	gitBranch: z.string().max(200).optional(),
+	gitSha: z.string().max(200).optional(),
 	tag: SessionTagSchema.optional(),
 	content: z.string(),
 	subagents: z.array(SubagentFileSchema).optional(),
-	organizationId: z.string().optional(),
+	organizationId: z.string().max(200).optional(),
 });
 
 export const IngestSessionOutputSchema = z.object({


### PR DESCRIPTION
## Summary
- Add rate limiting on ingest endpoint (configurable via `RATE_LIMIT_INGEST_MAX`, `RATE_LIMIT_INGEST_WINDOW` env vars)
- Add request body size limit (configurable via `MAX_REQUEST_BODY_BYTES` env var, defaults to 500 MB)
- Add metadata field length validation (sessionId, projectPath, gitRemote, gitBranch, gitSha, packageName, packageType, organizationId capped at 200 chars)

Content field remains unlimited to support large session transcripts.

## Test plan
- [x] All existing tests pass
- [x] New rate limit tests verify metadata field length constraints
- [x] Verify rate limiting on ingest endpoint
- [x] Verify request body size rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)