### PR TITLE
fix: disable API key plugin rate limit

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -41,6 +41,9 @@ export function createAuth(db: object, config: AuthConfig) {
 				keyExpiration: {
 					defaultExpiresIn: null,
 				},
+				rateLimit: {
+					enabled: false,
+				},
 				permissions: {
 					defaultPermissions: {
 						ingest: ["write"],


### PR DESCRIPTION
Disables the Better Auth API key plugin rate limiter in the API auth configuration. This keeps the existing app-level ingest rate limiting intact while removing the plugin-level throttle.