### PR TITLE
docs: add analytics transparency note

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Rudel is designed to ingest full coding-agent session data for analytics. That m
 
 Only enable Rudel on projects and environments where you are comfortable uploading that data. If you use the hosted service at `app.rudel.ai`, we do not have access to personal data contained in uploaded transcripts and cannot read that data. Review the [Rudel Privacy Policy](https://rudel.ai/privacy-policy) before enabling uploads for yourself or your team.
 
+We also use limited product analytics on the hosted app to understand whether core workflows work, diagnose failures, and improve the product. Today this is explicit event tracking around signup, dashboard usage, insight clicks, lifecycle CLI activity, and upload outcomes; it does not enable blanket click autocapture or session replay by default. By using the hosted app, you agree to this limited analytics processing as part of the service. The implementation landed incrementally in [#160](https://github.com/obsessiondb/rudel/pull/160), [#161](https://github.com/obsessiondb/rudel/pull/161), [#162](https://github.com/obsessiondb/rudel/pull/162), [#163](https://github.com/obsessiondb/rudel/pull/163), and [#167](https://github.com/obsessiondb/rudel/pull/167).
+
 ## Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, development commands, and PR guidelines.


### PR DESCRIPTION
## Summary
- add a short README disclosure that the hosted app uses limited product analytics
- clarify that the tracking is explicit event-based rather than blanket autocapture
- link to the analytics implementation PRs for technical transparency

## Testing
- not run (README-only change)