### PR TITLE
fix: cap analytics query inputs and add rate limiting

### DIFF
--- a/apps/api/src/__tests__/rate-limit.test.ts
+++ b/apps/api/src/__tests__/rate-limit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { IngestSessionInputSchema } from "@rudel/api-routes";
+import { checkAnalyticsRateLimit } from "../rate-limit.js";
 
 describe("IngestSessionInputSchema metadata field limits", () => {
 	const validBase = {
@@ -78,5 +79,33 @@ describe("IngestSessionInputSchema metadata field limits", () => {
 			subagents: [{ agentId: "agent-1", content: "y".repeat(1_000_000) }],
 		});
 		expect(result.success).toBe(true);
+	});
+});
+
+describe("checkAnalyticsRateLimit", () => {
+	test("allows requests under the limit", () => {
+		const userId = `test-under-${Date.now()}`;
+		expect(() => checkAnalyticsRateLimit(userId)).not.toThrow();
+	});
+
+	test("throws after exceeding the limit", () => {
+		const userId = `test-over-${Date.now()}`;
+		// Default is 90 requests per 60 seconds
+		for (let i = 0; i < 90; i++) {
+			checkAnalyticsRateLimit(userId);
+		}
+		expect(() => checkAnalyticsRateLimit(userId)).toThrow(
+			"Rate limit exceeded",
+		);
+	});
+
+	test("different users have independent limits", () => {
+		const userA = `test-a-${Date.now()}`;
+		const userB = `test-b-${Date.now()}`;
+		for (let i = 0; i < 90; i++) {
+			checkAnalyticsRateLimit(userA);
+		}
+		// userA is exhausted, userB should still work
+		expect(() => checkAnalyticsRateLimit(userB)).not.toThrow();
 	});
 });

--- a/apps/api/src/middleware.ts
+++ b/apps/api/src/middleware.ts
@@ -4,6 +4,7 @@ import { member } from "@rudel/sql-schema";
 import { and, eq } from "drizzle-orm";
 import type { Session } from "./auth.js";
 import { db } from "./db.js";
+import { checkAnalyticsRateLimit } from "./rate-limit.js";
 
 export interface AppContext {
 	user: Session["user"] | null;
@@ -30,6 +31,8 @@ export const orgMiddleware = os.middleware(async ({ context, next }) => {
 	if (!context.user || !context.session) {
 		throw new ORPCError("UNAUTHORIZED");
 	}
+
+	checkAnalyticsRateLimit(context.user.id);
 	const organizationId =
 		(context.session as Record<string, unknown>).activeOrganizationId ??
 		context.user.id;

--- a/apps/api/src/rate-limit.ts
+++ b/apps/api/src/rate-limit.ts
@@ -5,6 +5,51 @@ import { queryClickhouse } from "./clickhouse.js";
 
 const logger = getLogger(["rudel", "api", "rate-limit"]);
 
+// ── In-memory sliding-window rate limiter ─────────────────────────
+
+interface SlidingWindowEntry {
+	timestamps: number[];
+}
+
+const analyticsWindows = new Map<string, SlidingWindowEntry>();
+
+const ANALYTICS_MAX_REQUESTS = Number(
+	process.env.RATE_LIMIT_ANALYTICS_MAX ?? 90,
+);
+const ANALYTICS_WINDOW_MS =
+	Number(process.env.RATE_LIMIT_ANALYTICS_WINDOW ?? 60) * 1000;
+
+export function checkAnalyticsRateLimit(userId: string): void {
+	const now = Date.now();
+	const cutoff = now - ANALYTICS_WINDOW_MS;
+
+	let entry = analyticsWindows.get(userId);
+	if (!entry) {
+		entry = { timestamps: [] };
+		analyticsWindows.set(userId, entry);
+	}
+
+	// Evict expired timestamps
+	entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+
+	if (entry.timestamps.length >= ANALYTICS_MAX_REQUESTS) {
+		logger.warn(
+			"Analytics rate limit exceeded for user {userId}: {count}/{max} in {window}s",
+			{
+				userId,
+				count: entry.timestamps.length,
+				max: ANALYTICS_MAX_REQUESTS,
+				window: ANALYTICS_WINDOW_MS / 1000,
+			},
+		);
+		throw new ORPCError("TOO_MANY_REQUESTS", {
+			message: `Rate limit exceeded. Maximum ${ANALYTICS_MAX_REQUESTS} requests per ${Math.round(ANALYTICS_WINDOW_MS / 1000)} seconds.`,
+		});
+	}
+
+	entry.timestamps.push(now);
+}
+
 export interface RateLimitConfig {
 	maxRequests: number;
 	windowSeconds: number;

--- a/packages/api-routes/src/__tests__/analytics-schema.test.ts
+++ b/packages/api-routes/src/__tests__/analytics-schema.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+	DaysInputSchema,
 	DeveloperDetailsInputSchema,
+	DeveloperSessionsInputSchema,
+	DimensionAnalysisInputSchema,
+	RecurringErrorsInputSchema,
 	SessionDetailInputSchema,
 	SessionListInputSchema,
 } from "../schemas/analytics.js";
@@ -24,5 +28,60 @@ describe("analytics input schemas", () => {
 				sessionId: "a".repeat(513),
 			}),
 		).toThrow();
+	});
+
+	test("days capped at 365", () => {
+		expect(DaysInputSchema.safeParse({ days: 365 }).success).toBe(true);
+		expect(DaysInputSchema.safeParse({ days: 366 }).success).toBe(false);
+	});
+
+	test("limit capped at 1000 on session list", () => {
+		expect(SessionListInputSchema.safeParse({ limit: 1000 }).success).toBe(
+			true,
+		);
+		expect(SessionListInputSchema.safeParse({ limit: 1001 }).success).toBe(
+			false,
+		);
+	});
+
+	test("limit capped at 1000 on dimension analysis", () => {
+		expect(
+			DimensionAnalysisInputSchema.safeParse({
+				dimension: "user_id",
+				metric: "session_count",
+				limit: 1000,
+			}).success,
+		).toBe(true);
+		expect(
+			DimensionAnalysisInputSchema.safeParse({
+				dimension: "user_id",
+				metric: "session_count",
+				limit: 1001,
+			}).success,
+		).toBe(false);
+	});
+
+	test("limit capped at 1000 on developer sessions", () => {
+		expect(
+			DeveloperSessionsInputSchema.safeParse({
+				userId: "u1",
+				limit: 1000,
+			}).success,
+		).toBe(true);
+		expect(
+			DeveloperSessionsInputSchema.safeParse({
+				userId: "u1",
+				limit: 1001,
+			}).success,
+		).toBe(false);
+	});
+
+	test("limit capped at 1000 on recurring errors", () => {
+		expect(RecurringErrorsInputSchema.safeParse({ limit: 1000 }).success).toBe(
+			true,
+		);
+		expect(RecurringErrorsInputSchema.safeParse({ limit: 1001 }).success).toBe(
+			false,
+		);
 	});
 });

