### PR TITLE
feat(web): identify posthog users by email

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -60,9 +60,24 @@ function App() {
 			typeof session.user.id === "string"
 				? session.user.id
 				: null;
+		const email =
+			session?.user &&
+			"email" in session.user &&
+			typeof session.user.email === "string"
+				? session.user.email
+				: undefined;
+		const name =
+			session?.user &&
+			"name" in session.user &&
+			typeof session.user.name === "string"
+				? session.user.name
+				: undefined;
 
 		if (userId) {
-			identifyProductAnalyticsUser(userId);
+			identifyProductAnalyticsUser(userId, {
+				email,
+				name,
+			});
 			return;
 		}
 

--- a/apps/web/src/lib/product-analytics.ts
+++ b/apps/web/src/lib/product-analytics.ts
@@ -59,14 +59,23 @@ export function initProductAnalytics() {
 	initialized = true;
 }
 
-export function identifyProductAnalyticsUser(userId: string) {
+export function identifyProductAnalyticsUser(
+	userId: string,
+	properties?: {
+		email?: string;
+		name?: string | null;
+	},
+) {
 	if (!initialized) {
 		initProductAnalytics();
 	}
 	if (!getConfig()) {
 		return;
 	}
-	posthog.identify(userId);
+	posthog.identify(userId, {
+		email: properties?.email,
+		name: properties?.name ?? undefined,
+	});
 }
 
 export function resetProductAnalytics() {


### PR DESCRIPTION
## Summary
- pass email and name into PostHog identify on the web app
- make PostHog people easier to read than opaque distinct IDs
- keep the change web-only and avoid any new events or backend plumbing

## Notes
- I could not run a full workspace install in this shell because the repo's Prisma preinstall requires a newer Node version than is available here.
- The change is limited to the existing web identify call in  and .