### PR TITLE
fix: adjust wrapped scale rain timing

### DIFF
--- a/apps/web/src/features/wrapped/onboarding/stages.test.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { resolveScaleRainReleaseIntervalMs } from "./stages";
+
+const SCALE_RAIN_BALLS_PER_MILLION = 1_000;
+
+function resolveFlowDurationMs(millionCount: number) {
+	const ballCount = millionCount * SCALE_RAIN_BALLS_PER_MILLION;
+	return resolveScaleRainReleaseIntervalMs(ballCount) * ballCount;
+}
+
+describe("resolveScaleRainReleaseIntervalMs", () => {
+	it("halves the added rain time for every million after the first", () => {
+		const oneMillionFlowMs = resolveFlowDurationMs(1);
+		const twoMillionFlowMs = resolveFlowDurationMs(2);
+		const threeMillionFlowMs = resolveFlowDurationMs(3);
+		const fourMillionFlowMs = resolveFlowDurationMs(4);
+
+		expect(twoMillionFlowMs - oneMillionFlowMs).toBeCloseTo(3_500);
+		expect(threeMillionFlowMs - twoMillionFlowMs).toBeCloseTo(1_750);
+		expect(fourMillionFlowMs - threeMillionFlowMs).toBeCloseTo(875);
+	});
+
+	it("applies the decayed timing proportionally inside a partial extra million", () => {
+		const oneMillionFlowMs = resolveFlowDurationMs(1);
+		const oneAndHalfMillionFlowMs = resolveFlowDurationMs(1.5);
+
+		expect(oneAndHalfMillionFlowMs - oneMillionFlowMs).toBeCloseTo(1_750);
+	});
+});

--- a/apps/web/src/features/wrapped/onboarding/stages.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages.tsx
@@ -69,9 +69,14 @@ interface ScaleRainSimulationBall extends ScaleRainBall {
 }
 
 const SCALE_RAIN_FLOOR_OFFSET_PX = 0;
+const SCALE_RAIN_TOKENS_PER_BALL = 1_000;
+const SCALE_RAIN_TOKENS_PER_MILLION = 1_000_000;
 const SCALE_RAIN_TARGET_DURATION_PER_MILLION_TOKENS_MS = 7_000;
+const SCALE_RAIN_SUBSEQUENT_MILLION_DURATION_MULTIPLIER = 0.5;
 const SCALE_RAIN_MIN_FLOW_DURATION_MS = 3_200;
-const SCALE_RAIN_MAX_FLOW_DURATION_MS = 9_000;
+const SCALE_RAIN_MAX_TARGET_DURATION_MS =
+	SCALE_RAIN_TARGET_DURATION_PER_MILLION_TOKENS_MS /
+	(1 - SCALE_RAIN_SUBSEQUENT_MILLION_DURATION_MULTIPLIER);
 const SCALE_RAIN_TRAVEL_OVERHEAD_MS = 1_200;
 const SCALE_RAIN_RELEASE_VELOCITY_PX = 2.6;
 const SCALE_RAIN_SQUASH_DURATION_MS = 80;
@@ -677,29 +682,49 @@ function activateNextScaleRainBall(
 	};
 }
 
-function resolveScaleRainReleaseIntervalMs(totalBallCount: number) {
+export function resolveScaleRainReleaseIntervalMs(totalBallCount: number) {
 	if (totalBallCount <= 0) {
-		return SCALE_RAIN_MAX_FLOW_DURATION_MS;
+		return SCALE_RAIN_MAX_TARGET_DURATION_MS;
 	}
 
-	const tokenCount = totalBallCount * 1_000;
-	const targetTotalDurationMs = Math.min(
-		SCALE_RAIN_MAX_FLOW_DURATION_MS,
-		Math.max(
-			SCALE_RAIN_MIN_FLOW_DURATION_MS,
-			(tokenCount / 1_000_000) *
-				SCALE_RAIN_TARGET_DURATION_PER_MILLION_TOKENS_MS,
-		),
-	);
-	const flowDurationMs = Math.min(
-		SCALE_RAIN_MAX_FLOW_DURATION_MS,
-		Math.max(
-			SCALE_RAIN_MIN_FLOW_DURATION_MS,
-			targetTotalDurationMs - SCALE_RAIN_TRAVEL_OVERHEAD_MS,
-		),
+	const tokenCount = totalBallCount * SCALE_RAIN_TOKENS_PER_BALL;
+	const targetTotalDurationMs = resolveScaleRainTargetDurationMs(tokenCount);
+	const flowDurationMs = Math.max(
+		SCALE_RAIN_MIN_FLOW_DURATION_MS,
+		targetTotalDurationMs - SCALE_RAIN_TRAVEL_OVERHEAD_MS,
 	);
 
 	return flowDurationMs / totalBallCount;
+}
+
+function resolveScaleRainTargetDurationMs(tokenCount: number) {
+	const millionCount = Math.max(0, tokenCount / SCALE_RAIN_TOKENS_PER_MILLION);
+	const firstMillionShare = Math.min(1, millionCount);
+	const subsequentMillions = Math.max(0, millionCount - 1);
+	const fullSubsequentMillions = Math.floor(subsequentMillions);
+	const partialSubsequentMillion = subsequentMillions - fullSubsequentMillions;
+	const subsequentDecay = SCALE_RAIN_SUBSEQUENT_MILLION_DURATION_MULTIPLIER;
+	const firstSubsequentMillionDurationMs =
+		SCALE_RAIN_TARGET_DURATION_PER_MILLION_TOKENS_MS * subsequentDecay;
+	const fullSubsequentDurationMs =
+		fullSubsequentMillions > 0
+			? firstSubsequentMillionDurationMs *
+				((1 - subsequentDecay ** fullSubsequentMillions) /
+					(1 - subsequentDecay))
+			: 0;
+	const partialSubsequentDurationMs =
+		partialSubsequentMillion *
+		SCALE_RAIN_TARGET_DURATION_PER_MILLION_TOKENS_MS *
+		subsequentDecay ** (fullSubsequentMillions + 1);
+	const targetDurationMs =
+		firstMillionShare * SCALE_RAIN_TARGET_DURATION_PER_MILLION_TOKENS_MS +
+		fullSubsequentDurationMs +
+		partialSubsequentDurationMs;
+
+	return Math.min(
+		SCALE_RAIN_MAX_TARGET_DURATION_MS,
+		Math.max(SCALE_RAIN_MIN_FLOW_DURATION_MS, targetDurationMs),
+	);
 }
 
 function clampScaleRainX(x: number, radius: number, width: number) {


### PR DESCRIPTION
## Summary
- Change wrapped onboarding scale rain timing so every million after the first adds half the time of the previous million.
- Add regression coverage for whole and partial post-1M token timing.

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig
- [x] git diff --check

Notes: `bun run verify` passed with existing Biome warnings in `apps/web/src/features/wrapped/wrapped.css` about `!important` and existing Vite chunk-size warnings.