### PR TITLE
fix: refresh upload hint after signup

### DIFF
--- a/apps/web/src/features/auth/AuthStateRefresh.test.tsx
+++ b/apps/web/src/features/auth/AuthStateRefresh.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LoginForm } from "./LoginForm";
+import { SignupForm } from "./SignupForm";
+
+const {
+	mockRefreshAuthClientState,
+	mockSignInEmail,
+	mockSignInSocial,
+	mockSignUpEmail,
+	mockTrackAuthenticationAction,
+} = vi.hoisted(() => ({
+	mockRefreshAuthClientState: vi.fn(),
+	mockSignInEmail: vi.fn(),
+	mockSignInSocial: vi.fn(),
+	mockSignUpEmail: vi.fn(),
+	mockTrackAuthenticationAction: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+	authClient: {
+		signIn: {
+			email: mockSignInEmail,
+			social: mockSignInSocial,
+		},
+		signUp: {
+			email: mockSignUpEmail,
+		},
+	},
+	refreshAuthClientState: mockRefreshAuthClientState,
+}));
+
+vi.mock("@/features/analytics/tracking/useAnalyticsTracking", () => ({
+	useAnalyticsTracking: () => ({
+		trackAuthenticationAction: mockTrackAuthenticationAction,
+	}),
+}));
+
+vi.mock("@/lib/product-analytics", () => ({
+	captureSignUpFailed: vi.fn(),
+	normalizeWebErrorCode: vi.fn(() => "unknown_error"),
+}));
+
+describe("auth state refresh", () => {
+	beforeEach(() => {
+		mockRefreshAuthClientState.mockReset();
+		mockSignInEmail.mockReset();
+		mockSignInSocial.mockReset();
+		mockSignUpEmail.mockReset();
+		mockTrackAuthenticationAction.mockReset();
+	});
+
+	it("refreshes the auth store after a successful email sign up", async () => {
+		mockSignUpEmail.mockResolvedValue({ error: null });
+
+		const user = userEvent.setup();
+		render(<SignupForm onSwitchToLogin={vi.fn()} />);
+
+		await user.type(screen.getByLabelText("Name"), "Ada Lovelace");
+		await user.type(screen.getByLabelText("Email"), "ada@example.com");
+		await user.type(screen.getByLabelText("Password"), "supersecure");
+		await user.click(screen.getByRole("button", { name: "Sign up" }));
+
+		await waitFor(() => {
+			expect(mockSignUpEmail).toHaveBeenCalledWith({
+				name: "Ada Lovelace",
+				email: "ada@example.com",
+				password: "supersecure",
+			});
+		});
+
+		await waitFor(() => {
+			expect(mockRefreshAuthClientState).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	it("refreshes the auth store after a successful email sign in", async () => {
+		mockSignInEmail.mockResolvedValue({ error: null });
+
+		const user = userEvent.setup();
+		render(<LoginForm onSwitchToSignup={vi.fn()} />);
+
+		await user.type(screen.getByLabelText("Email"), "ada@example.com");
+		await user.type(screen.getByLabelText("Password"), "supersecure");
+		await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+		await waitFor(() => {
+			expect(mockSignInEmail).toHaveBeenCalledWith({
+				email: "ada@example.com",
+				password: "supersecure",
+			});
+		});
+
+		await waitFor(() => {
+			expect(mockRefreshAuthClientState).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/apps/web/src/features/auth/LoginForm.tsx
+++ b/apps/web/src/features/auth/LoginForm.tsx
@@ -11,7 +11,7 @@ import { Input } from "@/app/ui/input";
 import { Label } from "@/app/ui/label";
 import { Separator } from "@/app/ui/separator";
 import { useAnalyticsTracking } from "@/features/analytics/tracking/useAnalyticsTracking";
-import { authClient } from "@/lib/auth-client";
+import { authClient, refreshAuthClientState } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 
 type FeedbackState = {
@@ -67,7 +67,10 @@ export function LoginForm({
 				kind: "error",
 				message: error.message ?? "Sign in failed",
 			});
+			return;
 		}
+
+		refreshAuthClientState();
 	}
 
 	async function handleRequestPasswordReset() {

--- a/apps/web/src/features/auth/SignupForm.tsx
+++ b/apps/web/src/features/auth/SignupForm.tsx
@@ -11,7 +11,7 @@ import { Input } from "@/app/ui/input";
 import { Label } from "@/app/ui/label";
 import { Separator } from "@/app/ui/separator";
 import { useAnalyticsTracking } from "@/features/analytics/tracking/useAnalyticsTracking";
-import { authClient } from "@/lib/auth-client";
+import { authClient, refreshAuthClientState } from "@/lib/auth-client";
 import {
 	captureSignUpFailed,
 	normalizeWebErrorCode,
@@ -102,7 +102,10 @@ export function SignupForm({
 				entry_point: signupContext.entryPoint,
 			});
 			setError(error.message ?? "Sign up failed");
+			return;
 		}
+
+		refreshAuthClientState();
 	}
 
 	async function handleSocialSignIn(provider: "google" | "github") {

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -9,6 +9,14 @@ export const authClient = createAuthClient({
 	plugins: [organizationClient()],
 });
 
+export function refreshAuthClientState() {
+	for (const key of Object.keys(authClient.$store.atoms)) {
+		if (key.startsWith("$")) {
+			authClient.$store.notify(key);
+		}
+	}
+}
+
 export async function signOut() {
 	resetChatwoot();
 	resetProductAnalytics();
@@ -17,11 +25,5 @@ export async function signOut() {
 	localStorage.removeItem("dateRange");
 	localStorage.removeItem("globalFilters");
 	localStorage.removeItem("rudel:activeOrg");
-	// Notify all better-auth signal atoms to trigger refetches,
-	// clearing stale org data that /sign-out doesn't reset
-	for (const key of Object.keys(authClient.$store.atoms)) {
-		if (key.startsWith("$")) {
-			authClient.$store.notify(key);
-		}
-	}
+	refreshAuthClientState();
 }


### PR DESCRIPTION
## Summary
- refresh Better Auth client atoms after successful email sign-up and sign-in so workspace-scoped dashboard queries can resolve immediately
- route brand-new signups to a dedicated `/dashboard/get-started` setup page instead of dropping them on the main dashboard first
- add web regression coverage for the auth refresh and post-signup redirect helpers

## Test Plan
- bun run verify