### PR TITLE
fix: block app under 500px

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import App from "@/App";
+
+const { mockUseSession } = vi.hoisted(() => ({
+	mockUseSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+	authClient: {
+		useSession: mockUseSession,
+	},
+}));
+
+vi.mock("@/features/analytics/tracking/ProductAnalyticsSessionSync", () => ({
+	ProductAnalyticsSessionSync: () => null,
+}));
+
+vi.mock("@/features/auth/GuestApp", () => ({
+	GuestApp: () => <div>Guest App</div>,
+}));
+
+vi.mock("@/features/auth/DeviceAuthorizationApp", () => ({
+	DeviceAuthorizationApp: () => <div>Device App</div>,
+}));
+
+vi.mock("@/features/auth/AuthenticatedApp", () => ({
+	AuthenticatedApp: () => <div>Authenticated App</div>,
+}));
+
+vi.mock("@/features/auth/ResetPasswordApp", () => ({
+	ResetPasswordApp: () => <div>Reset Password App</div>,
+}));
+
+vi.mock("@/features/get-started/GetStartedRouteGate", () => ({
+	GetStartedRouteGate: () => <div>Get Started Gate</div>,
+}));
+
+describe("App mobile desktop-only overlay", () => {
+	beforeEach(() => {
+		mockUseSession.mockReset();
+		mockUseSession.mockReturnValue({ data: null, isPending: false });
+	});
+
+	it("renders the desktop-only overlay on the guest homepage", () => {
+		render(
+			<MemoryRouter initialEntries={["/"]}>
+				<App />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Guest App")).toBeInTheDocument();
+		expect(screen.getByTestId("desktop-only-overlay")).toHaveClass(
+			"hidden",
+			"max-[499px]:flex",
+		);
+		expect(
+			screen.getByText(
+				"Please use it on desktop or resize your window. Otherwise it will look horrendous.",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("does not show the overlay for the device approval utility screen", () => {
+		mockUseSession.mockReturnValue({
+			data: { session: { userId: "user-1" }, user: { id: "user-1" } },
+			isPending: false,
+		});
+
+		render(
+			<MemoryRouter initialEntries={["/?user_code=ABCD-1234"]}>
+				<App />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Device App")).toBeInTheDocument();
+		expect(screen.queryByText("Desktop only")).toBeNull();
+	});
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { AppLoadingScreen } from "@/app/bootstrap/AppLoadingScreen";
+import { DesktopOnlyOverlay } from "@/app/ui/DesktopOnlyOverlay";
 import { ProductAnalyticsSessionSync } from "@/features/analytics/tracking/ProductAnalyticsSessionSync";
 import { AuthenticatedApp } from "@/features/auth/AuthenticatedApp";
 import {
@@ -24,6 +25,7 @@ function App() {
 		(location.pathname === "/"
 			? getPendingSignupRedirect(location.search)
 			: null);
+	const showDesktopOnlyOverlay = !deviceUserCode;
 
 	if (deviceUserCode) {
 		return (
@@ -47,6 +49,7 @@ function App() {
 					pathname={location.pathname}
 					session={session ?? null}
 				/>
+				{showDesktopOnlyOverlay ? <DesktopOnlyOverlay /> : null}
 			</>
 		);
 	}
@@ -56,6 +59,7 @@ function App() {
 			<>
 				<ProductAnalyticsSessionSync session={session} />
 				<AppLoadingScreen />
+				{showDesktopOnlyOverlay ? <DesktopOnlyOverlay /> : null}
 			</>
 		);
 	}
@@ -65,6 +69,7 @@ function App() {
 			<>
 				<ProductAnalyticsSessionSync session={session} />
 				<AuthenticatedApp rootRedirectTarget={rootRedirectTarget} />
+				{showDesktopOnlyOverlay ? <DesktopOnlyOverlay /> : null}
 			</>
 		);
 	}
@@ -74,6 +79,7 @@ function App() {
 			<>
 				<ProductAnalyticsSessionSync session={session} />
 				<ResetPasswordApp />
+				{showDesktopOnlyOverlay ? <DesktopOnlyOverlay /> : null}
 			</>
 		);
 	}
@@ -82,6 +88,7 @@ function App() {
 		<>
 			<ProductAnalyticsSessionSync session={session} />
 			<GuestApp />
+			{showDesktopOnlyOverlay ? <DesktopOnlyOverlay /> : null}
 		</>
 	);
 }

--- a/apps/web/src/app/ui/DesktopOnlyOverlay.tsx
+++ b/apps/web/src/app/ui/DesktopOnlyOverlay.tsx
@@ -1,0 +1,13 @@
+export function DesktopOnlyOverlay() {
+	return (
+		<div
+			data-testid="desktop-only-overlay"
+			className="fixed inset-0 z-[120] hidden items-center justify-center bg-background/96 px-6 text-center backdrop-blur-sm max-[499px]:flex"
+		>
+			<p className="max-w-md text-sm leading-6 text-muted-foreground">
+				Please use it on desktop or resize your window. Otherwise it will look
+				horrendous.
+			</p>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- add an app-wide desktop-only overlay for widths below 500px
- keep the device code approval utility flow exempt so CLI login can still be approved on narrow screens
- cover the overlay behavior with a focused app-level test

## Test plan
- [x] bun run verify
- [x] bun x vitest run src/App.test.tsx