### PR TITLE
fix: implement claude token accounting v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ For self-hosting your own instance, see [docs/self-hosting.md](docs/self-hosting
 
 For the Codex token and cost accounting rules used by Rudel, see [docs/codex-token-accounting.md](docs/codex-token-accounting.md).
 
+For the Claude token accounting rewrite based on Anthropic's prompt-caching and streaming semantics, see [docs/claude-token-accounting-v2.md](docs/claude-token-accounting-v2.md).
+
 ## Security
 
 To report a vulnerability, see [SECURITY.md](SECURITY.md). Do not open public issues for security concerns.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,8 @@
 		"test": "bun test",
 		"test:integration": "bun test src/__tests__/ingest-clickhouse.integration.ts",
 		"test:analytics": "bun test src/__tests__/analytics.integration.ts",
-		"test:migrate": "bun test src/__tests__/migrate-sessions.integration.ts"
+		"test:migrate": "bun test src/__tests__/migrate-sessions.integration.ts",
+		"backfill:claude-token-accounting": "bun src/scripts/backfill-claude-token-accounting-v2.ts"
 	},
 	"dependencies": {
 		"@better-auth/api-key": "^1.5.4",

--- a/apps/api/src/__tests__/claude-session-analytics.service.test.ts
+++ b/apps/api/src/__tests__/claude-session-analytics.service.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { buildClaudeSessionAnalyticsRow } from "../services/claude-session-analytics.service.js";
+
+describe("buildClaudeSessionAnalyticsRow", () => {
+	test("writes corrected Claude token totals and keeps timing metrics parent-scoped", () => {
+		const row = buildClaudeSessionAnalyticsRow({
+			session_id: "session-1",
+			organization_id: "org-1",
+			project_path: "/tmp/project",
+			git_remote: "git@github.com:obsessiondb/rudel.git",
+			package_name: "rudel",
+			package_type: "app",
+			content: [
+				'{"type":"user","timestamp":"2026-04-23T10:00:00Z","message":{"role":"user","content":"start"}}',
+				'{"type":"assistant","timestamp":"2026-04-23T10:00:05Z","message":{"id":"msg-parent-1","model":"claude-sonnet-4-20250514","usage":{"input_tokens":10,"cache_read_input_tokens":100,"output_tokens":3},"stop_reason":null}}',
+				'{"type":"assistant","timestamp":"2026-04-23T10:00:06Z","message":{"id":"msg-parent-1","model":"claude-sonnet-4-20250514","usage":{"input_tokens":10,"cache_read_input_tokens":100,"output_tokens":8},"stop_reason":"end_turn"}}',
+				'{"type":"user","timestamp":"2026-04-23T10:00:10Z","message":{"role":"user","content":"continue"}}',
+				'{"type":"assistant","timestamp":"2026-04-23T10:00:20Z","message":{"id":"msg-parent-2","model":"claude-sonnet-4-20250514","usage":{"input_tokens":5,"cache_creation_input_tokens":20,"output_tokens":4},"stop_reason":"end_turn"}}',
+			].join("\n"),
+			subagents: {
+				agent_1: [
+					'{"type":"assistant","timestamp":"2026-04-23T10:00:07Z","message":{"id":"msg-subagent","usage":{"input_tokens":2,"cache_read_input_tokens":4,"output_tokens":1},"stop_reason":"end_turn"}}',
+				].join("\n"),
+			},
+			user_id: "user-1",
+			git_branch: "evrendom/claude-token-v2",
+			git_sha: "abc123",
+			tag: "research",
+		});
+
+		expect(row.input_tokens).toBe("141");
+		expect(row.output_tokens).toBe("13");
+		expect(row.total_tokens).toBe("154");
+		expect(row.parent_total_tokens).toBe("147");
+		expect(row.subagent_total_tokens).toBe("7");
+		expect(row.token_accounting_version).toBe(2);
+		expect(row.total_interactions).toBe(5);
+		expect(row.inference_duration_sec).toBe(15);
+		expect(row.human_duration_sec).toBe(4);
+		expect(row.model_used).toBe("claude-sonnet-4-20250514");
+	});
+});

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -17,6 +17,7 @@ import {
 } from "./lib/product-analytics.js";
 import { authMiddleware, ingestAuthMiddleware, os } from "./middleware.js";
 import { checkIngestRateLimit } from "./rate-limit.js";
+import { rewriteClaudeSessionAnalyticsAfterIngest } from "./services/claude-session-analytics.service.js";
 import {
 	deleteOrgSessions,
 	getOrgSessionCount,
@@ -147,6 +148,17 @@ const ingestSessionHandler = os.ingestSession
 			userId: context.user.id,
 			organizationId: orgId,
 		});
+		if (input.source === "claude_code") {
+			// The raw Claude row is immutable source material. We immediately
+			// append a corrected analytics row so FINAL reads pick the docs-based
+			// Anthropic accounting instead of the MV bootstrap calculation.
+			await rewriteClaudeSessionAnalyticsAfterIngest(
+				input,
+				orgId,
+				context.user.id,
+				{ clickhouse: getClickhouse() },
+			);
+		}
 
 		const response = {
 			success: true as const,

--- a/apps/api/src/scripts/backfill-claude-token-accounting-v2.ts
+++ b/apps/api/src/scripts/backfill-claude-token-accounting-v2.ts
@@ -1,0 +1,147 @@
+import { ingestRudelSessionAnalytics } from "@rudel/ch-schema/generated";
+import { getClickhouse } from "../clickhouse.js";
+import {
+	buildClaudeSessionAnalyticsRow,
+	type ClaudeAnalyticsSource,
+} from "../services/claude-session-analytics.service.js";
+
+const DEFAULT_BATCH_SIZE = 100;
+
+type BackfillArgs = {
+	batchSize: number;
+	offset: number;
+	maxSessions: number | null;
+};
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const clickhouse = getClickhouse();
+	let processedSessions = 0;
+	let currentOffset = args.offset;
+
+	for (;;) {
+		const sources = await loadLatestClaudeSources(
+			args.batchSize,
+			currentOffset,
+		);
+		if (sources.length === 0) {
+			console.info(
+				`Claude token accounting backfill complete. Processed ${processedSessions} sessions.`,
+			);
+			return;
+		}
+
+		const remainingSessions =
+			args.maxSessions === null
+				? sources.length
+				: Math.max(args.maxSessions - processedSessions, 0);
+		const activeBatch = sources.slice(0, remainingSessions);
+		if (activeBatch.length === 0) {
+			console.info(
+				`Claude token accounting backfill reached maxSessions=${args.maxSessions}.`,
+			);
+			return;
+		}
+
+		const rows = activeBatch.map((source) =>
+			buildClaudeSessionAnalyticsRow(source),
+		);
+		await ingestRudelSessionAnalytics(clickhouse, rows, { validate: true });
+
+		processedSessions += rows.length;
+		currentOffset += sources.length;
+		console.info(
+			`Inserted ${rows.length} corrected Claude analytics rows (total ${processedSessions}).`,
+		);
+	}
+}
+
+async function loadLatestClaudeSources(
+	limit: number,
+	offset: number,
+): Promise<ClaudeAnalyticsSource[]> {
+	const clickhouse = getClickhouse();
+	return clickhouse.query<ClaudeAnalyticsSource>({
+		query: `
+      -- Rebuild from the latest raw transcript per session so the backfill
+      -- matches the same immutable source material as new ingest correction.
+      SELECT
+        session_id,
+        organization_id,
+        project_path,
+        git_remote,
+        package_name,
+        package_type,
+        content,
+        subagents,
+        user_id,
+        git_branch,
+        git_sha,
+        tag,
+        formatDateTime(session_date, '%Y-%m-%dT%H:%i:%S.%fZ') AS session_date,
+        formatDateTime(last_interaction_date, '%Y-%m-%dT%H:%i:%S.%fZ') AS last_interaction_date,
+        formatDateTime(ingested_at, '%Y-%m-%dT%H:%i:%S.%fZ') AS ingested_at
+      FROM rudel.claude_sessions
+      QUALIFY ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY ingested_at DESC) = 1
+      ORDER BY session_id
+      LIMIT {limit:UInt32}
+      OFFSET {offset:UInt32}
+    `,
+		query_params: {
+			limit,
+			offset,
+		},
+	});
+}
+
+function parseArgs(argv: string[]): BackfillArgs {
+	let batchSize = DEFAULT_BATCH_SIZE;
+	let offset = 0;
+	let maxSessions: number | null = null;
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		const nextArg = argv[index + 1];
+		if (arg === "--batch-size" && nextArg) {
+			batchSize = parsePositiveInt(nextArg, "--batch-size");
+			index += 1;
+			continue;
+		}
+
+		if (arg === "--offset" && nextArg) {
+			offset = parseNonNegativeInt(nextArg, "--offset");
+			index += 1;
+			continue;
+		}
+
+		if (arg === "--max-sessions" && nextArg) {
+			maxSessions = parsePositiveInt(nextArg, "--max-sessions");
+			index += 1;
+		}
+	}
+
+	return { batchSize, offset, maxSessions };
+}
+
+function parsePositiveInt(value: string, flag: string): number {
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		throw new Error(`${flag} must be a positive integer. Received: ${value}`);
+	}
+	return parsed;
+}
+
+function parseNonNegativeInt(value: string, flag: string): number {
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		throw new Error(
+			`${flag} must be a non-negative integer. Received: ${value}`,
+		);
+	}
+	return parsed;
+}
+
+void main().catch((error: unknown) => {
+	console.error("[backfill-claude-token-accounting-v2] failed", error);
+	process.exit(1);
+});

