### PR TITLE
feat(api): add resend invitation emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,11 @@ CLICKHOUSE_PASSWORD=
 # on every new user signup.
 # SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
 
+# Resend email integration.
+# RESEND_API_KEY=
+# RESEND_FROM_EMAIL=Rudel <noreply@example.com>
+# RESEND_AUDIENCE_ID=
+
 # Chatwoot website widget for the dashboard support launcher.
 # These are baked into the frontend at Vite build time (VITE_ prefix).
 # VITE_CHATWOOT_BASE_URL=https://app.chatwoot.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,9 @@ A platform for ingesting, storing, and analyzing Claude Code session transcripts
 | `CLICKHOUSE_DB` | No | ClickHouse database name |
 | `APP_URL` | No | API base URL (default: `http://localhost:4010`) |
 | `ALLOWED_ORIGIN` | No | CORS origin (default: `http://localhost:4011`) |
+| `RESEND_API_KEY` | No | Resend API key for email integration |
+| `RESEND_FROM_EMAIL` | No | Sender address for organization invitation emails |
+| `RESEND_AUDIENCE_ID` | No | Resend audience ID for signup contact sync |
 
 ## Local chkit development
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -18,6 +18,11 @@ CLICKHOUSE_PASSWORD=
 # Slack notifications (optional)
 # SLACK_WEBHOOK_URL=
 
+# Resend email (optional)
+# RESEND_API_KEY=
+# RESEND_FROM_EMAIL=     # Required to send organization invitation emails
+# RESEND_AUDIENCE_ID=    # Optional: sync new signups to a Resend audience
+#
 # PostHog product analytics (optional)
 # POSTHOG_KEY=
 # POSTHOG_HOST=https://us.i.posthog.com

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,7 +26,8 @@
 		"better-auth": "^1.5.4",
 		"drizzle-orm": "0.45.1",
 		"posthog-node": "^5.8.0",
-		"postgres": "^3.4.5"
+		"postgres": "^3.4.5",
+		"resend": "^6.9.3"
 	},
 	"devDependencies": {
 		"@rudel/typescript-config": "workspace:*",

--- a/apps/api/src/__tests__/email.test.ts
+++ b/apps/api/src/__tests__/email.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildInvitationEmailContent,
+	buildInvitationLink,
+	getResendConfigWarnings,
+	sendOrganizationInvitationEmail,
+	syncSignupContact,
+} from "../email.js";
+
+const invitation = {
+	frontendURL: "https://app.rudel.ai/",
+	invitationId: "invite_123",
+	inviteeEmail: "person@example.com",
+	inviterName: 'Alice <script>alert("x")</script>\nDoe',
+	organizationName: 'Team & "Co"',
+};
+
+describe("email helpers", () => {
+	test("buildInvitationLink trims trailing slashes", () => {
+		expect(buildInvitationLink("https://app.rudel.ai/", "invite_123")).toBe(
+			"https://app.rudel.ai/invitation/invite_123",
+		);
+	});
+
+	test("buildInvitationEmailContent escapes user-controlled HTML", () => {
+		const message = buildInvitationEmailContent(invitation);
+
+		expect(message.inviteLink).toBe(
+			"https://app.rudel.ai/invitation/invite_123",
+		);
+		expect(message.subject).toBe(
+			'Alice <script>alert("x")</script> Doe invited you to Team & "Co" on Rudel',
+		);
+		expect(message.html).toContain(
+			"Alice &lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; Doe",
+		);
+		expect(message.html).toContain("Team &amp; &quot;Co&quot;");
+		expect(message.html).not.toContain("<script>");
+	});
+
+	test("getResendConfigWarnings warns when sender is missing", () => {
+		expect(getResendConfigWarnings({ apiKey: "test-key" })).toEqual([
+			"Resend invitation emails are disabled because RESEND_FROM_EMAIL is not set.",
+		]);
+		expect(
+			getResendConfigWarnings({
+				apiKey: "test-key",
+				fromEmail: "Rudel <noreply@example.com>",
+			}),
+		).toEqual([]);
+	});
+
+	test("sendOrganizationInvitationEmail returns early when config is incomplete", async () => {
+		await expect(
+			sendOrganizationInvitationEmail({}, invitation),
+		).resolves.toBeUndefined();
+		await expect(
+			sendOrganizationInvitationEmail({ apiKey: "test-key" }, invitation),
+		).resolves.toBeUndefined();
+	});
+
+	test("syncSignupContact returns early when config is incomplete", async () => {
+		await expect(
+			syncSignupContact({}, { email: "person@example.com", name: "Alice Doe" }),
+		).resolves.toBeUndefined();
+		await expect(
+			syncSignupContact(
+				{ apiKey: "test-key" },
+				{ email: "person@example.com", name: "Alice Doe" },
+			),
+		).resolves.toBeUndefined();
+	});
+});

