### PR TITLE
refactor: remove session detail chart cursor for now

### DIFF
--- a/apps/web/src/components/conversation/ConversationView.tsx
+++ b/apps/web/src/components/conversation/ConversationView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import type { Conversation } from "@/lib/conversation-schema";
 import { parseConversations } from "@/lib/conversation-schema";
 import { isSlashCommandMessage } from "@/lib/parse-slash-command";
@@ -10,11 +10,8 @@ import type { ToolActivityPoint } from "./ToolActivityChart";
 interface ConversationViewProps {
 	content: string;
 	className?: string;
-	scrollContainerRef?: React.RefObject<HTMLElement | null>;
-	onActiveMessageChange?: (messageIndex: number) => void;
 	onTokenDataReady?: (data: TokenDataPoint[], totalMessages: number) => void;
 	onToolActivityReady?: (data: ToolActivityPoint[]) => void;
-	scrollToMessageIndex?: number | null;
 }
 
 /** Extract token usage data from parsed conversations */
@@ -117,16 +114,11 @@ function extractToolActivity(entries: Conversation[]): ToolActivityPoint[] {
 export function ConversationView({
 	content,
 	className,
-	scrollContainerRef,
-	onActiveMessageChange,
 	onTokenDataReady,
 	onToolActivityReady,
-	scrollToMessageIndex,
 }: ConversationViewProps) {
 	const [conversations, setConversations] = useState<Conversation[]>([]);
 	const [parseError, setParseError] = useState<string | null>(null);
-	const messageRefsMap = useRef<Map<number, HTMLDivElement>>(new Map());
-	const observerRef = useRef<IntersectionObserver | null>(null);
 
 	// Parse content
 	useEffect(() => {
@@ -169,78 +161,6 @@ export function ConversationView({
 		}
 	}, [content, onTokenDataReady, onToolActivityReady]);
 
-	// Set up IntersectionObserver for scroll tracking
-	useEffect(() => {
-		if (!onActiveMessageChange) return;
-
-		const root = scrollContainerRef?.current || null;
-
-		observerRef.current = new IntersectionObserver(
-			(entries) => {
-				let topmostIndex = -1;
-				let topmostTop = Infinity;
-
-				for (const ioEntry of entries) {
-					if (ioEntry.isIntersecting) {
-						const idx = Number(
-							ioEntry.target.getAttribute("data-message-index"),
-						);
-						if (
-							!Number.isNaN(idx) &&
-							ioEntry.boundingClientRect.top < topmostTop
-						) {
-							topmostTop = ioEntry.boundingClientRect.top;
-							topmostIndex = idx;
-						}
-					}
-				}
-
-				if (topmostIndex >= 0) {
-					onActiveMessageChange(topmostIndex);
-				}
-			},
-			{
-				root,
-				rootMargin: "0px 0px -80% 0px",
-				threshold: 0,
-			},
-		);
-
-		for (const [, el] of messageRefsMap.current) {
-			observerRef.current.observe(el);
-		}
-
-		return () => {
-			observerRef.current?.disconnect();
-		};
-	}, [onActiveMessageChange, scrollContainerRef]);
-
-	// Scroll to message when scrollToMessageIndex changes
-	useEffect(() => {
-		if (scrollToMessageIndex == null) return;
-
-		const el = messageRefsMap.current.get(scrollToMessageIndex);
-		if (el) {
-			el.scrollIntoView({ behavior: "smooth", block: "center" });
-		}
-	}, [scrollToMessageIndex]);
-
-	const registerMessageRef = useCallback(
-		(index: number, el: HTMLDivElement | null) => {
-			if (el) {
-				messageRefsMap.current.set(index, el);
-				observerRef.current?.observe(el);
-			} else {
-				const existing = messageRefsMap.current.get(index);
-				if (existing) {
-					observerRef.current?.unobserve(existing);
-				}
-				messageRefsMap.current.delete(index);
-			}
-		},
-		[],
-	);
-
 	if (parseError) {
 		return (
 			<div className={cn("py-8 text-center", className)}>
@@ -269,8 +189,6 @@ export function ConversationView({
 				<div
 					// biome-ignore lint/suspicious/noArrayIndexKey: stable conversation order
 					key={idx}
-					ref={(el) => registerMessageRef(idx, el)}
-					data-message-index={idx}
 				>
 					<ConversationMessage entry={entry} messageIndex={idx} />
 				</div>

--- a/apps/web/src/components/conversation/TokenUsageChart.tsx
+++ b/apps/web/src/components/conversation/TokenUsageChart.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAnalyticsTracking } from "@/hooks/useDashboardAnalytics";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 
 export interface TokenDataPoint {
@@ -11,8 +10,6 @@ export interface TokenDataPoint {
 interface TokenUsageChartProps {
 	data: TokenDataPoint[];
 	totalMessages: number;
-	activeMessageIndex: number;
-	onClickMessage: (messageIndex: number) => void;
 	className?: string;
 }
 
@@ -30,13 +27,10 @@ function formatTokenCount(n: number): string {
 export function TokenUsageChart({
 	data,
 	totalMessages,
-	activeMessageIndex,
-	onClickMessage,
 	className,
 }: TokenUsageChartProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [chartWidth, setChartWidth] = useState(400);
-	const { trackDrilldown } = useAnalyticsTracking();
 
 	useEffect(() => {
 		const el = containerRef.current;
@@ -70,37 +64,6 @@ export function TokenUsageChart({
 		[data],
 	);
 
-	const handleClick = useCallback(
-		(e: React.MouseEvent<SVGSVGElement>) => {
-			if (totalMessages === 0) return;
-
-			const svg = e.currentTarget;
-			const rect = svg.getBoundingClientRect();
-			const px = e.clientX - rect.left - LEFT_MARGIN;
-			const fraction = px / drawWidth;
-
-			let closest = data[0];
-			let closestDist = Infinity;
-			for (const d of data) {
-				const dx = Math.abs(d.messageIndex / totalMessages - fraction);
-				if (dx < closestDist) {
-					closestDist = dx;
-					closest = d;
-				}
-			}
-			if (closest) {
-				trackDrilldown({
-					drilldownMethod: "chart_click",
-					sourceComponent: "token_usage_chart",
-					targetType: "message",
-					targetId: String(closest.messageIndex),
-				});
-				onClickMessage(closest.messageIndex);
-			}
-		},
-		[data, totalMessages, drawWidth, onClickMessage, trackDrilldown],
-	);
-
 	if (data.length === 0) {
 		return (
 			<div className={cn("text-xs text-muted text-center py-4", className)}>
@@ -108,10 +71,6 @@ export function TokenUsageChart({
 			</div>
 		);
 	}
-
-	const cursorX =
-		LEFT_MARGIN +
-		(totalMessages > 0 ? activeMessageIndex / totalMessages : 0) * drawWidth;
 
 	const barWidth = Math.max(2, (drawWidth / totalMessages) * 0.8);
 
@@ -125,12 +84,10 @@ export function TokenUsageChart({
 			</div>
 
 			<div ref={containerRef}>
-				{/* biome-ignore lint/a11y/useKeyWithClickEvents: chart click navigation */}
 				<svg
 					viewBox={`0 0 ${chartWidth} ${CHART_HEIGHT}`}
-					className="w-full cursor-pointer"
+					className="w-full"
 					style={{ height: `${CHART_HEIGHT}px` }}
-					onClick={handleClick}
 					role="img"
 					aria-label="Token usage chart showing input and output tokens per message"
 				>
@@ -188,7 +145,7 @@ export function TokenUsageChart({
 								y={AXIS_Y - barH}
 								width={barWidth}
 								height={barH}
-								className="fill-blue-400/70 hover:fill-blue-500"
+								className="fill-blue-400/70"
 								rx="1"
 							/>
 						);
@@ -208,23 +165,11 @@ export function TokenUsageChart({
 								y={AXIS_Y}
 								width={barWidth}
 								height={barH}
-								className="fill-purple-400/70 hover:fill-purple-500"
+								className="fill-purple-400/70"
 								rx="1"
 							/>
 						);
 					})}
-
-					{/* Cursor line */}
-					<line
-						x1={cursorX}
-						y1="0"
-						x2={cursorX}
-						y2={CHART_HEIGHT}
-						stroke="currentColor"
-						strokeWidth="1"
-						className="text-foreground"
-						strokeDasharray="4,2"
-					/>
 				</svg>
 			</div>
 

--- a/apps/web/src/components/conversation/ToolActivityChart.tsx
+++ b/apps/web/src/components/conversation/ToolActivityChart.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAnalyticsTracking } from "@/hooks/useDashboardAnalytics";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 
 export interface ToolActivityPoint {
@@ -12,8 +11,6 @@ export interface ToolActivityPoint {
 interface ToolActivityChartProps {
 	data: ToolActivityPoint[];
 	totalMessages: number;
-	activeMessageIndex: number;
-	onClickMessage: (messageIndex: number) => void;
 	className?: string;
 }
 
@@ -40,13 +37,10 @@ const lanes: {
 export function ToolActivityChart({
 	data,
 	totalMessages,
-	activeMessageIndex,
-	onClickMessage,
 	className,
 }: ToolActivityChartProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [chartWidth, setChartWidth] = useState(400);
-	const { trackDrilldown } = useAnalyticsTracking();
 
 	useEffect(() => {
 		const el = containerRef.current;
@@ -69,37 +63,6 @@ export function ToolActivityChart({
 		return { tools, skills, subagents, errors };
 	}, [data]);
 
-	const handleClick = useCallback(
-		(e: React.MouseEvent<SVGSVGElement>) => {
-			if (totalMessages === 0 || data.length === 0) return;
-
-			const svg = e.currentTarget;
-			const rect = svg.getBoundingClientRect();
-			const px = e.clientX - rect.left - LEFT_MARGIN;
-			const fraction = px / drawWidth;
-
-			let closest = data[0];
-			let closestDist = Infinity;
-			for (const d of data) {
-				const dx = Math.abs(d.messageIndex / totalMessages - fraction);
-				if (dx < closestDist) {
-					closestDist = dx;
-					closest = d;
-				}
-			}
-			if (closest) {
-				trackDrilldown({
-					drilldownMethod: "chart_click",
-					sourceComponent: "tool_activity_chart",
-					targetType: closest.category,
-					targetId: String(closest.messageIndex),
-				});
-				onClickMessage(closest.messageIndex);
-			}
-		},
-		[data, totalMessages, drawWidth, onClickMessage, trackDrilldown],
-	);
-
 	if (data.length === 0) {
 		return (
 			<div className={cn("text-xs text-muted text-center py-4", className)}>
@@ -107,10 +70,6 @@ export function ToolActivityChart({
 			</div>
 		);
 	}
-
-	const cursorX =
-		LEFT_MARGIN +
-		(totalMessages > 0 ? activeMessageIndex / totalMessages : 0) * drawWidth;
 
 	return (
 		<div className={className}>
@@ -126,12 +85,10 @@ export function ToolActivityChart({
 			</div>
 
 			<div ref={containerRef}>
-				{/* biome-ignore lint/a11y/useKeyWithClickEvents: chart click navigation */}
 				<svg
 					viewBox={`0 0 ${chartWidth} ${CHART_HEIGHT}`}
-					className="w-full cursor-pointer"
+					className="w-full"
 					style={{ height: `${CHART_HEIGHT}px` }}
-					onClick={handleClick}
 					role="img"
 					aria-label="Tool activity chart showing tool, skill, and subagent usage"
 				>
@@ -185,28 +142,16 @@ export function ToolActivityChart({
 								r={DOT_RADIUS}
 								className={
 									d.isError
-										? "fill-red-400/80 hover:fill-red-500"
+										? "fill-red-400/80"
 										: d.category === "tool"
-											? "fill-green-400/80 hover:fill-green-500"
+											? "fill-green-400/80"
 											: d.category === "skill"
-												? "fill-purple-400/80 hover:fill-purple-500"
-												: "fill-orange-400/80 hover:fill-orange-500"
+												? "fill-purple-400/80"
+												: "fill-orange-400/80"
 								}
 							/>
 						);
 					})}
-
-					{/* Cursor line */}
-					<line
-						x1={cursorX}
-						y1="0"
-						x2={cursorX}
-						y2={CHART_HEIGHT}
-						stroke="currentColor"
-						strokeWidth="1"
-						className="text-foreground"
-						strokeDasharray="4,2"
-					/>
 				</svg>
 			</div>
 

--- a/apps/web/src/pages/dashboard/SessionDetailPage.tsx
+++ b/apps/web/src/pages/dashboard/SessionDetailPage.tsx
@@ -8,7 +8,7 @@ import {
 	GitCommitHorizontal,
 	User,
 } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { useParams } from "react-router-dom";
 import { ConversationView } from "@/components/conversation/ConversationView";
 import {
@@ -53,9 +53,6 @@ export function SessionDetailPage() {
 		[],
 	);
 	const [totalMessages, setTotalMessages] = useState(0);
-	const [activeMessageIndex, setActiveMessageIndex] = useState(0);
-	const [scrollToIndex, setScrollToIndex] = useState<number | null>(null);
-	const scrollContainerRef = useRef<HTMLDivElement>(null);
 
 	const handleTokenDataReady = useCallback(
 		(data: TokenDataPoint[], total: number) => {
@@ -67,12 +64,6 @@ export function SessionDetailPage() {
 
 	const handleToolActivityReady = useCallback((data: ToolActivityPoint[]) => {
 		setToolActivityData(data);
-	}, []);
-
-	const handleClickMessage = useCallback((messageIndex: number) => {
-		setScrollToIndex(messageIndex);
-		// Reset after triggering scroll so it can be re-triggered
-		setTimeout(() => setScrollToIndex(null), 100);
 	}, []);
 
 	const {
@@ -356,35 +347,25 @@ export function SessionDetailPage() {
 			</div>
 
 			{/* Scrollable content — two-column layout */}
-			<div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
+			<div className="flex-1 overflow-y-auto">
 				<div className="flex">
 					{/* Conversation — left */}
 					<div className="flex-1 min-w-0 py-6 px-8">
 						<ConversationView
 							content={session.content}
-							scrollContainerRef={scrollContainerRef}
-							onActiveMessageChange={setActiveMessageIndex}
 							onTokenDataReady={handleTokenDataReady}
 							onToolActivityReady={handleToolActivityReady}
-							scrollToMessageIndex={scrollToIndex}
 						/>
 					</div>
 
 					{/* Stats panel — right */}
 					<div className="w-[36rem] shrink-0 border-l border-border">
 						<div className="sticky top-0 px-6 py-4">
-							<TokenUsageChart
-								data={tokenData}
-								totalMessages={totalMessages}
-								activeMessageIndex={activeMessageIndex}
-								onClickMessage={handleClickMessage}
-							/>
+							<TokenUsageChart data={tokenData} totalMessages={totalMessages} />
 							<div className="border-t border-border my-4 pt-4">
 								<ToolActivityChart
 									data={toolActivityData}
 									totalMessages={totalMessages}
-									activeMessageIndex={activeMessageIndex}
-									onClickMessage={handleClickMessage}
 								/>
 							</div>
 						</div>


### PR DESCRIPTION
We are removing the session detail chart cursor for now because it suggests a level of transcript-to-chart precision that the current implementation does not reliably have. The cursor had become the unstable part of the feature, forcing increasingly complex scroll synchronization, interpolation, and anchor heuristics across variable-height transcript content. This change intentionally rolls the page back to the simpler, more honest behavior: keep the charts, remove the misleading interaction, and buy time to design a proper transcript-aware model later.

## What Changed
- removed the moving vertical line from the token and tool charts
- removed chart click navigation so the charts are read-only for now
- removed the active cursor state and prop plumbing from the session detail page
- removed the transcript scroll observer and message-anchor sync logic that only existed to support the cursor
- removed hover states that implied the charts were interactive

## Why This Is Better Right Now
- the page is materially simpler
- the charts no longer claim precision they cannot consistently deliver
- there is less state, less synchronization logic, and fewer transcript-layout edge cases
- the remaining charts should feel more stable and easier to trust

## Validation
- `apps/web`: `bun run check-types`
- targeted `biome check` on the four touched files