--- a/packages/api-routes/src/schemas/analytics.ts
+++ b/packages/api-routes/src/schemas/analytics.ts
@@ -3,12 +3,15 @@ import { SourceSchema } from "./source.js";
 
 // ── Common inputs ──────────────────────────────────────────────────
 
+const MAX_DAYS = 365;
+const MAX_LIMIT = 1000;
+
 export const DaysInputSchema = z.object({
-	days: z.number().int().positive().default(7),
+	days: z.number().int().positive().max(MAX_DAYS).default(7),
 });
 
 export const PaginatedDaysInputSchema = DaysInputSchema.extend({
-	limit: z.number().int().positive().default(100),
+	limit: z.number().int().positive().max(MAX_LIMIT).default(100),
 	offset: z.number().int().nonnegative().default(0),
 });
 
@@ -183,7 +186,7 @@ export const DeveloperSessionsInputSchema = DaysInputSchema.extend({
 	userId: z.string().max(MAX_ID_FILTER_LENGTH),
 	projectPath: z.string().max(MAX_PATH_FILTER_LENGTH).optional(),
 	outcome: z.enum(["all", "success"]).default("all"),
-	limit: z.number().int().positive().default(100),
+	limit: z.number().int().positive().max(MAX_LIMIT).default(100),
 	offset: z.number().int().nonnegative().default(0),
 	sortBy: z.enum(["date", "duration", "tokens"]).default("date"),
 	sortOrder: z.enum(["asc", "desc"]).default("desc"),
@@ -306,7 +309,7 @@ export const SessionListInputSchema = DaysInputSchema.extend({
 	projectPath: z.string().max(MAX_PATH_FILTER_LENGTH).optional(),
 	repository: z.string().max(MAX_PATH_FILTER_LENGTH).optional(),
 	source: SourceSchema.optional(),
-	limit: z.number().int().positive().default(100),
+	limit: z.number().int().positive().max(MAX_LIMIT).default(100),
 	offset: z.number().int().nonnegative().default(0),
 	sortBy: z
 		.enum(["session_date", "duration_min", "total_tokens", "success_score"])
@@ -346,7 +349,7 @@ export const DimensionAnalysisInputSchema = DaysInputSchema.extend({
 	dimension: z.enum(VALID_DIMENSIONS),
 	metric: z.enum(VALID_METRICS),
 	splitBy: z.enum(VALID_DIMENSIONS).optional(),
-	limit: z.number().int().positive().default(20),
+	limit: z.number().int().positive().max(MAX_LIMIT).default(20),
 	userId: z.string().max(MAX_ID_FILTER_LENGTH).optional(),
 	projectPath: z.string().max(MAX_PATH_FILTER_LENGTH).optional(),
 });
@@ -473,7 +476,7 @@ export const ErrorTrendsInputSchema = DateRangeInputSchema.extend({
 
 export const RecurringErrorsInputSchema = DaysInputSchema.extend({
 	minOccurrences: z.number().int().positive().default(2),
-	limit: z.number().int().positive().default(20),
+	limit: z.number().int().positive().max(MAX_LIMIT).default(20),
 });
 
 // ── Learnings ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Cap analytics query inputs: `days` max 365, `limit` max 1000
- Add in-memory sliding-window rate limiter: 90 requests/min per user
- Wire rate limiter into `orgMiddleware` to apply across all analytics routes
- Add regression tests for input caps and rate limiter behavior

Prevents cost/latency spikes from oversized lookback windows, pagination, and request bursts by enforcing constraints server-side.

## Test plan
- [x] All 11 tasks in `bun run verify` pass (type check, lint, test, build)
- [x] 5 new schema validation tests for input caps
- [x] 3 new rate limiter tests (basic, threshold, isolation)
- [x] Frontend type safety verified: no `as any` casts in analytics path
- [x] Contract types flow from Zod schemas through API handlers to frontend client

🤖 Generated with [Claude Code](https://claude.com/claude-code)