### PR TITLE
feat: add product analytics event contract

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "rudel-monorepo",
@@ -126,6 +125,7 @@
       },
       "devDependencies": {
         "@rudel/typescript-config": "workspace:*",
+        "bun-types": "latest",
         "typescript": "5.9.2",
       },
     },
@@ -445,7 +445,7 @@
 
     "@orpc/client": ["@orpc/client@1.13.6", "", { "dependencies": { "@orpc/shared": "1.13.6", "@orpc/standard-server": "1.13.6", "@orpc/standard-server-fetch": "1.13.6", "@orpc/standard-server-peer": "1.13.6" } }, "sha512-M6lYM6fJUFp9GR+It/qglYTeXwspb6sGj46xXWHqHS6iDVquqju0bdYuLOfHx8CGJcUSzi0aKUcqMXiGJhBG3w=="],
 
-    "@orpc/contract": ["@orpc/contract@1.13.6", "", { "dependencies": { "@orpc/client": "1.13.6", "@orpc/shared": "1.13.6", "@standard-schema/spec": "^1.1.0", "openapi-types": "^12.1.3" } }, "sha512-wjnpKMsCBbUE7MxdS+9by1BIDTJ4vnfUk9he4GmxKQ8fvK/MRNHUR5jkNhsBCoLnigBrsAedHrr9AIqNgqquyQ=="],
+    "@orpc/contract": ["@orpc/contract@1.13.7", "", { "dependencies": { "@orpc/client": "1.13.7", "@orpc/shared": "1.13.7", "@standard-schema/spec": "^1.1.0", "openapi-types": "^12.1.3" } }, "sha512-zRm+5tvn8DVM4DHJVxQEiuoM7mGdlgIQzRjTqnJMBRV0+rBNyZniokZCGwfJHKCjtBaAtJWieuJLQ+dFj3gbcw=="],
 
     "@orpc/interop": ["@orpc/interop@1.13.6", "", {}, "sha512-m28QpydaYIAkP9lRfwX8lRCxbdsqn734F/bSiS0yuakSCv+PP10SXBUkt4w+OkvZxdxRpj0pOJFJP8F5O0nAoA=="],
 
