### PR TITLE
fix: temp disablement of auto deletion

### DIFF
--- a/apps/web/src/features/settings/workspace/WorkspaceSettingsSection.tsx
+++ b/apps/web/src/features/settings/workspace/WorkspaceSettingsSection.tsx
@@ -279,11 +279,7 @@ export function WorkspaceSettingsSection() {
 					</div>
 
 					<div className="mt-4 px-4 lg:px-6">
-						<WorkspaceDangerZoneCard
-							organization={data.activeOrg}
-							organizations={data.organizations}
-							canManage={data.canManage}
-						/>
+						<WorkspaceDangerZoneCard />
 					</div>
 				</>
 			) : null}

--- a/apps/web/src/features/settings/workspace/components/WorkspaceDangerZoneCard.test.tsx
+++ b/apps/web/src/features/settings/workspace/components/WorkspaceDangerZoneCard.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { WorkspaceDangerZoneCard } from "./WorkspaceDangerZoneCard";
+
+const { mockOpenChatwoot } = vi.hoisted(() => ({
+	mockOpenChatwoot: vi.fn(),
+}));
+
+vi.mock("@/lib/chatwoot", () => ({
+	openChatwoot: mockOpenChatwoot,
+}));
+
+describe("WorkspaceDangerZoneCard", () => {
+	it("renders support guidance instead of a delete action", () => {
+		render(<WorkspaceDangerZoneCard />);
+
+		expect(screen.getByText("Delete workspace")).toHaveClass(
+			"text-destructive",
+		);
+		expect(
+			screen.getByText(
+				"Workspace deletion is handled by support. Contact us if you'd like this workspace and its data removed.",
+			),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Delete workspace" }),
+		).not.toBeInTheDocument();
+
+		const supportLink = screen.getByRole("link", { name: "support chat" });
+		expect(supportLink).toHaveAttribute("href", "https://app.chatwoot.com");
+
+		const emailLink = screen.getByRole("link", { name: "evren@rudel.ai" });
+		expect(emailLink).toHaveAttribute("href", "mailto:evren@rudel.ai");
+	});
+
+	it("opens support chat when the support link is clicked", async () => {
+		mockOpenChatwoot.mockClear();
+		const user = userEvent.setup();
+
+		render(<WorkspaceDangerZoneCard />);
+
+		await user.click(screen.getByRole("link", { name: "support chat" }));
+
+		expect(mockOpenChatwoot).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/features/settings/workspace/components/WorkspaceDangerZoneCard.tsx
+++ b/apps/web/src/features/settings/workspace/components/WorkspaceDangerZoneCard.tsx
@@ -1,7 +1,3 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { appRoutes } from "@/app/routes";
-import { Button } from "@/app/ui/button";
 import {
 	Card,
 	CardContent,
@@ -9,88 +5,44 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/app/ui/card";
-import { useAnalyticsTracking } from "@/features/analytics/tracking/useAnalyticsTracking";
-import { DeleteWorkspaceDialog } from "@/features/settings/workspace/components/DeleteWorkspaceDialog";
-import { authClient } from "@/lib/auth-client";
+import { openChatwoot } from "@/lib/chatwoot";
 
-export function WorkspaceDangerZoneCard({
-	organization,
-	organizations,
-	canManage,
-}: {
-	organization: { id: string; name: string };
-	organizations: readonly { id: string; name: string }[];
-	canManage: boolean;
-}) {
-	const navigate = useNavigate();
-	const { trackOrganizationAction } = useAnalyticsTracking({
-		pageName: "organization",
-	});
-	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+export function WorkspaceDangerZoneCard() {
+	const supportLink = (
+		import.meta.env.VITE_CHATWOOT_BASE_URL ?? "https://app.chatwoot.com"
+	).trim();
+	const inlineLinkClassName = "underline underline-offset-4 hover:text-primary";
 
 	return (
-		<>
-			<Card size="sm" className="bg-card/95 shadow-none ring-1 ring-border/60">
-				<CardHeader>
-					<CardTitle>Danger zone</CardTitle>
-					<CardDescription>
-						Delete this workspace when you no longer need any of its data or
-						member access.
-					</CardDescription>
-				</CardHeader>
-				<CardContent className="flex flex-wrap items-center gap-3">
-					{organizations.length <= 1 ? (
-						<Button type="button" variant="destructive" disabled>
-							Delete workspace
-						</Button>
-					) : (
-						<Button
-							type="button"
-							variant="destructive"
-							onClick={() => {
-								trackOrganizationAction({
-									actionName: "open_delete_organization",
-									targetType: "organization",
-									sourceComponent: "workspace_settings_section",
-									targetId: organization.id,
-								});
-								setIsDeleteDialogOpen(true);
-							}}
-							disabled={!canManage}
-						>
-							Delete workspace
-						</Button>
-					)}
-					{organizations.length <= 1 ? (
-						<span className="text-sm text-muted-foreground">
-							You can&apos;t delete your only workspace.
-						</span>
-					) : null}
-				</CardContent>
-			</Card>
-
-			<DeleteWorkspaceDialog
-				open={isDeleteDialogOpen}
-				onOpenChange={setIsDeleteDialogOpen}
-				organization={organization}
-				onDeleted={async () => {
-					setIsDeleteDialogOpen(false);
-					const otherOrganization = organizations.find(
-						(candidate) => candidate.id !== organization.id,
-					);
-					if (otherOrganization) {
-						await authClient.organization.setActive({
-							organizationId: otherOrganization.id,
-						});
-					}
-					for (const key of Object.keys(authClient.$store.atoms)) {
-						if (key.startsWith("$")) {
-							authClient.$store.notify(key);
-						}
-					}
-					navigate(appRoutes.dashboard());
-				}}
-			/>
-		</>
+		<Card size="sm" className="bg-card/95 shadow-none ring-1 ring-border/60">
+			<CardHeader>
+				<CardTitle className="text-destructive">Delete workspace</CardTitle>
+				<CardDescription>
+					Workspace deletion is handled by support. Contact us if you&apos;d
+					like this workspace and its data removed.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<p className="text-sm text-muted-foreground">
+					Shoot us a message via the{" "}
+					<a
+						href={supportLink}
+						className={inlineLinkClassName}
+						onClick={(event) => {
+							event.preventDefault();
+							void openChatwoot();
+						}}
+					>
+						support chat
+					</a>
+					. (you&apos;ll write with someone out of the team, not some AI bot).
+					Or email{" "}
+					<a href="mailto:evren@rudel.ai" className={inlineLinkClassName}>
+						evren@rudel.ai
+					</a>
+					.
+				</p>
+			</CardContent>
+		</Card>
 	);
 }


### PR DESCRIPTION
## Summary
- remove the visible workspace delete action from the redesigned settings card
- replace it with support-chat and email guidance while keeping the redesigned card styling
- add focused test coverage for the static support state and support-chat click behavior

## Test plan
- [x] bun run verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)