### PR TITLE
fix: normalize codex token accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, development commands, an
 
 For self-hosting your own instance, see [docs/self-hosting.md](docs/self-hosting.md).
 
+For the Codex token and cost accounting rules used by Rudel, see [docs/codex-token-accounting.md](docs/codex-token-accounting.md).
+
 ## Security
 
 To report a vulnerability, see [SECURITY.md](SECURITY.md). Do not open public issues for security concerns.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ For self-hosting your own instance, see [docs/self-hosting.md](docs/self-hosting
 
 For the Codex token and cost accounting rules used by Rudel, see [docs/codex-token-accounting.md](docs/codex-token-accounting.md).
 
+For the Claude token accounting rewrite based on Anthropic's prompt-caching and streaming semantics, see [docs/claude-token-accounting-v2.md](docs/claude-token-accounting-v2.md).
+
 ## Security
 
 To report a vulnerability, see [SECURITY.md](SECURITY.md). Do not open public issues for security concerns.

--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, development commands, an
 
 For self-hosting your own instance, see [docs/self-hosting.md](docs/self-hosting.md).
 
-For the Codex token and cost accounting rules used by Rudel, see [docs/codex-token-accounting.md](docs/codex-token-accounting.md).
-
 ## Security
 
 To report a vulnerability, see [SECURITY.md](SECURITY.md). Do not open public issues for security concerns.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,8 @@
 		"test": "bun test",
 		"test:integration": "bun test src/__tests__/ingest-clickhouse.integration.ts",
 		"test:analytics": "bun test src/__tests__/analytics.integration.ts",
-		"test:migrate": "bun test src/__tests__/migrate-sessions.integration.ts"
+		"test:migrate": "bun test src/__tests__/migrate-sessions.integration.ts",
+		"backfill:claude-token-accounting": "bun src/scripts/backfill-claude-token-accounting-v2.ts"
 	},
 	"dependencies": {
 		"@better-auth/api-key": "^1.5.4",

--- a/apps/api/src/__tests__/claude-session-analytics.service.test.ts
+++ b/apps/api/src/__tests__/claude-session-analytics.service.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { buildClaudeSessionAnalyticsRow } from "../services/claude-session-analytics.service.js";
+
+describe("buildClaudeSessionAnalyticsRow", () => {
+	test("writes corrected Claude token totals and keeps timing metrics parent-scoped", () => {
+		const row = buildClaudeSessionAnalyticsRow({
+			session_id: "session-1",
+			organization_id: "org-1",
+			project_path: "/tmp/project",
+			git_remote: "git@github.com:obsessiondb/rudel.git",
+			package_name: "rudel",
+			package_type: "app",
+			content: [
+				'{"type":"user","timestamp":"2026-04-23T10:00:00Z","message":{"role":"user","content":"start"}}',
+				'{"type":"assistant","timestamp":"2026-04-23T10:00:05Z","message":{"id":"msg-parent-1","model":"claude-sonnet-4-20250514","usage":{"input_tokens":10,"cache_read_input_tokens":100,"output_tokens":3},"stop_reason":null}}',
+				'{"type":"assistant","timestamp":"2026-04-23T10:00:06Z","message":{"id":"msg-parent-1","model":"claude-sonnet-4-20250514","usage":{"input_tokens":10,"cache_read_input_tokens":100,"output_tokens":8},"stop_reason":"end_turn"}}',
+				'{"type":"user","timestamp":"2026-04-23T10:00:10Z","message":{"role":"user","content":"continue"}}',
+				'{"type":"assistant","timestamp":"2026-04-23T10:00:20Z","message":{"id":"msg-parent-2","model":"claude-sonnet-4-20250514","usage":{"input_tokens":5,"cache_creation_input_tokens":20,"output_tokens":4},"stop_reason":"end_turn"}}',
+			].join("\n"),
+			subagents: {
+				agent_1: [
+					'{"type":"assistant","timestamp":"2026-04-23T10:00:07Z","message":{"id":"msg-subagent","usage":{"input_tokens":2,"cache_read_input_tokens":4,"output_tokens":1},"stop_reason":"end_turn"}}',
+				].join("\n"),
+			},
+			user_id: "user-1",
+			git_branch: "evrendom/claude-token-v2",
+			git_sha: "abc123",
+			tag: "research",
+		});
+
+		expect(row.input_tokens).toBe("141");
+		expect(row.output_tokens).toBe("13");
+		expect(row.total_tokens).toBe("154");
+		expect(row.parent_total_tokens).toBe("147");
+		expect(row.subagent_total_tokens).toBe("7");
+		expect(row.token_accounting_version).toBe(2);
+		expect(row.total_interactions).toBe(5);
+		expect(row.inference_duration_sec).toBe(15);
+		expect(row.human_duration_sec).toBe(4);
+		expect(row.model_used).toBe("claude-sonnet-4-20250514");
+	});
+});

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -17,6 +17,7 @@ import {
 } from "./lib/product-analytics.js";
 import { authMiddleware, ingestAuthMiddleware, os } from "./middleware.js";
 import { checkIngestRateLimit } from "./rate-limit.js";
+import { rewriteClaudeSessionAnalyticsAfterIngest } from "./services/claude-session-analytics.service.js";
 import {
 	deleteOrgSessions,
 	getOrgSessionCount,
@@ -147,6 +148,17 @@ const ingestSessionHandler = os.ingestSession
 			userId: context.user.id,
 			organizationId: orgId,
 		});
+		if (input.source === "claude_code") {
+			// The raw Claude row is immutable source material. We immediately
+			// append a corrected analytics row so FINAL reads pick the docs-based
+			// Anthropic accounting instead of the MV bootstrap calculation.
+			await rewriteClaudeSessionAnalyticsAfterIngest(
+				input,
+				orgId,
+				context.user.id,
+				{ clickhouse: getClickhouse() },
+			);
+		}
 
 		const response = {
 			success: true as const,

--- a/apps/api/src/scripts/backfill-claude-token-accounting-v2.ts
+++ b/apps/api/src/scripts/backfill-claude-token-accounting-v2.ts
@@ -1,0 +1,147 @@
+import { ingestRudelSessionAnalytics } from "@rudel/ch-schema/generated";
+import { getClickhouse } from "../clickhouse.js";
+import {
+	buildClaudeSessionAnalyticsRow,
+	type ClaudeAnalyticsSource,
+} from "../services/claude-session-analytics.service.js";
+
+const DEFAULT_BATCH_SIZE = 100;
+
+type BackfillArgs = {
+	batchSize: number;
+	offset: number;
+	maxSessions: number | null;
+};
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const clickhouse = getClickhouse();
+	let processedSessions = 0;
+	let currentOffset = args.offset;
+
+	for (;;) {
+		const sources = await loadLatestClaudeSources(
+			args.batchSize,
+			currentOffset,
+		);
+		if (sources.length === 0) {
+			console.info(
+				`Claude token accounting backfill complete. Processed ${processedSessions} sessions.`,
+			);
+			return;
+		}
+
+		const remainingSessions =
+			args.maxSessions === null
+				? sources.length
+				: Math.max(args.maxSessions - processedSessions, 0);
+		const activeBatch = sources.slice(0, remainingSessions);
+		if (activeBatch.length === 0) {
+			console.info(
+				`Claude token accounting backfill reached maxSessions=${args.maxSessions}.`,
+			);
+			return;
+		}
+
+		const rows = activeBatch.map((source) =>
+			buildClaudeSessionAnalyticsRow(source),
+		);
+		await ingestRudelSessionAnalytics(clickhouse, rows, { validate: true });
+
+		processedSessions += rows.length;
+		currentOffset += sources.length;
+		console.info(
+			`Inserted ${rows.length} corrected Claude analytics rows (total ${processedSessions}).`,
+		);
+	}
+}
+
+async function loadLatestClaudeSources(
+	limit: number,
+	offset: number,
+): Promise<ClaudeAnalyticsSource[]> {
+	const clickhouse = getClickhouse();
+	return clickhouse.query<ClaudeAnalyticsSource>({
+		query: `
+      -- Rebuild from the latest raw transcript per session so the backfill
+      -- matches the same immutable source material as new ingest correction.
+      SELECT
+        session_id,
+        organization_id,
+        project_path,
+        git_remote,
+        package_name,
+        package_type,
+        content,
+        subagents,
+        user_id,
+        git_branch,
+        git_sha,
+        tag,
+        formatDateTime(session_date, '%Y-%m-%dT%H:%i:%S.%fZ') AS session_date,
+        formatDateTime(last_interaction_date, '%Y-%m-%dT%H:%i:%S.%fZ') AS last_interaction_date,
+        formatDateTime(ingested_at, '%Y-%m-%dT%H:%i:%S.%fZ') AS ingested_at
+      FROM rudel.claude_sessions
+      QUALIFY ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY ingested_at DESC) = 1
+      ORDER BY session_id
+      LIMIT {limit:UInt32}
+      OFFSET {offset:UInt32}
+    `,
+		query_params: {
+			limit,
+			offset,
+		},
+	});
+}
+
+function parseArgs(argv: string[]): BackfillArgs {
+	let batchSize = DEFAULT_BATCH_SIZE;
+	let offset = 0;
+	let maxSessions: number | null = null;
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		const nextArg = argv[index + 1];
+		if (arg === "--batch-size" && nextArg) {
+			batchSize = parsePositiveInt(nextArg, "--batch-size");
+			index += 1;
+			continue;
+		}
+
+		if (arg === "--offset" && nextArg) {
+			offset = parseNonNegativeInt(nextArg, "--offset");
+			index += 1;
+			continue;
+		}
+
+		if (arg === "--max-sessions" && nextArg) {
+			maxSessions = parsePositiveInt(nextArg, "--max-sessions");
+			index += 1;
+		}
+	}
+
+	return { batchSize, offset, maxSessions };
+}
+
+function parsePositiveInt(value: string, flag: string): number {
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		throw new Error(`${flag} must be a positive integer. Received: ${value}`);
+	}
+	return parsed;
+}
+
+function parseNonNegativeInt(value: string, flag: string): number {
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		throw new Error(
+			`${flag} must be a non-negative integer. Received: ${value}`,
+		);
+	}
+	return parsed;
+}
+
+void main().catch((error: unknown) => {
+	console.error("[backfill-claude-token-accounting-v2] failed", error);
+	process.exit(1);
+});

