### PR TITLE
fix: improve ingestion rate limit handling in CLI and API

### DIFF
--- a/apps/api/src/rate-limit.ts
+++ b/apps/api/src/rate-limit.ts
@@ -70,7 +70,7 @@ const ingestCountQuery = (
 });
 
 export const INGEST_RATE_LIMIT: RateLimitConfig = {
-	maxRequests: Number(process.env.RATE_LIMIT_INGEST_MAX ?? 120),
+	maxRequests: Number(process.env.RATE_LIMIT_INGEST_MAX ?? 500),
 	windowSeconds: Number(process.env.RATE_LIMIT_INGEST_WINDOW ?? 3600),
 	countQuery: ingestCountQuery,
 };
@@ -97,7 +97,12 @@ export async function checkIngestRateLimit(
 				{ userId, count, maxRequests, windowSeconds },
 			);
 			throw new ORPCError("TOO_MANY_REQUESTS", {
-				message: `Rate limit exceeded. Maximum ${maxRequests} requests per ${Math.round(windowSeconds / 60)} minutes.`,
+				message: `Rate limit exceeded. Maximum ${maxRequests} sessions per ${Math.round(windowSeconds / 60)} minutes. Try again later.`,
+				data: {
+					limit: maxRequests,
+					windowSeconds,
+					current: count,
+				},
 			});
 		}
 	} catch (error) {

--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -33,6 +33,8 @@ interface UploadFlags {
 	concurrency: number;
 }
 
+const RATE_LIMIT_WARNING_THRESHOLD = 480;
+
 async function runInteractiveUpload(flags: UploadFlags): Promise<void> {
 	const credentials = loadCredentials();
 	if (!credentials && !flags.dryRun) {
@@ -95,6 +97,20 @@ async function runInteractiveUpload(flags: UploadFlags): Promise<void> {
 	p.log.info(
 		`Uploading ${totalSessions} session(s) from ${selected.length} project(s)`,
 	);
+
+	if (totalSessions > RATE_LIMIT_WARNING_THRESHOLD) {
+		p.log.warn(
+			`You're about to upload ${totalSessions} sessions. The server allows 500 sessions per hour — uploads beyond that limit will fail and can be retried later with \`rudel upload --retry\`.`,
+		);
+		const shouldContinue = await p.confirm({
+			message: "Continue?",
+			initialValue: true,
+		});
+		if (p.isCancel(shouldContinue) || !shouldContinue) {
+			p.cancel("Upload cancelled.");
+			return;
+		}
+	}
 
 	const uploadConfig: UploadConfig = {
 		endpoint: flags.endpoint,
@@ -308,6 +324,12 @@ async function runRetryUpload(flags: UploadFlags): Promise<void> {
 	}
 	if (failures.length > 10) {
 		p.log.warn(`  ...and ${failures.length - 10} more`);
+	}
+
+	if (failures.length > RATE_LIMIT_WARNING_THRESHOLD) {
+		p.log.warn(
+			`You're about to retry ${failures.length} sessions. The server allows 500 sessions per hour — uploads beyond that limit will fail and can be retried again later.`,
+		);
 	}
 
 	const shouldRetry = await p.confirm({

--- a/apps/cli/src/lib/batch-upload.ts
+++ b/apps/cli/src/lib/batch-upload.ts
@@ -42,12 +42,31 @@ export async function batchUpload<T extends BatchUploadItem>(
 	const total = items.length;
 	let succeeded = 0;
 	let failed = 0;
+	let skipped = 0;
 	let completed = 0;
+	let rateLimited = false;
 	const errors: Array<{ label: string; error: string }> = [];
 
 	await pMap(
 		items,
 		async (item) => {
+			if (rateLimited) {
+				skipped++;
+				const error =
+					"Skipped — rate limit reached. Run `rudel upload --retry` to upload remaining sessions.";
+				await recordFailedUpload({
+					sessionId: item.sessionId,
+					transcriptPath: item.transcriptPath,
+					projectPath: item.projectPath,
+					source: item.source,
+					organizationId: item.organizationId,
+					error,
+				});
+				completed++;
+				onItemComplete?.(completed, total);
+				return;
+			}
+
 			const itemOnRetry = (
 				attempt: number,
 				maxAttempts: number,
@@ -65,6 +84,9 @@ export async function batchUpload<T extends BatchUploadItem>(
 					failed++;
 					const error = result.error ?? "Unknown error";
 					errors.push({ label: item.label, error });
+					if (result.rateLimited) {
+						rateLimited = true;
+					}
 					await recordFailedUpload({
 						sessionId: item.sessionId,
 						transcriptPath: item.transcriptPath,
@@ -93,6 +115,14 @@ export async function batchUpload<T extends BatchUploadItem>(
 		},
 		{ concurrency, stopOnError: false },
 	);
+
+	if (rateLimited && skipped > 0) {
+		errors.push({
+			label: "Rate limit",
+			error: `${skipped} session(s) skipped. Run \`rudel upload --retry\` later to upload them.`,
+		});
+		failed += skipped;
+	}
 
 	return { succeeded, failed, total, errors };
 }

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -22,6 +22,7 @@ export interface UploadResult {
 	status?: number;
 	error?: string;
 	attempts?: number;
+	rateLimited?: boolean;
 }
 
 export const DEFAULT_ENDPOINT = "https://app.rudel.ai/rpc";

--- a/apps/cli/src/lib/uploader.ts
+++ b/apps/cli/src/lib/uploader.ts
@@ -11,7 +11,7 @@ export interface UploadConfig {
 	onRetry?: (attempt: number, maxAttempts: number, error: string) => void;
 }
 
-const RETRYABLE_STATUS_CODES = new Set([502, 503, 429]);
+const RETRYABLE_STATUS_CODES = new Set([502, 503]);
 const MAX_ATTEMPTS = 3;
 const BASE_DELAY_MS = 1_000;
 
@@ -25,7 +25,22 @@ function isRetryable(error: unknown): boolean {
 	return false;
 }
 
+function isRateLimited(error: unknown): boolean {
+	return error instanceof ORPCError && error.status === 429;
+}
+
 function formatError(error: unknown): string {
+	if (isRateLimited(error)) {
+		const data = (error as { data?: unknown }).data as {
+			limit?: number;
+			windowSeconds?: number;
+		} | null;
+		const windowMin = data?.windowSeconds
+			? Math.round(data.windowSeconds / 60)
+			: 60;
+		const limit = data?.limit ?? "unknown";
+		return `Rate limit reached (${limit} sessions per ${windowMin} min). Wait and retry with: rudel upload --retry`;
+	}
 	if (error instanceof ORPCError) {
 		return `${error.status} ${error.message}`;
 	}
@@ -37,7 +52,8 @@ function formatError(error: unknown): string {
 
 /**
  * Upload a session transcript to the backend via oRPC.
- * Retries on transient errors (502, 503, 429) with exponential backoff.
+ * Retries on transient errors (502, 503) with exponential backoff.
+ * Rate limit errors (429) are not retried — the window is too long.
  */
 export async function uploadSession(
 	request: IngestSessionInput,
@@ -59,6 +75,15 @@ export async function uploadSession(
 			return { success: true, status: 200, attempts: attempt };
 		} catch (error) {
 			const errorMessage = formatError(error);
+
+			if (isRateLimited(error)) {
+				return {
+					success: false,
+					error: errorMessage,
+					attempts: attempt,
+					rateLimited: true,
+				};
+			}
 
 			if (isRetryable(error) && attempt < MAX_ATTEMPTS) {
 				config.onRetry?.(attempt, MAX_ATTEMPTS, errorMessage);


### PR DESCRIPTION
## Summary

- CLI now gracefully handles rate limit errors (429) by immediately skipping remaining uploads and saving them for retry
- API default ingest limit increased from 120 to 500 sessions/hour
- CLI warns users with a confirmation prompt before uploading if session count exceeds 480 (buffer below server limit)
- Error responses include structured data (limit, windowSeconds, current) for better client-side handling

## Test plan

- [x] All tests pass (bun run verify)
- [x] Rate limit handling works for both initial and retry uploads
- [x] Sessions hit with rate limits are saved and can be retried later

🤖 Generated with [Claude Code](https://claude.com/claude-code)