### PR TITLE
fix: redirect after uploads

### DIFF
--- a/apps/web/src/components/analytics/CliSetupHint.tsx
+++ b/apps/web/src/components/analytics/CliSetupHint.tsx
@@ -1,41 +1,78 @@
+import { cn } from "@/lib/utils";
+
 const setupCommands = [
 	{
 		command: "npm install -g rudel",
+		id: "install-cli",
 		title: "Install CLI",
 	},
 	{
 		command: "rudel login",
+		id: "log-in",
 		title: "Log in",
 	},
 	{
 		command: "rudel enable",
+		id: "enable-auto-upload",
 		title: "Enable auto-upload",
 	},
 	{
 		command: "rudel upload",
+		id: "upload-sessions",
 		title: "Upload sessions",
 	},
 ] as const;
 
+export type CliSetupStepId = (typeof setupCommands)[number]["id"];
+
 interface CommandBlockProps {
 	label: string;
 	command: string;
+	isComplete?: boolean;
 }
 
-function CommandBlock({ label, command }: CommandBlockProps) {
+function CommandBlock({
+	label,
+	command,
+	isComplete = false,
+}: CommandBlockProps) {
 	return (
-		<div className="rounded-[1.75rem] border border-border/60 bg-card px-5 py-5 shadow-none">
-			<p className="[font-family:var(--app-font-heading)] text-lg font-extrabold tracking-[-0.02em] text-foreground">
+		<div
+			data-complete={isComplete ? "true" : "false"}
+			className={cn(
+				"rounded-[1.75rem] border border-border/60 bg-card px-5 py-5 shadow-none transition-colors",
+				isComplete &&
+					"border-status-success-border bg-status-success-bg text-status-success-text",
+			)}
+		>
+			<p
+				className={cn(
+					"[font-family:var(--app-font-heading)] text-lg font-extrabold tracking-[-0.02em] text-foreground transition-colors",
+					isComplete && "text-status-success-text",
+				)}
+			>
 				{label}
 			</p>
-			<code className="mt-4 block rounded-2xl border border-border/60 bg-background px-3 py-3 font-mono text-[13px] text-foreground">
+			<code
+				className={cn(
+					"mt-4 block rounded-2xl border border-border/60 bg-background px-3 py-3 font-mono text-[13px] text-foreground transition-colors",
+					isComplete &&
+						"border-status-success-border bg-status-success-bg text-status-success-text",
+				)}
+			>
 				{command}
 			</code>
 		</div>
 	);
 }
 
-export function CliSetupHint() {
+export function CliSetupHint({
+	completedStepIds = [],
+}: {
+	completedStepIds?: readonly CliSetupStepId[];
+}) {
+	const completedSteps = new Set(completedStepIds);
+
 	return (
 		<div className="mt-4 mx-auto grid w-full max-w-xl gap-3">
 			{setupCommands.map((step) => (
@@ -43,6 +80,7 @@ export function CliSetupHint() {
 					key={step.command}
 					label={step.title}
 					command={step.command}
+					isComplete={completedSteps.has(step.id)}
 				/>
 			))}
 		</div>

--- a/apps/web/src/features/auth/DeviceAuthorizationApp.test.tsx
+++ b/apps/web/src/features/auth/DeviceAuthorizationApp.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { appRoutes } from "@/app/routes";
+import { DeviceAuthorizationApp } from "./DeviceAuthorizationApp";
+
+const { mockTrackAuthenticationAction, mockUseSetupProgress } = vi.hoisted(
+	() => ({
+		mockTrackAuthenticationAction: vi.fn(),
+		mockUseSetupProgress: vi.fn(),
+	}),
+);
+
+vi.mock("@/features/analytics/tracking/useAnalyticsTracking", () => ({
+	useAnalyticsTracking: () => ({
+		trackAuthenticationAction: mockTrackAuthenticationAction,
+	}),
+}));
+
+vi.mock("@/features/get-started/use-setup-progress", () => ({
+	useSetupProgress: mockUseSetupProgress,
+}));
+
+const now = new Date("2026-04-11T08:00:00.000Z");
+
+const session = {
+	session: {
+		id: "session-1",
+		token: "token-1",
+		userId: "user-1",
+		createdAt: now,
+		updatedAt: now,
+		expiresAt: now,
+	},
+	user: {
+		id: "user-1",
+		email: "ada@example.com",
+		name: "Ada Lovelace",
+		emailVerified: true,
+		image: null,
+		createdAt: now,
+		updatedAt: now,
+	},
+};
+
+describe("DeviceAuthorizationApp", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		mockTrackAuthenticationAction.mockReset();
+		mockUseSetupProgress.mockReset();
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: false,
+			isLoading: false,
+			totalSessionCount: 0,
+		});
+	});
+
+	it("marks install and login as completed after approving CLI login", async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(null, { status: 200 }));
+
+		const user = userEvent.setup();
+		render(
+			<DeviceAuthorizationApp deviceUserCode="ABCD-1234" session={session} />,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Approve" }));
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("heading", { name: "CLI login approved" }),
+			).toBeInTheDocument();
+		});
+
+		expect(fetchMock).toHaveBeenCalledWith("/api/auth/device/approve", {
+			method: "POST",
+			credentials: "include",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ userCode: "ABCD-1234" }),
+		});
+
+		const installStep = screen
+			.getByText("Install CLI")
+			.closest("[data-complete]");
+		const loginStep = screen.getByText("Log in").closest("[data-complete]");
+		const enableStep = screen
+			.getByText("Enable auto-upload")
+			.closest("[data-complete]");
+
+		expect(installStep).toHaveAttribute("data-complete", "true");
+		expect(loginStep).toHaveAttribute("data-complete", "true");
+		expect(enableStep).toHaveAttribute("data-complete", "false");
+	});
+
+	it("redirects to the dashboard after approval once sessions exist", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(null, { status: 200 }),
+		);
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 1,
+		});
+
+		const user = userEvent.setup();
+		render(
+			<MemoryRouter initialEntries={["/device?user_code=ABCD-1234"]}>
+				<Routes>
+					<Route
+						path="/device"
+						element={
+							<DeviceAuthorizationApp
+								deviceUserCode="ABCD-1234"
+								session={session}
+							/>
+						}
+					/>
+					<Route path={appRoutes.dashboard()} element={<div>Dashboard</div>} />
+				</Routes>
+			</MemoryRouter>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Approve" }));
+
+		await waitFor(() => {
+			expect(screen.getByText("Dashboard")).toBeInTheDocument();
+		});
+	});
+});

