### PR TITLE
fix: stop wrapped token rain loop

### DIFF
--- a/apps/web/src/features/wrapped/onboarding/models/scale.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/scale.ts
@@ -141,39 +141,15 @@ export function resolveScaleRainDisplayedTokens(
 		return 0;
 	}
 
+	const normalizedTotalTokens = Math.max(0, Math.round(totalTokens));
 	const clampedBallProgress = Math.max(
 		0,
 		Math.min(totalBallCount, displayedBallProgress),
 	);
 
-	if (totalBallCount === 1) {
-		return Math.min(
-			Math.max(0, Math.round(totalTokens)),
-			Math.round(totalTokens * clampedBallProgress),
-		);
-	}
-
-	const fullBallCount = Math.max(0, totalBallCount - 1);
-	const fullBallTokens = fullBallCount * SCALE_STAGE_TOKENS_PER_BALL;
-	const finalBallTokens = Math.max(0, totalTokens - fullBallTokens);
-
-	if (clampedBallProgress <= fullBallCount) {
-		return Math.min(
-			Math.max(0, Math.round(totalTokens)),
-			Math.round(clampedBallProgress * SCALE_STAGE_TOKENS_PER_BALL),
-		);
-	}
-
-	const finalBallProgress = Math.min(1, clampedBallProgress - fullBallCount);
 	return Math.min(
-		Math.max(0, Math.round(totalTokens)),
-		fullBallTokens +
-			Math.round(
-				finalBallProgress *
-					(finalBallTokens === 0
-						? SCALE_STAGE_TOKENS_PER_BALL
-						: finalBallTokens),
-			),
+		normalizedTotalTokens,
+		Math.round((clampedBallProgress / totalBallCount) * normalizedTotalTokens),
 	);
 }
 

--- a/apps/web/src/features/wrapped/onboarding/stages.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages.tsx
@@ -7,7 +7,6 @@ import type { WrappedStepContentLine } from "./helpers";
 import {
 	buildScaleRainBalls,
 	buildStepContent,
-	resolveScaleRainBallCount,
 	resolveScaleRainDisplayedTokens,
 	type ScaleRainBall,
 } from "./models";
@@ -248,7 +247,7 @@ export function WrappedOnboardingScaleRainBackdrop(
 ) {
 	const { onDisplayedTokensChange, reduceMotion, totalTokens } = props;
 	const balls = buildScaleRainBalls(totalTokens);
-	const logicalBallCount = resolveScaleRainBallCount(totalTokens);
+	const animationBallCount = balls.length;
 
 	return (
 		<WrappedOnboardingScaleRainSimulation
@@ -257,7 +256,7 @@ export function WrappedOnboardingScaleRainBackdrop(
 			onDisplayedTokensChange={onDisplayedTokensChange}
 			reduceMotion={reduceMotion}
 			totalTokens={totalTokens}
-			totalBallCount={logicalBallCount}
+			totalBallCount={animationBallCount}
 		/>
 	);
 }


### PR DESCRIPTION
## Summary
Fixes the wrapped scale-stage token rain by using the capped rendered ball count as the animation count instead of the uncapped logical token-derived count.
Updates token display progress to scale linearly to the real total across that capped animation count, so large totals complete instead of recycling the same nodes for thousands of emissions.

## Verification
- \`bun run verify\`
- \`bun run lint:wrapped:hig\`
- \`bun run check-types\`
- \`./node_modules/.bin/biome check apps/web/src/features/wrapped/onboarding/stages.tsx apps/web/src/features/wrapped/onboarding/models/scale.ts\`