### PR TITLE
feat: add Chatwoot dashboard support widget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,9 @@ CLICKHOUSE_PASSWORD=
 # Slack incoming webhook URL. When set, sends a notification to the channel
 # on every new user signup.
 # SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+
+# Chatwoot website widget for the dashboard support launcher. These are public
+# frontend values used by the web app only.
+# VITE_CHATWOOT_BASE_URL=https://app.chatwoot.com
+# VITE_CHATWOOT_WEBSITE_TOKEN=
+# VITE_CHATWOOT_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Each uploaded session includes:
 
 Rudel is designed to ingest full coding-agent session data for analytics. That means uploaded transcripts and related metadata may contain sensitive material, including source code, prompts, tool output, file contents, command output, URLs, and secrets that appeared during a session.
 
-Only enable Rudel on projects and environments where you are comfortable uploading that data. If you use the hosted service at `app.rudel.ai`, we do not have access to personal data contained in uploaded transcripts and cannot read that data. Review the [Rudel Privacy Policy](https://app.rudel.ai/privacy) before enabling uploads for yourself or your team.
+Only enable Rudel on projects and environments where you are comfortable uploading that data. If you use the hosted service at `app.rudel.ai`, we do not have access to personal data contained in uploaded transcripts and cannot read that data. Review the [Rudel Privacy Policy](https://rudel.ai/privacy-policy) before enabling uploads for yourself or your team.
 
 ## Development
 

--- a/apps/web/src/components/analytics/Sidebar.tsx
+++ b/apps/web/src/components/analytics/Sidebar.tsx
@@ -253,18 +253,65 @@ export function Sidebar() {
 				</nav>
 
 				{session?.user && (
-					<div
-						className={cn(
-							"border-t border-border p-2 flex items-center gap-2",
-							collapsed ? "justify-center" : "px-2",
-						)}
-					>
+					<div className="border-t border-border p-2">
 						{collapsed ? (
-							<Tooltip>
-								<TooltipTrigger asChild>
+							<div className="mb-2 flex justify-center">
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<div className="flex h-7 w-7 items-center justify-center rounded-md bg-hover text-[0.5625rem] font-bold tracking-[0.14em] text-accent">
+											A
+										</div>
+									</TooltipTrigger>
+									<TooltipContent side="right">
+										OPEN ALPHA Testing v{__APP_VERSION__}
+									</TooltipContent>
+								</Tooltip>
+							</div>
+						) : (
+							<div className="mb-2 flex items-center justify-between gap-2 rounded-lg bg-hover px-2 py-2">
+								<div className="truncate text-[0.6875rem] font-bold tracking-[0.08em] text-accent">
+									OPEN ALPHA Testing
+								</div>
+								<div className="shrink-0 text-[0.6875rem] text-muted">
+									v{__APP_VERSION__}
+								</div>
+							</div>
+						)}
+						<div
+							className={cn(
+								"flex items-center gap-2",
+								collapsed ? "justify-center" : "px-0",
+							)}
+						>
+							{collapsed ? (
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Link
+											to="/dashboard/profile"
+											className="flex items-center gap-2 min-w-0"
+										>
+											<Avatar size="sm" className="shrink-0">
+												{session.user.image && (
+													<AvatarImage
+														src={session.user.image}
+														alt={session.user.name}
+													/>
+												)}
+												<AvatarFallback>
+													{getInitials(session.user.name)}
+												</AvatarFallback>
+											</Avatar>
+										</Link>
+									</TooltipTrigger>
+									<TooltipContent side="right">
+										{session.user.name}
+									</TooltipContent>
+								</Tooltip>
+							) : (
+								<>
 									<Link
 										to="/dashboard/profile"
-										className="flex items-center gap-2 min-w-0"
+										className="flex-1 flex items-center gap-2 min-w-0"
 									>
 										<Avatar size="sm" className="shrink-0">
 											{session.user.image && (
@@ -277,44 +324,22 @@ export function Sidebar() {
 												{getInitials(session.user.name)}
 											</AvatarFallback>
 										</Avatar>
+										<span className="flex-1 truncate text-xs font-medium text-foreground hover:text-heading transition-colors">
+											{session.user.name}
+										</span>
 									</Link>
-								</TooltipTrigger>
-								<TooltipContent side="right">
-									{session.user.name}
-								</TooltipContent>
-							</Tooltip>
-						) : (
-							<>
-								<Link
-									to="/dashboard/profile"
-									className="flex-1 flex items-center gap-2 min-w-0"
-								>
-									<Avatar size="sm" className="shrink-0">
-										{session.user.image && (
-											<AvatarImage
-												src={session.user.image}
-												alt={session.user.name}
-											/>
-										)}
-										<AvatarFallback>
-											{getInitials(session.user.name)}
-										</AvatarFallback>
-									</Avatar>
-									<span className="flex-1 truncate text-xs font-medium text-foreground hover:text-heading transition-colors">
-										{session.user.name}
-									</span>
-								</Link>
-								<ThemeToggle />
-								<button
-									type="button"
-									onClick={() => signOut()}
-									className="p-1 rounded-md text-muted hover:text-foreground hover:bg-hover transition-colors shrink-0"
-									title="Sign out"
-								>
-									<LogOut className="h-3.5 w-3.5" />
-								</button>
-							</>
-						)}
+									<ThemeToggle />
+									<button
+										type="button"
+										onClick={() => signOut()}
+										className="p-1 rounded-md text-muted hover:text-foreground hover:bg-hover transition-colors shrink-0"
+										title="Sign out"
+									>
+										<LogOut className="h-3.5 w-3.5" />
+									</button>
+								</>
+							)}
+						</div>
 					</div>
 				)}
 			</div>

--- a/apps/web/src/components/support/ChatwootBootstrap.tsx
+++ b/apps/web/src/components/support/ChatwootBootstrap.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { useOrganization } from "../../contexts/OrganizationContext";
+import { authClient } from "../../lib/auth-client";
+import {
+	ensureChatwootLoaded,
+	isChatwootEnabled,
+	syncChatwootUser,
+} from "../../lib/chatwoot";
+
+export function ChatwootBootstrap() {
+	const { data: session } = authClient.useSession();
+	const { activeOrg } = useOrganization();
+
+	useEffect(() => {
+		if (!isChatwootEnabled()) {
+			return;
+		}
+
+		void ensureChatwootLoaded().catch(() => {
+			// Keep the dashboard usable even if Chatwoot is unavailable.
+		});
+	}, []);
+
+	useEffect(() => {
+		if (!isChatwootEnabled() || !session?.user) {
+			return;
+		}
+
+		const identifier =
+			("id" in session.user && typeof session.user.id === "string"
+				? session.user.id
+				: undefined) ??
+			("email" in session.user && typeof session.user.email === "string"
+				? session.user.email
+				: undefined);
+
+		if (!identifier) {
+			return;
+		}
+
+		void syncChatwootUser({
+			identifier,
+			email:
+				"email" in session.user && typeof session.user.email === "string"
+					? session.user.email
+					: undefined,
+			name: session.user.name,
+			avatarUrl: session.user.image,
+			organizationName: activeOrg?.name,
+		});
+	}, [activeOrg?.name, session?.user]);
+
+	return null;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -245,3 +245,35 @@
 		@apply h-full;
 	}
 }
+
+body .woot-widget-bubble.woot-widget-bubble {
+	width: 52px;
+	height: 52px;
+	bottom: 16px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+body .woot-widget-bubble.woot-widget-bubble svg {
+	width: 20px;
+	height: 20px;
+	margin: 0;
+}
+
+body .woot-widget-bubble.woot-widget-bubble.woot--close::before,
+body .woot-widget-bubble.woot-widget-bubble.woot--close::after {
+	top: 16px;
+	left: 25px;
+	height: 20px;
+}
+
+body .woot-widget-holder.woot-widget-holder {
+	width: min(352px, calc(100vw - 24px));
+	max-height: min(540px, calc(100vh - 88px));
+	bottom: 80px;
+}
+
+body .woot-widget-holder.woot-widget-holder iframe {
+	border-radius: 16px;
+}

--- a/apps/web/src/layouts/DashboardLayout.tsx
+++ b/apps/web/src/layouts/DashboardLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from "react-router-dom";
 import { Breadcrumb } from "../components/analytics/Breadcrumb";
 import { Sidebar } from "../components/analytics/Sidebar";
+import { ChatwootBootstrap } from "../components/support/ChatwootBootstrap";
 import { DateRangeProvider } from "../contexts/DateRangeContext";
 import { FilterProvider } from "../contexts/FilterContext";
 import { OrganizationProvider } from "../contexts/OrganizationContext";
@@ -11,6 +12,7 @@ export function DashboardLayout() {
 			<DateRangeProvider>
 				<FilterProvider>
 					<div className="fixed inset-0 flex overflow-hidden bg-surface">
+						<ChatwootBootstrap />
 						<Sidebar />
 						<div className="flex min-h-0 flex-1 flex-col overflow-hidden">
 							<Breadcrumb />

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,5 +1,6 @@
 import { organizationClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
+import { resetChatwoot } from "./chatwoot";
 import { queryClient } from "./query-client";
 
 export const authClient = createAuthClient({
@@ -8,6 +9,7 @@ export const authClient = createAuthClient({
 });
 
 export async function signOut() {
+	resetChatwoot();
 	await authClient.signOut();
 	queryClient.clear();
 	localStorage.removeItem("dateRange");

--- a/apps/web/src/lib/chatwoot.ts
+++ b/apps/web/src/lib/chatwoot.ts
@@ -1,0 +1,209 @@
+type ChatwootSDK = {
+	run: (config: { websiteToken: string; baseUrl: string }) => void;
+};
+
+type ChatwootUser = {
+	email?: string;
+	name?: string;
+	avatar_url?: string;
+	phone_number?: string;
+	description?: string;
+	company_name?: string;
+};
+
+type ChatwootAPI = {
+	hasLoaded?: boolean;
+	toggle: (state?: "open" | "close") => void;
+	setUser: (identifier: string | number, user: ChatwootUser) => void;
+	setLabel: (label: string) => void;
+	reset: () => void;
+};
+
+declare global {
+	interface Window {
+		chatwootSDK?: ChatwootSDK;
+		$chatwoot?: ChatwootAPI;
+	}
+}
+
+const BASE_URL = import.meta.env.VITE_CHATWOOT_BASE_URL?.trim() ?? "";
+const WEBSITE_TOKEN = import.meta.env.VITE_CHATWOOT_WEBSITE_TOKEN?.trim() ?? "";
+const ENABLED = import.meta.env.VITE_CHATWOOT_ENABLED !== "false";
+const SCRIPT_ID = "rudel-chatwoot-sdk";
+const LOAD_TIMEOUT_MS = 5_000;
+
+let loadPromise: Promise<void> | null = null;
+
+function getScriptUrl() {
+	return `${BASE_URL.replace(/\/$/, "")}/packs/js/sdk.js`;
+}
+
+function delay(ms: number) {
+	return new Promise<void>((resolve) => {
+		window.setTimeout(resolve, ms);
+	});
+}
+
+async function waitForChatwoot() {
+	const startedAt = Date.now();
+
+	while (Date.now() - startedAt < LOAD_TIMEOUT_MS) {
+		if (window.$chatwoot?.hasLoaded) {
+			return;
+		}
+		await delay(50);
+	}
+
+	throw new Error("Timed out waiting for Chatwoot to initialize");
+}
+
+function runChatwoot() {
+	if (!window.chatwootSDK) {
+		throw new Error("Chatwoot SDK failed to load");
+	}
+
+	window.chatwootSDK.run({
+		websiteToken: WEBSITE_TOKEN,
+		baseUrl: BASE_URL,
+	});
+}
+
+export function isChatwootEnabled() {
+	return ENABLED && BASE_URL.length > 0 && WEBSITE_TOKEN.length > 0;
+}
+
+export function ensureChatwootLoaded(): Promise<void> {
+	if (
+		typeof window === "undefined" ||
+		typeof document === "undefined" ||
+		!isChatwootEnabled()
+	) {
+		return Promise.resolve();
+	}
+
+	if (window.$chatwoot?.hasLoaded) {
+		return Promise.resolve();
+	}
+
+	if (loadPromise) {
+		return loadPromise;
+	}
+
+	if (window.$chatwoot) {
+		loadPromise = waitForChatwoot();
+		return loadPromise.catch((error) => {
+			loadPromise = null;
+			throw error;
+		});
+	}
+
+	loadPromise = new Promise<void>((resolve, reject) => {
+		const existingScript = document.getElementById(
+			SCRIPT_ID,
+		) as HTMLScriptElement | null;
+
+		const startWidget = () => {
+			try {
+				runChatwoot();
+				void waitForChatwoot().then(resolve, reject);
+			} catch (error) {
+				reject(error);
+			}
+		};
+
+		if (existingScript) {
+			if (window.chatwootSDK) {
+				startWidget();
+				return;
+			}
+
+			existingScript.addEventListener("load", startWidget, { once: true });
+			existingScript.addEventListener(
+				"error",
+				() => reject(new Error("Chatwoot SDK failed to load")),
+				{ once: true },
+			);
+			return;
+		}
+
+		const script = document.createElement("script");
+		script.id = SCRIPT_ID;
+		script.async = true;
+		script.src = getScriptUrl();
+		script.addEventListener("load", startWidget, { once: true });
+		script.addEventListener(
+			"error",
+			() => reject(new Error("Chatwoot SDK failed to load")),
+			{ once: true },
+		);
+
+		document.head.appendChild(script);
+	});
+
+	return loadPromise.catch((error) => {
+		loadPromise = null;
+		throw error;
+	});
+}
+
+export async function openChatwoot() {
+	if (!isChatwootEnabled()) {
+		return;
+	}
+
+	try {
+		await ensureChatwootLoaded();
+		window.$chatwoot?.toggle("open");
+	} catch {
+		// Ignore widget load failures so the dashboard remains functional.
+	}
+}
+
+function trimValue(value: string | null | undefined) {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+export async function syncChatwootUser(user: {
+	identifier: string | number;
+	email?: string | null;
+	name?: string | null;
+	avatarUrl?: string | null;
+	organizationName?: string | null;
+}) {
+	if (!isChatwootEnabled()) {
+		return;
+	}
+
+	try {
+		await ensureChatwootLoaded();
+
+		const api = window.$chatwoot;
+		if (!api) {
+			return;
+		}
+
+		const contact: ChatwootUser = {
+			email: trimValue(user.email),
+			name: trimValue(user.name),
+			avatar_url: trimValue(user.avatarUrl),
+			company_name: trimValue(user.organizationName),
+			description: trimValue(user.organizationName)
+				? `Rudel dashboard user from ${user.organizationName}`
+				: "Rudel dashboard user",
+		};
+
+		if (!contact.email && !contact.name && !contact.avatar_url) {
+			return;
+		}
+
+		api.setUser(user.identifier, contact);
+		api.setLabel("rudel-dashboard");
+	} catch {
+		// Keep the dashboard usable even if Chatwoot is unavailable.
+	}
+}
+
+export function resetChatwoot() {
+	window.$chatwoot?.reset();
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,20 +1,87 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-export default defineConfig({
-	plugins: [react(), tailwindcss()],
-	server: {
-		port: 4011,
-		proxy: {
-			"/api": "http://localhost:4010",
-			"/rpc": "http://localhost:4010",
+const { version } = JSON.parse(
+	readFileSync(new URL("./package.json", import.meta.url), "utf-8"),
+) as { version: string };
+
+async function getLatestGitHubVersion() {
+	const response = await fetch(
+		"https://api.github.com/repos/obsessiondb/rudel/releases/latest",
+		{
+			headers: {
+				Accept: "application/vnd.github+json",
+				"User-Agent": "rudel-web-build",
+			},
 		},
-	},
-	resolve: {
-		alias: {
-			"@": path.resolve(__dirname, "./src"),
+	);
+
+	if (!response.ok) {
+		throw new Error(`GitHub returned ${response.status}`);
+	}
+
+	const data = (await response.json()) as { tag_name?: string };
+
+	if (!data.tag_name) {
+		throw new Error("GitHub release response did not include a tag");
+	}
+
+	return data.tag_name.replace(/^rudel@/, "");
+}
+
+function getLatestLocalTagVersion() {
+	const output = execFileSync("git", ["tag", "--sort=-version:refname"], {
+		cwd: __dirname,
+		encoding: "utf-8",
+	});
+
+	const tag = output
+		.split("\n")
+		.map((line) => line.trim())
+		.find(Boolean);
+
+	if (!tag) {
+		throw new Error("No git tags found");
+	}
+
+	return tag.replace(/^rudel@/, "");
+}
+
+async function resolveAppVersion() {
+	try {
+		return await getLatestGitHubVersion();
+	} catch {
+		try {
+			return getLatestLocalTagVersion();
+		} catch {
+			return version;
+		}
+	}
+}
+
+export default defineConfig(async () => {
+	const appVersion = await resolveAppVersion();
+
+	return {
+		define: {
+			__APP_VERSION__: JSON.stringify(appVersion),
 		},
-	},
+		plugins: [react(), tailwindcss()],
+		server: {
+			port: 4011,
+			proxy: {
+				"/api": "http://localhost:4010",
+				"/rpc": "http://localhost:4010",
+			},
+		},
+		resolve: {
+			alias: {
+				"@": path.resolve(__dirname, "./src"),
+			},
+		},
+	};
 });

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.2/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",


### PR DESCRIPTION
Adds a Chatwoot website widget to dashboard routes with local loader/bootstrap logic, user sync/reset handling, and launcher styling tuned for Rudel. Also adds the OPEN ALPHA Testing sidebar badge with a GitHub/latest-tag-backed version label and documents the env/config needed for Chatwoot. Includes the Chatwoot rollout plan doc used to wire the dashboard-to-Slack support flow.