--- a/apps/web/src/features/auth/DeviceAuthorizationApp.tsx
+++ b/apps/web/src/features/auth/DeviceAuthorizationApp.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
+import { Navigate } from "react-router-dom";
 import { AppLoadingScreen } from "@/app/bootstrap/AppLoadingScreen";
+import { appRoutes } from "@/app/routes";
 import { Button } from "@/app/ui/button";
 import { useAnalyticsTracking } from "@/features/analytics/tracking/useAnalyticsTracking";
 import {
@@ -7,6 +9,24 @@ import {
 	getSessionUserId,
 } from "@/features/auth/auth-route-utils";
 import { GuestApp } from "@/features/auth/GuestApp";
+import { UploadSetupPage } from "@/features/get-started/UploadSetupPage";
+import { useSetupProgress } from "@/features/get-started/use-setup-progress";
+
+function ApprovedDeviceSetupPage() {
+	const { hasUploadedSessions } = useSetupProgress({ enabled: true });
+
+	if (hasUploadedSessions) {
+		return <Navigate replace to={appRoutes.dashboard()} />;
+	}
+
+	return (
+		<UploadSetupPage
+			completedStepIds={["install-cli", "log-in"]}
+			description="Install CLI and Log in are done. Enable auto-upload next."
+			title="CLI login approved"
+		/>
+	);
+}
 
 export function DeviceAuthorizationApp({
 	deviceUserCode,
@@ -82,20 +102,13 @@ export function DeviceAuthorizationApp({
 	}
 
 	if (deviceApproved) {
-		return (
-			<div className="flex min-h-screen flex-col items-center justify-center gap-2">
-				<p className="text-xl font-semibold">CLI login approved</p>
-				<p className="text-muted-foreground">
-					Return to your terminal to continue.
-				</p>
-			</div>
-		);
+		return <ApprovedDeviceSetupPage />;
 	}
 
 	if (deviceDenied) {
 		return (
 			<div className="flex min-h-screen flex-col items-center justify-center gap-2">
-				<p className="text-xl font-semibold">CLI login denied</p>
+				<h1 className="text-xl font-semibold">CLI login denied</h1>
 				<p className="text-muted-foreground">
 					This authorization request was not approved.
 				</p>
@@ -105,7 +118,7 @@ export function DeviceAuthorizationApp({
 
 	return (
 		<div className="flex min-h-screen flex-col items-center justify-center gap-4">
-			<p className="text-xl font-semibold">Authorize CLI login</p>
+			<h1 className="text-xl font-semibold">Authorize CLI login</h1>
 			<p className="text-muted-foreground">
 				User code: <span className="font-mono">{deviceUserCode}</span>
 			</p>

--- a/apps/web/src/features/get-started/GetStartedRouteGate.test.tsx
+++ b/apps/web/src/features/get-started/GetStartedRouteGate.test.tsx
@@ -1,9 +1,17 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { appRoutes } from "@/app/routes";
 import type { AppSession } from "@/features/auth/auth-route-utils";
 import { GetStartedRouteGate } from "@/features/get-started/GetStartedRouteGate";
+
+const { mockUseSetupProgress } = vi.hoisted(() => ({
+	mockUseSetupProgress: vi.fn(),
+}));
+
+vi.mock("@/features/get-started/use-setup-progress", () => ({
+	useSetupProgress: mockUseSetupProgress,
+}));
 
 const now = new Date("2026-04-10T15:00:00.000Z");
 
@@ -28,6 +36,15 @@ const session: NonNullable<AppSession> = {
 };
 
 describe("GetStartedRouteGate", () => {
+	beforeEach(() => {
+		mockUseSetupProgress.mockReset();
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: false,
+			isLoading: false,
+			totalSessionCount: 0,
+		});
+	});
+
 	it("renders the setup page immediately while auth is pending", () => {
 		render(
 			<MemoryRouter initialEntries={[appRoutes.getStarted()]}>
@@ -116,5 +133,33 @@ describe("GetStartedRouteGate", () => {
 			}),
 		).toBeInTheDocument();
 		expect(screen.queryByRole("link")).toBeNull();
+	});
+
+	it("redirects to the dashboard once sessions exist", () => {
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 3,
+		});
+
+		render(
+			<MemoryRouter initialEntries={[appRoutes.getStarted()]}>
+				<Routes>
+					<Route
+						path={appRoutes.getStarted()}
+						element={
+							<GetStartedRouteGate
+								isPending={false}
+								pathname={appRoutes.getStarted()}
+								session={session}
+							/>
+						}
+					/>
+					<Route path={appRoutes.dashboard()} element={<div>Dashboard</div>} />
+				</Routes>
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Dashboard")).toBeInTheDocument();
 	});
 });

--- a/apps/web/src/features/get-started/GetStartedRouteGate.tsx
+++ b/apps/web/src/features/get-started/GetStartedRouteGate.tsx
@@ -5,6 +5,7 @@ import {
 	isGetStartedPath,
 } from "@/features/auth/auth-route-utils";
 import { UploadSetupPage } from "@/features/get-started/UploadSetupPage";
+import { useSetupProgress } from "@/features/get-started/use-setup-progress";
 
 type GetStartedRouteGateProps = {
 	isPending: boolean;
@@ -17,6 +18,10 @@ export function GetStartedRouteGate({
 	pathname,
 	session,
 }: GetStartedRouteGateProps) {
+	const { hasUploadedSessions } = useSetupProgress({
+		enabled: !isPending && !!session,
+	});
+
 	if (isPending) {
 		return <UploadSetupPage />;
 	}
@@ -30,6 +35,10 @@ export function GetStartedRouteGate({
 	}
 
 	if (!isGetStartedPath(pathname)) {
+		return <Navigate to={appRoutes.dashboard()} replace />;
+	}
+
+	if (hasUploadedSessions) {
 		return <Navigate to={appRoutes.dashboard()} replace />;
 	}
 

--- a/apps/web/src/features/get-started/UploadSetupPage.tsx
+++ b/apps/web/src/features/get-started/UploadSetupPage.tsx
@@ -1,16 +1,32 @@
-import { CliSetupHint } from "@/components/analytics/CliSetupHint";
+import {
+	CliSetupHint,
+	type CliSetupStepId,
+} from "@/components/analytics/CliSetupHint";
 
-export function UploadSetupPage() {
+export function UploadSetupPage({
+	completedStepIds,
+	description,
+	title = "Run these commands first so your dashboard isn't empty",
+}: {
+	completedStepIds?: readonly CliSetupStepId[];
+	description?: string;
+	title?: string;
+}) {
 	return (
 		<div className="flex min-h-screen items-center bg-background px-4 py-6 sm:px-6 lg:px-8">
 			<div className="mx-auto w-full max-w-4xl space-y-10">
 				<div className="px-2 py-1 text-center sm:px-0">
 					<h1 className="mx-auto max-w-2xl text-3xl font-semibold tracking-[-0.04em] text-foreground">
-						Run these commands first so your dashboard isn't empty
+						{title}
 					</h1>
+					{description ? (
+						<p className="mx-auto mt-2 max-w-2xl text-sm text-muted-foreground sm:text-[0.9375rem]">
+							{description}
+						</p>
+					) : null}
 				</div>
 
-				<CliSetupHint />
+				<CliSetupHint completedStepIds={completedStepIds} />
 			</div>
 		</div>
 	);

--- a/apps/web/src/features/get-started/use-setup-progress.ts
+++ b/apps/web/src/features/get-started/use-setup-progress.ts
@@ -1,0 +1,38 @@
+import { useAnalyticsQuery } from "@/features/analytics/queries/useAnalyticsQuery";
+import { useOrganization } from "@/features/workspace/organization/useOrganization";
+import { orpc } from "@/lib/orpc";
+
+const SETUP_PROGRESS_LOOKBACK_DAYS = 365;
+const SETUP_PROGRESS_REFETCH_INTERVAL_MS = 3_000;
+
+export function useSetupProgress({
+	enabled = true,
+}: {
+	enabled?: boolean;
+} = {}) {
+	const { state } = useOrganization();
+	const summaryQuery = useAnalyticsQuery({
+		...orpc.analytics.sessions.summary.queryOptions({
+			input: { days: SETUP_PROGRESS_LOOKBACK_DAYS },
+		}),
+		enabled,
+		refetchInterval: (query) => {
+			const totalSessions = query.state.data?.total_sessions ?? 0;
+			if (!enabled || totalSessions > 0) {
+				return false;
+			}
+
+			return SETUP_PROGRESS_REFETCH_INTERVAL_MS;
+		},
+	});
+
+	const totalSessionCount = summaryQuery.data?.total_sessions ?? 0;
+
+	return {
+		hasUploadedSessions: totalSessionCount > 0,
+		isLoading:
+			enabled &&
+			(state.isLoading || summaryQuery.isPending || summaryQuery.isRefetching),
+		totalSessionCount,
+	};
+}


### PR DESCRIPTION
## Summary
- poll lightweight session setup progress on the get-started and approved CLI flows
- redirect to the dashboard once uploads appear instead of leaving users on setup screens
- mark Install CLI and Log in as completed in the approved CLI state and cover the behavior with focused tests

## Test plan
- [x] bun run verify
- [x] BASE_URL=http://localhost:4021 python3 .context/playwright_step_trace.py