--- a/apps/api/src/services/claude-session-analytics.service.ts
+++ b/apps/api/src/services/claude-session-analytics.service.ts
@@ -1,0 +1,488 @@
+import { toClickHouseDateTime } from "@rudel/agent-adapters";
+import {
+	buildClaudeSessionTokenBreakdown,
+	type IngestSessionInput,
+} from "@rudel/api-routes";
+import {
+	ingestRudelSessionAnalytics,
+	type RudelSessionAnalyticsRow,
+} from "@rudel/ch-schema/generated";
+import type { ClickHouseExecutor } from "../clickhouse.js";
+
+const CLAUDE_TOKEN_ACCOUNTING_VERSION = 2;
+
+const ClaudeTimedInteractionLineSchema = {
+	isTimedInteractionLine(value: unknown): value is {
+		type: "user" | "assistant";
+		timestamp: string;
+		message?: { model?: string };
+	} {
+		if (!isRecord(value)) {
+			return false;
+		}
+
+		if (value.type !== "user" && value.type !== "assistant") {
+			return false;
+		}
+
+		return typeof value.timestamp === "string";
+	},
+};
+
+export interface ClaudeAnalyticsSource {
+	session_id: string;
+	organization_id: string;
+	project_path: string;
+	git_remote: string;
+	package_name: string;
+	package_type: string;
+	content: string;
+	subagents: Record<string, string>;
+	user_id: string;
+	git_branch: string | null;
+	git_sha: string | null;
+	tag: string | null;
+	session_date?: string;
+	last_interaction_date?: string;
+	ingested_at?: string;
+}
+
+export async function rewriteClaudeSessionAnalyticsAfterIngest(
+	input: IngestSessionInput,
+	organizationId: string,
+	userId: string,
+	env: { clickhouse: ClickHouseExecutor },
+): Promise<void> {
+	const source = toClaudeAnalyticsSource(input, organizationId, userId);
+	const row = buildClaudeSessionAnalyticsRow(source);
+
+	await ingestRudelSessionAnalytics(env.clickhouse, [row], {
+		validate: true,
+	});
+}
+
+export function buildClaudeSessionAnalyticsRow(
+	source: ClaudeAnalyticsSource,
+): RudelSessionAnalyticsRow {
+	const timedInteractions = parseTimedInteractions(source.content);
+	const interactionMetrics = buildInteractionMetrics(timedInteractions);
+	const tokenBreakdown = buildClaudeSessionTokenBreakdown(
+		source.content,
+		source.subagents,
+	);
+	const sessionBounds = resolveSessionBounds(
+		timedInteractions,
+		source.session_date,
+		source.last_interaction_date,
+	);
+	const modelUsed = findLastAssistantModel(source.content);
+	const skills = extractDistinctMatches(
+		source.content,
+		/"name":"Skill"[^}]*"skill":"([^"]+)"/g,
+	);
+	const subagentTypes = extractDistinctMatches(
+		source.content,
+		/"name":"Task"[^}]*"subagent_type":"([^"]+)"/g,
+	);
+	const slashCommands = extractDistinctMatches(
+		source.content,
+		/<command-name>\/([^<]+)<\/command-name>/g,
+	);
+	const totalTokens = tokenBreakdown.session.total_tokens;
+	const outputTokens = tokenBreakdown.session.output_tokens;
+	const inputTokens = tokenBreakdown.session.input_tokens;
+	const ingestedAt =
+		source.ingested_at ?? toClickHouseDateTime(new Date().toISOString());
+	const sessionArchetype = buildSessionArchetype({
+		durationMin: interactionMetrics.actualDurationMin,
+		inputTokens,
+		outputTokens,
+		totalTokens,
+		hasCommit: Boolean(source.git_sha),
+		skillsCount: skills.length,
+	});
+
+	return {
+		session_date: sessionBounds.sessionDate,
+		last_interaction_date: sessionBounds.lastInteractionDate,
+		session_id: source.session_id,
+		organization_id: source.organization_id,
+		project_path: source.project_path,
+		git_remote: source.git_remote,
+		package_name: source.package_name,
+		package_type: source.package_type,
+		content: source.content,
+		subagents: source.subagents,
+		skills,
+		slash_commands: slashCommands,
+		subagent_types: subagentTypes,
+		ingested_at: ingestedAt,
+		user_id: source.user_id,
+		git_branch: source.git_branch,
+		git_sha: source.git_sha,
+		input_tokens: toUInt64String(inputTokens),
+		output_tokens: toUInt64String(outputTokens),
+		cache_read_input_tokens: toUInt64String(
+			tokenBreakdown.session.cache_read_input_tokens,
+		),
+		cache_creation_input_tokens: toUInt64String(
+			tokenBreakdown.session.cache_creation_input_tokens,
+		),
+		total_tokens: toUInt64String(totalTokens),
+		parent_input_tokens: toUInt64String(tokenBreakdown.parent.input_tokens),
+		parent_output_tokens: toUInt64String(tokenBreakdown.parent.output_tokens),
+		parent_cache_read_input_tokens: toUInt64String(
+			tokenBreakdown.parent.cache_read_input_tokens,
+		),
+		parent_cache_creation_input_tokens: toUInt64String(
+			tokenBreakdown.parent.cache_creation_input_tokens,
+		),
+		parent_total_tokens: toUInt64String(tokenBreakdown.parent.total_tokens),
+		subagent_input_tokens: toUInt64String(tokenBreakdown.subagent.input_tokens),
+		subagent_output_tokens: toUInt64String(
+			tokenBreakdown.subagent.output_tokens,
+		),
+		subagent_cache_read_input_tokens: toUInt64String(
+			tokenBreakdown.subagent.cache_read_input_tokens,
+		),
+		subagent_cache_creation_input_tokens: toUInt64String(
+			tokenBreakdown.subagent.cache_creation_input_tokens,
+		),
+		subagent_total_tokens: toUInt64String(tokenBreakdown.subagent.total_tokens),
+		token_accounting_version: CLAUDE_TOKEN_ACCOUNTING_VERSION,
+		tag: source.tag,
+		source: "claude_code",
+		total_interactions: interactionMetrics.totalInteractions,
+		actual_duration_min: interactionMetrics.actualDurationMin,
+		avg_period_sec: interactionMetrics.avgPeriodSec,
+		median_period_sec: interactionMetrics.medianPeriodSec,
+		quick_responses: interactionMetrics.quickResponses,
+		normal_responses: interactionMetrics.normalResponses,
+		long_pauses: interactionMetrics.longPauses,
+		error_count: countErrorMarkers(source.content),
+		model_used: modelUsed,
+		has_commit: source.git_sha ? 1 : 0,
+		session_archetype: sessionArchetype,
+		// Timing metrics stay parent-only on purpose: subagents add token work to
+		// the session, but they are not extra human interaction time.
+		success_score: buildSuccessScore({
+			hasCommit: Boolean(source.git_sha),
+			inputTokens,
+			outputTokens,
+			totalTokens,
+			skillsCount: skills.length,
+			errorCount: countErrorMarkers(source.content),
+			durationMin: interactionMetrics.actualDurationMin,
+		}),
+		used_plan_mode: source.content.includes('"name":"EnterPlanMode"') ? 1 : 0,
+		inference_duration_sec: interactionMetrics.inferenceDurationSec,
+		human_duration_sec: interactionMetrics.humanDurationSec,
+	};
+}
+
+function toClaudeAnalyticsSource(
+	input: IngestSessionInput,
+	organizationId: string,
+	userId: string,
+): ClaudeAnalyticsSource {
+	return {
+		session_id: input.sessionId,
+		organization_id: organizationId,
+		project_path: input.projectPath,
+		git_remote: input.gitRemote ?? "",
+		package_name: input.packageName ?? "",
+		package_type: input.packageType ?? "",
+		content: input.content,
+		subagents: Object.fromEntries(
+			(input.subagents ?? []).map((subagent) => [
+				subagent.agentId,
+				subagent.content,
+			]),
+		),
+		user_id: userId,
+		git_branch: input.gitBranch ?? null,
+		git_sha: input.gitSha ?? null,
+		tag: input.tag ?? null,
+	};
+}
+
+function parseTimedInteractions(content: string): Array<{
+	type: "user" | "assistant";
+	timestamp: string;
+}> {
+	const interactions: Array<{ type: "user" | "assistant"; timestamp: string }> =
+		[];
+
+	for (const line of content.split("\n")) {
+		if (!line || line.trim() === "") {
+			continue;
+		}
+
+		try {
+			const parsed = JSON.parse(line) as unknown;
+			if (!ClaudeTimedInteractionLineSchema.isTimedInteractionLine(parsed)) {
+				continue;
+			}
+
+			interactions.push({
+				type: parsed.type,
+				timestamp: parsed.timestamp,
+			});
+		} catch {
+			// Skip malformed JSON lines while keeping the session ingestible.
+		}
+	}
+
+	return interactions;
+}
+
+function buildInteractionMetrics(
+	interactions: Array<{ type: "user" | "assistant"; timestamp: string }>,
+) {
+	const promptPeriodsSec: number[] = [];
+	const inferenceGaps: number[] = [];
+	const humanGaps: number[] = [];
+
+	for (let index = 0; index < interactions.length - 1; index += 1) {
+		const current = interactions[index];
+		const next = interactions[index + 1];
+		if (!current || !next) {
+			continue;
+		}
+
+		const gapSec = getDiffSeconds(current.timestamp, next.timestamp);
+		promptPeriodsSec.push(gapSec);
+
+		if (current.type === "user" && next.type === "assistant") {
+			inferenceGaps.push(gapSec);
+		}
+
+		if (current.type === "assistant" && next.type === "user") {
+			humanGaps.push(gapSec);
+		}
+	}
+
+	const sortedPromptPeriods = [...promptPeriodsSec].sort((left, right) => {
+		return left - right;
+	});
+
+	return {
+		totalInteractions: interactions.length,
+		actualDurationMin:
+			interactions.length > 1
+				? Math.max(
+						0,
+						Math.round(
+							getDiffSeconds(
+								interactions[0]?.timestamp ?? "",
+								interactions[interactions.length - 1]?.timestamp ?? "",
+							) / 60,
+						),
+					)
+				: 0,
+		avgPeriodSec: roundToTwoDecimals(getAverage(promptPeriodsSec)),
+		medianPeriodSec: getMedian(sortedPromptPeriods),
+		quickResponses: promptPeriodsSec.filter((period) => period < 5).length,
+		normalResponses: promptPeriodsSec.filter(
+			(period) => period >= 5 && period <= 60,
+		).length,
+		longPauses: promptPeriodsSec.filter((period) => period > 300).length,
+		inferenceDurationSec: sumNumbers(inferenceGaps),
+		humanDurationSec: sumNumbers(humanGaps),
+	};
+}
+
+function resolveSessionBounds(
+	interactions: Array<{ type: "user" | "assistant"; timestamp: string }>,
+	fallbackSessionDate?: string,
+	fallbackLastInteractionDate?: string,
+) {
+	const firstTimestamp = interactions[0]?.timestamp;
+	const lastTimestamp = interactions[interactions.length - 1]?.timestamp;
+
+	if (firstTimestamp && lastTimestamp) {
+		return {
+			sessionDate: toClickHouseDateTime(firstTimestamp),
+			lastInteractionDate: toClickHouseDateTime(lastTimestamp),
+		};
+	}
+
+	if (fallbackSessionDate && fallbackLastInteractionDate) {
+		return {
+			sessionDate: fallbackSessionDate,
+			lastInteractionDate: fallbackLastInteractionDate,
+		};
+	}
+
+	const now = toClickHouseDateTime(new Date().toISOString());
+	return {
+		sessionDate: now,
+		lastInteractionDate: now,
+	};
+}
+
+function findLastAssistantModel(content: string): string {
+	let modelUsed = "";
+
+	for (const line of content.split("\n")) {
+		if (!line || line.trim() === "") {
+			continue;
+		}
+
+		try {
+			const parsed = JSON.parse(line) as unknown;
+			if (!ClaudeTimedInteractionLineSchema.isTimedInteractionLine(parsed)) {
+				continue;
+			}
+
+			if (parsed.type !== "assistant") {
+				continue;
+			}
+
+			if (
+				parsed.message &&
+				isRecord(parsed.message) &&
+				typeof parsed.message.model === "string"
+			) {
+				modelUsed = parsed.message.model;
+			}
+		} catch {
+			// Skip malformed JSON lines while preserving the last good model value.
+		}
+	}
+
+	return modelUsed;
+}
+
+function extractDistinctMatches(content: string, regex: RegExp): string[] {
+	const values = new Set<string>();
+	for (const match of content.matchAll(regex)) {
+		const value = match[1];
+		if (typeof value === "string" && value !== "") {
+			values.add(value);
+		}
+	}
+	return Array.from(values);
+}
+
+function buildSessionArchetype(params: {
+	durationMin: number;
+	inputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+	hasCommit: boolean;
+	skillsCount: number;
+}): string {
+	const { durationMin, inputTokens, outputTokens, totalTokens, hasCommit } =
+		params;
+
+	if (durationMin <= 10 && totalTokens < 500_000 && outputTokens > 1_000) {
+		return "quick_win";
+	}
+
+	if (durationMin > 30 && outputTokens > 50_000 && hasCommit) {
+		return "deep_work";
+	}
+
+	if (
+		totalTokens > 1_000_000 &&
+		getRatio(outputTokens, inputTokens) < 0.3 &&
+		durationMin > 20
+	) {
+		return "struggle";
+	}
+
+	if (params.skillsCount >= 3 && !hasCommit && totalTokens > 200_000) {
+		return "exploration";
+	}
+
+	if (durationMin < 3 && outputTokens < 500) {
+		return "abandoned";
+	}
+
+	return "standard";
+}
+
+function buildSuccessScore(params: {
+	hasCommit: boolean;
+	inputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+	skillsCount: number;
+	errorCount: number;
+	durationMin: number;
+}): number {
+	const { hasCommit, inputTokens, outputTokens, totalTokens } = params;
+
+	const score =
+		50 +
+		(hasCommit ? 20 : 0) +
+		(getRatio(outputTokens, inputTokens) > 0.5 ? 15 : 0) +
+		Math.min(params.skillsCount, 3) * 5 -
+		(totalTokens > 1_500_000 && !hasCommit ? 20 : 0) -
+		(params.durationMin < 2 && outputTokens < 200 ? 30 : 0) -
+		Math.min(params.errorCount, 10) * 2;
+
+	return Math.max(0, Math.min(100, Math.round(score)));
+}
+
+function countErrorMarkers(content: string): number {
+	const apiErrors = content.match(/"isApiErrorMessage":true/g)?.length ?? 0;
+	const toolErrors = content.match(/"is_error":true/g)?.length ?? 0;
+	return apiErrors + toolErrors;
+}
+
+function getAverage(values: number[]): number {
+	if (values.length === 0) {
+		return 0;
+	}
+
+	return sumNumbers(values) / values.length;
+}
+
+function getMedian(sortedValues: number[]): number {
+	if (sortedValues.length === 0) {
+		return 0;
+	}
+
+	const middleIndex = Math.ceil(sortedValues.length / 2) - 1;
+	return sortedValues[middleIndex] ?? 0;
+}
+
+function getDiffSeconds(leftTimestamp: string, rightTimestamp: string): number {
+	const leftMs = Date.parse(leftTimestamp);
+	const rightMs = Date.parse(rightTimestamp);
+	if (Number.isNaN(leftMs) || Number.isNaN(rightMs)) {
+		return 0;
+	}
+
+	return Math.max(0, Math.round((rightMs - leftMs) / 1000));
+}
+
+function getRatio(numerator: number, denominator: number): number {
+	if (denominator <= 0) {
+		return 0;
+	}
+
+	return numerator / denominator;
+}
+
+function sumNumbers(values: number[]): number {
+	let total = 0;
+	for (const value of values) {
+		total += value;
+	}
+	return total;
+}
+
+function roundToTwoDecimals(value: number): number {
+	return Math.round(value * 100) / 100;
+}
+
+function toUInt64String(value: number): string {
+	return Math.max(0, Math.round(value)).toString();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/apps/api/src/services/session-analytics.service.ts
+++ b/apps/api/src/services/session-analytics.service.ts
@@ -1,8 +1,13 @@
-import type {
-	DimensionAnalysisInput,
-	SessionAnalytics,
-	SessionAnalyticsSummary as SessionAnalyticsSummaryBase,
-	SessionDetail,
+import {
+	buildClaudeSessionTokenBreakdown,
+	type ClaudeSessionTokenBreakdown,
+	type ClaudeTokenTimelinePoint,
+	type DimensionAnalysisInput,
+	deriveClaudeUncachedInputTokens,
+	type SessionAnalytics,
+	type SessionAnalyticsSummary as SessionAnalyticsSummaryBase,
+	type SessionDetail,
+	type Source,
 } from "@rudel/api-routes";
 import {
 	addOptionalStringEqFilter,
@@ -35,6 +40,9 @@ export interface SessionAnalyticsRaw {
 	total_tokens: number;
 	input_tokens: number;
 	output_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
+	token_accounting_version: number;
 
 	// Git activity
 	git_sha: string;
@@ -62,6 +70,43 @@ export interface SessionAnalyticsSummary extends SessionAnalyticsSummaryBase {
 	median_response_time_sec: number;
 	quick_response_rate: number;
 	long_pause_rate: number;
+}
+
+interface SessionDetailRaw {
+	session_id: string;
+	user_id: string;
+	session_date: string;
+	last_interaction_date: string;
+	project_path: string;
+	repository: string | null;
+	content: string;
+	subagents: Record<string, string>;
+	skills: string[];
+	slash_commands: string[];
+	git_branch: string | null;
+	git_sha: string | null;
+	total_tokens: number;
+	input_tokens: number;
+	output_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
+	parent_input_tokens: number;
+	parent_output_tokens: number;
+	parent_cache_read_input_tokens: number;
+	parent_cache_creation_input_tokens: number;
+	parent_total_tokens: number;
+	subagent_input_tokens: number;
+	subagent_output_tokens: number;
+	subagent_cache_read_input_tokens: number;
+	subagent_cache_creation_input_tokens: number;
+	subagent_total_tokens: number;
+	token_accounting_version: number;
+	success_score?: number;
+	duration_min?: number;
+	total_interactions?: number;
+	session_archetype?: string;
+	model_used?: string;
+	source?: Source;
 }
 
 /**
@@ -145,11 +190,14 @@ export async function getSessionAnalytics(
       long_pauses,
       actual_duration_min,
       formatDateTime(sa.last_interaction_date, '%Y-%m-%dT%H:%i:%SZ') as last_interaction_date,
-      total_tokens,
-      input_tokens,
-      output_tokens,
-      git_sha,
-      git_branch,
+	      total_tokens,
+	      input_tokens,
+	      output_tokens,
+	      cache_read_input_tokens,
+	      cache_creation_input_tokens,
+	      token_accounting_version,
+	      git_sha,
+	      git_branch,
       has_commit,
       subagent_types,
       skills,
@@ -186,6 +234,14 @@ export async function getSessionAnalytics(
 			total_tokens: row.total_tokens,
 			input_tokens: row.input_tokens,
 			output_tokens: row.output_tokens,
+			cache_read_input_tokens: row.cache_read_input_tokens,
+			cache_creation_input_tokens: row.cache_creation_input_tokens,
+			uncached_input_tokens: deriveClaudeUncachedInputTokens(
+				row.input_tokens,
+				row.cache_read_input_tokens,
+				row.cache_creation_input_tokens,
+			),
+			token_accounting_version: row.token_accounting_version,
 			success_score: row.success_score,
 			total_interactions: row.total_interactions,
 			avg_period_sec: row.avg_period_sec,
@@ -694,11 +750,25 @@ export async function getSessionDetail(
       total_tokens,
       input_tokens,
       output_tokens,
+      cache_read_input_tokens,
+      cache_creation_input_tokens,
+      parent_input_tokens,
+      parent_output_tokens,
+      parent_cache_read_input_tokens,
+      parent_cache_creation_input_tokens,
+      parent_total_tokens,
+      subagent_input_tokens,
+      subagent_output_tokens,
+      subagent_cache_read_input_tokens,
+      subagent_cache_creation_input_tokens,
+      subagent_total_tokens,
+      token_accounting_version,
       success_score,
       actual_duration_min as duration_min,
       total_interactions,
       session_archetype,
-      model_used
+      model_used,
+      source
     FROM rudel.session_analytics FINAL sa
     WHERE session_id = {sessionId:String}
       AND organization_id = {orgId:String}
@@ -706,7 +776,7 @@ export async function getSessionDetail(
     LIMIT 1
   `;
 
-	const results = await queryClickhouse<SessionDetail>({
+	const results = await queryClickhouse<SessionDetailRaw>({
 		query,
 		query_params: {
 			orgId,
@@ -718,10 +788,135 @@ export async function getSessionDetail(
 	if (!row) {
 		return null;
 	}
+
+	const claudeTokenBreakdown = buildClaudeDetailTokenBreakdown(row);
+	const tokenBreakdown = claudeTokenBreakdown ?? buildStoredTokenBreakdown(row);
+	const inputTokens = tokenBreakdown.session.input_tokens;
+	const outputTokens = tokenBreakdown.session.output_tokens;
+	const cacheReadInputTokens = tokenBreakdown.session.cache_read_input_tokens;
+	const cacheCreationInputTokens =
+		tokenBreakdown.session.cache_creation_input_tokens;
+	const uncachedInputTokens = tokenBreakdown.session.uncached_input_tokens;
+	const tokenTimeline =
+		claudeTokenBreakdown?.timeline ?? ([] as ClaudeTokenTimelinePoint[]);
+
 	return {
 		...row,
 		repository: row.repository || null,
 		git_branch: row.git_branch || null,
 		git_sha: row.git_sha || null,
+		total_tokens: tokenBreakdown.session.total_tokens,
+		input_tokens: inputTokens,
+		output_tokens: outputTokens,
+		cache_read_input_tokens: cacheReadInputTokens,
+		cache_creation_input_tokens: cacheCreationInputTokens,
+		uncached_input_tokens: uncachedInputTokens,
+		parent_input_tokens: tokenBreakdown.parent.input_tokens,
+		parent_output_tokens: tokenBreakdown.parent.output_tokens,
+		parent_cache_read_input_tokens:
+			tokenBreakdown.parent.cache_read_input_tokens,
+		parent_cache_creation_input_tokens:
+			tokenBreakdown.parent.cache_creation_input_tokens,
+		parent_uncached_input_tokens: tokenBreakdown.parent.uncached_input_tokens,
+		parent_total_tokens: tokenBreakdown.parent.total_tokens,
+		subagent_input_tokens: tokenBreakdown.subagent.input_tokens,
+		subagent_output_tokens: tokenBreakdown.subagent.output_tokens,
+		subagent_cache_read_input_tokens:
+			tokenBreakdown.subagent.cache_read_input_tokens,
+		subagent_cache_creation_input_tokens:
+			tokenBreakdown.subagent.cache_creation_input_tokens,
+		subagent_uncached_input_tokens:
+			tokenBreakdown.subagent.uncached_input_tokens,
+		subagent_total_tokens: tokenBreakdown.subagent.total_tokens,
+		token_accounting_version:
+			row.source === "claude_code" ? 2 : row.token_accounting_version,
+		token_breakdown: tokenBreakdown,
+		token_timeline: tokenTimeline,
 	};
+}
+
+function buildClaudeDetailTokenBreakdown(
+	row: SessionDetailRaw,
+): ClaudeSessionTokenBreakdown | null {
+	if (row.source !== "claude_code") {
+		return null;
+	}
+
+	// Session detail recalculates Claude directly from raw transcript content so
+	// the detail page is correct even before a historical backfill is run.
+	return buildClaudeSessionTokenBreakdown(row.content, row.subagents);
+}
+
+function buildStoredTokenBreakdown(
+	row: SessionDetailRaw,
+): ClaudeSessionTokenBreakdown {
+	const parentCacheReadInputTokens = toNumber(
+		row.parent_cache_read_input_tokens,
+	);
+	const parentCacheCreationInputTokens = toNumber(
+		row.parent_cache_creation_input_tokens,
+	);
+	const parentInputTokens = toNumber(row.parent_input_tokens);
+	const parentOutputTokens = toNumber(row.parent_output_tokens);
+	const subagentCacheReadInputTokens = toNumber(
+		row.subagent_cache_read_input_tokens,
+	);
+	const subagentCacheCreationInputTokens = toNumber(
+		row.subagent_cache_creation_input_tokens,
+	);
+	const subagentInputTokens = toNumber(row.subagent_input_tokens);
+	const subagentOutputTokens = toNumber(row.subagent_output_tokens);
+
+	return {
+		parent: {
+			input_tokens: parentInputTokens,
+			uncached_input_tokens: deriveClaudeUncachedInputTokens(
+				parentInputTokens,
+				parentCacheReadInputTokens,
+				parentCacheCreationInputTokens,
+			),
+			cache_read_input_tokens: parentCacheReadInputTokens,
+			cache_creation_input_tokens: parentCacheCreationInputTokens,
+			output_tokens: parentOutputTokens,
+			total_tokens: toNumber(row.parent_total_tokens),
+		},
+		subagent: {
+			input_tokens: subagentInputTokens,
+			uncached_input_tokens: deriveClaudeUncachedInputTokens(
+				subagentInputTokens,
+				subagentCacheReadInputTokens,
+				subagentCacheCreationInputTokens,
+			),
+			cache_read_input_tokens: subagentCacheReadInputTokens,
+			cache_creation_input_tokens: subagentCacheCreationInputTokens,
+			output_tokens: subagentOutputTokens,
+			total_tokens: toNumber(row.subagent_total_tokens),
+		},
+		session: {
+			input_tokens: toNumber(row.input_tokens),
+			uncached_input_tokens: deriveClaudeUncachedInputTokens(
+				toNumber(row.input_tokens),
+				toNumber(row.cache_read_input_tokens),
+				toNumber(row.cache_creation_input_tokens),
+			),
+			cache_read_input_tokens: toNumber(row.cache_read_input_tokens),
+			cache_creation_input_tokens: toNumber(row.cache_creation_input_tokens),
+			output_tokens: toNumber(row.output_tokens),
+			total_tokens: toNumber(row.total_tokens),
+		},
+		timeline: [],
+	};
+}
+
+function toNumber(value: number | string | undefined): number {
+	if (typeof value === "number") {
+		return value;
+	}
+
+	if (typeof value === "string") {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? parsed : 0;
+	}
+
+	return 0;
 }

--- a/apps/web/src/features/conversation-internal/lib/analysis-types.ts
+++ b/apps/web/src/features/conversation-internal/lib/analysis-types.ts
@@ -2,6 +2,13 @@ export interface TokenDataPoint {
 	messageIndex: number;
 	inputTokens: number;
 	outputTokens: number;
+	uncachedInputTokens?: number;
+	cacheReadInputTokens?: number;
+	cacheCreationInputTokens?: number;
+	totalTokens?: number;
+	source?: "parent" | "subagent";
+	sourceId?: string;
+	timestamp?: string;
 }
 
 export interface ToolActivityPoint {

--- a/apps/web/src/features/conversation-internal/lib/conversation-analysis.ts
+++ b/apps/web/src/features/conversation-internal/lib/conversation-analysis.ts
@@ -1,3 +1,4 @@
+import { buildClaudeTokenTimeline } from "@rudel/api-routes";
 import type {
 	TokenDataPoint,
 	ToolActivityPoint,
@@ -18,42 +19,6 @@ export interface ConversationArtifacts {
 	totalMessages: number;
 }
 
-function extractTokenData(content: string): TokenDataPoint[] {
-	const points: TokenDataPoint[] = [];
-	const lines = content.split("\n").filter((line) => line.trim() !== "");
-
-	for (let i = 0; i < lines.length; i += 1) {
-		const line = lines[i];
-		if (!line) continue;
-
-		try {
-			const parsed = JSON.parse(line) as {
-				type?: string;
-				message?: {
-					usage?: {
-						input_tokens?: number;
-						output_tokens?: number;
-					};
-				};
-			};
-
-			if (parsed.type !== "assistant") continue;
-			const usage = parsed.message?.usage;
-			if (!usage) continue;
-
-			points.push({
-				messageIndex: i,
-				inputTokens: usage.input_tokens ?? 0,
-				outputTokens: usage.output_tokens ?? 0,
-			});
-		} catch {
-			// Skip malformed JSON lines.
-		}
-	}
-
-	return points;
-}
-
 function getTokenData(content: string): TokenDataPoint[] {
 	// Internal conversation charts need provider-specific token extraction
 	// because Codex does not emit Claude-style assistant usage entries.
@@ -61,7 +26,20 @@ function getTokenData(content: string): TokenDataPoint[] {
 		return extractCodexTokenData(content);
 	}
 
-	return extractTokenData(content);
+	// Anthropic reports uncached input separately from cache reads and writes,
+	// so Claude charts must expand those fields to show the true processed input.
+	return buildClaudeTokenTimeline(content, {}).map((point, messageIndex) => ({
+		messageIndex,
+		inputTokens: point.input_tokens,
+		outputTokens: point.output_tokens,
+		uncachedInputTokens: point.uncached_input_tokens,
+		cacheReadInputTokens: point.cache_read_input_tokens,
+		cacheCreationInputTokens: point.cache_creation_input_tokens,
+		totalTokens: point.total_tokens,
+		source: point.source,
+		sourceId: point.source_id,
+		timestamp: point.timestamp,
+	}));
 }
 
 function extractToolActivity(entries: Conversation[]): ToolActivityPoint[] {

--- a/apps/web/src/features/sessions/components/SessionDetailView.tsx
+++ b/apps/web/src/features/sessions/components/SessionDetailView.tsx
@@ -105,8 +105,20 @@ export function SessionDetailView({
 		safeUserId === "unknown-user"
 			? "User"
 			: formatUsername(safeUserId, userMap);
+	const safeTotalTokens = toNumber(session.total_tokens);
 	const safeInputTokens = toNumber(session.input_tokens);
 	const safeOutputTokens = toNumber(session.output_tokens);
+	const safeCacheReadInputTokens = toNumber(session.cache_read_input_tokens);
+	const safeCacheCreationInputTokens = toNumber(
+		session.cache_creation_input_tokens,
+	);
+	const safeUncachedInputTokens = toNumber(session.uncached_input_tokens);
+	const safeParentTotalTokens = toNumber(session.parent_total_tokens);
+	const safeSubagentTotalTokens = toNumber(session.subagent_total_tokens);
+	const safeTokenAccountingVersion = toNumber(
+		session.token_accounting_version,
+		1,
+	);
 	const safeDurationMin =
 		session.duration_min === undefined
 			? undefined
@@ -143,6 +155,8 @@ export function SessionDetailView({
 		safeSkills.length > 0 ||
 		safeSlashCommands.length > 0 ||
 		subagentNames.length > 0;
+	const hasClaudeTokenBreakdown =
+		session.source === "claude_code" && safeTokenAccountingVersion >= 2;
 
 	return (
 		<SessionDetailErrorBoundary>
@@ -251,7 +265,7 @@ export function SessionDetailView({
 										/>
 										<SessionDetailMetric
 											className="grid min-w-[8rem] flex-[1.35] gap-1 border-l border-[color:var(--dashboardy-divider)] px-3 py-2"
-											label="Tokens"
+											label="Processed / output"
 											value={`${safeInputTokens.toLocaleString()} / ${safeOutputTokens.toLocaleString()}`}
 											valueClassName="text-[0.95rem] font-semibold tabular-nums whitespace-nowrap text-[color:var(--dashboardy-heading)]"
 										/>
@@ -328,6 +342,43 @@ export function SessionDetailView({
 									</div>
 								) : null}
 							</div>
+
+							{hasClaudeTokenBreakdown ? (
+								<div className="grid gap-3 rounded-[1rem] border border-[color:var(--dashboardy-divider)] bg-[color:var(--dashboardy-surface)] px-4 py-4">
+									<div className="flex items-center gap-2">
+										<h2 className="text-sm font-semibold text-[color:var(--dashboardy-heading)]">
+											Claude token accounting
+										</h2>
+										<InfoTooltip text="Anthropic reports uncached input separately from cache reads and cache writes. This panel shows the v2 processed-input breakdown used by the corrected Claude analytics path." />
+									</div>
+									<div className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
+										<SessionDetailMetric
+											label="Session total"
+											value={safeTotalTokens.toLocaleString()}
+										/>
+										<SessionDetailMetric
+											label="Uncached input"
+											value={safeUncachedInputTokens.toLocaleString()}
+										/>
+										<SessionDetailMetric
+											label="Cache read"
+											value={safeCacheReadInputTokens.toLocaleString()}
+										/>
+										<SessionDetailMetric
+											label="Cache write"
+											value={safeCacheCreationInputTokens.toLocaleString()}
+										/>
+										<SessionDetailMetric
+											label="Parent total"
+											value={safeParentTotalTokens.toLocaleString()}
+										/>
+										<SessionDetailMetric
+											label="Subagent total"
+											value={safeSubagentTotalTokens.toLocaleString()}
+										/>
+									</div>
+								</div>
+							) : null}
 
 							<ConversationView content={safeContent} showHeader={false} />
 						</div>

--- a/docs/claude-token-accounting-v2.md
+++ b/docs/claude-token-accounting-v2.md
@@ -1,0 +1,147 @@
+# Claude Token Accounting V2
+
+This document explains the Anthropic-grounded Claude token accounting model introduced in the stacked PR on top of the Codex accounting work.
+
+## Why this exists
+
+The old Claude pipeline mixed three incompatible ideas:
+
+- Anthropic `usage.input_tokens`, which is the uncached input suffix
+- Rudel `session_analytics.input_tokens`, which was intended to mean processed input
+- A ClickHouse materialized view that summed every assistant usage line in the parent transcript, including repeated streamed updates for the same `message.id`
+
+That produced two different classes of bugs at the same time:
+
+- Claude chart/detail surfaces could look too low because they only read `usage.input_tokens`
+- Claude aggregate/session rows could look too high because duplicate assistant usage rows were summed repeatedly
+
+## Anthropic rules this implementation follows
+
+Source of truth:
+
+- `https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching`
+- `https://docs.anthropic.com/en/api/messages-streaming`
+- `https://docs.anthropic.com/en/api/usage-cost-api`
+
+Canonical Anthropic semantics:
+
+- `usage.input_tokens` is uncached input
+- processed input is `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`
+- streamed usage is cumulative for a given response
+- the final token total for one Claude response is the last usage snapshot for that `message.id`
+
+## Rudel V2 decisions
+
+These are intentional product and data-model decisions, not implementation accidents.
+
+### 1. `input_tokens` means processed input
+
+For Claude rows in `session_analytics`, `input_tokens` now means total processed input, not just Anthropic uncached input.
+
+Derived field:
+
+- `uncached_input_tokens = input_tokens - cache_read_input_tokens - cache_creation_input_tokens`
+
+### 2. The counting unit is one final assistant snapshot per `message.id`
+
+Claude streams can emit multiple assistant lines with the same `message.id` as output grows. V2 groups those lines by `message.id` and keeps the last usage snapshot in transcript order.
+
+This prevents duplicate streamed updates from inflating totals.
+
+### 3. Session token totals include subagents
+
+Parent transcript totals and subagent transcript totals are computed separately, then folded into the session-wide token totals:
+
+- `session = parent + subagents`
+
+This is why already-uploaded raw Claude sessions can be corrected without user reupload. The raw parent transcript and raw subagent transcripts are already stored in `rudel.claude_sessions`.
+
+### 4. Timing metrics remain parent-scoped
+
+`total_interactions`, `duration`, `avg_period_sec`, `inference_duration_sec`, and `human_duration_sec` remain based on the parent transcript only.
+
+That is deliberate:
+
+- tokens measure total work performed by the session, including subagents
+- timing metrics measure the parent human conversation rhythm
+
+Mixing subagent token work into timing metrics would make session pacing harder to interpret.
+
+### 5. The ClickHouse MV is now a bootstrap path, not the Claude token authority
+
+The existing Claude MV still writes an initial `session_analytics` row. The API then writes a corrected replacement row with a newer `ingested_at` and `token_accounting_version = 2`.
+
+This keeps the transition safe while moving the Claude token truth into shared TypeScript code that can be used by:
+
+- ingest correction
+- historical backfill
+- session detail breakdown
+- Claude token charts
+
+## Storage changes
+
+`rudel.session_analytics` now stores:
+
+- `parent_input_tokens`
+- `parent_output_tokens`
+- `parent_cache_read_input_tokens`
+- `parent_cache_creation_input_tokens`
+- `parent_total_tokens`
+- `subagent_input_tokens`
+- `subagent_output_tokens`
+- `subagent_cache_read_input_tokens`
+- `subagent_cache_creation_input_tokens`
+- `subagent_total_tokens`
+- `token_accounting_version`
+
+These columns make the corrected Claude totals explainable in the database instead of hiding the relationship in application code only.
+
+## API and UI changes
+
+`SessionDetail` now exposes:
+
+- processed input
+- uncached input
+- cache read
+- cache write
+- parent totals
+- subagent totals
+- a token timeline based on the canonical final-per-message accounting
+
+The Claude session detail card surfaces the exact processed-input breakdown so reviewers can reconcile the session totals visually.
+
+The internal Claude token chart path also uses processed input now, rather than Anthropic uncached input alone.
+
+## Historical correction
+
+No user reupload is required for already-uploaded Claude sessions.
+
+Run the backfill with Rudel env loaded:
+
+```bash
+doppler run --project rudel --config prd -- \
+  bun run --cwd apps/api backfill:claude-token-accounting -- --batch-size 100
+```
+
+Optional flags:
+
+- `--offset <n>`
+- `--max-sessions <n>`
+
+The backfill reads the latest raw row per Claude `session_id` from `rudel.claude_sessions`, rebuilds the V2 analytics row, and appends a replacement row into `rudel.session_analytics`.
+
+Because `session_analytics` is a `ReplacingMergeTree(ingested_at)`, `FINAL` will pick the corrected row.
+
+## Verification checklist
+
+The implementation is behaving correctly when all of the following are true:
+
+- `input_tokens = uncached_input_tokens + cache_read_input_tokens + cache_creation_input_tokens`
+- `total_tokens = input_tokens + output_tokens`
+- `parent_total_tokens + subagent_total_tokens = total_tokens`
+- Claude session detail totals match the raw transcript reconstruction
+- Claude aggregate rows stop inflating duplicate streamed assistant updates
+
+## Scope boundary
+
+This PR does not remove the old Claude MV yet. It makes V2 authoritative by appending corrected rows on ingest and via backfill, which is the safer migration path for a production analytics table already in use.

--- a/packages/api-routes/src/__tests__/claude-token-accounting.test.ts
+++ b/packages/api-routes/src/__tests__/claude-token-accounting.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildClaudeSessionTokenBreakdown,
+	deriveClaudeUncachedInputTokens,
+} from "../claude-token-accounting.js";
+
+describe("claude token accounting", () => {
+	test("uses the final usage snapshot for each Claude message id", () => {
+		const content = [
+			'{"type":"assistant","timestamp":"2026-04-23T10:00:00Z","message":{"id":"msg-parent-1","usage":{"input_tokens":10,"cache_read_input_tokens":100,"output_tokens":3},"stop_reason":null}}',
+			'{"type":"assistant","timestamp":"2026-04-23T10:00:01Z","message":{"id":"msg-parent-1","usage":{"input_tokens":10,"cache_read_input_tokens":100,"output_tokens":8},"stop_reason":"end_turn"}}',
+			'{"type":"assistant","timestamp":"2026-04-23T10:00:02Z","message":{"id":"msg-parent-2","usage":{"input_tokens":5,"cache_creation_input_tokens":20,"output_tokens":4},"stop_reason":"end_turn"}}',
+		].join("\n");
+
+		const breakdown = buildClaudeSessionTokenBreakdown(content, {});
+
+		expect(breakdown.parent.input_tokens).toBe(135);
+		expect(breakdown.parent.output_tokens).toBe(12);
+		expect(breakdown.parent.cache_read_input_tokens).toBe(100);
+		expect(breakdown.parent.cache_creation_input_tokens).toBe(20);
+		expect(breakdown.parent.uncached_input_tokens).toBe(15);
+		expect(breakdown.parent.total_tokens).toBe(147);
+		expect(breakdown.timeline).toHaveLength(2);
+		expect(breakdown.timeline[0]?.output_tokens).toBe(8);
+	});
+
+	test("adds subagent transcript tokens into the session-wide Claude total", () => {
+		const parentContent = [
+			'{"type":"assistant","timestamp":"2026-04-23T10:00:00Z","message":{"id":"msg-parent","usage":{"input_tokens":10,"output_tokens":3},"stop_reason":"end_turn"}}',
+		].join("\n");
+		const subagents = {
+			agent_1: [
+				'{"type":"assistant","timestamp":"2026-04-23T10:00:00.500Z","message":{"id":"msg-subagent","usage":{"input_tokens":2,"cache_read_input_tokens":4,"output_tokens":1},"stop_reason":"end_turn"}}',
+			].join("\n"),
+		};
+
+		const breakdown = buildClaudeSessionTokenBreakdown(
+			parentContent,
+			subagents,
+		);
+
+		expect(breakdown.parent.total_tokens).toBe(13);
+		expect(breakdown.subagent.total_tokens).toBe(7);
+		expect(breakdown.session.total_tokens).toBe(20);
+		expect(breakdown.timeline.map((point) => point.source)).toEqual([
+			"parent",
+			"subagent",
+		]);
+	});
+
+	test("derives Claude uncached input from processed input and cache usage", () => {
+		expect(deriveClaudeUncachedInputTokens(2_662_604, 2_370_740, 191_681)).toBe(
+			100_183,
+		);
+	});
+});

--- a/packages/api-routes/src/claude-token-accounting.ts
+++ b/packages/api-routes/src/claude-token-accounting.ts
@@ -1,0 +1,321 @@
+import { z } from "zod";
+
+const PARENT_SOURCE_ID = "parent";
+
+const ClaudeUsageSchema = z.object({
+	input_tokens: z.number().nonnegative().optional(),
+	output_tokens: z.number().nonnegative().optional(),
+	cache_read_input_tokens: z.number().nonnegative().optional(),
+	cache_creation_input_tokens: z.number().nonnegative().optional(),
+});
+
+const ClaudeAssistantUsageLineSchema = z.object({
+	type: z.literal("assistant"),
+	timestamp: z.string(),
+	message: z.object({
+		id: z.string().optional(),
+		usage: ClaudeUsageSchema.optional(),
+	}),
+});
+
+export const ClaudeTokenBreakdownSchema = z.object({
+	input_tokens: z.number(),
+	uncached_input_tokens: z.number(),
+	cache_read_input_tokens: z.number(),
+	cache_creation_input_tokens: z.number(),
+	output_tokens: z.number(),
+	total_tokens: z.number(),
+});
+
+export const ClaudeTokenTimelinePointSchema = z.object({
+	timestamp: z.string(),
+	source: z.enum(["parent", "subagent"]),
+	source_id: z.string(),
+	message_id: z.string(),
+	input_tokens: z.number(),
+	uncached_input_tokens: z.number(),
+	cache_read_input_tokens: z.number(),
+	cache_creation_input_tokens: z.number(),
+	output_tokens: z.number(),
+	total_tokens: z.number(),
+});
+
+export const ClaudeSessionTokenBreakdownSchema = z.object({
+	parent: ClaudeTokenBreakdownSchema,
+	subagent: ClaudeTokenBreakdownSchema,
+	session: ClaudeTokenBreakdownSchema,
+	timeline: z.array(ClaudeTokenTimelinePointSchema),
+});
+
+export type ClaudeTokenBreakdown = z.infer<typeof ClaudeTokenBreakdownSchema>;
+export type ClaudeTokenTimelinePoint = z.infer<
+	typeof ClaudeTokenTimelinePointSchema
+>;
+export type ClaudeSessionTokenBreakdown = z.infer<
+	typeof ClaudeSessionTokenBreakdownSchema
+>;
+
+type ClaudeUsageSnapshot = {
+	lineIndex: number;
+	timestamp: string;
+	source: ClaudeTokenTimelinePoint["source"];
+	sourceId: string;
+	messageId: string;
+	uncachedInputTokens: number;
+	cacheReadInputTokens: number;
+	cacheCreationInputTokens: number;
+	outputTokens: number;
+};
+
+export function buildClaudeSessionTokenBreakdown(
+	content: string,
+	subagents: Record<string, string>,
+): ClaudeSessionTokenBreakdown {
+	// Claude V2 treats session tokens as parent work plus subagent work, while
+	// still preserving the split so reviewers can reconcile the combined total.
+	const parentTimeline = buildClaudeTokenTimelinePoints(
+		content,
+		"parent",
+		PARENT_SOURCE_ID,
+	);
+	const subagentTimeline = Object.entries(subagents).flatMap(
+		([agentId, agentContent]) =>
+			buildClaudeTokenTimelinePoints(agentContent, "subagent", agentId),
+	);
+	const timeline = [...parentTimeline, ...subagentTimeline].sort(
+		compareTimelinePoints,
+	);
+
+	return {
+		parent: summarizeTimeline(parentTimeline),
+		subagent: summarizeTimeline(subagentTimeline),
+		session: summarizeTimeline(timeline),
+		timeline,
+	};
+}
+
+export function buildClaudeTokenTimeline(
+	content: string,
+	subagents: Record<string, string>,
+): ClaudeTokenTimelinePoint[] {
+	return buildClaudeSessionTokenBreakdown(content, subagents).timeline;
+}
+
+export function deriveClaudeUncachedInputTokens(
+	processedInputTokens: number,
+	cacheReadInputTokens: number,
+	cacheCreationInputTokens: number,
+): number {
+	return Math.max(
+		processedInputTokens - cacheReadInputTokens - cacheCreationInputTokens,
+		0,
+	);
+}
+
+function buildClaudeTokenTimelinePoints(
+	content: string,
+	source: ClaudeTokenTimelinePoint["source"],
+	sourceId: string,
+): ClaudeTokenTimelinePoint[] {
+	const snapshots = parseClaudeUsageSnapshots(content, source, sourceId);
+	const finalSnapshots = selectFinalUsageSnapshots(snapshots);
+
+	return finalSnapshots
+		.sort(compareSnapshots)
+		.map((snapshot) => toTimelinePoint(snapshot));
+}
+
+function parseClaudeUsageSnapshots(
+	content: string,
+	source: ClaudeTokenTimelinePoint["source"],
+	sourceId: string,
+): ClaudeUsageSnapshot[] {
+	const snapshots: ClaudeUsageSnapshot[] = [];
+	const lines = content.split("\n");
+
+	for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+		const line = lines[lineIndex];
+		if (!line || line.trim() === "") {
+			continue;
+		}
+
+		const parsedLine = parseClaudeAssistantUsageLine(line);
+		if (!parsedLine) {
+			continue;
+		}
+
+		const usage = parsedLine.message.usage;
+		if (!usage) {
+			continue;
+		}
+
+		const messageId =
+			parsedLine.message.id ??
+			`${sourceId}:${parsedLine.timestamp}:${lineIndex}`;
+
+		snapshots.push({
+			lineIndex,
+			timestamp: parsedLine.timestamp,
+			source,
+			sourceId,
+			messageId,
+			uncachedInputTokens: usage.input_tokens ?? 0,
+			cacheReadInputTokens: usage.cache_read_input_tokens ?? 0,
+			cacheCreationInputTokens: usage.cache_creation_input_tokens ?? 0,
+			outputTokens: usage.output_tokens ?? 0,
+		});
+	}
+
+	return snapshots;
+}
+
+function selectFinalUsageSnapshots(
+	snapshots: ClaudeUsageSnapshot[],
+): ClaudeUsageSnapshot[] {
+	const snapshotsByMessageId = new Map<string, ClaudeUsageSnapshot>();
+
+	for (const snapshot of snapshots) {
+		const existingSnapshot = snapshotsByMessageId.get(snapshot.messageId);
+		if (
+			!existingSnapshot ||
+			shouldReplaceSnapshot(existingSnapshot, snapshot)
+		) {
+			// Anthropic streams emit cumulative usage updates for the same message id,
+			// so the last snapshot in transcript order is the authoritative total.
+			snapshotsByMessageId.set(snapshot.messageId, snapshot);
+		}
+	}
+
+	return Array.from(snapshotsByMessageId.values());
+}
+
+function shouldReplaceSnapshot(
+	existingSnapshot: ClaudeUsageSnapshot,
+	candidateSnapshot: ClaudeUsageSnapshot,
+): boolean {
+	if (candidateSnapshot.lineIndex !== existingSnapshot.lineIndex) {
+		return candidateSnapshot.lineIndex > existingSnapshot.lineIndex;
+	}
+
+	return (
+		getSnapshotTotalTokens(candidateSnapshot) >=
+		getSnapshotTotalTokens(existingSnapshot)
+	);
+}
+
+function toTimelinePoint(
+	snapshot: ClaudeUsageSnapshot,
+): ClaudeTokenTimelinePoint {
+	// Anthropic's `usage.input_tokens` is only the uncached suffix. Rudel's
+	// public `input_tokens` field is processed input, so we expand cache reads
+	// and cache writes here before the value leaves this module.
+	const inputTokens =
+		snapshot.uncachedInputTokens +
+		snapshot.cacheReadInputTokens +
+		snapshot.cacheCreationInputTokens;
+
+	return {
+		timestamp: snapshot.timestamp,
+		source: snapshot.source,
+		source_id: snapshot.sourceId,
+		message_id: snapshot.messageId,
+		input_tokens: inputTokens,
+		uncached_input_tokens: snapshot.uncachedInputTokens,
+		cache_read_input_tokens: snapshot.cacheReadInputTokens,
+		cache_creation_input_tokens: snapshot.cacheCreationInputTokens,
+		output_tokens: snapshot.outputTokens,
+		total_tokens: inputTokens + snapshot.outputTokens,
+	};
+}
+
+function summarizeTimeline(
+	timeline: ClaudeTokenTimelinePoint[],
+): ClaudeTokenBreakdown {
+	let inputTokens = 0;
+	let uncachedInputTokens = 0;
+	let cacheReadInputTokens = 0;
+	let cacheCreationInputTokens = 0;
+	let outputTokens = 0;
+
+	for (const point of timeline) {
+		inputTokens += point.input_tokens;
+		uncachedInputTokens += point.uncached_input_tokens;
+		cacheReadInputTokens += point.cache_read_input_tokens;
+		cacheCreationInputTokens += point.cache_creation_input_tokens;
+		outputTokens += point.output_tokens;
+	}
+
+	return {
+		input_tokens: inputTokens,
+		uncached_input_tokens: uncachedInputTokens,
+		cache_read_input_tokens: cacheReadInputTokens,
+		cache_creation_input_tokens: cacheCreationInputTokens,
+		output_tokens: outputTokens,
+		total_tokens: inputTokens + outputTokens,
+	};
+}
+
+function parseClaudeAssistantUsageLine(line: string) {
+	try {
+		const parsed = JSON.parse(line) as unknown;
+		const result = ClaudeAssistantUsageLineSchema.safeParse(parsed);
+		return result.success ? result.data : null;
+	} catch {
+		return null;
+	}
+}
+
+function compareSnapshots(
+	left: ClaudeUsageSnapshot,
+	right: ClaudeUsageSnapshot,
+): number {
+	const leftTimestampMs = Date.parse(left.timestamp);
+	const rightTimestampMs = Date.parse(right.timestamp);
+	if (
+		Number.isFinite(leftTimestampMs) &&
+		Number.isFinite(rightTimestampMs) &&
+		leftTimestampMs !== rightTimestampMs
+	) {
+		return leftTimestampMs - rightTimestampMs;
+	}
+
+	if (left.timestamp === right.timestamp) {
+		return left.lineIndex - right.lineIndex;
+	}
+
+	return left.timestamp.localeCompare(right.timestamp);
+}
+
+function compareTimelinePoints(
+	left: ClaudeTokenTimelinePoint,
+	right: ClaudeTokenTimelinePoint,
+): number {
+	const leftTimestampMs = Date.parse(left.timestamp);
+	const rightTimestampMs = Date.parse(right.timestamp);
+	if (
+		Number.isFinite(leftTimestampMs) &&
+		Number.isFinite(rightTimestampMs) &&
+		leftTimestampMs !== rightTimestampMs
+	) {
+		return leftTimestampMs - rightTimestampMs;
+	}
+
+	if (left.timestamp === right.timestamp) {
+		if (left.source_id === right.source_id) {
+			return left.message_id.localeCompare(right.message_id);
+		}
+
+		return left.source_id.localeCompare(right.source_id);
+	}
+
+	return left.timestamp.localeCompare(right.timestamp);
+}
+
+function getSnapshotTotalTokens(snapshot: ClaudeUsageSnapshot): number {
+	return (
+		snapshot.uncachedInputTokens +
+		snapshot.cacheReadInputTokens +
+		snapshot.cacheCreationInputTokens +
+		snapshot.outputTokens
+	);
+}

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -60,6 +60,7 @@ import {
 	UserTokenUsageDataSchema,
 } from "./schemas/analytics.js";
 
+export * from "./claude-token-accounting.js";
 export * from "./model-pricing.js";
 export * from "./product-analytics.js";
 export * from "./schemas/analytics.js";

--- a/packages/api-routes/src/schemas/analytics.ts
+++ b/packages/api-routes/src/schemas/analytics.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import {
+	ClaudeTokenBreakdownSchema,
+	ClaudeTokenTimelinePointSchema,
+} from "../claude-token-accounting.js";
 import { ESTIMATED_PRICING_MODE } from "../model-pricing.js";
 import { SourceSchema } from "./source.js";
 
@@ -326,8 +330,14 @@ export const SessionAnalyticsSchema = z.object({
 	git_remote: z.string().optional(),
 	duration_min: z.number(),
 	total_tokens: z.number(),
+	// `input_tokens` is the provider-normalized processed input across sources.
+	// Claude's uncached suffix is exposed separately as `uncached_input_tokens`.
 	input_tokens: z.number(),
 	output_tokens: z.number(),
+	cache_read_input_tokens: z.number(),
+	cache_creation_input_tokens: z.number(),
+	uncached_input_tokens: z.number(),
+	token_accounting_version: z.number().int().positive(),
 	success_score: z.number(),
 	total_interactions: z.number(),
 	avg_period_sec: z.number(),
@@ -432,6 +442,30 @@ export const SessionDetailSchema = z.object({
 	total_tokens: z.number(),
 	input_tokens: z.number(),
 	output_tokens: z.number(),
+	// Session detail carries the full Claude V2 breakdown so reviewers can
+	// reconcile parent, subagent, uncached, and cached totals explicitly.
+	cache_read_input_tokens: z.number(),
+	cache_creation_input_tokens: z.number(),
+	uncached_input_tokens: z.number(),
+	parent_input_tokens: z.number(),
+	parent_output_tokens: z.number(),
+	parent_cache_read_input_tokens: z.number(),
+	parent_cache_creation_input_tokens: z.number(),
+	parent_uncached_input_tokens: z.number(),
+	parent_total_tokens: z.number(),
+	subagent_input_tokens: z.number(),
+	subagent_output_tokens: z.number(),
+	subagent_cache_read_input_tokens: z.number(),
+	subagent_cache_creation_input_tokens: z.number(),
+	subagent_uncached_input_tokens: z.number(),
+	subagent_total_tokens: z.number(),
+	token_accounting_version: z.number().int().positive(),
+	token_breakdown: z.object({
+		parent: ClaudeTokenBreakdownSchema,
+		subagent: ClaudeTokenBreakdownSchema,
+		session: ClaudeTokenBreakdownSchema,
+	}),
+	token_timeline: z.array(ClaudeTokenTimelinePointSchema),
 	success_score: z.number().optional(),
 	duration_min: z.number().optional(),
 	total_interactions: z.number().optional(),

--- a/packages/ch-schema/chx/meta/snapshot.json
+++ b/packages/ch-schema/chx/meta/snapshot.json
@@ -1,6 +1,6 @@
 {
 	"version": 1,
-	"generatedAt": "2026-04-22T14:49:31.343Z",
+	"generatedAt": "2026-04-23T15:38:34.936Z",
 	"definitions": [
 		{
 			"database": "rudel",
@@ -278,6 +278,61 @@
 					"name": "total_tokens",
 					"type": "UInt64",
 					"default": "fn:0"
+				},
+				{
+					"name": "parent_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "parent_output_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "parent_cache_read_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "parent_cache_creation_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "parent_total_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "subagent_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "subagent_output_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "subagent_cache_read_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "subagent_cache_creation_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "subagent_total_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "token_accounting_version",
+					"type": "UInt8",
+					"default": "fn:1"
 				},
 				{
 					"name": "tag",

--- a/packages/ch-schema/chx/migrations/20260423153834_auto.sql
+++ b/packages/ch-schema/chx/migrations/20260423153834_auto.sql
@@ -1,0 +1,47 @@
+-- chkit-migration-format: v1
+-- generated-at: 2026-04-23T15:38:34.935Z
+-- cli-version: 0.1.0-beta.16
+-- definition-count: 5
+-- operation-count: 13
+-- rename-suggestion-count: 0
+-- risk-summary: safe=11, caution=2, danger=0
+
+-- operation: drop_materialized_view key=materialized_view:rudel.session_analytics_mv risk=caution
+DROP TABLE IF EXISTS rudel.session_analytics_mv SYNC;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:parent_cache_creation_input_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `parent_cache_creation_input_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:parent_cache_read_input_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `parent_cache_read_input_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:parent_input_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `parent_input_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:parent_output_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `parent_output_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:parent_total_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `parent_total_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:subagent_cache_creation_input_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `subagent_cache_creation_input_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:subagent_cache_read_input_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `subagent_cache_read_input_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:subagent_input_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `subagent_input_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:subagent_output_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `subagent_output_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:subagent_total_tokens risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `subagent_total_tokens` UInt64 DEFAULT 0;
+
+-- operation: alter_table_add_column key=table:rudel.session_analytics:column:token_accounting_version risk=safe
+ALTER TABLE rudel.session_analytics ADD COLUMN IF NOT EXISTS `token_accounting_version` UInt8 DEFAULT 1;
+
+-- operation: create_materialized_view key=materialized_view:rudel.session_analytics_mv risk=caution
+CREATE MATERIALIZED VIEW IF NOT EXISTS rudel.session_analytics_mv TO rudel.session_analytics AS
+WITH arrayFilter( x -> JSONExtractString(x, 'type') IN ('user', 'assistant'), splitByChar('\n', cs.content) ) AS _interaction_lines, arrayFilter(x -> JSONHas(x, 'timestamp'), _interaction_lines) AS _ts_lines, arrayMap( x -> parseDateTime64BestEffort(JSONExtractString(x, 'timestamp')), _ts_lines ) AS _timestamps, arrayMap( x -> JSONExtractString(x, 'type'), _ts_lines ) AS _msg_types, if(length(_timestamps) > 1, arrayMap(i -> dateDiff('second', _timestamps[i], _timestamps[i+1]), range(1, length(_timestamps))), [] ) AS _prompt_periods_sec, if(length(_timestamps) > 1, arrayMap(i -> if(_msg_types[i] = 'user' AND _msg_types[i+1] = 'assistant', dateDiff('second', _timestamps[i], _timestamps[i+1]), 0), range(1, length(_timestamps))), [] ) AS _inference_gaps, if(length(_timestamps) > 1, arrayMap(i -> if(_msg_types[i] = 'assistant' AND _msg_types[i+1] = 'user', dateDiff('second', _timestamps[i], _timestamps[i+1]), 0), range(1, length(_timestamps))), [] ) AS _human_gaps, arrayFilter( x -> JSONExtractString(x, 'type') = 'assistant' AND JSONHas(x, 'message'), splitByChar('\n', cs.content) ) AS _assistant_lines, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'input_tokens')) + toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_read_input_tokens')) + toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_creation_input_tokens')), _assistant_lines)) AS _input_tokens, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'output_tokens')), _assistant_lines)) AS _output_tokens, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_read_input_tokens')), _assistant_lines)) AS _cache_read, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_creation_input_tokens')), _assistant_lines)) AS _cache_creation, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '"name":"Skill"[^}]*"skill":"([^"]+)"'))) AS _skills, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '"name":"Task"[^}]*"subagent_type":"([^"]+)"'))) AS _subagent_types, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '<command-name>/([^<]+)</command-name>'))) AS _slash_commands, arrayMin(_timestamps) AS _session_date, arrayMax(_timestamps) AS _last_interaction_date, dateDiff('minute', _session_date, _last_interaction_date) AS _duration_min SELECT * EXCEPT (session_date, last_interaction_date), _session_date as session_date, _last_interaction_date as last_interaction_date, 'claude_code' as source, _input_tokens as input_tokens, _output_tokens as output_tokens, _cache_read as cache_read_input_tokens, _cache_creation as cache_creation_input_tokens, _input_tokens + _output_tokens as total_tokens, _skills as skills, _slash_commands as slash_commands, _subagent_types as subagent_types, toUInt32(length(_timestamps)) as total_interactions, toUInt32(_duration_min) as actual_duration_min, if(length(_prompt_periods_sec) > 0, round(arrayAvg(_prompt_periods_sec), 2), 0) as avg_period_sec, if( length(_prompt_periods_sec) > 0, toFloat64(arrayElement( arraySort(_prompt_periods_sec), toUInt64(ceil(length(_prompt_periods_sec) / 2)) )), 0 ) as median_period_sec, toUInt32(arrayCount(x -> x < 5, _prompt_periods_sec)) as quick_responses, toUInt32(arrayCount(x -> x >= 5 AND x <= 60, _prompt_periods_sec)) as normal_responses, toUInt32(arrayCount(x -> x > 300, _prompt_periods_sec)) as long_pauses, toUInt32( length(extractAll(cs.content, '"isApiErrorMessage":true')) + length(extractAll(cs.content, '"is_error":true')) ) as error_count, JSONExtractString( JSONExtractRaw( arrayElement( arrayFilter( x -> JSONExtractString(x, 'type') = 'assistant', splitByChar('\n', cs.content) ), -1 ), 'message' ), 'model' ) as model_used, toUInt8(if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 1, 0)) as has_commit, toUInt8(if(position(cs.content, '"name":"EnterPlanMode"') > 0, 1, 0)) as used_plan_mode, toUInt32(arraySum(_inference_gaps)) as inference_duration_sec, toUInt32(arraySum(_human_gaps)) as human_duration_sec, CASE WHEN _duration_min <= 10 AND (_input_tokens + _output_tokens) < 500000 AND _output_tokens > 1000 THEN 'quick_win' WHEN _duration_min > 30 AND _output_tokens > 50000 AND cs.git_sha IS NOT NULL AND cs.git_sha != '' THEN 'deep_work' WHEN (_input_tokens + _output_tokens) > 1000000 AND (_output_tokens / nullif(_input_tokens, 0)) < 0.3 AND _duration_min > 20 THEN 'struggle' WHEN length(_skills) >= 3 AND (cs.git_sha IS NULL OR cs.git_sha = '') AND (_input_tokens + _output_tokens) > 200000 THEN 'exploration' WHEN _duration_min < 3 AND _output_tokens < 500 THEN 'abandoned' ELSE 'standard' END as session_archetype, toUInt8(round( 50 + (if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 20, 0)) + (if((_output_tokens / nullif(_input_tokens, 0)) > 0.5, 15, 0)) + (least(toUInt32(length(_skills)), 3) * 5) - (if((_input_tokens + _output_tokens) > 1500000 AND (cs.git_sha IS NULL OR cs.git_sha = ''), 20, 0)) - (if(_duration_min < 2 AND _output_tokens < 200, 30, 0)) - (least(toUInt32( length(extractAll(cs.content, '"isApiErrorMessage":true')) + length(extractAll(cs.content, '"is_error":true')) ), 10) * 2) )) as success_score FROM rudel.claude_sessions AS cs WHERE length(_timestamps) > 0 QUALIFY ROW_NUMBER() OVER (PARTITION BY cs.session_id ORDER BY cs.ingested_at DESC) = 1;

--- a/packages/ch-schema/src/db/schema/session-analytics.ts
+++ b/packages/ch-schema/src/db/schema/session-analytics.ts
@@ -40,6 +40,39 @@ const rudel_session_analytics = table({
 		{ name: "cache_read_input_tokens", type: "UInt64", default: "fn:0" },
 		{ name: "cache_creation_input_tokens", type: "UInt64", default: "fn:0" },
 		{ name: "total_tokens", type: "UInt64", default: "fn:0" },
+		// Claude V2 stores parent and subagent token totals separately so the
+		// session-wide aggregates remain explainable after we fold them together.
+		{ name: "parent_input_tokens", type: "UInt64", default: "fn:0" },
+		{ name: "parent_output_tokens", type: "UInt64", default: "fn:0" },
+		{
+			name: "parent_cache_read_input_tokens",
+			type: "UInt64",
+			default: "fn:0",
+		},
+		{
+			name: "parent_cache_creation_input_tokens",
+			type: "UInt64",
+			default: "fn:0",
+		},
+		{ name: "parent_total_tokens", type: "UInt64", default: "fn:0" },
+		{ name: "subagent_input_tokens", type: "UInt64", default: "fn:0" },
+		{ name: "subagent_output_tokens", type: "UInt64", default: "fn:0" },
+		{
+			name: "subagent_cache_read_input_tokens",
+			type: "UInt64",
+			default: "fn:0",
+		},
+		{
+			name: "subagent_cache_creation_input_tokens",
+			type: "UInt64",
+			default: "fn:0",
+		},
+		{ name: "subagent_total_tokens", type: "UInt64", default: "fn:0" },
+		{
+			name: "token_accounting_version",
+			type: "UInt8",
+			default: "fn:1",
+		},
 		{ name: "tag", type: "String", nullable: true },
 		{
 			name: "source",
@@ -113,6 +146,9 @@ const rudel_session_analytics_mv = materializedView({
 	database: "rudel",
 	name: "session_analytics_mv",
 	to: { database: "rudel", name: "session_analytics" },
+	// The Claude MV still provides a bootstrap analytics row, but the API
+	// reinserts a corrected replacement row because Anthropic's final-per-
+	// message semantics and subagent folding are easier to audit in TS.
 	as: `
   WITH
     arrayFilter(

--- a/packages/ch-schema/src/generated/chkit-types.ts
+++ b/packages/ch-schema/src/generated/chkit-types.ts
@@ -102,6 +102,17 @@ export type RudelSessionAnalyticsRow = {
   cache_read_input_tokens: string
   cache_creation_input_tokens: string
   total_tokens: string
+  parent_input_tokens: string
+  parent_output_tokens: string
+  parent_cache_read_input_tokens: string
+  parent_cache_creation_input_tokens: string
+  parent_total_tokens: string
+  subagent_input_tokens: string
+  subagent_output_tokens: string
+  subagent_cache_read_input_tokens: string
+  subagent_cache_creation_input_tokens: string
+  subagent_total_tokens: string
+  token_accounting_version: number
   tag: string | null
   source: string
   total_interactions: number
@@ -144,6 +155,17 @@ export const RudelSessionAnalyticsRowSchema = z.object({
   cache_read_input_tokens: z.string(),
   cache_creation_input_tokens: z.string(),
   total_tokens: z.string(),
+  parent_input_tokens: z.string(),
+  parent_output_tokens: z.string(),
+  parent_cache_read_input_tokens: z.string(),
+  parent_cache_creation_input_tokens: z.string(),
+  parent_total_tokens: z.string(),
+  subagent_input_tokens: z.string(),
+  subagent_output_tokens: z.string(),
+  subagent_cache_read_input_tokens: z.string(),
+  subagent_cache_creation_input_tokens: z.string(),
+  subagent_total_tokens: z.string(),
+  token_accounting_version: z.number(),
   tag: z.string().nullable(),
   source: z.string(),
   total_interactions: z.number(),


### PR DESCRIPTION
## Summary
- replace Claude token accounting with an Anthropic-docs-compliant V2 path that treats `usage.input_tokens` as uncached input and rebuilds processed input as `uncached + cache read + cache write`
- add a shared Claude accounting module, new session analytics columns, an API-side correction service, and a historical backfill script so existing uploaded Claude sessions can be fixed without user reupload
- update session detail APIs and the web session detail UI to expose parent vs subagent totals, cache read/write totals, uncached input, and a timeline derived from final assistant message snapshots
- document every accounting rule, migration decision, and rollout invariant in code comments plus `docs/claude-token-accounting-v2.md`

## Problem
Claude token numbers were inconsistent across surfaces:
- transcript-style views treated `usage.input_tokens` as if it were total processed input, which makes cache-heavy Claude sessions look far too low
- aggregate analytics summed repeated assistant `message.id` usage rows, which overcounted parent-session totals
- aggregate analytics ignored subagent transcript usage, which undercounted session-wide totals
- no shared runtime module defined a single canonical Claude token model

## Decisions
- canonical session input is processed input, not uncached input
- canonical Claude aggregation unit is the final usage snapshot per assistant `message.id`
- session-wide Claude totals include parent and subagent transcripts
- timing and interaction metrics remain parent-scoped in this rollout so the token correction stays isolated from unrelated behavior changes
- session detail recalculates Claude token truth directly from raw stored transcript content so detail views are correct even before the historical backfill completes

## Implementation Notes
- `packages/api-routes/src/claude-token-accounting.ts` is the shared source of truth for Claude token breakdowns and timelines
- `apps/api/src/services/claude-session-analytics.service.ts` rewrites Claude analytics rows after ingest using the shared accounting module
- `apps/api/src/scripts/backfill-claude-token-accounting-v2.ts` backfills historical Claude analytics rows from raw `rudel.claude_sessions` data
- `packages/ch-schema/src/db/schema/session-analytics.ts` adds explicit parent/subagent breakdown columns plus `token_accounting_version`
- `apps/api/src/services/session-analytics.service.ts` and `apps/web/src/features/sessions/components/SessionDetailView.tsx` surface the corrected Claude breakdown

## Verification
- [x] `bun run --cwd packages/api-routes check-types`
- [x] `bun run --cwd packages/api-routes test`
- [x] `bun run --cwd packages/ch-schema check-types`
- [x] `bun run --cwd packages/ch-schema ch:generate:dryrun`
- [x] `bun test apps/api/src/__tests__/claude-session-analytics.service.test.ts apps/api/src/__tests__/ingest.test.ts`
- [x] `bun run --cwd apps/web check-types`
- [x] `bun run --cwd apps/web build`
- [x] `bun run lint`
- [x] `bun run verify` fails only on the pre-existing unrelated `@rudel/api#check-types` Drizzle type-resolution issue already present in `apps/api/src/handlers/admin/delete-user.ts`, `apps/api/src/router.ts`, and `apps/api/src/services/overview.service.ts`

## Stack
- base PR: #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)