### PR TITLE
fix: rename aggregate aliases to avoid nested-aggregate error

### DIFF
--- a/apps/api/src/services/developer.service.ts
+++ b/apps/api/src/services/developer.service.ts
@@ -179,16 +179,16 @@ export async function getDeveloperTeamCards(
       user_id,
       COUNT(*) as total_sessions,
       COUNT(DISTINCT toDate(session_date)) as active_days,
-      SUM(ifNull(input_tokens, 0)) as input_tokens,
-      SUM(ifNull(output_tokens, 0)) as output_tokens,
-      SUM(ifNull(input_tokens, 0) + ifNull(output_tokens, 0)) as total_tokens,
+      SUM(ifNull(input_tokens, 0)) as input_tokens_sum,
+      SUM(ifNull(output_tokens, 0)) as output_tokens_sum,
+      SUM(ifNull(input_tokens, 0) + ifNull(output_tokens, 0)) as total_tokens_sum,
       round(SUM(${PER_SESSION_COST_SQL}), 4) as cost,
       toString(max(session_date)) as last_active_date
     FROM rudel.session_analytics
     WHERE ${buildDateFilter("days")}
       AND organization_id = {orgId:String}
     GROUP BY user_id
-    ORDER BY total_tokens DESC, user_id ASC
+    ORDER BY total_tokens_sum DESC, user_id ASC
   `;
 
 	const topSkillsQuery = `
@@ -210,9 +210,9 @@ export async function getDeveloperTeamCards(
 		user_id: string;
 		total_sessions: number;
 		active_days: number;
-		input_tokens: number;
-		output_tokens: number;
-		total_tokens: number;
+		input_tokens_sum: number;
+		output_tokens_sum: number;
+		total_tokens_sum: number;
 		cost: number;
 		last_active_date: string;
 	}
@@ -283,9 +283,9 @@ export async function getDeveloperTeamCards(
 				user_id: row.user_id,
 				display_name: displayName,
 				cost: Number(row.cost) || 0,
-				input_tokens: Number(row.input_tokens) || 0,
-				output_tokens: Number(row.output_tokens) || 0,
-				total_tokens: Number(row.total_tokens) || 0,
+				input_tokens: Number(row.input_tokens_sum) || 0,
+				output_tokens: Number(row.output_tokens_sum) || 0,
+				total_tokens: Number(row.total_tokens_sum) || 0,
 				total_sessions: Number(row.total_sessions) || 0,
 				active_days: Number(row.active_days) || 0,
 				last_active_date: row.last_active_date,

--- a/apps/api/src/services/overview.service.ts
+++ b/apps/api/src/services/overview.service.ts
@@ -178,9 +178,9 @@ export async function getUsersTokenUsage(
 		repositories_touched: string[];
 		user_id: string;
 		total_commits: number;
-		total_tokens: number;
-		input_tokens: number;
-		output_tokens: number;
+		total_tokens_sum: number;
+		input_tokens_sum: number;
+		output_tokens_sum: number;
 		cost: number;
 		total_sessions: number;
 		total_duration_min: number;
@@ -214,9 +214,9 @@ export async function getUsersTokenUsage(
         )
       ) as repositories_touched,
       sum(has_commit) as total_commits,
-      sum(ifNull(total_tokens, 0)) as total_tokens,
-      sum(ifNull(input_tokens, 0)) as input_tokens,
-      sum(ifNull(output_tokens, 0)) as output_tokens,
+      sum(ifNull(total_tokens, 0)) as total_tokens_sum,
+      sum(ifNull(input_tokens, 0)) as input_tokens_sum,
+      sum(ifNull(output_tokens, 0)) as output_tokens_sum,
       round(sum(${PER_SESSION_COST_SQL}), 4) as cost,
       count() as total_sessions,
       round(sum(actual_duration_min), 2) as total_duration_min,
@@ -228,7 +228,7 @@ export async function getUsersTokenUsage(
       AND organization_id = {orgId:String}
       AND user_id != ''
     GROUP BY user_id
-    ORDER BY total_tokens DESC
+    ORDER BY total_tokens_sum DESC
   `,
 		query_params: {
 			startDate,
@@ -247,9 +247,9 @@ export async function getUsersTokenUsage(
 		user_id: row.user_id,
 		user_label: row.user_id,
 		total_commits: Number(row.total_commits),
-		total_tokens: Number(row.total_tokens),
-		input_tokens: Number(row.input_tokens),
-		output_tokens: Number(row.output_tokens),
+		total_tokens: Number(row.total_tokens_sum),
+		input_tokens: Number(row.input_tokens_sum),
+		output_tokens: Number(row.output_tokens_sum),
 		cost: Number(row.cost),
 		total_sessions: Number(row.total_sessions),
 		total_duration_min: Number(row.total_duration_min),


### PR DESCRIPTION
## Summary
- Fixes `ILLEGAL_AGGREGATION` error: `sum(ifNull(input_tokens, 0))` reported as nested inside another aggregate.
- Root cause: in `getUsersTokenUsage` (overview.service.ts) and `getDeveloperTeamCards` (developer.service.ts), SELECT lists aliased `sum(ifNull(input_tokens, 0)) as input_tokens` (and same for `output_tokens` / `total_tokens`). With ClickHouse's default `prefer_column_name_to_alias=0`, the `input_tokens` / `output_tokens` identifiers inside the sibling `sum(${PER_SESSION_COST_SQL})` resolved to those aliases — producing `sum(sum(...))` and the illegal-aggregate error.
- Rename the conflicting aliases to `input_tokens_sum` / `output_tokens_sum` / `total_tokens_sum` and remap them in the TypeScript row handlers. Mirrors the pattern already used in `project.service.ts` and the `current_period` CTE in `developer.service.ts`.

## Test plan
- [ ] `bun run verify` passes in CI (with Doppler secrets)
- [ ] Overview users-token-usage endpoint returns data without `ILLEGAL_AGGREGATION`
- [ ] Developer team cards endpoint returns data without `ILLEGAL_AGGREGATION`

🤖 Generated with [Claude Code](https://claude.com/claude-code)