### PR TITLE
fix: quote deploy build args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,10 @@ jobs:
       - name: Deploy
         run: |
           flyctl deploy --remote-only \
-            --build-arg VITE_CHATWOOT_BASE_URL=${{ secrets.VITE_CHATWOOT_BASE_URL }} \
-            --build-arg VITE_CHATWOOT_WEBSITE_TOKEN=${{ secrets.VITE_CHATWOOT_WEBSITE_TOKEN }} \
-            --build-arg VITE_POSTHOG_KEY=${{ secrets.VITE_POSTHOG_KEY }} \
-            --build-arg VITE_POSTHOG_HOST=${{ secrets.VITE_POSTHOG_HOST }} \
-            --build-arg VITE_POSTHOG_ENABLED=${{ secrets.VITE_POSTHOG_ENABLED }}
+            --build-arg "VITE_CHATWOOT_BASE_URL=${{ secrets.VITE_CHATWOOT_BASE_URL }}" \
+            --build-arg "VITE_CHATWOOT_WEBSITE_TOKEN=${{ secrets.VITE_CHATWOOT_WEBSITE_TOKEN }}" \
+            --build-arg "VITE_POSTHOG_KEY=${{ secrets.VITE_POSTHOG_KEY }}" \
+            --build-arg "VITE_POSTHOG_HOST=${{ secrets.VITE_POSTHOG_HOST }}" \
+            --build-arg "VITE_POSTHOG_ENABLED=${{ secrets.VITE_POSTHOG_ENABLED }}"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- quote all frontend build-arg values in the deploy workflow
- prevent secret values from breaking the multiline shell command

## Why
After fixing the shell continuation, the deploy job still failed with `--build-arg: command not found`, which strongly suggests one of the secret values contains a newline or shell-significant content. Quoting the full `KEY=value` payload for each build arg makes the deploy robust.
