### PR TITLE
fix: route new signups to setup page

### DIFF
--- a/apps/web/src/app/AppRouter.tsx
+++ b/apps/web/src/app/AppRouter.tsx
@@ -1,5 +1,6 @@
 import { type ComponentType, lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
+import { appRoutes } from "@/app/routes";
 import { NotFoundPage } from "@/app/system/NotFoundPage";
 import { AcceptInvitationPage } from "@/features/invitations/AcceptInvitationPage";
 import { settingsRouteMap } from "@/features/settings/config/settings-routes";
@@ -22,6 +23,10 @@ function lazyNamed<TModule extends Record<string, unknown>>(
 const DashboardPage = lazyNamed(
 	() => import("@/features/dashboard/DashboardPage"),
 	"DashboardPage",
+);
+const DashboardGetStartedPage = lazyNamed(
+	() => import("@/features/dashboard/DashboardGetStartedPage"),
+	"DashboardGetStartedPage",
 );
 const SessionsListPage = lazyNamed(
 	() => import("@/pages/dashboard/SessionsListPage"),
@@ -103,6 +108,10 @@ export function AppRouter({
 				<Route
 					path={shellRouteMap.dashboard.path}
 					element={<LazyRoute Component={DashboardPage} />}
+				/>
+				<Route
+					path={appRoutes.dashboardGetStarted()}
+					element={<LazyRoute Component={DashboardGetStartedPage} />}
 				/>
 				<Route
 					path={`${shellRouteMap.dashboard.path}/sessions`}

--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -1,4 +1,5 @@
 const DASHBOARD_PATH = "/dashboard";
+const DASHBOARD_GET_STARTED_PATH = `${DASHBOARD_PATH}/get-started`;
 const TEAM_PATH = "/team";
 const SETTINGS_ROOT_PATH = "/settings";
 const SETTINGS_WORKSPACE_PATH = `${SETTINGS_ROOT_PATH}/workspace`;
@@ -10,6 +11,7 @@ const PRESET_BASELINE_PATH = "/__preset-baseline";
 export const appRoutes = {
 	home: () => DASHBOARD_PATH,
 	dashboard: () => DASHBOARD_PATH,
+	dashboardGetStarted: () => DASHBOARD_GET_STARTED_PATH,
 	team: () => TEAM_PATH,
 	settings: () => SETTINGS_ROOT_PATH,
 	settingsRoot: () => SETTINGS_ROOT_PATH,

--- a/apps/web/src/features/auth/AuthStateRefresh.test.tsx
+++ b/apps/web/src/features/auth/AuthStateRefresh.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LoginForm } from "./LoginForm";
-import { SignupForm } from "./SignupForm";
+import {
+	getSignupCallbackURL,
+	redirectAfterSignup,
+	SignupForm,
+} from "./SignupForm";
 
 const {
 	mockRefreshAuthClientState,
@@ -43,7 +47,12 @@ vi.mock("@/lib/product-analytics", () => ({
 }));
 
 describe("auth state refresh", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	beforeEach(() => {
+		window.history.replaceState({}, "", "/");
 		mockRefreshAuthClientState.mockReset();
 		mockSignInEmail.mockReset();
 		mockSignInSocial.mockReset();
@@ -51,8 +60,31 @@ describe("auth state refresh", () => {
 		mockTrackAuthenticationAction.mockReset();
 	});
 
+	it("routes fresh signups to the get-started page by default", () => {
+		expect(getSignupCallbackURL("/", "")).toBe(
+			"/?redirect=%2Fdashboard%2Fget-started",
+		);
+	});
+
+	it("preserves an explicit redirect when building the signup callback URL", () => {
+		expect(getSignupCallbackURL("/", "?redirect=%2Fdashboard%2Fsessions")).toBe(
+			"/?redirect=%2Fdashboard%2Fsessions",
+		);
+	});
+
+	it("redirects signups to the get-started page", () => {
+		const assignMock = vi.fn();
+
+		redirectAfterSignup({ assign: assignMock });
+
+		expect(assignMock).toHaveBeenCalledWith(
+			"/?redirect=%2Fdashboard%2Fget-started",
+		);
+	});
+
 	it("refreshes the auth store after a successful email sign up", async () => {
 		mockSignUpEmail.mockResolvedValue({ error: null });
+		vi.spyOn(console, "error").mockImplementation(() => {});
 
 		const user = userEvent.setup();
 		render(<SignupForm onSwitchToLogin={vi.fn()} />);

--- a/apps/web/src/features/auth/SignupForm.tsx
+++ b/apps/web/src/features/auth/SignupForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { appRoutes } from "@/app/routes";
 import { Button } from "@/app/ui/button";
 import {
 	Card,
@@ -17,8 +18,11 @@ import {
 	normalizeWebErrorCode,
 } from "@/lib/product-analytics";
 
-function getCallbackURL(): string {
-	const params = new URLSearchParams(window.location.search);
+export function getSignupCallbackURL(
+	pathname = window.location.pathname,
+	search = window.location.search,
+): string {
+	const params = new URLSearchParams(search);
 	const userCode = params.get("user_code");
 	if (userCode) {
 		return `/?user_code=${encodeURIComponent(userCode)}`;
@@ -27,12 +31,20 @@ function getCallbackURL(): string {
 	if (redirect) {
 		return `/?redirect=${encodeURIComponent(redirect)}`;
 	}
-	const path = window.location.pathname;
-	const search = window.location.search;
-	if (path !== "/" && path !== "") {
-		return `/?redirect=${encodeURIComponent(`${path}${search}`)}`;
+	if (pathname !== "/" && pathname !== "") {
+		return `/?redirect=${encodeURIComponent(`${pathname}${search}`)}`;
 	}
-	return "/";
+	return `/?redirect=${encodeURIComponent(appRoutes.dashboardGetStarted())}`;
+}
+
+type SignupRedirectLocation = {
+	assign: (url: string) => void;
+};
+
+export function redirectAfterSignup(
+	location: SignupRedirectLocation = window.location,
+) {
+	location.assign(getSignupCallbackURL());
 }
 
 function getSignupContext() {
@@ -106,6 +118,7 @@ export function SignupForm({
 		}
 
 		refreshAuthClientState();
+		redirectAfterSignup();
 	}
 
 	async function handleSocialSignIn(provider: "google" | "github") {
@@ -119,7 +132,7 @@ export function SignupForm({
 		});
 		const { error } = await authClient.signIn.social({
 			provider,
-			callbackURL: getCallbackURL(),
+			callbackURL: getSignupCallbackURL(),
 		});
 		if (error) {
 			captureSignUpFailed({

--- a/apps/web/src/features/dashboard/DashboardGetStartedPage.tsx
+++ b/apps/web/src/features/dashboard/DashboardGetStartedPage.tsx
@@ -1,0 +1,40 @@
+import { Link } from "react-router-dom";
+import { appRoutes } from "@/app/routes";
+import { buttonVariants } from "@/app/ui/button";
+import { CliSetupHint } from "@/components/analytics/CliSetupHint";
+import { cn } from "@/lib/utils";
+import "@/features/dashboard/dashboard-theme.css";
+
+export function DashboardGetStartedPage() {
+	return (
+		<div className="dashboardy-page px-4 pb-6 pt-2 sm:px-6 lg:px-[76px] lg:pb-8">
+			<div className="@container/dashboard-page mx-auto flex w-full max-w-4xl flex-col gap-6">
+				<div className="dashboardy-card rounded-[1.75rem] border px-6 py-7 sm:px-8 sm:py-8">
+					<div className="flex flex-col gap-4">
+						<div className="flex flex-col gap-2">
+							<p className="text-[11px] font-semibold tracking-[0.26em] text-[color:var(--dashboardy-subtle)] uppercase">
+								Get started
+							</p>
+							<h1 className="dashboardy-section-title text-3xl font-semibold tracking-[-0.04em]">
+								Set up uploads before you open the dashboard
+							</h1>
+							<p className="dashboardy-summary-copy max-w-2xl text-sm leading-6 sm:text-[15px]">
+								Your workspace is ready. Run these commands once so Rudel can
+								start ingesting sessions, then come back to the dashboard.
+							</p>
+						</div>
+						<div className="flex flex-wrap gap-3">
+							<Link
+								to={appRoutes.dashboard()}
+								className={cn(buttonVariants({ size: "sm" }))}
+							>
+								Go to dashboard
+							</Link>
+						</div>
+					</div>
+				</div>
+				<CliSetupHint />
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- route brand-new signups to `/dashboard/get-started` instead of dropping them on the main dashboard first
- preserve existing invite, device-login, and explicit redirect flows when building the signup callback URL
- add regression coverage for the post-signup redirect helpers and the auth refresh behavior

## Test Plan
- bun run verify