### PR TITLE
fix: pass build args correctly in deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,12 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy
-        run: >
-          flyctl deploy --remote-only
-          --build-arg VITE_CHATWOOT_BASE_URL=${{ secrets.VITE_CHATWOOT_BASE_URL }}
-          --build-arg VITE_CHATWOOT_WEBSITE_TOKEN=${{ secrets.VITE_CHATWOOT_WEBSITE_TOKEN }}
-          --build-arg VITE_POSTHOG_KEY=${{ secrets.VITE_POSTHOG_KEY }}
-          --build-arg VITE_POSTHOG_HOST=${{ secrets.VITE_POSTHOG_HOST }}
-          --build-arg VITE_POSTHOG_ENABLED=${{ secrets.VITE_POSTHOG_ENABLED }}
+        run: |
+          flyctl deploy --remote-only \
+            --build-arg VITE_CHATWOOT_BASE_URL=${{ secrets.VITE_CHATWOOT_BASE_URL }} \
+            --build-arg VITE_CHATWOOT_WEBSITE_TOKEN=${{ secrets.VITE_CHATWOOT_WEBSITE_TOKEN }} \
+            --build-arg VITE_POSTHOG_KEY=${{ secrets.VITE_POSTHOG_KEY }} \
+            --build-arg VITE_POSTHOG_HOST=${{ secrets.VITE_POSTHOG_HOST }} \
+            --build-arg VITE_POSTHOG_ENABLED=${{ secrets.VITE_POSTHOG_ENABLED }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- fix the deploy workflow shell syntax so Fly receives the PostHog build args
- keep the existing Chatwoot and PostHog build arg mapping intact

## Why
The previous workflow used YAML folded syntax, so GitHub executed `flyctl deploy --remote-only` first and then treated each `--build-arg ...` as a separate shell command. That meant the deploy succeeded without the new PostHog build args actually reaching the frontend build.
