### PR TITLE
fix: harden admin access management in org auth routes

### DIFF
--- a/apps/api/src/__tests__/organization-role-policy.test.ts
+++ b/apps/api/src/__tests__/organization-role-policy.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getAdminAccessBlockMessage,
+	getRoles,
+	hasAdminRole,
+	isAdminAccessPath,
+	isOwnerRole,
+	ONLY_OWNER_CAN_MANAGE_ADMIN_MESSAGE,
+	ORGANIZATION_AUTH_PATHS,
+} from "../organization-role-policy.js";
+
+describe("organization role policy", () => {
+	test("recognizes endpoints that touch admin access", () => {
+		expect(isAdminAccessPath(ORGANIZATION_AUTH_PATHS.addMember)).toBe(true);
+		expect(isAdminAccessPath(ORGANIZATION_AUTH_PATHS.inviteMember)).toBe(true);
+		expect(isAdminAccessPath(ORGANIZATION_AUTH_PATHS.updateMemberRole)).toBe(
+			true,
+		);
+		expect(isAdminAccessPath(ORGANIZATION_AUTH_PATHS.removeMember)).toBe(true);
+		expect(isAdminAccessPath(ORGANIZATION_AUTH_PATHS.cancelInvitation)).toBe(
+			true,
+		);
+		expect(isAdminAccessPath("/api/auth/organization/list-members")).toBe(
+			false,
+		);
+	});
+
+	test("normalizes role input from strings and arrays", () => {
+		expect(getRoles("admin")).toEqual(["admin"]);
+		expect(getRoles("member, admin")).toEqual(["member", "admin"]);
+		expect(getRoles(["member", "admin"])).toEqual(["member", "admin"]);
+		expect(getRoles(["member,admin", 123])).toEqual(["member", "admin"]);
+		expect(getRoles(null)).toEqual([]);
+	});
+
+	test("detects admin and owner roles", () => {
+		expect(hasAdminRole("admin")).toBe(true);
+		expect(hasAdminRole(["member", "admin"])).toBe(true);
+		expect(hasAdminRole("member")).toBe(false);
+		expect(isOwnerRole("owner")).toBe(true);
+		expect(isOwnerRole("admin,owner")).toBe(true);
+		expect(isOwnerRole("admin")).toBe(false);
+	});
+
+	test("blocks non-owners from assigning admin", () => {
+		const message = getAdminAccessBlockMessage({
+			pathname: ORGANIZATION_AUTH_PATHS.updateMemberRole,
+			actorRole: "admin",
+			requestedRole: "admin",
+		});
+
+		expect(message).toBe(ONLY_OWNER_CAN_MANAGE_ADMIN_MESSAGE);
+	});
+
+	test("blocks non-owners from demoting an existing admin", () => {
+		const message = getAdminAccessBlockMessage({
+			pathname: ORGANIZATION_AUTH_PATHS.updateMemberRole,
+			actorRole: "admin",
+			requestedRole: "member",
+			targetMemberRole: "admin",
+		});
+
+		expect(message).toBe(ONLY_OWNER_CAN_MANAGE_ADMIN_MESSAGE);
+	});
+
+	test("blocks non-owners from removing an admin member", () => {
+		const message = getAdminAccessBlockMessage({
+			pathname: ORGANIZATION_AUTH_PATHS.removeMember,
+			actorRole: "admin",
+			targetMemberRole: "admin",
+		});
+
+		expect(message).toBe(ONLY_OWNER_CAN_MANAGE_ADMIN_MESSAGE);
+	});
+
+	test("blocks non-owners from canceling an admin invitation", () => {
+		const message = getAdminAccessBlockMessage({
+			pathname: ORGANIZATION_AUTH_PATHS.cancelInvitation,
+			actorRole: "admin",
+			targetInvitationRole: "admin",
+		});
+
+		expect(message).toBe(ONLY_OWNER_CAN_MANAGE_ADMIN_MESSAGE);
+	});
+
+	test("allows owners to manage admin access", () => {
+		const message = getAdminAccessBlockMessage({
+			pathname: ORGANIZATION_AUTH_PATHS.updateMemberRole,
+			actorRole: "owner",
+			requestedRole: "admin",
+			targetMemberRole: "admin",
+		});
+
+		expect(message).toBeNull();
+	});
+
+	test("allows non-admin changes to pass through", () => {
+		const message = getAdminAccessBlockMessage({
+			pathname: ORGANIZATION_AUTH_PATHS.removeMember,
+			actorRole: "admin",
+			targetMemberRole: "member",
+		});
+
+		expect(message).toBeNull();
+	});
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,14 +2,24 @@ import { join } from "node:path";
 import { getLogger, withContext } from "@logtape/logtape";
 import { onError } from "@orpc/server";
 import { RPCHandler } from "@orpc/server/fetch";
-import { user as userTable } from "@rudel/sql-schema";
-import { eq } from "drizzle-orm";
+import {
+	invitation as invitationTable,
+	member as memberTable,
+	user as userTable,
+} from "@rudel/sql-schema";
+import { and, eq } from "drizzle-orm";
 import type { Session as AuthSession } from "./auth.js";
 import { createAuth } from "./auth.js";
 import { db } from "./db.js";
 import { getResendConfigWarnings } from "./email.js";
 import { shutdownApiProductAnalytics } from "./lib/product-analytics.js";
 import { setupLogging } from "./logging.js";
+import {
+	getAdminAccessBlockMessage,
+	isAdminAccessPath,
+	isOwnerRole,
+	ORGANIZATION_AUTH_PATHS,
+} from "./organization-role-policy.js";
 import { router } from "./router.js";
 
 await setupLogging();
@@ -179,6 +189,16 @@ async function handleRequest(
 	if (url.pathname === "/api/auth/organization/delete") {
 		return new Response("Not Found", { status: 404, headers: cors });
 	}
+
+	const rolePolicyResponse = await blockUnauthorizedAdminAssignment(
+		request,
+		url.pathname,
+		cors,
+	);
+	if (rolePolicyResponse) {
+		return rolePolicyResponse;
+	}
+
 	if (url.pathname.startsWith("/api/auth")) {
 		const response = await auth.handler(request);
 		for (const [key, value] of Object.entries(cors)) {
@@ -230,6 +250,193 @@ async function handleRequest(
 	}
 
 	return new Response("Not found", { status: 404, headers: cors });
+}
+
+async function blockUnauthorizedAdminAssignment(
+	request: Request,
+	pathname: string,
+	cors: Record<string, string>,
+) {
+	if (!isAdminAccessPath(pathname)) {
+		return null;
+	}
+
+	const body = await readJsonBody(request);
+	if (!body) {
+		return null;
+	}
+
+	const session = await auth.api.getSession({
+		headers: request.headers,
+	});
+	if (!session) {
+		return null;
+	}
+
+	const organizationId =
+		getOrganizationIdFromBody(body) ?? session.session.activeOrganizationId;
+	if (!organizationId) {
+		return null;
+	}
+
+	const [actorMembership] = await db
+		.select({ role: memberTable.role })
+		.from(memberTable)
+		.where(
+			and(
+				eq(memberTable.organizationId, organizationId),
+				eq(memberTable.userId, session.user.id),
+			),
+		)
+		.limit(1);
+
+	const actorRole = actorMembership?.role ?? null;
+	if (isOwnerRole(actorRole)) {
+		return null;
+	}
+
+	const targetMemberRole = await getTargetMemberRole(
+		pathname,
+		body,
+		organizationId,
+	);
+	const targetInvitationRole = await getTargetInvitationRole(
+		pathname,
+		body,
+		organizationId,
+	);
+
+	const blockMessage = getAdminAccessBlockMessage({
+		pathname,
+		actorRole,
+		requestedRole: body.role,
+		targetMemberRole,
+		targetInvitationRole,
+	});
+
+	if (!blockMessage) {
+		return null;
+	}
+
+	return Response.json(
+		{
+			code: "FORBIDDEN",
+			message: blockMessage,
+		},
+		{
+			status: 403,
+			headers: cors,
+		},
+	);
+}
+
+function getOrganizationIdFromBody(body: Record<string, unknown>) {
+	return typeof body.organizationId === "string" ? body.organizationId : null;
+}
+
+async function getTargetMemberRole(
+	pathname: string,
+	body: Record<string, unknown>,
+	organizationId: string,
+) {
+	switch (pathname) {
+		case ORGANIZATION_AUTH_PATHS.updateMemberRole:
+			return getMemberRoleById(body.memberId, organizationId);
+		case ORGANIZATION_AUTH_PATHS.removeMember:
+			return getMemberRoleByIdOrEmail(body.memberIdOrEmail, organizationId);
+		default:
+			return null;
+	}
+}
+
+async function getTargetInvitationRole(
+	pathname: string,
+	body: Record<string, unknown>,
+	organizationId: string,
+) {
+	if (pathname !== ORGANIZATION_AUTH_PATHS.cancelInvitation) {
+		return null;
+	}
+
+	if (typeof body.invitationId !== "string") {
+		return null;
+	}
+
+	const [invitation] = await db
+		.select({ role: invitationTable.role })
+		.from(invitationTable)
+		.where(
+			and(
+				eq(invitationTable.id, body.invitationId),
+				eq(invitationTable.organizationId, organizationId),
+			),
+		)
+		.limit(1);
+
+	return invitation?.role ?? null;
+}
+
+async function getMemberRoleById(memberId: unknown, organizationId: string) {
+	if (typeof memberId !== "string") {
+		return null;
+	}
+
+	const [member] = await db
+		.select({ role: memberTable.role })
+		.from(memberTable)
+		.where(
+			and(
+				eq(memberTable.id, memberId),
+				eq(memberTable.organizationId, organizationId),
+			),
+		)
+		.limit(1);
+
+	return member?.role ?? null;
+}
+
+async function getMemberRoleByIdOrEmail(
+	memberIdOrEmail: unknown,
+	organizationId: string,
+) {
+	if (typeof memberIdOrEmail !== "string") {
+		return null;
+	}
+
+	if (memberIdOrEmail.includes("@")) {
+		return getMemberRoleByEmail(memberIdOrEmail, organizationId);
+	}
+
+	return getMemberRoleById(memberIdOrEmail, organizationId);
+}
+
+async function getMemberRoleByEmail(email: string, organizationId: string) {
+	const [member] = await db
+		.select({ role: memberTable.role })
+		.from(memberTable)
+		.innerJoin(userTable, eq(memberTable.userId, userTable.id))
+		.where(
+			and(
+				eq(memberTable.organizationId, organizationId),
+				eq(userTable.email, email),
+			),
+		)
+		.limit(1);
+
+	return member?.role ?? null;
+}
+
+async function readJsonBody(request: Request) {
+	try {
+		const body = await request.clone().json();
+		if (!body || typeof body !== "object" || Array.isArray(body)) {
+			return null;
+		}
+
+		return body as Record<string, unknown>;
+	} catch {
+		return null;
+	}
 }
 
 async function getContext(request: Request) {

--- a/apps/api/src/organization-role-policy.ts
+++ b/apps/api/src/organization-role-policy.ts
@@ -1,0 +1,101 @@
+const ADMIN_ROLE = "admin";
+const OWNER_ROLE = "owner";
+
+export const ORGANIZATION_AUTH_PATHS = {
+	addMember: "/api/auth/organization/add-member",
+	inviteMember: "/api/auth/organization/invite-member",
+	updateMemberRole: "/api/auth/organization/update-member-role",
+	removeMember: "/api/auth/organization/remove-member",
+	cancelInvitation: "/api/auth/organization/cancel-invitation",
+} as const;
+
+export const ONLY_OWNER_CAN_MANAGE_ADMIN_MESSAGE =
+	"Only organization owners can manage admin access.";
+
+export function isAdminAccessPath(pathname: string) {
+	switch (pathname) {
+		case ORGANIZATION_AUTH_PATHS.addMember:
+		case ORGANIZATION_AUTH_PATHS.inviteMember:
+		case ORGANIZATION_AUTH_PATHS.updateMemberRole:
+		case ORGANIZATION_AUTH_PATHS.removeMember:
+		case ORGANIZATION_AUTH_PATHS.cancelInvitation:
+			return true;
+		default:
+			return false;
+	}
+}
+
+export function getRoles(value: unknown): string[] {
+	if (typeof value === "string") {
+		return splitRoles(value);
+	}
+
+	if (!Array.isArray(value)) {
+		return [];
+	}
+
+	return value.flatMap((item) => {
+		if (typeof item !== "string") {
+			return [];
+		}
+
+		return splitRoles(item);
+	});
+}
+
+export function hasAdminRole(value: unknown) {
+	return getRoles(value).includes(ADMIN_ROLE);
+}
+
+export function isOwnerRole(value: string | null | undefined) {
+	if (!value) {
+		return false;
+	}
+
+	return getRoles(value).includes(OWNER_ROLE);
+}
+
+export function getAdminAccessBlockMessage(input: {
+	pathname: string;
+	actorRole: string | null | undefined;
+	requestedRole?: unknown;
+	targetMemberRole?: string | null;
+	targetInvitationRole?: string | null;
+}) {
+	if (isOwnerRole(input.actorRole)) {
+		return null;
+	}
+
+	switch (input.pathname) {
+		case ORGANIZATION_AUTH_PATHS.addMember:
+		case ORGANIZATION_AUTH_PATHS.inviteMember:
+			return hasAdminRole(input.requestedRole)
+				? ONLY_OWNER_CAN_MANAGE_ADMIN_MESSAGE
+				: null;
+		case ORGANIZATION_AUTH_PATHS.updateMemberRole:
+			if (hasAdminRole(input.requestedRole)) {
+				return ONLY_OWNER_CAN_MANAGE_ADMIN_MESSAGE;
+			}
+
+			return hasAdminRole(input.targetMemberRole)
+				? ONLY_OWNER_CAN_MANAGE_ADMIN_MESSAGE
+				: null;
+		case ORGANIZATION_AUTH_PATHS.removeMember:
+			return hasAdminRole(input.targetMemberRole)
+				? ONLY_OWNER_CAN_MANAGE_ADMIN_MESSAGE
+				: null;
+		case ORGANIZATION_AUTH_PATHS.cancelInvitation:
+			return hasAdminRole(input.targetInvitationRole)
+				? ONLY_OWNER_CAN_MANAGE_ADMIN_MESSAGE
+				: null;
+		default:
+			return null;
+	}
+}
+
+function splitRoles(value: string) {
+	return value
+		.split(",")
+		.map((role) => role.trim())
+		.filter(Boolean);
+}


### PR DESCRIPTION
## Summary

This is a backend-only hardening change for organization membership management.

It adds an explicit admin-access policy in the API layer and applies it before Better Auth handles membership mutations. The goal is to keep admin privilege changes owner-only without relying on frontend behavior.

## What changed

- added a small policy module to keep the admin-access rule explicit and easy to read
- enforced that policy before Better Auth handles org membership mutations
- covered `add-member`, `invite-member`, `update-member-role`, `remove-member`, and `cancel-invitation`
- added focused tests for promotion, demotion, removal, and admin-invite cancellation

## Behavior

Non-owners are now blocked from:

- assigning the `admin` role
- demoting an existing admin
- removing an admin member
- canceling an invitation that grants admin access

Owners keep existing admin-management behavior.

Frontend behavior is unchanged. This is enforced on the backend.

## Testing

- `bun test src/__tests__/organization-role-policy.test.ts`