--- a/apps/api/src/services/claude-session-analytics.service.ts
+++ b/apps/api/src/services/claude-session-analytics.service.ts
@@ -1,0 +1,488 @@
+import { toClickHouseDateTime } from "@rudel/agent-adapters";
+import {
+	buildClaudeSessionTokenBreakdown,
+	type IngestSessionInput,
+} from "@rudel/api-routes";
+import {
+	ingestRudelSessionAnalytics,
+	type RudelSessionAnalyticsRow,
+} from "@rudel/ch-schema/generated";
+import type { ClickHouseExecutor } from "../clickhouse.js";
+
+const CLAUDE_TOKEN_ACCOUNTING_VERSION = 2;
+
+const ClaudeTimedInteractionLineSchema = {
+	isTimedInteractionLine(value: unknown): value is {
+		type: "user" | "assistant";
+		timestamp: string;
+		message?: { model?: string };
+	} {
+		if (!isRecord(value)) {
+			return false;
+		}
+
+		if (value.type !== "user" && value.type !== "assistant") {
+			return false;
+		}
+
+		return typeof value.timestamp === "string";
+	},
+};
+
+export interface ClaudeAnalyticsSource {
+	session_id: string;
+	organization_id: string;
+	project_path: string;
+	git_remote: string;
+	package_name: string;
+	package_type: string;
+	content: string;
+	subagents: Record<string, string>;
+	user_id: string;
+	git_branch: string | null;
+	git_sha: string | null;
+	tag: string | null;
+	session_date?: string;
+	last_interaction_date?: string;
+	ingested_at?: string;
+}
+
+export async function rewriteClaudeSessionAnalyticsAfterIngest(
+	input: IngestSessionInput,
+	organizationId: string,
+	userId: string,
+	env: { clickhouse: ClickHouseExecutor },
+): Promise<void> {
+	const source = toClaudeAnalyticsSource(input, organizationId, userId);
+	const row = buildClaudeSessionAnalyticsRow(source);
+
+	await ingestRudelSessionAnalytics(env.clickhouse, [row], {
+		validate: true,
+	});
+}
+
+export function buildClaudeSessionAnalyticsRow(
+	source: ClaudeAnalyticsSource,
+): RudelSessionAnalyticsRow {
+	const timedInteractions = parseTimedInteractions(source.content);
+	const interactionMetrics = buildInteractionMetrics(timedInteractions);
+	const tokenBreakdown = buildClaudeSessionTokenBreakdown(
+		source.content,
+		source.subagents,
+	);
+	const sessionBounds = resolveSessionBounds(
+		timedInteractions,
+		source.session_date,
+		source.last_interaction_date,
+	);
+	const modelUsed = findLastAssistantModel(source.content);
+	const skills = extractDistinctMatches(
+		source.content,
+		/"name":"Skill"[^}]*"skill":"([^"]+)"/g,
+	);
+	const subagentTypes = extractDistinctMatches(
+		source.content,
+		/"name":"Task"[^}]*"subagent_type":"([^"]+)"/g,
+	);
+	const slashCommands = extractDistinctMatches(
+		source.content,
+		/<command-name>\/([^<]+)<\/command-name>/g,
+	);
+	const totalTokens = tokenBreakdown.session.total_tokens;
+	const outputTokens = tokenBreakdown.session.output_tokens;
+	const inputTokens = tokenBreakdown.session.input_tokens;
+	const ingestedAt =
+		source.ingested_at ?? toClickHouseDateTime(new Date().toISOString());
+	const sessionArchetype = buildSessionArchetype({
+		durationMin: interactionMetrics.actualDurationMin,
+		inputTokens,
+		outputTokens,
+		totalTokens,
+		hasCommit: Boolean(source.git_sha),
+		skillsCount: skills.length,
+	});
+
+	return {
+		session_date: sessionBounds.sessionDate,
+		last_interaction_date: sessionBounds.lastInteractionDate,
+		session_id: source.session_id,
+		organization_id: source.organization_id,
+		project_path: source.project_path,
+		git_remote: source.git_remote,
+		package_name: source.package_name,
+		package_type: source.package_type,
+		content: source.content,
+		subagents: source.subagents,
+		skills,
+		slash_commands: slashCommands,
+		subagent_types: subagentTypes,
+		ingested_at: ingestedAt,
+		user_id: source.user_id,
+		git_branch: source.git_branch,
+		git_sha: source.git_sha,
+		input_tokens: toUInt64String(inputTokens),
+		output_tokens: toUInt64String(outputTokens),
+		cache_read_input_tokens: toUInt64String(
+			tokenBreakdown.session.cache_read_input_tokens,
+		),
+		cache_creation_input_tokens: toUInt64String(
+			tokenBreakdown.session.cache_creation_input_tokens,
+		),
+		total_tokens: toUInt64String(totalTokens),
+		parent_input_tokens: toUInt64String(tokenBreakdown.parent.input_tokens),
+		parent_output_tokens: toUInt64String(tokenBreakdown.parent.output_tokens),
+		parent_cache_read_input_tokens: toUInt64String(
+			tokenBreakdown.parent.cache_read_input_tokens,
+		),
+		parent_cache_creation_input_tokens: toUInt64String(
+			tokenBreakdown.parent.cache_creation_input_tokens,
+		),
+		parent_total_tokens: toUInt64String(tokenBreakdown.parent.total_tokens),
+		subagent_input_tokens: toUInt64String(tokenBreakdown.subagent.input_tokens),
+		subagent_output_tokens: toUInt64String(
+			tokenBreakdown.subagent.output_tokens,
+		),
+		subagent_cache_read_input_tokens: toUInt64String(
+			tokenBreakdown.subagent.cache_read_input_tokens,
+		),
+		subagent_cache_creation_input_tokens: toUInt64String(
+			tokenBreakdown.subagent.cache_creation_input_tokens,
+		),
+		subagent_total_tokens: toUInt64String(tokenBreakdown.subagent.total_tokens),
+		token_accounting_version: CLAUDE_TOKEN_ACCOUNTING_VERSION,
+		tag: source.tag,
+		source: "claude_code",
+		total_interactions: interactionMetrics.totalInteractions,
+		actual_duration_min: interactionMetrics.actualDurationMin,
+		avg_period_sec: interactionMetrics.avgPeriodSec,
+		median_period_sec: interactionMetrics.medianPeriodSec,
+		quick_responses: interactionMetrics.quickResponses,
+		normal_responses: interactionMetrics.normalResponses,
+		long_pauses: interactionMetrics.longPauses,
+		error_count: countErrorMarkers(source.content),
+		model_used: modelUsed,
+		has_commit: source.git_sha ? 1 : 0,
+		session_archetype: sessionArchetype,
+		// Timing metrics stay parent-only on purpose: subagents add token work to
+		// the session, but they are not extra human interaction time.
+		success_score: buildSuccessScore({
+			hasCommit: Boolean(source.git_sha),
+			inputTokens,
+			outputTokens,
+			totalTokens,
+			skillsCount: skills.length,
+			errorCount: countErrorMarkers(source.content),
+			durationMin: interactionMetrics.actualDurationMin,
+		}),
+		used_plan_mode: source.content.includes('"name":"EnterPlanMode"') ? 1 : 0,
+		inference_duration_sec: interactionMetrics.inferenceDurationSec,
+		human_duration_sec: interactionMetrics.humanDurationSec,
+	};
+}
+
+function toClaudeAnalyticsSource(
+	input: IngestSessionInput,
+	organizationId: string,
+	userId: string,
+): ClaudeAnalyticsSource {
+	return {
+		session_id: input.sessionId,
+		organization_id: organizationId,
+		project_path: input.projectPath,
+		git_remote: input.gitRemote ?? "",
+		package_name: input.packageName ?? "",
+		package_type: input.packageType ?? "",
+		content: input.content,
+		subagents: Object.fromEntries(
+			(input.subagents ?? []).map((subagent) => [
+				subagent.agentId,
+				subagent.content,
+			]),
+		),
+		user_id: userId,
+		git_branch: input.gitBranch ?? null,
+		git_sha: input.gitSha ?? null,
+		tag: input.tag ?? null,
+	};
+}
+
+function parseTimedInteractions(content: string): Array<{
+	type: "user" | "assistant";
+	timestamp: string;
+}> {
+	const interactions: Array<{ type: "user" | "assistant"; timestamp: string }> =
+		[];
+
+	for (const line of content.split("\n")) {
+		if (!line || line.trim() === "") {
+			continue;
+		}
+
+		try {
+			const parsed = JSON.parse(line) as unknown;
+			if (!ClaudeTimedInteractionLineSchema.isTimedInteractionLine(parsed)) {
+				continue;
+			}
+
+			interactions.push({
+				type: parsed.type,
+				timestamp: parsed.timestamp,
+			});
+		} catch {
+			// Skip malformed JSON lines while keeping the session ingestible.
+		}
+	}
+
+	return interactions;
+}
+
+function buildInteractionMetrics(
+	interactions: Array<{ type: "user" | "assistant"; timestamp: string }>,
+) {
+	const promptPeriodsSec: number[] = [];
+	const inferenceGaps: number[] = [];
+	const humanGaps: number[] = [];
+
+	for (let index = 0; index < interactions.length - 1; index += 1) {
+		const current = interactions[index];
+		const next = interactions[index + 1];
+		if (!current || !next) {
+			continue;
+		}
+
+		const gapSec = getDiffSeconds(current.timestamp, next.timestamp);
+		promptPeriodsSec.push(gapSec);
+
+		if (current.type === "user" && next.type === "assistant") {
+			inferenceGaps.push(gapSec);
+		}
+
+		if (current.type === "assistant" && next.type === "user") {
+			humanGaps.push(gapSec);
+		}
+	}
+
+	const sortedPromptPeriods = [...promptPeriodsSec].sort((left, right) => {
+		return left - right;
+	});
+
+	return {
+		totalInteractions: interactions.length,
+		actualDurationMin:
+			interactions.length > 1
+				? Math.max(
+						0,
+						Math.round(
+							getDiffSeconds(
+								interactions[0]?.timestamp ?? "",
+								interactions[interactions.length - 1]?.timestamp ?? "",
+							) / 60,
+						),
+					)
+				: 0,
+		avgPeriodSec: roundToTwoDecimals(getAverage(promptPeriodsSec)),
+		medianPeriodSec: getMedian(sortedPromptPeriods),
+		quickResponses: promptPeriodsSec.filter((period) => period < 5).length,
+		normalResponses: promptPeriodsSec.filter(
+			(period) => period >= 5 && period <= 60,
+		).length,
+		longPauses: promptPeriodsSec.filter((period) => period > 300).length,
+		inferenceDurationSec: sumNumbers(inferenceGaps),
+		humanDurationSec: sumNumbers(humanGaps),
+	};
+}
+
+function resolveSessionBounds(
+	interactions: Array<{ type: "user" | "assistant"; timestamp: string }>,
+	fallbackSessionDate?: string,
+	fallbackLastInteractionDate?: string,
+) {
+	const firstTimestamp = interactions[0]?.timestamp;
+	const lastTimestamp = interactions[interactions.length - 1]?.timestamp;
+
+	if (firstTimestamp && lastTimestamp) {
+		return {
+			sessionDate: toClickHouseDateTime(firstTimestamp),
+			lastInteractionDate: toClickHouseDateTime(lastTimestamp),
+		};
+	}
+
+	if (fallbackSessionDate && fallbackLastInteractionDate) {
+		return {
+			sessionDate: fallbackSessionDate,
+			lastInteractionDate: fallbackLastInteractionDate,
+		};
+	}
+
+	const now = toClickHouseDateTime(new Date().toISOString());
+	return {
+		sessionDate: now,
+		lastInteractionDate: now,
+	};
+}
+
+function findLastAssistantModel(content: string): string {
+	let modelUsed = "";
+
+	for (const line of content.split("\n")) {
+		if (!line || line.trim() === "") {
+			continue;
+		}
+
+		try {
+			const parsed = JSON.parse(line) as unknown;
+			if (!ClaudeTimedInteractionLineSchema.isTimedInteractionLine(parsed)) {
+				continue;
+			}
+
+			if (parsed.type !== "assistant") {
+				continue;
+			}
+
+			if (
+				parsed.message &&
+				isRecord(parsed.message) &&
+				typeof parsed.message.model === "string"
+			) {
+				modelUsed = parsed.message.model;
+			}
+		} catch {
+			// Skip malformed JSON lines while preserving the last good model value.
+		}
+	}
+
+	return modelUsed;
+}
+
+function extractDistinctMatches(content: string, regex: RegExp): string[] {
+	const values = new Set<string>();
+	for (const match of content.matchAll(regex)) {
+		const value = match[1];
+		if (typeof value === "string" && value !== "") {
+			values.add(value);
+		}
+	}
+	return Array.from(values);
+}
+
+function buildSessionArchetype(params: {
+	durationMin: number;
+	inputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+	hasCommit: boolean;
+	skillsCount: number;
+}): string {
+	const { durationMin, inputTokens, outputTokens, totalTokens, hasCommit } =
+		params;
+
+	if (durationMin <= 10 && totalTokens < 500_000 && outputTokens > 1_000) {
+		return "quick_win";
+	}
+
+	if (durationMin > 30 && outputTokens > 50_000 && hasCommit) {
+		return "deep_work";
+	}
+
+	if (
+		totalTokens > 1_000_000 &&
+		getRatio(outputTokens, inputTokens) < 0.3 &&
+		durationMin > 20
+	) {
+		return "struggle";
+	}
+
+	if (params.skillsCount >= 3 && !hasCommit && totalTokens > 200_000) {
+		return "exploration";
+	}
+
+	if (durationMin < 3 && outputTokens < 500) {
+		return "abandoned";
+	}
+
+	return "standard";
+}
+
+function buildSuccessScore(params: {
+	hasCommit: boolean;
+	inputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+	skillsCount: number;
+	errorCount: number;
+	durationMin: number;
+}): number {
+	const { hasCommit, inputTokens, outputTokens, totalTokens } = params;
+
+	const score =
+		50 +
+		(hasCommit ? 20 : 0) +
+		(getRatio(outputTokens, inputTokens) > 0.5 ? 15 : 0) +
+		Math.min(params.skillsCount, 3) * 5 -
+		(totalTokens > 1_500_000 && !hasCommit ? 20 : 0) -
+		(params.durationMin < 2 && outputTokens < 200 ? 30 : 0) -
+		Math.min(params.errorCount, 10) * 2;
+
+	return Math.max(0, Math.min(100, Math.round(score)));
+}
+
+function countErrorMarkers(content: string): number {
+	const apiErrors = content.match(/"isApiErrorMessage":true/g)?.length ?? 0;
+	const toolErrors = content.match(/"is_error":true/g)?.length ?? 0;
+	return apiErrors + toolErrors;
+}
+
+function getAverage(values: number[]): number {
+	if (values.length === 0) {
+		return 0;
+	}
+
+	return sumNumbers(values) / values.length;
+}
+
+function getMedian(sortedValues: number[]): number {
+	if (sortedValues.length === 0) {
+		return 0;
+	}
+
+	const middleIndex = Math.ceil(sortedValues.length / 2) - 1;
+	return sortedValues[middleIndex] ?? 0;
+}
+
+function getDiffSeconds(leftTimestamp: string, rightTimestamp: string): number {
+	const leftMs = Date.parse(leftTimestamp);
+	const rightMs = Date.parse(rightTimestamp);
+	if (Number.isNaN(leftMs) || Number.isNaN(rightMs)) {
+		return 0;
+	}
+
+	return Math.max(0, Math.round((rightMs - leftMs) / 1000));
+}
+
+function getRatio(numerator: number, denominator: number): number {
+	if (denominator <= 0) {
+		return 0;
+	}
+
+	return numerator / denominator;
+}
+
+function sumNumbers(values: number[]): number {
+	let total = 0;
+	for (const value of values) {
+		total += value;
+	}
+	return total;
+}
+
+function roundToTwoDecimals(value: number): number {
+	return Math.round(value * 100) / 100;
+}
+
+function toUInt64String(value: number): string {
+	return Math.max(0, Math.round(value)).toString();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/apps/api/src/services/project.service.ts
+++ b/apps/api/src/services/project.service.ts
@@ -13,11 +13,19 @@ import {
 	buildDateFilter,
 	queryClickhouse,
 } from "../clickhouse.js";
+import { buildEstimatedCostSql } from "./pricing.service.js";
 
 const logger = getLogger(["rudel", "api", "project-service"]);
 
 const PROJECT_KEY_EXPR = `if(git_remote != '', git_remote, if(package_name != '', package_name, project_path))`;
 const PROJECT_DISPLAY_EXPR = `if(git_remote != '', arrayElement(splitByChar('/', git_remote), -1), arrayElement(splitByChar('/', replaceAll(project_path, '\\\\', '/')), -1))`;
+const PER_SESSION_COST_SQL = buildEstimatedCostSql({
+	modelExpr: "model_used",
+	inputExpr: "ifNull(input_tokens, 0)",
+	outputExpr: "ifNull(output_tokens, 0)",
+	cacheReadInputExpr: "ifNull(cache_read_input_tokens, 0)",
+	cacheCreationInputExpr: "ifNull(cache_creation_input_tokens, 0)",
+});
 
 function buildProjectDisplaySubquery(
 	orgParamName: string,
@@ -158,7 +166,8 @@ export async function getProjectInvestment(
         SUM(ifNull(input_tokens, 0) + ifNull(output_tokens, 0)) as total_tokens,
         round(SUM(actual_duration_min), 2) as total_duration_min,
         round(AVG(actual_duration_min), 2) as avg_session_duration_min,
-        round(AVG(success_score), 2) as success_rate
+        round(AVG(success_score), 2) as success_rate,
+        round(SUM(${PER_SESSION_COST_SQL}), 4) as total_cost
       FROM rudel.session_analytics FINAL
       WHERE ${buildDateFilter("currentDays")}
         AND organization_id = {orgId:String}
@@ -190,7 +199,7 @@ export async function getProjectInvestment(
       c.total_duration_min,
       c.avg_session_duration_min,
       c.success_rate,
-      round((c.output_tokens_sum / 1000000.0) * 15.0 + (c.input_tokens_sum / 1000000.0) * 3.0, 4) as cost,
+      c.total_cost as cost,
       round(c.success_rate - ifNull(p.prev_success_rate, c.success_rate), 2) as success_rate_trend
     FROM current_period c
     LEFT JOIN previous_period p ON c.project_display = p.project_display
@@ -382,13 +391,12 @@ export async function getProjectDetails(
       any(project_path) as raw_project_path,
       COUNT(*) as total_sessions,
       SUM(ifNull(input_tokens, 0) + ifNull(output_tokens, 0)) as total_tokens,
-      SUM(ifNull(input_tokens, 0)) as input_tokens_sum,
-      SUM(ifNull(output_tokens, 0)) as output_tokens_sum,
       COUNT(DISTINCT user_id) as contributors_count,
       countIf(success_score < 40) as errors_count,
       ifNull(round(avgOrNull(actual_duration_min), 2), 0) as avg_session_duration_min,
       ifNull(round(avgOrNull(success_score), 2), 0) as success_rate,
-      round(SUM(actual_duration_min), 2) as total_duration_min
+      round(SUM(actual_duration_min), 2) as total_duration_min,
+      round(SUM(${PER_SESSION_COST_SQL}), 4) as total_cost
     FROM rudel.session_analytics FINAL
     WHERE ${PROJECT_DISPLAY_EXPR} = ${projectDisplaySubquery}
       AND ${buildDateFilter("days")}
@@ -398,15 +406,13 @@ export async function getProjectDetails(
 
 	let results: (Omit<ProjectDetails, "project_path"> & {
 		raw_project_path: string;
-		input_tokens_sum: number;
-		output_tokens_sum: number;
+		total_cost: number;
 	})[];
 	try {
 		results = await queryClickhouse<
 			Omit<ProjectDetails, "project_path"> & {
 				raw_project_path: string;
-				input_tokens_sum: number;
-				output_tokens_sum: number;
+				total_cost: number;
 			}
 		>({
 			query,
@@ -422,8 +428,6 @@ export async function getProjectDetails(
 
 	const [row] = results;
 	if (!row || row.total_sessions === 0) return null;
-	const cost =
-		row.output_tokens_sum * 0.000015 + row.input_tokens_sum * 0.000003;
 	return {
 		project_path: row.raw_project_path,
 		total_sessions: row.total_sessions,
@@ -433,7 +437,7 @@ export async function getProjectDetails(
 		avg_session_duration_min: row.avg_session_duration_min,
 		success_rate: row.success_rate,
 		total_duration_min: row.total_duration_min,
-		cost: parseFloat(cost.toFixed(4)),
+		cost: Number(row.total_cost) || 0,
 	};
 }
 

--- a/apps/api/src/services/project.service.ts
+++ b/apps/api/src/services/project.service.ts
@@ -19,6 +19,8 @@ const logger = getLogger(["rudel", "api", "project-service"]);
 
 const PROJECT_KEY_EXPR = `if(git_remote != '', git_remote, if(package_name != '', package_name, project_path))`;
 const PROJECT_DISPLAY_EXPR = `if(git_remote != '', arrayElement(splitByChar('/', git_remote), -1), arrayElement(splitByChar('/', replaceAll(project_path, '\\\\', '/')), -1))`;
+// Project cost views must reuse the shared pricing helper so Codex cached-input
+// fixes stay consistent with the rest of the analytics surface.
 const PER_SESSION_COST_SQL = buildEstimatedCostSql({
 	modelExpr: "model_used",
 	inputExpr: "ifNull(input_tokens, 0)",

--- a/apps/api/src/services/roi.service.ts
+++ b/apps/api/src/services/roi.service.ts
@@ -18,6 +18,8 @@ import {
 } from "./pricing.service.js";
 
 const DEFAULT_DEV_HOURLY_RATE = 100;
+// ROI rollups need model-aware per-session pricing; a flat token rate would
+// reintroduce the Codex cached-input bug at the aggregate layer.
 const PER_SESSION_COST_SQL = buildEstimatedCostSql({
 	modelExpr: "model_used",
 	inputExpr: "ifNull(input_tokens, 0)",

--- a/apps/api/src/services/roi.service.ts
+++ b/apps/api/src/services/roi.service.ts
@@ -17,13 +17,6 @@ import {
 	getModelPricingCatalog,
 } from "./pricing.service.js";
 
-// Pricing constants based on Claude Sonnet 4 rates, used as a default approximation
-// across all models. TODO: implement per-model pricing using the model_used column.
-// Sonnet 4: input=$3/MTok, output=$15/MTok
-// Opus 4:   input=$5/MTok, output=$25/MTok
-// Haiku 4:  input=$1/MTok, output=$5/MTok
-const INPUT_PRICE_PER_MILLION = 3.0;
-const OUTPUT_PRICE_PER_MILLION = 15.0;
 const DEFAULT_DEV_HOURLY_RATE = 100;
 const PER_SESSION_COST_SQL = buildEstimatedCostSql({
 	modelExpr: "model_used",
@@ -240,6 +233,7 @@ export async function getROIMetrics(
         AVG(success_score) as avg_success_score,
         COUNT(DISTINCT user_id) as active_developers,
         SUM(has_commit) as total_commits,
+        SUM(${PER_SESSION_COST_SQL}) as total_cost,
         now64(3) - toIntervalDay({currentDays:UInt32}) as period_start,
         now64(3) as period_end
       FROM rudel.session_analytics FINAL
@@ -252,6 +246,7 @@ export async function getROIMetrics(
         SUM(input_tokens) as total_input_tokens,
         SUM(output_tokens) as total_output_tokens,
         SUM(has_commit) as total_commits,
+        SUM(${PER_SESSION_COST_SQL}) as total_cost,
         now64(3) - toIntervalDay({previousDays:UInt32}) as period_start,
         now64(3) - toIntervalDay({currentDays:UInt32}) as period_end
       FROM rudel.session_analytics FINAL
@@ -268,21 +263,15 @@ export async function getROIMetrics(
       c.avg_success_score,
       c.active_developers,
       c.total_commits,
-      round((c.total_output_tokens / 1000000.0) * ${OUTPUT_PRICE_PER_MILLION} +
-            (c.total_input_tokens / 1000000.0) * ${INPUT_PRICE_PER_MILLION}, 2) as total_cost,
-      round((c.total_output_tokens / 1000000.0) * ${OUTPUT_PRICE_PER_MILLION} +
-            (c.total_input_tokens / 1000000.0) * ${INPUT_PRICE_PER_MILLION}, 4) / c.total_sessions as cost_per_session,
+      round(c.total_cost, 2) as total_cost,
+      if(c.total_sessions > 0, round(c.total_cost / c.total_sessions, 4), 0) as cost_per_session,
       if(c.total_commits > 0,
-        round((c.total_output_tokens / 1000000.0) * ${OUTPUT_PRICE_PER_MILLION} +
-              (c.total_input_tokens / 1000000.0) * ${INPUT_PRICE_PER_MILLION}, 4) / c.total_commits,
+        round(c.total_cost / c.total_commits, 4),
         0) as cost_per_commit,
-      round((p.total_output_tokens / 1000000.0) * ${OUTPUT_PRICE_PER_MILLION} +
-            (p.total_input_tokens / 1000000.0) * ${INPUT_PRICE_PER_MILLION}, 2) as prev_total_cost,
-      round((p.total_output_tokens / 1000000.0) * ${OUTPUT_PRICE_PER_MILLION} +
-            (p.total_input_tokens / 1000000.0) * ${INPUT_PRICE_PER_MILLION}, 4) / p.total_sessions as prev_cost_per_session,
+      round(p.total_cost, 2) as prev_total_cost,
+      if(p.total_sessions > 0, round(p.total_cost / p.total_sessions, 4), 0) as prev_cost_per_session,
       if(p.total_commits > 0,
-        round((p.total_output_tokens / 1000000.0) * ${OUTPUT_PRICE_PER_MILLION} +
-              (p.total_input_tokens / 1000000.0) * ${INPUT_PRICE_PER_MILLION}, 4) / p.total_commits,
+        round(p.total_cost / p.total_commits, 4),
         0) as prev_cost_per_commit,
       p.total_commits as prev_total_commits,
       p.total_output_tokens as prev_total_output_tokens,
@@ -419,8 +408,7 @@ export async function getROITrends(
       SUM(has_commit) as total_commits,
       COUNT(DISTINCT user_id) as active_developers,
       AVG(success_score) as avg_success_score,
-      round((SUM(output_tokens) / 1000000.0) * ${OUTPUT_PRICE_PER_MILLION} +
-            (SUM(input_tokens) / 1000000.0) * ${INPUT_PRICE_PER_MILLION}, 2) as total_cost
+      round(SUM(${PER_SESSION_COST_SQL}), 4) as total_cost
     FROM rudel.session_analytics FINAL
     WHERE session_date >= now64(3) - toIntervalDay({days:UInt32})
       AND organization_id = {orgId:String}
@@ -471,8 +459,7 @@ export async function getDeveloperCostBreakdown(
       SUM(output_tokens) as total_output_tokens,
       SUM(total_tokens) as total_tokens,
       AVG(success_score) as avg_success_score,
-      round((SUM(output_tokens) / 1000000.0) * ${OUTPUT_PRICE_PER_MILLION} +
-            (SUM(input_tokens) / 1000000.0) * ${INPUT_PRICE_PER_MILLION}, 2) as total_cost
+      round(SUM(${PER_SESSION_COST_SQL}), 4) as total_cost
     FROM rudel.session_analytics FINAL
     WHERE ${buildDateFilter("days")}
       AND organization_id = {orgId:String}
@@ -528,8 +515,7 @@ export async function getProjectCostBreakdown(
       SUM(output_tokens) as total_output_tokens,
       SUM(total_tokens) as total_tokens,
       AVG(success_score) as avg_success_score,
-      round((SUM(output_tokens) / 1000000.0) * ${OUTPUT_PRICE_PER_MILLION} +
-            (SUM(input_tokens) / 1000000.0) * ${INPUT_PRICE_PER_MILLION}, 2) as total_cost
+      round(SUM(${PER_SESSION_COST_SQL}), 4) as total_cost
     FROM rudel.session_analytics FINAL
     WHERE ${buildDateFilter("days")}
       AND organization_id = {orgId:String}

--- a/apps/api/src/services/session-analytics.service.ts
+++ b/apps/api/src/services/session-analytics.service.ts
@@ -1,8 +1,13 @@
-import type {
-	DimensionAnalysisInput,
-	SessionAnalytics,
-	SessionAnalyticsSummary as SessionAnalyticsSummaryBase,
-	SessionDetail,
+import {
+	buildClaudeSessionTokenBreakdown,
+	type ClaudeSessionTokenBreakdown,
+	type ClaudeTokenTimelinePoint,
+	type DimensionAnalysisInput,
+	deriveClaudeUncachedInputTokens,
+	type SessionAnalytics,
+	type SessionAnalyticsSummary as SessionAnalyticsSummaryBase,
+	type SessionDetail,
+	type Source,
 } from "@rudel/api-routes";
 import {
 	addOptionalStringEqFilter,
@@ -35,6 +40,9 @@ export interface SessionAnalyticsRaw {
 	total_tokens: number;
 	input_tokens: number;
 	output_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
+	token_accounting_version: number;
 
 	// Git activity
 	git_sha: string;
@@ -62,6 +70,43 @@ export interface SessionAnalyticsSummary extends SessionAnalyticsSummaryBase {
 	median_response_time_sec: number;
 	quick_response_rate: number;
 	long_pause_rate: number;
+}
+
+interface SessionDetailRaw {
+	session_id: string;
+	user_id: string;
+	session_date: string;
+	last_interaction_date: string;
+	project_path: string;
+	repository: string | null;
+	content: string;
+	subagents: Record<string, string>;
+	skills: string[];
+	slash_commands: string[];
+	git_branch: string | null;
+	git_sha: string | null;
+	total_tokens: number;
+	input_tokens: number;
+	output_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
+	parent_input_tokens: number;
+	parent_output_tokens: number;
+	parent_cache_read_input_tokens: number;
+	parent_cache_creation_input_tokens: number;
+	parent_total_tokens: number;
+	subagent_input_tokens: number;
+	subagent_output_tokens: number;
+	subagent_cache_read_input_tokens: number;
+	subagent_cache_creation_input_tokens: number;
+	subagent_total_tokens: number;
+	token_accounting_version: number;
+	success_score?: number;
+	duration_min?: number;
+	total_interactions?: number;
+	session_archetype?: string;
+	model_used?: string;
+	source?: Source;
 }
 
 /**
@@ -145,11 +190,14 @@ export async function getSessionAnalytics(
       long_pauses,
       actual_duration_min,
       formatDateTime(sa.last_interaction_date, '%Y-%m-%dT%H:%i:%SZ') as last_interaction_date,
-      total_tokens,
-      input_tokens,
-      output_tokens,
-      git_sha,
-      git_branch,
+	      total_tokens,
+	      input_tokens,
+	      output_tokens,
+	      cache_read_input_tokens,
+	      cache_creation_input_tokens,
+	      token_accounting_version,
+	      git_sha,
+	      git_branch,
       has_commit,
       subagent_types,
       skills,
@@ -186,6 +234,14 @@ export async function getSessionAnalytics(
 			total_tokens: row.total_tokens,
 			input_tokens: row.input_tokens,
 			output_tokens: row.output_tokens,
+			cache_read_input_tokens: row.cache_read_input_tokens,
+			cache_creation_input_tokens: row.cache_creation_input_tokens,
+			uncached_input_tokens: deriveClaudeUncachedInputTokens(
+				row.input_tokens,
+				row.cache_read_input_tokens,
+				row.cache_creation_input_tokens,
+			),
+			token_accounting_version: row.token_accounting_version,
 			success_score: row.success_score,
 			total_interactions: row.total_interactions,
 			avg_period_sec: row.avg_period_sec,
@@ -694,11 +750,25 @@ export async function getSessionDetail(
       total_tokens,
       input_tokens,
       output_tokens,
+      cache_read_input_tokens,
+      cache_creation_input_tokens,
+      parent_input_tokens,
+      parent_output_tokens,
+      parent_cache_read_input_tokens,
+      parent_cache_creation_input_tokens,
+      parent_total_tokens,
+      subagent_input_tokens,
+      subagent_output_tokens,
+      subagent_cache_read_input_tokens,
+      subagent_cache_creation_input_tokens,
+      subagent_total_tokens,
+      token_accounting_version,
       success_score,
       actual_duration_min as duration_min,
       total_interactions,
       session_archetype,
-      model_used
+      model_used,
+      source
     FROM rudel.session_analytics FINAL sa
     WHERE session_id = {sessionId:String}
       AND organization_id = {orgId:String}
@@ -706,7 +776,7 @@ export async function getSessionDetail(
     LIMIT 1
   `;
 
-	const results = await queryClickhouse<SessionDetail>({
+	const results = await queryClickhouse<SessionDetailRaw>({
 		query,
 		query_params: {
 			orgId,
@@ -718,10 +788,135 @@ export async function getSessionDetail(
 	if (!row) {
 		return null;
 	}
+
+	const claudeTokenBreakdown = buildClaudeDetailTokenBreakdown(row);
+	const tokenBreakdown = claudeTokenBreakdown ?? buildStoredTokenBreakdown(row);
+	const inputTokens = tokenBreakdown.session.input_tokens;
+	const outputTokens = tokenBreakdown.session.output_tokens;
+	const cacheReadInputTokens = tokenBreakdown.session.cache_read_input_tokens;
+	const cacheCreationInputTokens =
+		tokenBreakdown.session.cache_creation_input_tokens;
+	const uncachedInputTokens = tokenBreakdown.session.uncached_input_tokens;
+	const tokenTimeline =
+		claudeTokenBreakdown?.timeline ?? ([] as ClaudeTokenTimelinePoint[]);
+
 	return {
 		...row,
 		repository: row.repository || null,
 		git_branch: row.git_branch || null,
 		git_sha: row.git_sha || null,
+		total_tokens: tokenBreakdown.session.total_tokens,
+		input_tokens: inputTokens,
+		output_tokens: outputTokens,
+		cache_read_input_tokens: cacheReadInputTokens,
+		cache_creation_input_tokens: cacheCreationInputTokens,
+		uncached_input_tokens: uncachedInputTokens,
+		parent_input_tokens: tokenBreakdown.parent.input_tokens,
+		parent_output_tokens: tokenBreakdown.parent.output_tokens,
+		parent_cache_read_input_tokens:
+			tokenBreakdown.parent.cache_read_input_tokens,
+		parent_cache_creation_input_tokens:
+			tokenBreakdown.parent.cache_creation_input_tokens,
+		parent_uncached_input_tokens: tokenBreakdown.parent.uncached_input_tokens,
+		parent_total_tokens: tokenBreakdown.parent.total_tokens,
+		subagent_input_tokens: tokenBreakdown.subagent.input_tokens,
+		subagent_output_tokens: tokenBreakdown.subagent.output_tokens,
+		subagent_cache_read_input_tokens:
+			tokenBreakdown.subagent.cache_read_input_tokens,
+		subagent_cache_creation_input_tokens:
+			tokenBreakdown.subagent.cache_creation_input_tokens,
+		subagent_uncached_input_tokens:
+			tokenBreakdown.subagent.uncached_input_tokens,
+		subagent_total_tokens: tokenBreakdown.subagent.total_tokens,
+		token_accounting_version:
+			row.source === "claude_code" ? 2 : row.token_accounting_version,
+		token_breakdown: tokenBreakdown,
+		token_timeline: tokenTimeline,
 	};
+}
+
+function buildClaudeDetailTokenBreakdown(
+	row: SessionDetailRaw,
+): ClaudeSessionTokenBreakdown | null {
+	if (row.source !== "claude_code") {
+		return null;
+	}
+
+	// Session detail recalculates Claude directly from raw transcript content so
+	// the detail page is correct even before a historical backfill is run.
+	return buildClaudeSessionTokenBreakdown(row.content, row.subagents);
+}
+
+function buildStoredTokenBreakdown(
+	row: SessionDetailRaw,
+): ClaudeSessionTokenBreakdown {
+	const parentCacheReadInputTokens = toNumber(
+		row.parent_cache_read_input_tokens,
+	);
+	const parentCacheCreationInputTokens = toNumber(
+		row.parent_cache_creation_input_tokens,
+	);
+	const parentInputTokens = toNumber(row.parent_input_tokens);
+	const parentOutputTokens = toNumber(row.parent_output_tokens);
+	const subagentCacheReadInputTokens = toNumber(
+		row.subagent_cache_read_input_tokens,
+	);
+	const subagentCacheCreationInputTokens = toNumber(
+		row.subagent_cache_creation_input_tokens,
+	);
+	const subagentInputTokens = toNumber(row.subagent_input_tokens);
+	const subagentOutputTokens = toNumber(row.subagent_output_tokens);
+
+	return {
+		parent: {
+			input_tokens: parentInputTokens,
+			uncached_input_tokens: deriveClaudeUncachedInputTokens(
+				parentInputTokens,
+				parentCacheReadInputTokens,
+				parentCacheCreationInputTokens,
+			),
+			cache_read_input_tokens: parentCacheReadInputTokens,
+			cache_creation_input_tokens: parentCacheCreationInputTokens,
+			output_tokens: parentOutputTokens,
+			total_tokens: toNumber(row.parent_total_tokens),
+		},
+		subagent: {
+			input_tokens: subagentInputTokens,
+			uncached_input_tokens: deriveClaudeUncachedInputTokens(
+				subagentInputTokens,
+				subagentCacheReadInputTokens,
+				subagentCacheCreationInputTokens,
+			),
+			cache_read_input_tokens: subagentCacheReadInputTokens,
+			cache_creation_input_tokens: subagentCacheCreationInputTokens,
+			output_tokens: subagentOutputTokens,
+			total_tokens: toNumber(row.subagent_total_tokens),
+		},
+		session: {
+			input_tokens: toNumber(row.input_tokens),
+			uncached_input_tokens: deriveClaudeUncachedInputTokens(
+				toNumber(row.input_tokens),
+				toNumber(row.cache_read_input_tokens),
+				toNumber(row.cache_creation_input_tokens),
+			),
+			cache_read_input_tokens: toNumber(row.cache_read_input_tokens),
+			cache_creation_input_tokens: toNumber(row.cache_creation_input_tokens),
+			output_tokens: toNumber(row.output_tokens),
+			total_tokens: toNumber(row.total_tokens),
+		},
+		timeline: [],
+	};
+}
+
+function toNumber(value: number | string | undefined): number {
+	if (typeof value === "number") {
+		return value;
+	}
+
+	if (typeof value === "string") {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? parsed : 0;
+	}
+
+	return 0;
 }

--- a/apps/web/src/features/conversation-internal/lib/analysis-types.ts
+++ b/apps/web/src/features/conversation-internal/lib/analysis-types.ts
@@ -2,6 +2,13 @@ export interface TokenDataPoint {
 	messageIndex: number;
 	inputTokens: number;
 	outputTokens: number;
+	uncachedInputTokens?: number;
+	cacheReadInputTokens?: number;
+	cacheCreationInputTokens?: number;
+	totalTokens?: number;
+	source?: "parent" | "subagent";
+	sourceId?: string;
+	timestamp?: string;
 }
 
 export interface ToolActivityPoint {

--- a/apps/web/src/features/conversation-internal/lib/conversation-analysis.ts
+++ b/apps/web/src/features/conversation-internal/lib/conversation-analysis.ts
@@ -55,6 +55,8 @@ function extractTokenData(content: string): TokenDataPoint[] {
 }
 
 function getTokenData(content: string): TokenDataPoint[] {
+	// Internal conversation charts need provider-specific token extraction
+	// because Codex does not emit Claude-style assistant usage entries.
 	if (isCodexFormat(content)) {
 		return extractCodexTokenData(content);
 	}

--- a/apps/web/src/features/conversation-internal/lib/conversation-analysis.ts
+++ b/apps/web/src/features/conversation-internal/lib/conversation-analysis.ts
@@ -1,3 +1,4 @@
+import { buildClaudeTokenTimeline } from "@rudel/api-routes";
 import type {
 	TokenDataPoint,
 	ToolActivityPoint,
@@ -18,42 +19,6 @@ export interface ConversationArtifacts {
 	totalMessages: number;
 }
 
-function extractTokenData(content: string): TokenDataPoint[] {
-	const points: TokenDataPoint[] = [];
-	const lines = content.split("\n").filter((line) => line.trim() !== "");
-
-	for (let i = 0; i < lines.length; i += 1) {
-		const line = lines[i];
-		if (!line) continue;
-
-		try {
-			const parsed = JSON.parse(line) as {
-				type?: string;
-				message?: {
-					usage?: {
-						input_tokens?: number;
-						output_tokens?: number;
-					};
-				};
-			};
-
-			if (parsed.type !== "assistant") continue;
-			const usage = parsed.message?.usage;
-			if (!usage) continue;
-
-			points.push({
-				messageIndex: i,
-				inputTokens: usage.input_tokens ?? 0,
-				outputTokens: usage.output_tokens ?? 0,
-			});
-		} catch {
-			// Skip malformed JSON lines.
-		}
-	}
-
-	return points;
-}
-
 function getTokenData(content: string): TokenDataPoint[] {
 	// Internal conversation charts need provider-specific token extraction
 	// because Codex does not emit Claude-style assistant usage entries.
@@ -61,7 +26,20 @@ function getTokenData(content: string): TokenDataPoint[] {
 		return extractCodexTokenData(content);
 	}
 
-	return extractTokenData(content);
+	// Anthropic reports uncached input separately from cache reads and writes,
+	// so Claude charts must expand those fields to show the true processed input.
+	return buildClaudeTokenTimeline(content, {}).map((point, messageIndex) => ({
+		messageIndex,
+		inputTokens: point.input_tokens,
+		outputTokens: point.output_tokens,
+		uncachedInputTokens: point.uncached_input_tokens,
+		cacheReadInputTokens: point.cache_read_input_tokens,
+		cacheCreationInputTokens: point.cache_creation_input_tokens,
+		totalTokens: point.total_tokens,
+		source: point.source,
+		sourceId: point.source_id,
+		timestamp: point.timestamp,
+	}));
 }
 
 function extractToolActivity(entries: Conversation[]): ToolActivityPoint[] {

--- a/apps/web/src/features/conversation-internal/lib/conversation-analysis.ts
+++ b/apps/web/src/features/conversation-internal/lib/conversation-analysis.ts
@@ -5,6 +5,10 @@ import type {
 import type { Conversation } from "@/features/conversation-internal/lib/conversation-schema";
 import { parseConversations } from "@/features/conversation-internal/lib/conversation-schema";
 import { isSlashCommandMessage } from "@/features/conversation-internal/lib/parse-slash-command";
+import {
+	extractCodexTokenData,
+	isCodexFormat,
+} from "@/lib/codex-conversation-parser";
 
 export interface ConversationArtifacts {
 	conversations: Conversation[];
@@ -48,6 +52,14 @@ function extractTokenData(content: string): TokenDataPoint[] {
 	}
 
 	return points;
+}
+
+function getTokenData(content: string): TokenDataPoint[] {
+	if (isCodexFormat(content)) {
+		return extractCodexTokenData(content);
+	}
+
+	return extractTokenData(content);
 }
 
 function extractToolActivity(entries: Conversation[]): ToolActivityPoint[] {
@@ -138,7 +150,7 @@ export function buildConversationArtifacts(
 		return {
 			conversations,
 			parseError,
-			tokenData: conversations.length > 0 ? extractTokenData(content) : [],
+			tokenData: conversations.length > 0 ? getTokenData(content) : [],
 			toolActivityData:
 				conversations.length > 0 ? extractToolActivity(conversations) : [],
 			totalMessages: conversations.length,

--- a/apps/web/src/features/conversation-internal/lib/conversation-schema.ts
+++ b/apps/web/src/features/conversation-internal/lib/conversation-schema.ts
@@ -101,6 +101,8 @@ export type Conversation = z.infer<typeof ConversationSchema>;
 
 // Parser
 export function parseConversations(content: string): Array<Conversation> {
+	// Route Codex transcripts through the Codex parser first so the internal view
+	// sees the same normalized message shape as the shared session detail flow.
 	if (isCodexFormat(content)) {
 		return parseCodexConversations(content);
 	}

--- a/apps/web/src/features/conversation-internal/lib/conversation-schema.ts
+++ b/apps/web/src/features/conversation-internal/lib/conversation-schema.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import {
+	isCodexFormat,
+	parseCodexConversations,
+} from "@/lib/codex-conversation-parser";
 
 // Content block schemas
 export const TextContentSchema = z.object({
@@ -97,6 +101,10 @@ export type Conversation = z.infer<typeof ConversationSchema>;
 
 // Parser
 export function parseConversations(content: string): Array<Conversation> {
+	if (isCodexFormat(content)) {
+		return parseCodexConversations(content);
+	}
+
 	const conversations: Array<Conversation> = [];
 	const lines = content.split("\n").filter(Boolean);
 

--- a/apps/web/src/features/sessions/components/SessionDetailView.tsx
+++ b/apps/web/src/features/sessions/components/SessionDetailView.tsx
@@ -105,8 +105,20 @@ export function SessionDetailView({
 		safeUserId === "unknown-user"
 			? "User"
 			: formatUsername(safeUserId, userMap);
+	const safeTotalTokens = toNumber(session.total_tokens);
 	const safeInputTokens = toNumber(session.input_tokens);
 	const safeOutputTokens = toNumber(session.output_tokens);
+	const safeCacheReadInputTokens = toNumber(session.cache_read_input_tokens);
+	const safeCacheCreationInputTokens = toNumber(
+		session.cache_creation_input_tokens,
+	);
+	const safeUncachedInputTokens = toNumber(session.uncached_input_tokens);
+	const safeParentTotalTokens = toNumber(session.parent_total_tokens);
+	const safeSubagentTotalTokens = toNumber(session.subagent_total_tokens);
+	const safeTokenAccountingVersion = toNumber(
+		session.token_accounting_version,
+		1,
+	);
 	const safeDurationMin =
 		session.duration_min === undefined
 			? undefined
@@ -143,6 +155,8 @@ export function SessionDetailView({
 		safeSkills.length > 0 ||
 		safeSlashCommands.length > 0 ||
 		subagentNames.length > 0;
+	const hasClaudeTokenBreakdown =
+		session.source === "claude_code" && safeTokenAccountingVersion >= 2;
 
 	return (
 		<SessionDetailErrorBoundary>
@@ -251,7 +265,7 @@ export function SessionDetailView({
 										/>
 										<SessionDetailMetric
 											className="grid min-w-[8rem] flex-[1.35] gap-1 border-l border-[color:var(--dashboardy-divider)] px-3 py-2"
-											label="Tokens"
+											label="Processed / output"
 											value={`${safeInputTokens.toLocaleString()} / ${safeOutputTokens.toLocaleString()}`}
 											valueClassName="text-[0.95rem] font-semibold tabular-nums whitespace-nowrap text-[color:var(--dashboardy-heading)]"
 										/>
@@ -328,6 +342,43 @@ export function SessionDetailView({
 									</div>
 								) : null}
 							</div>
+
+							{hasClaudeTokenBreakdown ? (
+								<div className="grid gap-3 rounded-[1rem] border border-[color:var(--dashboardy-divider)] bg-[color:var(--dashboardy-surface)] px-4 py-4">
+									<div className="flex items-center gap-2">
+										<h2 className="text-sm font-semibold text-[color:var(--dashboardy-heading)]">
+											Claude token accounting
+										</h2>
+										<InfoTooltip text="Anthropic reports uncached input separately from cache reads and cache writes. This panel shows the v2 processed-input breakdown used by the corrected Claude analytics path." />
+									</div>
+									<div className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
+										<SessionDetailMetric
+											label="Session total"
+											value={safeTotalTokens.toLocaleString()}
+										/>
+										<SessionDetailMetric
+											label="Uncached input"
+											value={safeUncachedInputTokens.toLocaleString()}
+										/>
+										<SessionDetailMetric
+											label="Cache read"
+											value={safeCacheReadInputTokens.toLocaleString()}
+										/>
+										<SessionDetailMetric
+											label="Cache write"
+											value={safeCacheCreationInputTokens.toLocaleString()}
+										/>
+										<SessionDetailMetric
+											label="Parent total"
+											value={safeParentTotalTokens.toLocaleString()}
+										/>
+										<SessionDetailMetric
+											label="Subagent total"
+											value={safeSubagentTotalTokens.toLocaleString()}
+										/>
+									</div>
+								</div>
+							) : null}
 
 							<ConversationView content={safeContent} showHeader={false} />
 						</div>

--- a/apps/web/src/lib/codex-conversation-parser.ts
+++ b/apps/web/src/lib/codex-conversation-parser.ts
@@ -194,11 +194,7 @@ export function extractCodexTokenData(
 
 			const usage = parsed.payload.info?.total_token_usage;
 			if (!usage) continue;
-			const currentInputTokens = Math.max(
-				0,
-				(usage.input_tokens ?? previousInputTokens) -
-					(usage.cached_input_tokens ?? 0),
-			);
+			const currentInputTokens = usage.input_tokens ?? previousInputTokens;
 			const currentOutputTokens = usage.output_tokens ?? previousOutputTokens;
 			const inputTokens = Math.max(0, currentInputTokens - previousInputTokens);
 			const outputTokens = Math.max(

--- a/apps/web/src/lib/codex-conversation-parser.ts
+++ b/apps/web/src/lib/codex-conversation-parser.ts
@@ -194,6 +194,8 @@ export function extractCodexTokenData(
 
 			const usage = parsed.payload.info?.total_token_usage;
 			if (!usage) continue;
+			// Codex snapshots already report total input with cached tokens included,
+			// so the per-point delta should be based on raw cumulative input.
 			const currentInputTokens = usage.input_tokens ?? previousInputTokens;
 			const currentOutputTokens = usage.output_tokens ?? previousOutputTokens;
 			const inputTokens = Math.max(0, currentInputTokens - previousInputTokens);

--- a/docs/claude-token-accounting-v2.md
+++ b/docs/claude-token-accounting-v2.md
@@ -1,0 +1,147 @@
+# Claude Token Accounting V2
+
+This document explains the Anthropic-grounded Claude token accounting model introduced in the stacked PR on top of the Codex accounting work.
+
+## Why this exists
+
+The old Claude pipeline mixed three incompatible ideas:
+
+- Anthropic `usage.input_tokens`, which is the uncached input suffix
+- Rudel `session_analytics.input_tokens`, which was intended to mean processed input
+- A ClickHouse materialized view that summed every assistant usage line in the parent transcript, including repeated streamed updates for the same `message.id`
+
+That produced two different classes of bugs at the same time:
+
+- Claude chart/detail surfaces could look too low because they only read `usage.input_tokens`
+- Claude aggregate/session rows could look too high because duplicate assistant usage rows were summed repeatedly
+
+## Anthropic rules this implementation follows
+
+Source of truth:
+
+- `https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching`
+- `https://docs.anthropic.com/en/api/messages-streaming`
+- `https://docs.anthropic.com/en/api/usage-cost-api`
+
+Canonical Anthropic semantics:
+
+- `usage.input_tokens` is uncached input
+- processed input is `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`
+- streamed usage is cumulative for a given response
+- the final token total for one Claude response is the last usage snapshot for that `message.id`
+
+## Rudel V2 decisions
+
+These are intentional product and data-model decisions, not implementation accidents.
+
+### 1. `input_tokens` means processed input
+
+For Claude rows in `session_analytics`, `input_tokens` now means total processed input, not just Anthropic uncached input.
+
+Derived field:
+
+- `uncached_input_tokens = input_tokens - cache_read_input_tokens - cache_creation_input_tokens`
+
+### 2. The counting unit is one final assistant snapshot per `message.id`
+
+Claude streams can emit multiple assistant lines with the same `message.id` as output grows. V2 groups those lines by `message.id` and keeps the last usage snapshot in transcript order.
+
+This prevents duplicate streamed updates from inflating totals.
+
+### 3. Session token totals include subagents
+
+Parent transcript totals and subagent transcript totals are computed separately, then folded into the session-wide token totals:
+
+- `session = parent + subagents`
+
+This is why already-uploaded raw Claude sessions can be corrected without user reupload. The raw parent transcript and raw subagent transcripts are already stored in `rudel.claude_sessions`.
+
+### 4. Timing metrics remain parent-scoped
+
+`total_interactions`, `duration`, `avg_period_sec`, `inference_duration_sec`, and `human_duration_sec` remain based on the parent transcript only.
+
+That is deliberate:
+
+- tokens measure total work performed by the session, including subagents
+- timing metrics measure the parent human conversation rhythm
+
+Mixing subagent token work into timing metrics would make session pacing harder to interpret.
+
+### 5. The ClickHouse MV is now a bootstrap path, not the Claude token authority
+
+The existing Claude MV still writes an initial `session_analytics` row. The API then writes a corrected replacement row with a newer `ingested_at` and `token_accounting_version = 2`.
+
+This keeps the transition safe while moving the Claude token truth into shared TypeScript code that can be used by:
+
+- ingest correction
+- historical backfill
+- session detail breakdown
+- Claude token charts
+
+## Storage changes
+
+`rudel.session_analytics` now stores:
+
+- `parent_input_tokens`
+- `parent_output_tokens`
+- `parent_cache_read_input_tokens`
+- `parent_cache_creation_input_tokens`
+- `parent_total_tokens`
+- `subagent_input_tokens`
+- `subagent_output_tokens`
+- `subagent_cache_read_input_tokens`
+- `subagent_cache_creation_input_tokens`
+- `subagent_total_tokens`
+- `token_accounting_version`
+
+These columns make the corrected Claude totals explainable in the database instead of hiding the relationship in application code only.
+
+## API and UI changes
+
+`SessionDetail` now exposes:
+
+- processed input
+- uncached input
+- cache read
+- cache write
+- parent totals
+- subagent totals
+- a token timeline based on the canonical final-per-message accounting
+
+The Claude session detail card surfaces the exact processed-input breakdown so reviewers can reconcile the session totals visually.
+
+The internal Claude token chart path also uses processed input now, rather than Anthropic uncached input alone.
+
+## Historical correction
+
+No user reupload is required for already-uploaded Claude sessions.
+
+Run the backfill with Rudel env loaded:
+
+```bash
+doppler run --project rudel --config prd -- \
+  bun run --cwd apps/api backfill:claude-token-accounting -- --batch-size 100
+```
+
+Optional flags:
+
+- `--offset <n>`
+- `--max-sessions <n>`
+
+The backfill reads the latest raw row per Claude `session_id` from `rudel.claude_sessions`, rebuilds the V2 analytics row, and appends a replacement row into `rudel.session_analytics`.
+
+Because `session_analytics` is a `ReplacingMergeTree(ingested_at)`, `FINAL` will pick the corrected row.
+
+## Verification checklist
+
+The implementation is behaving correctly when all of the following are true:
+
+- `input_tokens = uncached_input_tokens + cache_read_input_tokens + cache_creation_input_tokens`
+- `total_tokens = input_tokens + output_tokens`
+- `parent_total_tokens + subagent_total_tokens = total_tokens`
+- Claude session detail totals match the raw transcript reconstruction
+- Claude aggregate rows stop inflating duplicate streamed assistant updates
+
+## Scope boundary
+
+This PR does not remove the old Claude MV yet. It makes V2 authoritative by appending corrected rows on ingest and via backfill, which is the safer migration path for a production analytics table already in use.

--- a/docs/codex-token-accounting.md
+++ b/docs/codex-token-accounting.md
@@ -1,0 +1,126 @@
+# Codex Token Accounting
+
+This document is the source of truth for how Rudel should interpret Codex token usage and estimated cost.
+
+## Canonical semantics
+
+For `rudel.session_analytics` rows with `source = 'codex'`:
+
+- `input_tokens` means all provider-reported input processed by the model.
+- `cache_read_input_tokens` is a subset of `input_tokens`.
+- `cache_creation_input_tokens` is currently `0` for Codex rows.
+- `output_tokens` means all provider-reported output processed by the model.
+- `total_tokens` must equal `input_tokens + output_tokens`.
+
+For estimated pricing, only uncached input should be charged at the full input-token rate:
+
+```text
+base_rate_input_tokens =
+  max(input_tokens - cache_read_input_tokens - cache_creation_input_tokens, 0)
+
+estimated_cost =
+  base_rate_input_tokens * input_rate
+  + cache_read_input_tokens * cached_input_rate
+  + cache_creation_input_tokens * cache_write_rate
+  + output_tokens * output_rate
+```
+
+## What went wrong
+
+Two issues drifted apart at the same time:
+
+1. Historical Codex analytics rows were written with mixed `input_tokens` semantics.
+   - Older rows stored `input_tokens = raw_input - cached_input`.
+   - Newer rows store `input_tokens = raw_input`.
+2. Estimated pricing charged `input_tokens` at the full input rate and then charged cached input again at the cached rate.
+
+That combination made Codex usage look wrong in two different ways:
+
+- Session and aggregate token charts mixed incompatible definitions of “input”.
+- Cached Codex input was double-counted in estimated cost.
+
+## Live data shape that triggered this fix
+
+The validation query run against ClickHouse on 2026-04-23 returned:
+
+- `31` Codex rows checked in `rudel.session_analytics FINAL`
+- `31` rows whose `output_tokens` matched the raw Codex `token_count` event
+- `31` rows whose `cache_read_input_tokens` matched the raw Codex `token_count` event
+- `24` rows whose stored `input_tokens` matched `raw_input - cached_input`
+- `8` rows whose stored `input_tokens` matched raw `input_tokens`
+
+That means the cost bug and the token-accounting bug were both real in live data, not just in source code.
+
+## What this change does
+
+### Backend
+
+- Fixes `packages/api-routes/src/model-pricing.ts` so cached input and cache writes are removed from the full-rate input bucket before cost is calculated.
+- Replaces remaining hard-coded token-cost formulas in `apps/api/src/services/project.service.ts` and `apps/api/src/services/roi.service.ts` with the shared pricing SQL helper.
+
+### Frontend
+
+- Fixes `apps/web/src/lib/codex-conversation-parser.ts` so Codex token deltas use provider-reported cumulative input tokens instead of `input - cached_input`.
+- Fixes `apps/web/src/features/conversation-internal/lib/conversation-analysis.ts` so Codex transcripts use the Codex token extractor.
+- Fixes `apps/web/src/features/conversation-internal/lib/conversation-schema.ts` so the internal conversation view parses Codex transcripts instead of falling back to the Claude-only parser.
+
+### Data correction
+
+- Adds `packages/ch-schema/chx/migrations/20260423161000_auto.sql`.
+- The migration reinserts the latest canonical Codex projection into `rudel.session_analytics` with a fresh `ingested_at`.
+- Because `session_analytics` is a `ReplacingMergeTree(ingested_at)`, `FINAL` will prefer the corrected Codex row for each `(organization_id, session_date, session_id)` key.
+
+## Why a backfill is required
+
+Recreating the materialized view is not enough. Existing rows already written into `rudel.session_analytics` keep their old `input_tokens` values until they are replaced.
+
+Without the backfill:
+
+- new Codex sessions look correct,
+- old Codex sessions stay wrong,
+- aggregate dashboards still mix both definitions.
+
+## Validation query
+
+Use this to compare stored Codex analytics rows with the raw final `token_count` payload:
+
+```sql
+WITH raw_codex AS (
+  SELECT
+    session_id,
+    toUInt64OrZero(JSONExtractRaw(_final_usage, 'input_tokens')) AS raw_input_tokens,
+    toUInt64OrZero(JSONExtractRaw(_final_usage, 'output_tokens')) AS raw_output_tokens,
+    toUInt64OrZero(JSONExtractRaw(_final_usage, 'cached_input_tokens')) AS raw_cached_input_tokens
+  FROM (
+    SELECT
+      session_id,
+      if(length(_token_count_lines) > 0,
+        JSONExtractRaw(JSONExtractRaw(JSONExtractRaw(arrayElement(_token_count_lines, -1), 'payload'), 'info'), 'total_token_usage'),
+        '{}'
+      ) AS _final_usage
+    FROM (
+      SELECT
+        session_id,
+        arrayFilter(
+          x -> JSONExtractString(x, 'type') = 'event_msg'
+            AND JSONExtractString(JSONExtractRaw(x, 'payload'), 'type') = 'token_count'
+            AND JSONExtractRaw(JSONExtractRaw(x, 'payload'), 'info') IS NOT NULL
+            AND JSONExtractRaw(JSONExtractRaw(x, 'payload'), 'info') != 'null',
+          splitByChar('\n', content)
+        ) AS _token_count_lines
+      FROM rudel.codex_sessions FINAL
+    )
+  )
+)
+SELECT
+  count() AS total_codex_rows,
+  countIf(sa.input_tokens = rc.raw_input_tokens) AS matches_raw_input,
+  countIf(sa.input_tokens = rc.raw_input_tokens - rc.raw_cached_input_tokens) AS matches_uncached_input,
+  countIf(sa.output_tokens = rc.raw_output_tokens) AS matches_output,
+  countIf(sa.cache_read_input_tokens = rc.raw_cached_input_tokens) AS matches_cached
+FROM rudel.session_analytics FINAL AS sa
+INNER JOIN raw_codex AS rc USING (session_id)
+WHERE sa.source = 'codex';
+```
+
+After the backfill, `matches_raw_input` should equal `total_codex_rows` and `matches_uncached_input` should only reflect rows where `cached_input_tokens = 0`.

--- a/packages/api-routes/package.json
+++ b/packages/api-routes/package.json
@@ -6,6 +6,10 @@
 	"exports": {
 		".": "./src/index.ts"
 	},
+	"scripts": {
+		"check-types": "tsc --noEmit",
+		"test": "bun test"
+	},
 	"dependencies": {
 		"@orpc/contract": "latest",
 		"zod": "^3.24.0"

--- a/packages/api-routes/src/__tests__/claude-token-accounting.test.ts
+++ b/packages/api-routes/src/__tests__/claude-token-accounting.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildClaudeSessionTokenBreakdown,
+	deriveClaudeUncachedInputTokens,
+} from "../claude-token-accounting.js";
+
+describe("claude token accounting", () => {
+	test("uses the final usage snapshot for each Claude message id", () => {
+		const content = [
+			'{"type":"assistant","timestamp":"2026-04-23T10:00:00Z","message":{"id":"msg-parent-1","usage":{"input_tokens":10,"cache_read_input_tokens":100,"output_tokens":3},"stop_reason":null}}',
+			'{"type":"assistant","timestamp":"2026-04-23T10:00:01Z","message":{"id":"msg-parent-1","usage":{"input_tokens":10,"cache_read_input_tokens":100,"output_tokens":8},"stop_reason":"end_turn"}}',
+			'{"type":"assistant","timestamp":"2026-04-23T10:00:02Z","message":{"id":"msg-parent-2","usage":{"input_tokens":5,"cache_creation_input_tokens":20,"output_tokens":4},"stop_reason":"end_turn"}}',
+		].join("\n");
+
+		const breakdown = buildClaudeSessionTokenBreakdown(content, {});
+
+		expect(breakdown.parent.input_tokens).toBe(135);
+		expect(breakdown.parent.output_tokens).toBe(12);
+		expect(breakdown.parent.cache_read_input_tokens).toBe(100);
+		expect(breakdown.parent.cache_creation_input_tokens).toBe(20);
+		expect(breakdown.parent.uncached_input_tokens).toBe(15);
+		expect(breakdown.parent.total_tokens).toBe(147);
+		expect(breakdown.timeline).toHaveLength(2);
+		expect(breakdown.timeline[0]?.output_tokens).toBe(8);
+	});
+
+	test("adds subagent transcript tokens into the session-wide Claude total", () => {
+		const parentContent = [
+			'{"type":"assistant","timestamp":"2026-04-23T10:00:00Z","message":{"id":"msg-parent","usage":{"input_tokens":10,"output_tokens":3},"stop_reason":"end_turn"}}',
+		].join("\n");
+		const subagents = {
+			agent_1: [
+				'{"type":"assistant","timestamp":"2026-04-23T10:00:00.500Z","message":{"id":"msg-subagent","usage":{"input_tokens":2,"cache_read_input_tokens":4,"output_tokens":1},"stop_reason":"end_turn"}}',
+			].join("\n"),
+		};
+
+		const breakdown = buildClaudeSessionTokenBreakdown(
+			parentContent,
+			subagents,
+		);
+
+		expect(breakdown.parent.total_tokens).toBe(13);
+		expect(breakdown.subagent.total_tokens).toBe(7);
+		expect(breakdown.session.total_tokens).toBe(20);
+		expect(breakdown.timeline.map((point) => point.source)).toEqual([
+			"parent",
+			"subagent",
+		]);
+	});
+
+	test("derives Claude uncached input from processed input and cache usage", () => {
+		expect(deriveClaudeUncachedInputTokens(2_662_604, 2_370_740, 191_681)).toBe(
+			100_183,
+		);
+	});
+});

--- a/packages/api-routes/src/__tests__/model-pricing.test.ts
+++ b/packages/api-routes/src/__tests__/model-pricing.test.ts
@@ -6,6 +6,8 @@ import {
 } from "../model-pricing.js";
 
 describe("model pricing", () => {
+	// OpenAI/Codex cached input is a subset of total input, so the regression
+	// tests pin the non-double-counted formula in both JS and SQL paths.
 	test("charges OpenAI cached input at the cached rate instead of twice", () => {
 		const baseRateInputTokens = calculateBaseRateInputTokens({
 			inputTokens: 55_031,

--- a/packages/api-routes/src/__tests__/model-pricing.test.ts
+++ b/packages/api-routes/src/__tests__/model-pricing.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildEstimatedCostSql,
+	calculateBaseRateInputTokens,
+	calculateEstimatedCost,
+} from "../model-pricing.js";
+
+describe("model pricing", () => {
+	test("charges OpenAI cached input at the cached rate instead of twice", () => {
+		const baseRateInputTokens = calculateBaseRateInputTokens({
+			inputTokens: 55_031,
+			cacheReadInputTokens: 34_304,
+		});
+
+		expect(baseRateInputTokens).toBe(20_727);
+		expect(
+			calculateEstimatedCost({
+				model: "gpt-5.4",
+				inputTokens: 55_031,
+				outputTokens: 428,
+				cacheReadInputTokens: 34_304,
+			}),
+		).toBe(0.0668);
+	});
+
+	test("subtracts cached reads and cache writes before applying the base input rate", () => {
+		expect(
+			calculateEstimatedCost({
+				model: "claude-sonnet-4",
+				inputTokens: 1_000_000,
+				outputTokens: 250_000,
+				cacheReadInputTokens: 400_000,
+				cacheCreationInputTokens: 100_000,
+			}),
+		).toBe(5.745);
+	});
+
+	test("never produces negative base-rate input tokens", () => {
+		expect(
+			calculateBaseRateInputTokens({
+				inputTokens: 100,
+				cacheReadInputTokens: 80,
+				cacheCreationInputTokens: 40,
+			}),
+		).toBe(0);
+	});
+
+	test("builds SQL that prices only uncached input at the full input rate", () => {
+		const sql = buildEstimatedCostSql({
+			modelExpr: "model_used",
+			inputExpr: "ifNull(input_tokens, 0)",
+			outputExpr: "ifNull(output_tokens, 0)",
+			cacheReadInputExpr: "ifNull(cache_read_input_tokens, 0)",
+			cacheCreationInputExpr: "ifNull(cache_creation_input_tokens, 0)",
+			precision: 4,
+		});
+
+		expect(sql).toContain("greatest");
+		expect(sql).toContain(
+			"((ifNull(input_tokens, 0)) - (ifNull(cache_read_input_tokens, 0)) - (ifNull(cache_creation_input_tokens, 0)))",
+		);
+	});
+});

--- a/packages/api-routes/src/claude-token-accounting.ts
+++ b/packages/api-routes/src/claude-token-accounting.ts
@@ -1,0 +1,321 @@
+import { z } from "zod";
+
+const PARENT_SOURCE_ID = "parent";
+
+const ClaudeUsageSchema = z.object({
+	input_tokens: z.number().nonnegative().optional(),
+	output_tokens: z.number().nonnegative().optional(),
+	cache_read_input_tokens: z.number().nonnegative().optional(),
+	cache_creation_input_tokens: z.number().nonnegative().optional(),
+});
+
+const ClaudeAssistantUsageLineSchema = z.object({
+	type: z.literal("assistant"),
+	timestamp: z.string(),
+	message: z.object({
+		id: z.string().optional(),
+		usage: ClaudeUsageSchema.optional(),
+	}),
+});
+
+export const ClaudeTokenBreakdownSchema = z.object({
+	input_tokens: z.number(),
+	uncached_input_tokens: z.number(),
+	cache_read_input_tokens: z.number(),
+	cache_creation_input_tokens: z.number(),
+	output_tokens: z.number(),
+	total_tokens: z.number(),
+});
+
+export const ClaudeTokenTimelinePointSchema = z.object({
+	timestamp: z.string(),
+	source: z.enum(["parent", "subagent"]),
+	source_id: z.string(),
+	message_id: z.string(),
+	input_tokens: z.number(),
+	uncached_input_tokens: z.number(),
+	cache_read_input_tokens: z.number(),
+	cache_creation_input_tokens: z.number(),
+	output_tokens: z.number(),
+	total_tokens: z.number(),
+});
+
+export const ClaudeSessionTokenBreakdownSchema = z.object({
+	parent: ClaudeTokenBreakdownSchema,
+	subagent: ClaudeTokenBreakdownSchema,
+	session: ClaudeTokenBreakdownSchema,
+	timeline: z.array(ClaudeTokenTimelinePointSchema),
+});
+
+export type ClaudeTokenBreakdown = z.infer<typeof ClaudeTokenBreakdownSchema>;
+export type ClaudeTokenTimelinePoint = z.infer<
+	typeof ClaudeTokenTimelinePointSchema
+>;
+export type ClaudeSessionTokenBreakdown = z.infer<
+	typeof ClaudeSessionTokenBreakdownSchema
+>;
+
+type ClaudeUsageSnapshot = {
+	lineIndex: number;
+	timestamp: string;
+	source: ClaudeTokenTimelinePoint["source"];
+	sourceId: string;
+	messageId: string;
+	uncachedInputTokens: number;
+	cacheReadInputTokens: number;
+	cacheCreationInputTokens: number;
+	outputTokens: number;
+};
+
+export function buildClaudeSessionTokenBreakdown(
+	content: string,
+	subagents: Record<string, string>,
+): ClaudeSessionTokenBreakdown {
+	// Claude V2 treats session tokens as parent work plus subagent work, while
+	// still preserving the split so reviewers can reconcile the combined total.
+	const parentTimeline = buildClaudeTokenTimelinePoints(
+		content,
+		"parent",
+		PARENT_SOURCE_ID,
+	);
+	const subagentTimeline = Object.entries(subagents).flatMap(
+		([agentId, agentContent]) =>
+			buildClaudeTokenTimelinePoints(agentContent, "subagent", agentId),
+	);
+	const timeline = [...parentTimeline, ...subagentTimeline].sort(
+		compareTimelinePoints,
+	);
+
+	return {
+		parent: summarizeTimeline(parentTimeline),
+		subagent: summarizeTimeline(subagentTimeline),
+		session: summarizeTimeline(timeline),
+		timeline,
+	};
+}
+
+export function buildClaudeTokenTimeline(
+	content: string,
+	subagents: Record<string, string>,
+): ClaudeTokenTimelinePoint[] {
+	return buildClaudeSessionTokenBreakdown(content, subagents).timeline;
+}
+
+export function deriveClaudeUncachedInputTokens(
+	processedInputTokens: number,
+	cacheReadInputTokens: number,
+	cacheCreationInputTokens: number,
+): number {
+	return Math.max(
+		processedInputTokens - cacheReadInputTokens - cacheCreationInputTokens,
+		0,
+	);
+}
+
+function buildClaudeTokenTimelinePoints(
+	content: string,
+	source: ClaudeTokenTimelinePoint["source"],
+	sourceId: string,
+): ClaudeTokenTimelinePoint[] {
+	const snapshots = parseClaudeUsageSnapshots(content, source, sourceId);
+	const finalSnapshots = selectFinalUsageSnapshots(snapshots);
+
+	return finalSnapshots
+		.sort(compareSnapshots)
+		.map((snapshot) => toTimelinePoint(snapshot));
+}
+
+function parseClaudeUsageSnapshots(
+	content: string,
+	source: ClaudeTokenTimelinePoint["source"],
+	sourceId: string,
+): ClaudeUsageSnapshot[] {
+	const snapshots: ClaudeUsageSnapshot[] = [];
+	const lines = content.split("\n");
+
+	for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+		const line = lines[lineIndex];
+		if (!line || line.trim() === "") {
+			continue;
+		}
+
+		const parsedLine = parseClaudeAssistantUsageLine(line);
+		if (!parsedLine) {
+			continue;
+		}
+
+		const usage = parsedLine.message.usage;
+		if (!usage) {
+			continue;
+		}
+
+		const messageId =
+			parsedLine.message.id ??
+			`${sourceId}:${parsedLine.timestamp}:${lineIndex}`;
+
+		snapshots.push({
+			lineIndex,
+			timestamp: parsedLine.timestamp,
+			source,
+			sourceId,
+			messageId,
+			uncachedInputTokens: usage.input_tokens ?? 0,
+			cacheReadInputTokens: usage.cache_read_input_tokens ?? 0,
+			cacheCreationInputTokens: usage.cache_creation_input_tokens ?? 0,
+			outputTokens: usage.output_tokens ?? 0,
+		});
+	}
+
+	return snapshots;
+}
+
+function selectFinalUsageSnapshots(
+	snapshots: ClaudeUsageSnapshot[],
+): ClaudeUsageSnapshot[] {
+	const snapshotsByMessageId = new Map<string, ClaudeUsageSnapshot>();
+
+	for (const snapshot of snapshots) {
+		const existingSnapshot = snapshotsByMessageId.get(snapshot.messageId);
+		if (
+			!existingSnapshot ||
+			shouldReplaceSnapshot(existingSnapshot, snapshot)
+		) {
+			// Anthropic streams emit cumulative usage updates for the same message id,
+			// so the last snapshot in transcript order is the authoritative total.
+			snapshotsByMessageId.set(snapshot.messageId, snapshot);
+		}
+	}
+
+	return Array.from(snapshotsByMessageId.values());
+}
+
+function shouldReplaceSnapshot(
+	existingSnapshot: ClaudeUsageSnapshot,
+	candidateSnapshot: ClaudeUsageSnapshot,
+): boolean {
+	if (candidateSnapshot.lineIndex !== existingSnapshot.lineIndex) {
+		return candidateSnapshot.lineIndex > existingSnapshot.lineIndex;
+	}
+
+	return (
+		getSnapshotTotalTokens(candidateSnapshot) >=
+		getSnapshotTotalTokens(existingSnapshot)
+	);
+}
+
+function toTimelinePoint(
+	snapshot: ClaudeUsageSnapshot,
+): ClaudeTokenTimelinePoint {
+	// Anthropic's `usage.input_tokens` is only the uncached suffix. Rudel's
+	// public `input_tokens` field is processed input, so we expand cache reads
+	// and cache writes here before the value leaves this module.
+	const inputTokens =
+		snapshot.uncachedInputTokens +
+		snapshot.cacheReadInputTokens +
+		snapshot.cacheCreationInputTokens;
+
+	return {
+		timestamp: snapshot.timestamp,
+		source: snapshot.source,
+		source_id: snapshot.sourceId,
+		message_id: snapshot.messageId,
+		input_tokens: inputTokens,
+		uncached_input_tokens: snapshot.uncachedInputTokens,
+		cache_read_input_tokens: snapshot.cacheReadInputTokens,
+		cache_creation_input_tokens: snapshot.cacheCreationInputTokens,
+		output_tokens: snapshot.outputTokens,
+		total_tokens: inputTokens + snapshot.outputTokens,
+	};
+}
+
+function summarizeTimeline(
+	timeline: ClaudeTokenTimelinePoint[],
+): ClaudeTokenBreakdown {
+	let inputTokens = 0;
+	let uncachedInputTokens = 0;
+	let cacheReadInputTokens = 0;
+	let cacheCreationInputTokens = 0;
+	let outputTokens = 0;
+
+	for (const point of timeline) {
+		inputTokens += point.input_tokens;
+		uncachedInputTokens += point.uncached_input_tokens;
+		cacheReadInputTokens += point.cache_read_input_tokens;
+		cacheCreationInputTokens += point.cache_creation_input_tokens;
+		outputTokens += point.output_tokens;
+	}
+
+	return {
+		input_tokens: inputTokens,
+		uncached_input_tokens: uncachedInputTokens,
+		cache_read_input_tokens: cacheReadInputTokens,
+		cache_creation_input_tokens: cacheCreationInputTokens,
+		output_tokens: outputTokens,
+		total_tokens: inputTokens + outputTokens,
+	};
+}
+
+function parseClaudeAssistantUsageLine(line: string) {
+	try {
+		const parsed = JSON.parse(line) as unknown;
+		const result = ClaudeAssistantUsageLineSchema.safeParse(parsed);
+		return result.success ? result.data : null;
+	} catch {
+		return null;
+	}
+}
+
+function compareSnapshots(
+	left: ClaudeUsageSnapshot,
+	right: ClaudeUsageSnapshot,
+): number {
+	const leftTimestampMs = Date.parse(left.timestamp);
+	const rightTimestampMs = Date.parse(right.timestamp);
+	if (
+		Number.isFinite(leftTimestampMs) &&
+		Number.isFinite(rightTimestampMs) &&
+		leftTimestampMs !== rightTimestampMs
+	) {
+		return leftTimestampMs - rightTimestampMs;
+	}
+
+	if (left.timestamp === right.timestamp) {
+		return left.lineIndex - right.lineIndex;
+	}
+
+	return left.timestamp.localeCompare(right.timestamp);
+}
+
+function compareTimelinePoints(
+	left: ClaudeTokenTimelinePoint,
+	right: ClaudeTokenTimelinePoint,
+): number {
+	const leftTimestampMs = Date.parse(left.timestamp);
+	const rightTimestampMs = Date.parse(right.timestamp);
+	if (
+		Number.isFinite(leftTimestampMs) &&
+		Number.isFinite(rightTimestampMs) &&
+		leftTimestampMs !== rightTimestampMs
+	) {
+		return leftTimestampMs - rightTimestampMs;
+	}
+
+	if (left.timestamp === right.timestamp) {
+		if (left.source_id === right.source_id) {
+			return left.message_id.localeCompare(right.message_id);
+		}
+
+		return left.source_id.localeCompare(right.source_id);
+	}
+
+	return left.timestamp.localeCompare(right.timestamp);
+}
+
+function getSnapshotTotalTokens(snapshot: ClaudeUsageSnapshot): number {
+	return (
+		snapshot.uncachedInputTokens +
+		snapshot.cacheReadInputTokens +
+		snapshot.cacheCreationInputTokens +
+		snapshot.outputTokens
+	);
+}

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -60,6 +60,7 @@ import {
 	UserTokenUsageDataSchema,
 } from "./schemas/analytics.js";
 
+export * from "./claude-token-accounting.js";
 export * from "./model-pricing.js";
 export * from "./product-analytics.js";
 export * from "./schemas/analytics.js";

--- a/packages/api-routes/src/model-pricing.ts
+++ b/packages/api-routes/src/model-pricing.ts
@@ -359,6 +359,21 @@ export function getModelPricingCatalog() {
 	return MODEL_PRICING_CATALOG;
 }
 
+export function calculateBaseRateInputTokens({
+	inputTokens,
+	cacheReadInputTokens = 0,
+	cacheCreationInputTokens = 0,
+}: {
+	inputTokens: number;
+	cacheReadInputTokens?: number;
+	cacheCreationInputTokens?: number;
+}) {
+	return Math.max(
+		0,
+		inputTokens - cacheReadInputTokens - cacheCreationInputTokens,
+	);
+}
+
 export function calculateEstimatedCost({
 	model,
 	inputTokens,
@@ -375,8 +390,13 @@ export function calculateEstimatedCost({
 	precision?: number;
 }) {
 	const pricing = getResolvedPricing(model);
+	const baseRateInputTokens = calculateBaseRateInputTokens({
+		inputTokens,
+		cacheReadInputTokens,
+		cacheCreationInputTokens,
+	});
 	const cost =
-		(inputTokens / 1_000_000) * pricing.inputPerMillion +
+		(baseRateInputTokens / 1_000_000) * pricing.inputPerMillion +
 		(outputTokens / 1_000_000) * pricing.outputPerMillion +
 		(cacheReadInputTokens / 1_000_000) * pricing.cachedInputPerMillion +
 		(cacheCreationInputTokens / 1_000_000) * pricing.cacheWritePerMillion;
@@ -428,8 +448,9 @@ export function buildEstimatedCostSql({
 	const outputRateSql = buildRateSql(modelExpr, "outputPerMillion");
 	const cachedInputRateSql = buildRateSql(modelExpr, "cachedInputPerMillion");
 	const cacheWriteRateSql = buildRateSql(modelExpr, "cacheWritePerMillion");
+	const baseRateInputExpr = `greatest(((${inputExpr}) - (${cacheReadInputExpr}) - (${cacheCreationInputExpr})), 0)`;
 
-	const expression = `((${inputExpr}) / 1000000.0) * (${inputRateSql}) + ((${outputExpr}) / 1000000.0) * (${outputRateSql}) + ((${cacheReadInputExpr}) / 1000000.0) * (${cachedInputRateSql}) + ((${cacheCreationInputExpr}) / 1000000.0) * (${cacheWriteRateSql})`;
+	const expression = `((${baseRateInputExpr}) / 1000000.0) * (${inputRateSql}) + ((${outputExpr}) / 1000000.0) * (${outputRateSql}) + ((${cacheReadInputExpr}) / 1000000.0) * (${cachedInputRateSql}) + ((${cacheCreationInputExpr}) / 1000000.0) * (${cacheWriteRateSql})`;
 
 	if (typeof precision === "number") {
 		return `round(${expression}, ${precision})`;

--- a/packages/api-routes/src/model-pricing.ts
+++ b/packages/api-routes/src/model-pricing.ts
@@ -368,6 +368,8 @@ export function calculateBaseRateInputTokens({
 	cacheReadInputTokens?: number;
 	cacheCreationInputTokens?: number;
 }) {
+	// OpenAI/Codex report cached and cache-write tokens inside total input, so
+	// the full-rate bucket must exclude both before pricing the remainder.
 	return Math.max(
 		0,
 		inputTokens - cacheReadInputTokens - cacheCreationInputTokens,
@@ -448,6 +450,8 @@ export function buildEstimatedCostSql({
 	const outputRateSql = buildRateSql(modelExpr, "outputPerMillion");
 	const cachedInputRateSql = buildRateSql(modelExpr, "cachedInputPerMillion");
 	const cacheWriteRateSql = buildRateSql(modelExpr, "cacheWritePerMillion");
+	// Keep the SQL path aligned with the TypeScript estimator so aggregate API
+	// queries and per-session calculations cannot drift.
 	const baseRateInputExpr = `greatest(((${inputExpr}) - (${cacheReadInputExpr}) - (${cacheCreationInputExpr})), 0)`;
 
 	const expression = `((${baseRateInputExpr}) / 1000000.0) * (${inputRateSql}) + ((${outputExpr}) / 1000000.0) * (${outputRateSql}) + ((${cacheReadInputExpr}) / 1000000.0) * (${cachedInputRateSql}) + ((${cacheCreationInputExpr}) / 1000000.0) * (${cacheWriteRateSql})`;

--- a/packages/api-routes/src/schemas/analytics.ts
+++ b/packages/api-routes/src/schemas/analytics.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import {
+	ClaudeTokenBreakdownSchema,
+	ClaudeTokenTimelinePointSchema,
+} from "../claude-token-accounting.js";
 import { ESTIMATED_PRICING_MODE } from "../model-pricing.js";
 import { SourceSchema } from "./source.js";
 
@@ -326,8 +330,14 @@ export const SessionAnalyticsSchema = z.object({
 	git_remote: z.string().optional(),
 	duration_min: z.number(),
 	total_tokens: z.number(),
+	// `input_tokens` is the provider-normalized processed input across sources.
+	// Claude's uncached suffix is exposed separately as `uncached_input_tokens`.
 	input_tokens: z.number(),
 	output_tokens: z.number(),
+	cache_read_input_tokens: z.number(),
+	cache_creation_input_tokens: z.number(),
+	uncached_input_tokens: z.number(),
+	token_accounting_version: z.number().int().positive(),
 	success_score: z.number(),
 	total_interactions: z.number(),
 	avg_period_sec: z.number(),
@@ -432,6 +442,30 @@ export const SessionDetailSchema = z.object({
 	total_tokens: z.number(),
 	input_tokens: z.number(),
 	output_tokens: z.number(),
+	// Session detail carries the full Claude V2 breakdown so reviewers can
+	// reconcile parent, subagent, uncached, and cached totals explicitly.
+	cache_read_input_tokens: z.number(),
+	cache_creation_input_tokens: z.number(),
+	uncached_input_tokens: z.number(),
+	parent_input_tokens: z.number(),
+	parent_output_tokens: z.number(),
+	parent_cache_read_input_tokens: z.number(),
+	parent_cache_creation_input_tokens: z.number(),
+	parent_uncached_input_tokens: z.number(),
+	parent_total_tokens: z.number(),
+	subagent_input_tokens: z.number(),
+	subagent_output_tokens: z.number(),
+	subagent_cache_read_input_tokens: z.number(),
+	subagent_cache_creation_input_tokens: z.number(),
+	subagent_uncached_input_tokens: z.number(),
+	subagent_total_tokens: z.number(),
+	token_accounting_version: z.number().int().positive(),
+	token_breakdown: z.object({
+		parent: ClaudeTokenBreakdownSchema,
+		subagent: ClaudeTokenBreakdownSchema,
+		session: ClaudeTokenBreakdownSchema,
+	}),
+	token_timeline: z.array(ClaudeTokenTimelinePointSchema),
 	success_score: z.number().optional(),
 	duration_min: z.number().optional(),
 	total_interactions: z.number().optional(),

--- a/packages/ch-schema/chx/meta/snapshot.json
+++ b/packages/ch-schema/chx/meta/snapshot.json
@@ -1,6 +1,6 @@
 {
 	"version": 1,
-	"generatedAt": "2026-04-22T14:49:31.343Z",
+	"generatedAt": "2026-04-23T15:38:34.936Z",
 	"definitions": [
 		{
 			"database": "rudel",
@@ -278,6 +278,61 @@
 					"name": "total_tokens",
 					"type": "UInt64",
 					"default": "fn:0"
+				},
+				{
+					"name": "parent_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "parent_output_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "parent_cache_read_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "parent_cache_creation_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "parent_total_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "subagent_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "subagent_output_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "subagent_cache_read_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "subagent_cache_creation_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "subagent_total_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "token_accounting_version",
+					"type": "UInt8",
+					"default": "fn:1"
 				},
 				{
 					"name": "tag",

--- a/packages/ch-schema/chx/migrations/20260423153834_auto.sql
+++ b/packages/ch-schema/chx/migrations/20260423153834_auto.sql
@@ -1,0 +1,47 @@
+-- chkit-migration-format: v1
+-- generated-at: 2026-04-23T15:38:34.935Z
+-- cli-version: 0.1.0-beta.16
+-- definition-count: 5
+-- operation-count: 13
+-- rename-suggestion-count: 0
+-- risk-summary: safe=11, caution=2, danger=0
+
+-- operation: drop_materialized_view key=materialized_view:rudel.session_analytics_mv risk=caution
+DROP TABLE IF EXISTS rudel.session_analytics_mv SYNC;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:parent_cache_creation_input_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `parent_cache_creation_input_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:parent_cache_read_input_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `parent_cache_read_input_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:parent_input_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `parent_input_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:parent_output_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `parent_output_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:parent_total_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `parent_total_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:subagent_cache_creation_input_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `subagent_cache_creation_input_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:subagent_cache_read_input_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `subagent_cache_read_input_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:subagent_input_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `subagent_input_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:subagent_output_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `subagent_output_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:subagent_total_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `subagent_total_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:token_accounting_version risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `token_accounting_version` UInt8 DEFAULT 1;
+
+-- operation: create_materialized_view key=materialized_view:rudel.session_analytics_mv risk=caution
+CREATE MATERIALIZED VIEW IF NOT EXISTS rudel.session_analytics_mv TO rudel.session_analytics AS
+WITH arrayFilter( x -> JSONExtractString(x, 'type') IN ('user', 'assistant'), splitByChar('\n', cs.content) ) AS _interaction_lines, arrayFilter(x -> JSONHas(x, 'timestamp'), _interaction_lines) AS _ts_lines, arrayMap( x -> parseDateTime64BestEffort(JSONExtractString(x, 'timestamp')), _ts_lines ) AS _timestamps, arrayMap( x -> JSONExtractString(x, 'type'), _ts_lines ) AS _msg_types, if(length(_timestamps) > 1, arrayMap(i -> dateDiff('second', _timestamps[i], _timestamps[i+1]), range(1, length(_timestamps))), [] ) AS _prompt_periods_sec, if(length(_timestamps) > 1, arrayMap(i -> if(_msg_types[i] = 'user' AND _msg_types[i+1] = 'assistant', dateDiff('second', _timestamps[i], _timestamps[i+1]), 0), range(1, length(_timestamps))), [] ) AS _inference_gaps, if(length(_timestamps) > 1, arrayMap(i -> if(_msg_types[i] = 'assistant' AND _msg_types[i+1] = 'user', dateDiff('second', _timestamps[i], _timestamps[i+1]), 0), range(1, length(_timestamps))), [] ) AS _human_gaps, arrayFilter( x -> JSONExtractString(x, 'type') = 'assistant' AND JSONHas(x, 'message'), splitByChar('\n', cs.content) ) AS _assistant_lines, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'input_tokens')) + toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_read_input_tokens')) + toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_creation_input_tokens')), _assistant_lines)) AS _input_tokens, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'output_tokens')), _assistant_lines)) AS _output_tokens, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_read_input_tokens')), _assistant_lines)) AS _cache_read, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_creation_input_tokens')), _assistant_lines)) AS _cache_creation, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '"name":"Skill"[^}]*"skill":"([^"]+)"'))) AS _skills, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '"name":"Task"[^}]*"subagent_type":"([^"]+)"'))) AS _subagent_types, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '<command-name>/([^<]+)</command-name>'))) AS _slash_commands, arrayMin(_timestamps) AS _session_date, arrayMax(_timestamps) AS _last_interaction_date, dateDiff('minute', _session_date, _last_interaction_date) AS _duration_min SELECT * EXCEPT (session_date, last_interaction_date), _session_date as session_date, _last_interaction_date as last_interaction_date, 'claude_code' as source, _input_tokens as input_tokens, _output_tokens as output_tokens, _cache_read as cache_read_input_tokens, _cache_creation as cache_creation_input_tokens, _input_tokens + _output_tokens as total_tokens, _skills as skills, _slash_commands as slash_commands, _subagent_types as subagent_types, toUInt32(length(_timestamps)) as total_interactions, toUInt32(_duration_min) as actual_duration_min, if(length(_prompt_periods_sec) > 0, round(arrayAvg(_prompt_periods_sec), 2), 0) as avg_period_sec, if( length(_prompt_periods_sec) > 0, toFloat64(arrayElement( arraySort(_prompt_periods_sec), toUInt64(ceil(length(_prompt_periods_sec) / 2)) )), 0 ) as median_period_sec, toUInt32(arrayCount(x -> x < 5, _prompt_periods_sec)) as quick_responses, toUInt32(arrayCount(x -> x >= 5 AND x <= 60, _prompt_periods_sec)) as normal_responses, toUInt32(arrayCount(x -> x > 300, _prompt_periods_sec)) as long_pauses, toUInt32( length(extractAll(cs.content, '"isApiErrorMessage":true')) + length(extractAll(cs.content, '"is_error":true')) ) as error_count, JSONExtractString( JSONExtractRaw( arrayElement( arrayFilter( x -> JSONExtractString(x, 'type') = 'assistant', splitByChar('\n', cs.content) ), -1 ), 'message' ), 'model' ) as model_used, toUInt8(if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 1, 0)) as has_commit, toUInt8(if(position(cs.content, '"name":"EnterPlanMode"') > 0, 1, 0)) as used_plan_mode, toUInt32(arraySum(_inference_gaps)) as inference_duration_sec, toUInt32(arraySum(_human_gaps)) as human_duration_sec, CASE WHEN _duration_min <= 10 AND (_input_tokens + _output_tokens) < 500000 AND _output_tokens > 1000 THEN 'quick_win' WHEN _duration_min > 30 AND _output_tokens > 50000 AND cs.git_sha IS NOT NULL AND cs.git_sha != '' THEN 'deep_work' WHEN (_input_tokens + _output_tokens) > 1000000 AND (_output_tokens / nullif(_input_tokens, 0)) < 0.3 AND _duration_min > 20 THEN 'struggle' WHEN length(_skills) >= 3 AND (cs.git_sha IS NULL OR cs.git_sha = '') AND (_input_tokens + _output_tokens) > 200000 THEN 'exploration' WHEN _duration_min < 3 AND _output_tokens < 500 THEN 'abandoned' ELSE 'standard' END as session_archetype, toUInt8(round( 50 + (if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 20, 0)) + (if((_output_tokens / nullif(_input_tokens, 0)) > 0.5, 15, 0)) + (least(toUInt32(length(_skills)), 3) * 5) - (if((_input_tokens + _output_tokens) > 1500000 AND (cs.git_sha IS NULL OR cs.git_sha = ''), 20, 0)) - (if(_duration_min < 2 AND _output_tokens < 200, 30, 0)) - (least(toUInt32( length(extractAll(cs.content, '"isApiErrorMessage":true')) + length(extractAll(cs.content, '"is_error":true')) ), 10) * 2) )) as success_score FROM rudel.claude_sessions AS cs WHERE length(_timestamps) > 0 QUALIFY ROW_NUMBER() OVER (PARTITION BY cs.session_id ORDER BY cs.ingested_at DESC) = 1;

--- a/packages/ch-schema/chx/migrations/20260423161000_auto.sql
+++ b/packages/ch-schema/chx/migrations/20260423161000_auto.sql
@@ -1,0 +1,226 @@
+-- chkit-migration-format: v1
+-- generated-at: 2026-04-23T16:10:00.000Z
+-- cli-version: manual
+-- definition-count: 0
+-- operation-count: 1
+-- rename-suggestion-count: 0
+-- risk-summary: safe=0, caution=1, danger=0
+
+-- operation: insert key=table:rudel.session_analytics risk=caution
+-- Backfill historical Codex rows with canonical token semantics.
+-- session_analytics is a ReplacingMergeTree(ingested_at), so reinserting the
+-- latest Codex projection with a fresh ingested_at makes FINAL prefer the
+-- corrected row without deleting the legacy record.
+INSERT INTO rudel.session_analytics (
+  session_date,
+  last_interaction_date,
+  session_id,
+  organization_id,
+  project_path,
+  git_remote,
+  package_name,
+  package_type,
+  content,
+  subagents,
+  skills,
+  slash_commands,
+  subagent_types,
+  ingested_at,
+  user_id,
+  git_branch,
+  git_sha,
+  input_tokens,
+  output_tokens,
+  cache_read_input_tokens,
+  cache_creation_input_tokens,
+  total_tokens,
+  tag,
+  source,
+  total_interactions,
+  actual_duration_min,
+  avg_period_sec,
+  median_period_sec,
+  quick_responses,
+  normal_responses,
+  long_pauses,
+  error_count,
+  model_used,
+  has_commit,
+  session_archetype,
+  success_score,
+  used_plan_mode,
+  inference_duration_sec,
+  human_duration_sec
+)
+WITH
+  arrayFilter(
+    x -> x != '',
+    splitByChar('\n', cs.content)
+  ) AS _all_lines,
+
+  arrayFilter(x -> JSONHas(x, 'timestamp'), _all_lines) AS _ts_lines,
+
+  arrayMap(
+    x -> parseDateTime64BestEffort(JSONExtractString(x, 'timestamp')),
+    _ts_lines
+  ) AS _timestamps,
+
+  if(length(_timestamps) > 1,
+    arrayMap(i -> dateDiff('second', _timestamps[i], _timestamps[i+1]), range(1, length(_timestamps))),
+    []
+  ) AS _prompt_periods_sec,
+
+  if(length(_timestamps) > 1,
+    arrayMap(i -> if(i < length(_timestamps),
+      dateDiff('second', _timestamps[i], _timestamps[i+1]), 0), range(1, length(_timestamps))),
+    []
+  ) AS _inference_gaps,
+
+  arrayFilter(
+    x -> JSONExtractString(x, 'type') = 'response_item' OR JSONExtractString(x, 'type') = 'event_msg',
+    _all_lines
+  ) AS _interaction_lines,
+
+  arrayFilter(
+    x -> JSONExtractString(x, 'type') = 'response_item'
+      AND JSONExtractString(JSONExtractRaw(x, 'payload'), 'type') = 'function_call_output',
+    _all_lines
+  ) AS _tool_output_lines,
+
+  arrayFilter(
+    x -> JSONExtractString(x, 'type') = 'event_msg'
+      AND JSONExtractString(JSONExtractRaw(x, 'payload'), 'type') = 'token_count'
+      AND JSONExtractRaw(JSONExtractRaw(x, 'payload'), 'info') IS NOT NULL
+      AND JSONExtractRaw(JSONExtractRaw(x, 'payload'), 'info') != 'null',
+    _all_lines
+  ) AS _token_count_lines,
+
+  if(length(_token_count_lines) > 0,
+    JSONExtractRaw(JSONExtractRaw(JSONExtractRaw(arrayElement(_token_count_lines, -1), 'payload'), 'info'), 'total_token_usage'),
+    '{}'
+  ) AS _final_usage,
+
+  toUInt64OrZero(JSONExtractRaw(_final_usage, 'input_tokens')) AS _input_tokens,
+  toUInt64OrZero(JSONExtractRaw(_final_usage, 'output_tokens')) AS _output_tokens,
+  toUInt64OrZero(JSONExtractRaw(_final_usage, 'cached_input_tokens')) AS _cache_read_input_tokens,
+
+  arrayMin(_timestamps) AS _session_date,
+  arrayMax(_timestamps) AS _last_interaction_date,
+  dateDiff('minute', _session_date, _last_interaction_date) AS _duration_min,
+
+  arrayFilter(x -> JSONExtractString(x, 'type') = 'session_meta', _all_lines) AS _meta_lines,
+
+  JSONExtractString(
+    JSONExtractRaw(arrayElement(_meta_lines, 1), 'payload'),
+    'model_provider'
+  ) AS _model_provider,
+
+  arrayFilter(
+    x -> JSONExtractString(x, 'type') = 'turn_context',
+    _all_lines
+  ) AS _turn_context_lines,
+
+  if(length(_turn_context_lines) > 0,
+    JSONExtractString(JSONExtractRaw(arrayElement(_turn_context_lines, 1), 'payload'), 'model'),
+    ''
+  ) AS _model_from_turn_context,
+
+  arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '"name":"exec_command"[^}]*skills/([a-zA-Z0-9_-]+)/SKILL'))) AS _skills
+
+SELECT
+  _session_date as session_date,
+  _last_interaction_date as last_interaction_date,
+  cs.session_id,
+  cs.organization_id,
+  cs.project_path,
+  cs.git_remote,
+  cs.package_name,
+  cs.package_type,
+  cs.content,
+  map() as subagents,
+  _skills as skills,
+  [] :: Array(String) as slash_commands,
+  [] :: Array(String) as subagent_types,
+  now64(3) as ingested_at,
+  cs.user_id,
+  cs.git_branch,
+  cs.git_sha,
+  _input_tokens as input_tokens,
+  _output_tokens as output_tokens,
+  _cache_read_input_tokens as cache_read_input_tokens,
+  toUInt64(0) as cache_creation_input_tokens,
+  _input_tokens + _output_tokens as total_tokens,
+  cs.tag,
+  'codex' as source,
+  toUInt32(length(_interaction_lines)) as total_interactions,
+  toUInt32(_duration_min) as actual_duration_min,
+  if(length(_prompt_periods_sec) > 0, round(arrayAvg(_prompt_periods_sec), 2), 0) as avg_period_sec,
+  if(
+    length(_prompt_periods_sec) > 0,
+    toFloat64(arrayElement(
+      arraySort(_prompt_periods_sec),
+      toUInt64(ceil(length(_prompt_periods_sec) / 2))
+    )),
+    0
+  ) as median_period_sec,
+  toUInt32(arrayCount(x -> x < 5, _prompt_periods_sec)) as quick_responses,
+  toUInt32(arrayCount(x -> x >= 5 AND x <= 60, _prompt_periods_sec)) as normal_responses,
+  toUInt32(arrayCount(x -> x > 300, _prompt_periods_sec)) as long_pauses,
+  toUInt32(
+    length(extractAll(cs.content, '\\\\\\\\"exit_code\\\\\\\\":[1-9][0-9]*'))
+    + arrayCount(
+        x -> x ILIKE '%Error:%' OR x ILIKE '%Exception:%',
+        _tool_output_lines
+      )
+  ) as error_count,
+  multiIf(
+    _model_from_turn_context != '', _model_from_turn_context,
+    _model_provider != '', _model_provider,
+    'unknown'
+  ) as model_used,
+  toUInt8(if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 1, 0)) as has_commit,
+  CASE
+    WHEN _duration_min <= 10
+        AND (_input_tokens + _output_tokens) < 500000
+        AND _output_tokens > 1000
+    THEN 'quick_win'
+    WHEN _duration_min > 30
+        AND _output_tokens > 50000
+        AND cs.git_sha IS NOT NULL AND cs.git_sha != ''
+    THEN 'deep_work'
+    WHEN (_input_tokens + _output_tokens) > 1000000
+        AND (_output_tokens / nullif(_input_tokens, 0)) < 0.3
+        AND _duration_min > 20
+    THEN 'struggle'
+    WHEN length(_skills) >= 3
+        AND (cs.git_sha IS NULL OR cs.git_sha = '')
+        AND (_input_tokens + _output_tokens) > 200000
+    THEN 'exploration'
+    WHEN _duration_min < 3
+        AND _output_tokens < 500
+    THEN 'abandoned'
+    ELSE 'standard'
+  END as session_archetype,
+  toUInt8(round(
+    50
+    + (if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 20, 0))
+    + (if((_output_tokens / nullif(_input_tokens, 0)) > 0.5, 15, 0))
+    + (least(toUInt32(length(_skills)), 3) * 5)
+    - (if((_input_tokens + _output_tokens) > 1500000 AND (cs.git_sha IS NULL OR cs.git_sha = ''), 20, 0))
+    - (if(_duration_min < 2 AND _output_tokens < 200, 30, 0))
+    - (least(toUInt32(
+        length(extractAll(cs.content, '\\\\\\\\"exit_code\\\\\\\\":[1-9][0-9]*'))
+        + arrayCount(
+            x -> JSONExtractString(JSONExtractRaw(x, 'payload'), 'output') ILIKE '%Error:%'
+              OR JSONExtractString(JSONExtractRaw(x, 'payload'), 'output') ILIKE '%Exception:%',
+            _tool_output_lines
+          )
+      ), 10) * 2)
+  )) as success_score,
+  toUInt8(0) as used_plan_mode,
+  toUInt32(arraySum(_inference_gaps)) as inference_duration_sec,
+  toUInt32(0) as human_duration_sec
+
+FROM rudel.codex_sessions AS cs
+WHERE length(_timestamps) > 0
+QUALIFY ROW_NUMBER() OVER (PARTITION BY cs.session_id ORDER BY cs.ingested_at DESC) = 1;

--- a/packages/ch-schema/chx/migrations/20260423161000_auto.sql
+++ b/packages/ch-schema/chx/migrations/20260423161000_auto.sql
@@ -100,6 +100,8 @@ WITH
     '{}'
   ) AS _final_usage,
 
+  -- Keep the provider totals intact here: cached input is already nested inside
+  -- Codex/OpenAI input_tokens, and total_tokens remains input + output.
   toUInt64OrZero(JSONExtractRaw(_final_usage, 'input_tokens')) AS _input_tokens,
   toUInt64OrZero(JSONExtractRaw(_final_usage, 'output_tokens')) AS _output_tokens,
   toUInt64OrZero(JSONExtractRaw(_final_usage, 'cached_input_tokens')) AS _cache_read_input_tokens,

--- a/packages/ch-schema/src/db/schema/session-analytics.ts
+++ b/packages/ch-schema/src/db/schema/session-analytics.ts
@@ -40,6 +40,39 @@ const rudel_session_analytics = table({
 		{ name: "cache_read_input_tokens", type: "UInt64", default: "fn:0" },
 		{ name: "cache_creation_input_tokens", type: "UInt64", default: "fn:0" },
 		{ name: "total_tokens", type: "UInt64", default: "fn:0" },
+		// Claude V2 stores parent and subagent token totals separately so the
+		// session-wide aggregates remain explainable after we fold them together.
+		{ name: "parent_input_tokens", type: "UInt64", default: "fn:0" },
+		{ name: "parent_output_tokens", type: "UInt64", default: "fn:0" },
+		{
+			name: "parent_cache_read_input_tokens",
+			type: "UInt64",
+			default: "fn:0",
+		},
+		{
+			name: "parent_cache_creation_input_tokens",
+			type: "UInt64",
+			default: "fn:0",
+		},
+		{ name: "parent_total_tokens", type: "UInt64", default: "fn:0" },
+		{ name: "subagent_input_tokens", type: "UInt64", default: "fn:0" },
+		{ name: "subagent_output_tokens", type: "UInt64", default: "fn:0" },
+		{
+			name: "subagent_cache_read_input_tokens",
+			type: "UInt64",
+			default: "fn:0",
+		},
+		{
+			name: "subagent_cache_creation_input_tokens",
+			type: "UInt64",
+			default: "fn:0",
+		},
+		{ name: "subagent_total_tokens", type: "UInt64", default: "fn:0" },
+		{
+			name: "token_accounting_version",
+			type: "UInt8",
+			default: "fn:1",
+		},
 		{ name: "tag", type: "String", nullable: true },
 		{
 			name: "source",
@@ -113,6 +146,9 @@ const rudel_session_analytics_mv = materializedView({
 	database: "rudel",
 	name: "session_analytics_mv",
 	to: { database: "rudel", name: "session_analytics" },
+	// The Claude MV still provides a bootstrap analytics row, but the API
+	// reinserts a corrected replacement row because Anthropic's final-per-
+	// message semantics and subagent folding are easier to audit in TS.
 	as: `
   WITH
     arrayFilter(

--- a/packages/ch-schema/src/generated/chkit-types.ts
+++ b/packages/ch-schema/src/generated/chkit-types.ts
@@ -102,6 +102,17 @@ export type RudelSessionAnalyticsRow = {
   cache_read_input_tokens: string
   cache_creation_input_tokens: string
   total_tokens: string
+  parent_input_tokens: string
+  parent_output_tokens: string
+  parent_cache_read_input_tokens: string
+  parent_cache_creation_input_tokens: string
+  parent_total_tokens: string
+  subagent_input_tokens: string
+  subagent_output_tokens: string
+  subagent_cache_read_input_tokens: string
+  subagent_cache_creation_input_tokens: string
+  subagent_total_tokens: string
+  token_accounting_version: number
   tag: string | null
   source: string
   total_interactions: number
@@ -144,6 +155,17 @@ export const RudelSessionAnalyticsRowSchema = z.object({
   cache_read_input_tokens: z.string(),
   cache_creation_input_tokens: z.string(),
   total_tokens: z.string(),
+  parent_input_tokens: z.string(),
+  parent_output_tokens: z.string(),
+  parent_cache_read_input_tokens: z.string(),
+  parent_cache_creation_input_tokens: z.string(),
+  parent_total_tokens: z.string(),
+  subagent_input_tokens: z.string(),
+  subagent_output_tokens: z.string(),
+  subagent_cache_read_input_tokens: z.string(),
+  subagent_cache_creation_input_tokens: z.string(),
+  subagent_total_tokens: z.string(),
+  token_accounting_version: z.number(),
   tag: z.string().nullable(),
   source: z.string(),
   total_interactions: z.number(),


### PR DESCRIPTION
## Problem
- Codex/OpenAI token accounting was inconsistent across pricing, stored analytics rows, and the internal conversation view.
- Cached input was being charged twice in the shared estimated-cost path.
- Historical Codex rows in `rudel.session_analytics` do not all use the same meaning for `input_tokens`, so aggregate charts can drift even when the raw session file is correct.
- The internal Codex conversation view was not consistently using the Codex `token_count` parser, so UI token charts could disagree with provider snapshots.

## Root Cause
- For Codex/OpenAI, `input_tokens` is the total provider-reported input processed by the model.
- `cached_input_tokens` is already a subset of `input_tokens`; it is not an additive bucket that should be charged on top of full-rate input.
- Earlier Codex analytics rows were written with `input_tokens = raw_input - cached_input`, while newer rows store raw provider input.
- Some API aggregations still used local hard-coded token-price math instead of the shared model-aware pricing helper.

## What Changed
- `packages/api-routes/src/model-pricing.ts`
  - introduced a single base-rate input calculation: `max(input_tokens - cache_read_input_tokens - cache_creation_input_tokens, 0)`
  - reused the same semantics in both the TypeScript estimator and the SQL builder so all callers price sessions the same way
- `apps/api/src/services/project.service.ts`
  - replaced project investment/detail cost math with the shared pricing SQL helper
- `apps/api/src/services/roi.service.ts`
  - replaced ROI cost aggregation with the same per-session model-aware pricing helper
- `apps/web/src/lib/codex-conversation-parser.ts`
  - stopped subtracting cached input from cumulative Codex input snapshots
- `apps/web/src/features/conversation-internal/lib/conversation-analysis.ts`
  - routed Codex token extraction through the Codex parser instead of relying on Claude-style assistant usage entries
- `apps/web/src/features/conversation-internal/lib/conversation-schema.ts`
  - taught the internal parser to recognize Codex transcript format before building artifacts
- `packages/ch-schema/chx/migrations/20260423161000_auto.sql`
  - reinserts canonical Codex rows into `rudel.session_analytics` with a fresh `ingested_at` so `FINAL` prefers the corrected version
- `docs/codex-token-accounting.md`
  - documents the canonical token semantics, the failure mode, and the validation query used during investigation

## Reviewer Guide
- Start with `packages/api-routes/src/model-pricing.ts`; that file defines the accounting invariant the rest of the patch follows.
- Then inspect `apps/api/src/services/project.service.ts` and `apps/api/src/services/roi.service.ts` to confirm all aggregate API surfaces now reuse that invariant.
- Then inspect the Codex conversation parsing changes in `apps/web/src/lib/codex-conversation-parser.ts`, `apps/web/src/features/conversation-internal/lib/conversation-analysis.ts`, and `apps/web/src/features/conversation-internal/lib/conversation-schema.ts`.
- Finish with the ClickHouse backfill migration and `docs/codex-token-accounting.md` for the storage repair and operational context.

## Verification
- `bun run --cwd packages/api-routes check-types`
- `bun run --cwd packages/api-routes test`
- `bun run --cwd apps/web check-types`
- `bun run --cwd apps/web build`
- `bun -e "...extractCodexTokenData..."` against `packages/ch-schema/src/__tests__/fixtures/codex-session.jsonl`
- `bun -e "...buildConversationArtifacts..."` against the same fixture
- `bun run verify`
  - still fails in `@rudel/api#check-types` because of a pre-existing Drizzle type-resolution issue unrelated to this patch

## Known Unrelated Blockers
- The existing analytics integration harness in `apps/api` is not currently reliable for this fix:
  - the package script passes an incorrect Bun filter
  - direct invocation currently fails because the local test server does not boot and auth setup hits `ConnectionRefused`
