### PR TITLE
fix: left truncate wrapped repo names

### DIFF
--- a/apps/web/src/features/wrapped/WrappedSetupCompletePage.tsx
+++ b/apps/web/src/features/wrapped/WrappedSetupCompletePage.tsx
@@ -14,6 +14,7 @@ import {
 	WrappedPrimaryAction,
 	WrappedSecondaryAction,
 } from "@/features/wrapped/actions";
+import { shortenWrappedRepoLabelFromLeft } from "@/features/wrapped/repo-label";
 import { useMountEffect } from "@/hooks/useMountEffect";
 import { MAX_ANALYTICS_DAYS } from "@/lib/analytics-date-range";
 import { orpc } from "@/lib/orpc";
@@ -32,6 +33,7 @@ const SESSIONS_LANDED_EASE = [0.22, 1, 0.36, 1] as const;
 const SESSIONS_LANDED_HANDOFF_MS = 1000;
 const SESSIONS_LANDED_REDUCED_DURATION = 0.14;
 const SESSIONS_LANDED_ROW_STAGGER = 0.035;
+const UPLOADED_REPO_LABEL_MAX_LENGTH = 26;
 
 export function WrappedSetupCompletePage(props: WrappedSetupCompletePageProps) {
 	const [isUploadMoreVisible, setIsUploadMoreVisible] = useState(false);
@@ -449,8 +451,14 @@ function WrappedUploadedReposStage(props: {
 										}
 							}
 						>
-							<span className="mymind-wrapped-uploaded-repos__name">
-								{repo.name}
+							<span
+								className="mymind-wrapped-uploaded-repos__name"
+								title={repo.name}
+							>
+								{shortenWrappedRepoLabelFromLeft(
+									repo.name,
+									UPLOADED_REPO_LABEL_MAX_LENGTH,
+								)}
 							</span>
 							<span className="mymind-wrapped-uploaded-repos__count">
 								{formatSessionCount(repo.sessions)}

--- a/apps/web/src/features/wrapped/onboarding/stages/metrics.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/metrics.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import { useMountEffect } from "@/hooks/useMountEffect";
 import { formatCompactWholeCurrency } from "@/lib/format";
 import { cn } from "@/lib/utils";
+import { shortenWrappedRepoLabelFromLeft } from "../../repo-label";
 import {
 	resolveLockInPreviewInput,
 	resolveLockInStageModel,
@@ -108,6 +109,8 @@ const REPO_PULSE_STAGE_TRANSITION = {
 		ease: [0.22, 1, 0.36, 1] as const,
 	},
 };
+
+const REPO_PULSE_STAGE_REPO_LABEL_MAX_LENGTH = 20;
 
 const REPO_PULSE_STAGE_ROW_VARIANTS = {
 	hidden: {
@@ -1243,8 +1246,14 @@ export function WrappedOnboardingRepoPulseStage(props: SharedStageProps) {
 								>
 									<section className="mymind-wrapped-repo-pulse-stage__row-copy">
 										<div className="mymind-wrapped-repo-pulse-stage__row-main">
-											<p className="mymind-wrapped-repo-pulse-stage__repo">
-												{entry.repoName}
+											<p
+												className="mymind-wrapped-repo-pulse-stage__repo"
+												title={entry.repoName}
+											>
+												{shortenWrappedRepoLabelFromLeft(
+													entry.repoName,
+													REPO_PULSE_STAGE_REPO_LABEL_MAX_LENGTH,
+												)}
 											</p>
 											<p className="mymind-wrapped-repo-pulse-stage__meta">
 												{entry.sessionCountLabel}

--- a/apps/web/src/features/wrapped/repo-label.ts
+++ b/apps/web/src/features/wrapped/repo-label.ts
@@ -1,0 +1,27 @@
+export function shortenWrappedRepoLabelFromLeft(
+	label: string,
+	maxLength: number,
+) {
+	if (label.length <= maxLength) {
+		return label;
+	}
+
+	if (maxLength <= 3) {
+		return label.slice(-maxLength);
+	}
+
+	const slashSegments = label.split("/").filter(Boolean);
+	const trailingPair = slashSegments.slice(-2).join("/");
+
+	if (trailingPair.length > 0 && trailingPair.length + 4 <= maxLength) {
+		return `.../${trailingPair}`;
+	}
+
+	const trailingSegment = slashSegments.at(-1);
+
+	if (trailingSegment && trailingSegment.length + 4 <= maxLength) {
+		return `.../${trailingSegment}`;
+	}
+
+	return `...${label.slice(-(maxLength - 3))}`;
+}

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -1550,6 +1550,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 .mymind-wrapped-repo-pulse-stage__repo {
 	margin: 0;
 	flex: 1 1 auto;
+	max-width: 100%;
 	min-width: 0;
 	color: #17161c;
 	font-size: 1.22rem;
@@ -1557,7 +1558,9 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	font-weight: 800;
 	letter-spacing: -0.04em;
 	line-height: 1.08;
-	text-wrap: balance;
+	overflow: clip;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .mymind-wrapped-repo-pulse-stage__proof {
@@ -4458,8 +4461,12 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 .mymind-wrapped-uploaded-repos__name {
+	flex: 1 1 auto;
+	max-width: 100%;
 	min-width: 0;
-	overflow-wrap: anywhere;
+	overflow: clip;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .mymind-wrapped-uploaded-repos__count {


### PR DESCRIPTION
## Summary
- add a wrapped repo-label helper that caps long repo names from the left while preserving useful trailing segments
- apply left-capped labels to the wrapped repo pulse stage and uploaded repos list
- keep full repo names available via native title tooltips and preserve single-line row layout

## Test plan
- [x] bun run lint:wrapped:hig
- [x] bun run verify