--- a/apps/api/src/__tests__/org-deletion-security.test.ts
+++ b/apps/api/src/__tests__/org-deletion-security.test.ts
@@ -6,6 +6,7 @@ describe("organization deletion security", () => {
 		const mockDb = {};
 		const auth = createAuth(mockDb, {
 			appURL: "http://localhost:4010",
+			frontendURL: "http://localhost:4011",
 			secret: "test-secret",
 		});
 

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -5,6 +5,8 @@ import * as schema from "@rudel/sql-schema";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { bearer, deviceAuthorization, organization } from "better-auth/plugins";
+import type { ResendConfig } from "./email.js";
+import { sendOrganizationInvitationEmail, syncSignupContact } from "./email.js";
 import { captureApiProductAnalyticsEvent } from "./lib/product-analytics.js";
 import { fetchGitHubHandle, notifySignup } from "./slack.js";
 
@@ -35,16 +37,38 @@ function toTrackedOrganizationRole(
 
 export interface AuthConfig {
 	appURL: string;
+	frontendURL: string;
 	secret?: string;
+	resend?: ResendConfig;
 	socialProviders?: Record<string, { clientId: string; clientSecret: string }>;
 	trustedOrigins?: string[];
 	cliDeviceVerificationUrl?: string;
 	slackWebhookUrl?: string;
 }
 
+function createOrganizationPlugin(config: AuthConfig) {
+	const resend = config.resend ?? {};
+
+	return organization({
+		allowUserToCreateOrganization: true,
+		creatorRole: "owner",
+		disableOrganizationDeletion: true,
+		async sendInvitationEmail(data) {
+			await sendOrganizationInvitationEmail(resend, {
+				frontendURL: config.frontendURL,
+				invitationId: data.id,
+				inviteeEmail: data.email,
+				inviterName: data.inviter.user.name,
+				organizationName: data.organization.name,
+			});
+		},
+	});
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- drizzleAdapter accepts { [key: string]: any }
 export function createAuth(db: object, config: AuthConfig) {
 	const trustedOrigins = config.trustedOrigins ?? [];
+	const resend = config.resend ?? {};
 	if (!trustedOrigins.includes(config.appURL)) {
 		trustedOrigins.push(config.appURL);
 	}
@@ -76,11 +100,7 @@ export function createAuth(db: object, config: AuthConfig) {
 				validateClient: async (clientId) => clientId === "rudel-cli",
 				verificationUri: config.cliDeviceVerificationUrl,
 			}),
-			organization({
-				allowUserToCreateOrganization: true,
-				creatorRole: "owner",
-				disableOrganizationDeletion: true,
-			}),
+			createOrganizationPlugin(config),
 		],
 		session: {
 			expiresIn: 60 * 60 * 24 * 365,
@@ -147,6 +167,11 @@ export function createAuth(db: object, config: AuthConfig) {
 								is_default_organization_ready: isDefaultOrganizationReady,
 								organization_id: organizationId,
 							},
+						});
+
+						await syncSignupContact(resend, {
+							email: user.email,
+							name: user.name,
 						});
 
 						if (!config.slackWebhookUrl || !adapter) {

--- a/apps/api/src/email.ts
+++ b/apps/api/src/email.ts
@@ -1,0 +1,148 @@
+import { getLogger } from "@logtape/logtape";
+import { Resend } from "resend";
+
+const logger = getLogger(["rudel", "api", "email"]);
+
+export interface ResendConfig {
+	apiKey?: string;
+	audienceId?: string;
+	fromEmail?: string;
+}
+
+export interface InvitationEmailData {
+	frontendURL: string;
+	invitationId: string;
+	inviteeEmail: string;
+	inviterName: string;
+	organizationName: string;
+}
+
+export interface InvitationEmailContent {
+	inviteLink: string;
+	subject: string;
+	html: string;
+	text: string;
+}
+
+export function getResendConfigWarnings(config: ResendConfig): string[] {
+	if (!config.apiKey || config.fromEmail) {
+		return [];
+	}
+
+	return [
+		"Resend invitation emails are disabled because RESEND_FROM_EMAIL is not set.",
+	];
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+function normalizeText(value: string): string {
+	return value.replace(/[\r\n]+/g, " ").trim();
+}
+
+function splitName(name: string) {
+	const [firstName = "", ...rest] = normalizeText(name)
+		.split(/\s+/)
+		.filter(Boolean);
+
+	return {
+		firstName: firstName || undefined,
+		lastName: rest.join(" ") || undefined,
+	};
+}
+
+export function buildInvitationLink(
+	frontendURL: string,
+	invitationId: string,
+): string {
+	const trimmedFrontendURL = frontendURL.replace(/\/+$/, "");
+	return `${trimmedFrontendURL}/invitation/${invitationId}`;
+}
+
+export function buildInvitationEmailContent(
+	data: InvitationEmailData,
+): InvitationEmailContent {
+	const inviterName = normalizeText(data.inviterName);
+	const organizationName = normalizeText(data.organizationName);
+	const inviteLink = buildInvitationLink(data.frontendURL, data.invitationId);
+
+	return {
+		inviteLink,
+		subject: `${inviterName} invited you to ${organizationName} on Rudel`,
+		html: `
+<p>Hi,</p>
+<p><strong>${escapeHtml(inviterName)}</strong> has invited you to join <strong>${escapeHtml(organizationName)}</strong> on Rudel.</p>
+<p>
+  <a href="${escapeHtml(inviteLink)}" style="display:inline-block;padding:12px 24px;background:#000;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;">
+    Accept Invitation
+  </a>
+</p>
+<p>Or copy this link into your browser:</p>
+<p>${escapeHtml(inviteLink)}</p>
+`,
+		text: `${inviterName} invited you to join ${organizationName} on Rudel.\n\nAccept the invitation here: ${inviteLink}`,
+	};
+}
+
+export async function syncSignupContact(
+	config: ResendConfig,
+	user: { email: string; name: string },
+): Promise<void> {
+	if (!config.apiKey || !config.audienceId) {
+		return;
+	}
+
+	const name = splitName(user.name);
+
+	try {
+		const resend = new Resend(config.apiKey);
+		await resend.contacts.create({
+			audienceId: config.audienceId,
+			email: user.email,
+			firstName: name.firstName,
+			lastName: name.lastName,
+		});
+	} catch (err) {
+		logger.error("Failed to add Resend contact for {email}: {error}", {
+			email: user.email,
+			error: err,
+		});
+	}
+}
+
+export async function sendOrganizationInvitationEmail(
+	config: ResendConfig,
+	data: InvitationEmailData,
+): Promise<void> {
+	if (!config.apiKey || !config.fromEmail) {
+		return;
+	}
+
+	const message = buildInvitationEmailContent(data);
+
+	try {
+		const resend = new Resend(config.apiKey);
+		await resend.emails.send({
+			from: config.fromEmail,
+			to: data.inviteeEmail,
+			subject: message.subject,
+			html: message.html,
+			text: message.text,
+		});
+		logger.info("Invitation email sent to {email}", {
+			email: data.inviteeEmail,
+		});
+	} catch (err) {
+		logger.error("Failed to send invitation email to {email}: {error}", {
+			email: data.inviteeEmail,
+			error: err,
+		});
+	}
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,6 +7,7 @@ import { eq } from "drizzle-orm";
 import type { Session as AuthSession } from "./auth.js";
 import { createAuth } from "./auth.js";
 import { db } from "./db.js";
+import { getResendConfigWarnings } from "./email.js";
 import { shutdownApiProductAnalytics } from "./lib/product-analytics.js";
 import { setupLogging } from "./logging.js";
 import { router } from "./router.js";
@@ -38,10 +39,21 @@ const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN ?? "http://localhost:4011";
 const trustedOrigins = process.env.TRUSTED_ORIGINS
 	? process.env.TRUSTED_ORIGINS.split(",").map((o) => o.trim())
 	: [ALLOWED_ORIGIN];
+const resend = {
+	apiKey: process.env.RESEND_API_KEY,
+	audienceId: process.env.RESEND_AUDIENCE_ID,
+	fromEmail: process.env.RESEND_FROM_EMAIL,
+};
+
+for (const warning of getResendConfigWarnings(resend)) {
+	logger.warn(warning);
+}
 
 const auth = createAuth(db, {
 	appURL,
+	frontendURL: ALLOWED_ORIGIN,
 	secret: process.env.BETTER_AUTH_SECRET,
+	resend,
 	socialProviders,
 	trustedOrigins,
 	cliDeviceVerificationUrl:

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "drizzle-orm": "0.45.1",
         "postgres": "^3.4.5",
         "posthog-node": "^5.8.0",
+        "resend": "^6.9.3",
       },
       "devDependencies": {
         "@rudel/typescript-config": "workspace:*",
@@ -731,6 +732,8 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
@@ -1108,6 +1111,8 @@
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
@@ -1551,6 +1556,8 @@
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
+    "postal-mime": ["postal-mime@2.7.3", "", {}, "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw=="],
+
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
@@ -1655,6 +1662,8 @@
 
     "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
+    "resend": ["resend@6.9.4", "", { "dependencies": { "postal-mime": "2.7.3", "svix": "1.86.0" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-/M3dsJzu5OgozqVsA4Psd/1L7EdePgOIIxClas453GOQYFG3VHc2ZyCHZFlvqsc9aZCCd2BJRRqZgWC8D9c7/g=="],
+
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
@@ -1729,6 +1738,8 @@
 
     "sqlstring": ["sqlstring@2.3.3", "", {}, "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
@@ -1752,6 +1763,8 @@
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
+    "svix": ["svix@1.86.0", "", { "dependencies": { "standardwebhooks": "1.0.0", "uuid": "^10.0.0" } }, "sha512-/HTvXwjLJe1l/MsLXAO1ddCYxElJk4eNR4DzOjDOEmGrPN/3BtBE8perGwMAaJ2sT5T172VkBYzmHcjUfM1JRQ=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
@@ -1842,6 +1855,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
 


### PR DESCRIPTION
## Summary
- Send invitation emails via Resend when users are invited to an organization
- Sync new signups to a Resend audience for contact management
- Fix invite link URL to point to frontend (`ALLOWED_ORIGIN`) instead of API (`APP_URL`)
- HTML-escape user-controlled values in email templates to prevent XSS

## Test plan
- [x] Tested invitation email sends correctly with Resend credentials
- [ ] Verify invite link lands on `/invitation/:id` in the web app
- [ ] Verify contact sync on signup adds user to Resend audience
- [ ] Verify graceful degradation when `RESEND_API_KEY` is not set (no emails, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)