### PR TITLE
ci: enable turbo remote caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   verify:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "rudel-monorepo",


### PR DESCRIPTION
## Summary
- Add TURBO_TOKEN and TURBO_TEAM environment variables to CI workflow
- Enable Turborepo remote caching for faster CI builds
- Requires adding TURBO_TOKEN and TURBO_TEAM secrets to GitHub repository settings

## Test plan
- [x] Verification passed (lint, type checking, tests, build)
- Turbo will use remote cache when secrets are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)