@@ -1839,6 +1839,12 @@
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
+    "@orpc/contract/@orpc/client": ["@orpc/client@1.13.7", "", { "dependencies": { "@orpc/shared": "1.13.7", "@orpc/standard-server": "1.13.7", "@orpc/standard-server-fetch": "1.13.7", "@orpc/standard-server-peer": "1.13.7" } }, "sha512-qqmS28q0GOo9sfTstAc6cy0NoitYvdwZlgGBLXDgXsHNtSkkSm3nI5M1ohgWYpSL+lfP/jWriTbJJrBYPzyCiQ=="],
+
+    "@orpc/contract/@orpc/shared": ["@orpc/shared@1.13.7", "", { "dependencies": { "radash": "^12.1.1", "type-fest": "^5.4.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-yP0oDIC98sZHqSTmr4SUXJo4RNw9yias1GYVJTiVTXrRUEdniafkLrSkOrOHgrILP3w93sKiE69V3+/T0TNSOQ=="],
+
+    "@orpc/server/@orpc/contract": ["@orpc/contract@1.13.6", "", { "dependencies": { "@orpc/client": "1.13.6", "@orpc/shared": "1.13.6", "@standard-schema/spec": "^1.1.0", "openapi-types": "^12.1.3" } }, "sha512-wjnpKMsCBbUE7MxdS+9by1BIDTJ4vnfUk9he4GmxKQ8fvK/MRNHUR5jkNhsBCoLnigBrsAedHrr9AIqNgqquyQ=="],
+
     "@prisma/dev/@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
     "@prisma/dev/hono": ["hono@4.11.4", "", {}, "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA=="],
@@ -1850,6 +1856,8 @@
     "@prisma/get-platform/@prisma/debug": ["@prisma/debug@7.2.0", "", {}, "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
+
+    "@rudel/web/@orpc/contract": ["@orpc/contract@1.13.6", "", { "dependencies": { "@orpc/client": "1.13.6", "@orpc/shared": "1.13.6", "@standard-schema/spec": "^1.1.0", "openapi-types": "^12.1.3" } }, "sha512-wjnpKMsCBbUE7MxdS+9by1BIDTJ4vnfUk9he4GmxKQ8fvK/MRNHUR5jkNhsBCoLnigBrsAedHrr9AIqNgqquyQ=="],
 
     "@rudel/web/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -1904,6 +1912,8 @@
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
+    "rudel/@orpc/contract": ["@orpc/contract@1.13.6", "", { "dependencies": { "@orpc/client": "1.13.6", "@orpc/shared": "1.13.6", "@standard-schema/spec": "^1.1.0", "openapi-types": "^12.1.3" } }, "sha512-wjnpKMsCBbUE7MxdS+9by1BIDTJ4vnfUk9he4GmxKQ8fvK/MRNHUR5jkNhsBCoLnigBrsAedHrr9AIqNgqquyQ=="],
 
     "vite/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
@@ -1968,6 +1978,12 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@orpc/contract/@orpc/client/@orpc/standard-server": ["@orpc/standard-server@1.13.7", "", { "dependencies": { "@orpc/shared": "1.13.7" } }, "sha512-5btxVTRAtgl9lmzg1XTCJYT8qd2QAAwcQ6XRvGXgLz56rSUCMf2vl3WeWPwlwiXXpueNvucPea/CaRGhJ9ZTeQ=="],
+
+    "@orpc/contract/@orpc/client/@orpc/standard-server-fetch": ["@orpc/standard-server-fetch@1.13.7", "", { "dependencies": { "@orpc/shared": "1.13.7", "@orpc/standard-server": "1.13.7" } }, "sha512-Hj+41HAlao+JXuLffeLrPiADu8mhGqwVB34lf+JSLKGtZhxaX4n4MeZMYhFioExXC+/tanvSrbKKkJimfznIWQ=="],
+
+    "@orpc/contract/@orpc/client/@orpc/standard-server-peer": ["@orpc/standard-server-peer@1.13.7", "", { "dependencies": { "@orpc/shared": "1.13.7", "@orpc/standard-server": "1.13.7" } }, "sha512-mbjmkEVGtsWvGBBEieUuXdX+MAzllQZ0D9Z79kU4Ns9sVaBcvjCYSrL29/iXcYqVGTx23LS9PaYnIurAQejzSQ=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/packages/api-routes/package.json
+++ b/packages/api-routes/package.json
@@ -12,6 +12,7 @@
 	},
 	"devDependencies": {
 		"@rudel/typescript-config": "workspace:*",
+		"bun-types": "latest",
 		"typescript": "5.9.2"
 	}
 }

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -1,6 +1,11 @@
 import { oc } from "@orpc/contract";
 import { z } from "zod";
 import {
+	ProductAnalyticsClientSurfaceSchema,
+	ProductAnalyticsPlatformOsSchema,
+	ProductAnalyticsUploadModeSchema,
+} from "./product-analytics.js";
+import {
 	DateRangeInputSchema,
 	DaysInputSchema,
 	DeveloperCostBreakdownSchema,
@@ -49,6 +54,7 @@ import {
 	UsageTrendDataSchema,
 } from "./schemas/analytics.js";
 
+export * from "./product-analytics.js";
 export * from "./schemas/analytics.js";
 
 export const HealthSchema = z.object({
@@ -113,6 +119,10 @@ export const IngestSessionInputSchema = z.object({
 	content: z.string(),
 	subagents: z.array(SubagentFileSchema).optional(),
 	organizationId: z.string().max(200).optional(),
+	client_surface: ProductAnalyticsClientSurfaceSchema.optional(),
+	upload_mode: ProductAnalyticsUploadModeSchema.optional(),
+	cli_version: z.string().max(200).optional(),
+	platform_os: ProductAnalyticsPlatformOsSchema.optional(),
 });
 
 export const IngestSessionOutputSchema = z.object({

--- a/packages/api-routes/src/product-analytics.ts
+++ b/packages/api-routes/src/product-analytics.ts
@@ -1,0 +1,354 @@
+import { z } from "zod";
+import { SourceSchema } from "./schemas/source.js";
+
+export const PRODUCT_ANALYTICS_EVENT_VERSION = 1 as const;
+
+export const ProductAnalyticsSurfaceSchema = z.enum([
+	"web",
+	"cli",
+	"hook",
+	"api",
+]);
+
+export const ProductAnalyticsEnvironmentSchema = z.enum([
+	"production",
+	"staging",
+	"development",
+	"local",
+]);
+
+export const ProductAnalyticsUploadModeSchema = z.enum([
+	"hook",
+	"manual",
+	"retry",
+]);
+
+export const ProductAnalyticsClientSurfaceSchema = z.enum(["cli", "hook"]);
+
+export const ProductAnalyticsPlatformOsSchema = z.enum([
+	"macos",
+	"windows",
+	"linux",
+]);
+
+export const ProductAnalyticsSignupMethodSchema = z.enum([
+	"email_password",
+	"google",
+	"github",
+]);
+
+export const ProductAnalyticsAuthFlowSchema = z.literal("device_authorization");
+
+export const ProductAnalyticsEntryPointSchema = z.enum([
+	"homepage",
+	"cli_device_login",
+	"accept_invitation",
+	"direct",
+]);
+
+export const ProductAnalyticsPageNameSchema = z.enum([
+	"overview",
+	"projects",
+	"project_detail",
+	"sessions",
+	"session_detail",
+	"developers",
+	"errors",
+	"learnings",
+	"roi",
+	"organization",
+]);
+
+export const ProductAnalyticsInsightTypeSchema = z.enum([
+	"trend",
+	"performer",
+	"alert",
+	"info",
+]);
+
+export const ProductAnalyticsInsightSeveritySchema = z.enum([
+	"positive",
+	"warning",
+	"negative",
+	"info",
+]);
+
+export type ProductAnalyticsEnvironment = z.infer<
+	typeof ProductAnalyticsEnvironmentSchema
+>;
+export type ProductAnalyticsSurface = z.infer<
+	typeof ProductAnalyticsSurfaceSchema
+>;
+export type ProductAnalyticsUploadMode = z.infer<
+	typeof ProductAnalyticsUploadModeSchema
+>;
+export type ProductAnalyticsClientSurface = z.infer<
+	typeof ProductAnalyticsClientSurfaceSchema
+>;
+export type ProductAnalyticsPlatformOs = z.infer<
+	typeof ProductAnalyticsPlatformOsSchema
+>;
+
+export const ProductAnalyticsDashboardQueryNameSchema = z.enum([
+	"overview_kpis",
+	"overview_usage_trend",
+	"overview_model_tokens_trend",
+	"overview_insights",
+]);
+
+export const ProductAnalyticsLoginFailureStageSchema = z.enum([
+	"device_code_request",
+	"browser_approval_timeout",
+	"token_exchange",
+	"api_key_create",
+	"account_fetch",
+]);
+
+export const ProductAnalyticsEnableFailureStageSchema = z.enum([
+	"auth_verify",
+	"organization_fetch",
+	"organization_select",
+	"hook_install",
+]);
+
+export const ProductAnalyticsUploadFailureStageSchema = z.enum([
+	"session_discovery",
+	"read",
+	"serialize",
+	"auth",
+	"network",
+	"api",
+	"validation",
+	"rate_limit",
+	"unknown",
+]);
+
+const RequiredCommonSchema = z.object({
+	event_version: z.literal(PRODUCT_ANALYTICS_EVENT_VERSION),
+	surface: ProductAnalyticsSurfaceSchema,
+	environment: ProductAnalyticsEnvironmentSchema,
+});
+
+const idSchema = z.string().min(1);
+const nonEmptyStringSchema = z.string().min(1);
+
+export const PRODUCT_ANALYTICS_EVENTS = {
+	ACCOUNT_SIGNED_UP: "Account Signed Up",
+	SIGN_UP_FAILED: "Sign Up Failed",
+	CLI_LOGIN_APPROVED: "CLI Login Approved",
+	CLI_LOGIN_FAILED: "CLI Login Failed",
+	AUTO_UPLOAD_ENABLED: "Auto Upload Enabled",
+	AUTO_UPLOAD_ENABLE_FAILED: "Auto Upload Enable Failed",
+	SESSION_UPLOAD_COMPLETED: "Session Upload Completed",
+	SESSION_UPLOAD_FAILED: "Session Upload Failed",
+	DASHBOARD_VIEWED: "Dashboard Viewed",
+	DASHBOARD_LOAD_FAILED: "Dashboard Load Failed",
+	INSIGHT_CARD_CLICKED: "Insight Card Clicked",
+} as const;
+
+export type ProductAnalyticsEventName =
+	(typeof PRODUCT_ANALYTICS_EVENTS)[keyof typeof PRODUCT_ANALYTICS_EVENTS];
+
+export const AccountSignedUpEventSchema = RequiredCommonSchema.extend({
+	surface: z.literal("api"),
+	user_id: idSchema,
+	signup_method: ProductAnalyticsSignupMethodSchema,
+	is_default_organization_ready: z.boolean(),
+	organization_id: idSchema.optional(),
+	is_invite_flow: z.boolean().optional(),
+	entry_point: ProductAnalyticsEntryPointSchema.optional(),
+}).strict();
+
+export const SignUpFailedEventSchema = RequiredCommonSchema.extend({
+	surface: z.literal("web"),
+	signup_method: ProductAnalyticsSignupMethodSchema,
+	failure_stage: z.enum([
+		"form_submit",
+		"provider_redirect",
+		"provider_callback",
+		"server_validation",
+	]),
+	error_code: nonEmptyStringSchema,
+	is_invite_flow: z.boolean().optional(),
+	entry_point: ProductAnalyticsEntryPointSchema.optional(),
+}).strict();
+
+export const CliLoginApprovedEventSchema = RequiredCommonSchema.extend({
+	surface: z.literal("cli"),
+	user_id: idSchema,
+	auth_flow: ProductAnalyticsAuthFlowSchema,
+	cli_version: nonEmptyStringSchema,
+	platform_os: ProductAnalyticsPlatformOsSchema,
+	opened_browser: z.boolean().optional(),
+}).strict();
+
+export const CliLoginFailedEventSchema = RequiredCommonSchema.extend({
+	surface: z.literal("cli"),
+	auth_flow: ProductAnalyticsAuthFlowSchema,
+	failure_stage: ProductAnalyticsLoginFailureStageSchema,
+	failure_reason: nonEmptyStringSchema,
+	cli_version: nonEmptyStringSchema,
+	platform_os: ProductAnalyticsPlatformOsSchema,
+	opened_browser: z.boolean().optional(),
+}).strict();
+
+export const AutoUploadEnabledEventSchema = RequiredCommonSchema.extend({
+	surface: z.literal("cli"),
+	organization_id: idSchema,
+	user_id: idSchema,
+	agent_source: SourceSchema,
+	cli_version: nonEmptyStringSchema,
+	platform_os: ProductAnalyticsPlatformOsSchema,
+	is_already_enabled: z.boolean().optional(),
+}).strict();
+
+export const AutoUploadEnableFailedEventSchema = RequiredCommonSchema.extend({
+	surface: z.literal("cli"),
+	agent_source: z.union([SourceSchema, z.literal("unknown")]),
+	failure_stage: ProductAnalyticsEnableFailureStageSchema,
+	failure_reason: nonEmptyStringSchema,
+	cli_version: nonEmptyStringSchema,
+	platform_os: ProductAnalyticsPlatformOsSchema,
+	organization_id: idSchema.optional(),
+	user_id: idSchema.optional(),
+}).strict();
+
+export const SessionUploadCompletedEventSchema = RequiredCommonSchema.extend({
+	surface: z.literal("api"),
+	organization_id: idSchema,
+	user_id: idSchema,
+	client_surface: ProductAnalyticsClientSurfaceSchema,
+	upload_mode: ProductAnalyticsUploadModeSchema,
+	agent_source: SourceSchema,
+	cli_version: nonEmptyStringSchema,
+	platform_os: ProductAnalyticsPlatformOsSchema,
+	is_first_upload: z.boolean(),
+	project_id_hash: nonEmptyStringSchema.optional(),
+	session_tag: nonEmptyStringSchema.optional(),
+	attempt_number: z.number().int().positive().optional(),
+	content_size_bucket: nonEmptyStringSchema.optional(),
+}).strict();
+
+export const SessionUploadFailedEventSchema = RequiredCommonSchema.extend({
+	surface: z.union([z.literal("cli"), z.literal("hook")]),
+	client_surface: ProductAnalyticsClientSurfaceSchema,
+	upload_mode: ProductAnalyticsUploadModeSchema,
+	agent_source: SourceSchema,
+	failure_stage: ProductAnalyticsUploadFailureStageSchema,
+	failure_reason: nonEmptyStringSchema,
+	is_retryable: z.boolean(),
+	cli_version: nonEmptyStringSchema,
+	platform_os: ProductAnalyticsPlatformOsSchema,
+	organization_id: idSchema.optional(),
+	user_id: idSchema.optional(),
+	http_status: z.number().int().positive().optional(),
+	attempt_number: z.number().int().positive().optional(),
+	project_id_hash: nonEmptyStringSchema.optional(),
+}).strict();
+
+export const DashboardViewedEventSchema = RequiredCommonSchema.extend({
+	surface: z.literal("web"),
+	organization_id: idSchema,
+	user_id: idSchema,
+	page_name: ProductAnalyticsPageNameSchema,
+	has_data: z.boolean(),
+	date_range_days: z.number().int().nonnegative(),
+	insight_count: z.number().int().nonnegative(),
+	is_first_dashboard_view: z.boolean().optional(),
+	entry_point: nonEmptyStringSchema.optional(),
+}).strict();
+
+export const DashboardLoadFailedEventSchema = RequiredCommonSchema.extend({
+	surface: z.literal("web"),
+	organization_id: idSchema,
+	user_id: idSchema,
+	page_name: z.literal("overview"),
+	query_name: ProductAnalyticsDashboardQueryNameSchema,
+	error_code: nonEmptyStringSchema,
+	date_range_days: z.number().int().nonnegative(),
+	is_blocking: z.boolean(),
+	http_status: z.number().int().positive().optional(),
+}).strict();
+
+export const InsightCardClickedEventSchema = RequiredCommonSchema.extend({
+	surface: z.literal("web"),
+	organization_id: idSchema,
+	user_id: idSchema,
+	page_name: z.literal("overview"),
+	insight_key: nonEmptyStringSchema,
+	insight_type: ProductAnalyticsInsightTypeSchema,
+	insight_severity: ProductAnalyticsInsightSeveritySchema,
+	destination_path: nonEmptyStringSchema,
+	position_index: z.number().int().nonnegative(),
+	date_range_days: z.number().int().nonnegative(),
+}).strict();
+
+export const ProductAnalyticsEventSchemas = {
+	[PRODUCT_ANALYTICS_EVENTS.ACCOUNT_SIGNED_UP]: AccountSignedUpEventSchema,
+	[PRODUCT_ANALYTICS_EVENTS.SIGN_UP_FAILED]: SignUpFailedEventSchema,
+	[PRODUCT_ANALYTICS_EVENTS.CLI_LOGIN_APPROVED]: CliLoginApprovedEventSchema,
+	[PRODUCT_ANALYTICS_EVENTS.CLI_LOGIN_FAILED]: CliLoginFailedEventSchema,
+	[PRODUCT_ANALYTICS_EVENTS.AUTO_UPLOAD_ENABLED]: AutoUploadEnabledEventSchema,
+	[PRODUCT_ANALYTICS_EVENTS.AUTO_UPLOAD_ENABLE_FAILED]:
+		AutoUploadEnableFailedEventSchema,
+	[PRODUCT_ANALYTICS_EVENTS.SESSION_UPLOAD_COMPLETED]:
+		SessionUploadCompletedEventSchema,
+	[PRODUCT_ANALYTICS_EVENTS.SESSION_UPLOAD_FAILED]:
+		SessionUploadFailedEventSchema,
+	[PRODUCT_ANALYTICS_EVENTS.DASHBOARD_VIEWED]: DashboardViewedEventSchema,
+	[PRODUCT_ANALYTICS_EVENTS.DASHBOARD_LOAD_FAILED]:
+		DashboardLoadFailedEventSchema,
+	[PRODUCT_ANALYTICS_EVENTS.INSIGHT_CARD_CLICKED]:
+		InsightCardClickedEventSchema,
+} satisfies Record<ProductAnalyticsEventName, z.ZodTypeAny>;
+
+export type AccountSignedUpEvent = z.infer<typeof AccountSignedUpEventSchema>;
+export type SignUpFailedEvent = z.infer<typeof SignUpFailedEventSchema>;
+export type CliLoginApprovedEvent = z.infer<typeof CliLoginApprovedEventSchema>;
+export type CliLoginFailedEvent = z.infer<typeof CliLoginFailedEventSchema>;
+export type AutoUploadEnabledEvent = z.infer<
+	typeof AutoUploadEnabledEventSchema
+>;
+export type AutoUploadEnableFailedEvent = z.infer<
+	typeof AutoUploadEnableFailedEventSchema
+>;
+export type SessionUploadCompletedEvent = z.infer<
+	typeof SessionUploadCompletedEventSchema
+>;
+export type SessionUploadFailedEvent = z.infer<
+	typeof SessionUploadFailedEventSchema
+>;
+export type DashboardViewedEvent = z.infer<typeof DashboardViewedEventSchema>;
+export type DashboardLoadFailedEvent = z.infer<
+	typeof DashboardLoadFailedEventSchema
+>;
+export type InsightCardClickedEvent = z.infer<
+	typeof InsightCardClickedEventSchema
+>;
+
+export interface ProductAnalyticsEventPayloadMap {
+	[PRODUCT_ANALYTICS_EVENTS.ACCOUNT_SIGNED_UP]: AccountSignedUpEvent;
+	[PRODUCT_ANALYTICS_EVENTS.SIGN_UP_FAILED]: SignUpFailedEvent;
+	[PRODUCT_ANALYTICS_EVENTS.CLI_LOGIN_APPROVED]: CliLoginApprovedEvent;
+	[PRODUCT_ANALYTICS_EVENTS.CLI_LOGIN_FAILED]: CliLoginFailedEvent;
+	[PRODUCT_ANALYTICS_EVENTS.AUTO_UPLOAD_ENABLED]: AutoUploadEnabledEvent;
+	[PRODUCT_ANALYTICS_EVENTS.AUTO_UPLOAD_ENABLE_FAILED]: AutoUploadEnableFailedEvent;
+	[PRODUCT_ANALYTICS_EVENTS.SESSION_UPLOAD_COMPLETED]: SessionUploadCompletedEvent;
+	[PRODUCT_ANALYTICS_EVENTS.SESSION_UPLOAD_FAILED]: SessionUploadFailedEvent;
+	[PRODUCT_ANALYTICS_EVENTS.DASHBOARD_VIEWED]: DashboardViewedEvent;
+	[PRODUCT_ANALYTICS_EVENTS.DASHBOARD_LOAD_FAILED]: DashboardLoadFailedEvent;
+	[PRODUCT_ANALYTICS_EVENTS.INSIGHT_CARD_CLICKED]: InsightCardClickedEvent;
+}
+
+export type ProductAnalyticsEventPayload<
+	Name extends ProductAnalyticsEventName,
+> = ProductAnalyticsEventPayloadMap[Name];
+
+export function parseProductAnalyticsEvent<
+	Name extends ProductAnalyticsEventName,
+>(event: Name, payload: unknown): ProductAnalyticsEventPayload<Name> {
+	const schema = ProductAnalyticsEventSchemas[event] as unknown as z.ZodType<
+		ProductAnalyticsEventPayload<Name>
+	>;
+	return schema.parse(payload);
+}

--- a/packages/api-routes/tsconfig.json
+++ b/packages/api-routes/tsconfig.json
@@ -2,7 +2,8 @@
 	"extends": "@rudel/typescript-config/base.json",
 	"compilerOptions": {
 		"outDir": "./dist",
-		"rootDir": "./src"
+		"rootDir": "./src",
+		"types": ["bun-types"]
 	},
 	"include": ["src"]
 }

--- a/packages/sql-schema/db/migrations/0006_posthog_first_session_uploaded_at.sql
+++ b/packages/sql-schema/db/migrations/0006_posthog_first_session_uploaded_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "organization" ADD COLUMN "first_session_uploaded_at" timestamp with time zone;--> statement-breakpoint

--- a/packages/sql-schema/src/auth-schema.ts
+++ b/packages/sql-schema/src/auth-schema.ts
@@ -95,6 +95,10 @@ export const organization = pgTable("organization", {
 	slug: text("slug").notNull().unique(),
 	logo: text("logo"),
 	metadata: text("metadata"),
+	firstSessionUploadedAt: timestamp("first_session_uploaded_at", {
+		withTimezone: true,
+		mode: "date",
+	}),
 	createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
 		.defaultNow()
 		.notNull(),


### PR DESCRIPTION
## Summary
- add a shared product analytics event contract in `@rudel/api-routes`
- extend the ingest schema with product analytics telemetry fields
- add a durable `first_session_uploaded_at` marker to the organization schema and migration
- add package-level TypeScript support for the analytics contract test environment

## Verification
- `bunx tsc -p packages/api-routes/tsconfig.json --noEmit`
- `git pull --ff-only origin main` on a clean `origin/main` checkout: already up to date

## Notes
This is the base PR for the analytics stack. The CLI/API and web instrumentation PRs are opened separately on top of this branch.
