### PR TITLE
feat: pass posthog build args to deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,8 @@ jobs:
           flyctl deploy --remote-only
           --build-arg VITE_CHATWOOT_BASE_URL=${{ secrets.VITE_CHATWOOT_BASE_URL }}
           --build-arg VITE_CHATWOOT_WEBSITE_TOKEN=${{ secrets.VITE_CHATWOOT_WEBSITE_TOKEN }}
+          --build-arg VITE_POSTHOG_KEY=${{ secrets.VITE_POSTHOG_KEY }}
+          --build-arg VITE_POSTHOG_HOST=${{ secrets.VITE_POSTHOG_HOST }}
+          --build-arg VITE_POSTHOG_ENABLED=${{ secrets.VITE_POSTHOG_ENABLED }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ COPY turbo.json turbo.json
 ARG VITE_CHATWOOT_BASE_URL=""
 ARG VITE_CHATWOOT_WEBSITE_TOKEN=""
 ARG VITE_CHATWOOT_ENABLED="true"
+ARG VITE_POSTHOG_KEY=""
+ARG VITE_POSTHOG_HOST="https://us.i.posthog.com"
+ARG VITE_POSTHOG_ENABLED="false"
 
 # Build web app and place output where the API serves static files
 RUN bun run --cwd apps/web build


### PR DESCRIPTION
## Summary
- add PostHog Vite build args to the Docker frontend build
- forward those args in the CI deploy step
- keep the browser PostHog token out of git and sourced from deploy secrets

## Notes
- requires , , and  to exist in the deploy secrets mapping
- no application code changes in this PR
