### PR TITLE
fix: keep wrapped auth buttons in frame

### DIFF
--- a/apps/web/src/features/wrapped/WrappedAuthFlow.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.test.tsx
@@ -73,6 +73,8 @@ Object.defineProperty(window, "matchMedia", {
 
 const WRAPPED_UNKNOWN_CARD_OVERLAY_CLASS_NAME =
 	"mymind-wrapped-auth-card-preview--unknown-overlay";
+const WRAPPED_UNKNOWN_CARD_CLASS_NAME =
+	"mymind-wrapped-auth-card-preview--unknown";
 
 async function openWrappedLoginForm(user: ReturnType<typeof userEvent.setup>) {
 	await user.click(screen.getByRole("button", { name: "Log in" }));
@@ -259,6 +261,38 @@ describe("WrappedGuestPage", () => {
 		expect(
 			screen.getByRole("region", { name: "Wrapped player card preview" }),
 		).toHaveClass(WRAPPED_UNKNOWN_CARD_OVERLAY_CLASS_NAME);
+		expect(
+			screen.getByRole("region", { name: "Wrapped player card preview" }),
+		).toHaveClass(WRAPPED_UNKNOWN_CARD_CLASS_NAME);
+	});
+
+	it("restores the default card after backing out of signup", async () => {
+		const user = userEvent.setup();
+
+		render(
+			<MemoryRouter initialEntries={["/wrapped"]}>
+				<WrappedGuestPage />
+			</MemoryRouter>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Create account" }));
+		expect(await screen.findByText("Wrapped signup form")).toBeInTheDocument();
+		await waitFor(() => {
+			expect(
+				screen.getByRole("region", { name: "Wrapped player card preview" }),
+			).toHaveClass(WRAPPED_UNKNOWN_CARD_CLASS_NAME);
+		});
+
+		await user.click(screen.getByLabelText("Go back"));
+		expect(
+			await screen.findByRole("button", { name: "Create account" }),
+		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Log in" })).toBeInTheDocument();
+		await waitFor(() => {
+			expect(
+				screen.getByRole("region", { name: "Wrapped player card preview" }),
+			).not.toHaveClass(WRAPPED_UNKNOWN_CARD_CLASS_NAME);
+		});
 	});
 
 	it("keeps wrapped auth in place when the preview-only submit callback is absent", async () => {

--- a/apps/web/src/features/wrapped/WrappedAuthFlow.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.test.tsx
@@ -71,8 +71,8 @@ Object.defineProperty(window, "matchMedia", {
 	})),
 });
 
-const WRAPPED_UNKNOWN_CARD_CLASS_NAME =
-	"bg-[linear-gradient(180deg,_#FFFFFF_0%,_#FBFCFE_48%,_#EEF2F7_100%)]";
+const WRAPPED_UNKNOWN_CARD_OVERLAY_CLASS_NAME =
+	"mymind-wrapped-auth-card-preview--unknown-overlay";
 
 async function openWrappedLoginForm(user: ReturnType<typeof userEvent.setup>) {
 	await user.click(screen.getByRole("button", { name: "Log in" }));
@@ -257,10 +257,8 @@ describe("WrappedGuestPage", () => {
 		});
 		expect(screen.getAllByText("???").length).toBeGreaterThan(0);
 		expect(
-			screen
-				.getByRole("region", { name: "Wrapped player card preview" })
-				.querySelector(".team-lineup-featured-card"),
-		).toHaveClass(WRAPPED_UNKNOWN_CARD_CLASS_NAME);
+			screen.getByRole("region", { name: "Wrapped player card preview" }),
+		).toHaveClass(WRAPPED_UNKNOWN_CARD_OVERLAY_CLASS_NAME);
 	});
 
 	it("keeps wrapped auth in place when the preview-only submit callback is absent", async () => {

--- a/apps/web/src/features/wrapped/WrappedAuthFlow.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -238,7 +238,7 @@ describe("WrappedGuestPage", () => {
 		expect(screen.getByRole("button", { name: "Log in" })).toBeInTheDocument();
 	});
 
-	it("uses an unknown neutral card while the user creates an account", async () => {
+	it("uses an unknown neutral card after the signup card moves into place", async () => {
 		const user = userEvent.setup();
 
 		render(
@@ -250,7 +250,11 @@ describe("WrappedGuestPage", () => {
 		await user.click(screen.getByRole("button", { name: "Create account" }));
 
 		expect(await screen.findByText("Wrapped signup form")).toBeInTheDocument();
-		expect(screen.getAllByText("Unknown Archetype").length).toBeGreaterThan(0);
+		await waitFor(() => {
+			expect(screen.getAllByText("Unknown Archetype").length).toBeGreaterThan(
+				0,
+			);
+		});
 		expect(screen.getAllByText("???").length).toBeGreaterThan(0);
 		expect(
 			screen

--- a/apps/web/src/features/wrapped/WrappedAuthFlow.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.test.tsx
@@ -73,6 +73,8 @@ Object.defineProperty(window, "matchMedia", {
 
 const WRAPPED_UNKNOWN_CARD_OVERLAY_CLASS_NAME =
 	"mymind-wrapped-auth-card-preview--unknown-overlay";
+const WRAPPED_UNKNOWN_TO_DEFAULT_CARD_OVERLAY_CLASS_NAME =
+	"mymind-wrapped-auth-card-preview--unknown-appearance-overlay";
 const WRAPPED_UNKNOWN_CARD_CLASS_NAME =
 	"mymind-wrapped-auth-card-preview--unknown";
 
@@ -288,6 +290,11 @@ describe("WrappedGuestPage", () => {
 			await screen.findByRole("button", { name: "Create account" }),
 		).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Log in" })).toBeInTheDocument();
+		await waitFor(() => {
+			expect(
+				screen.getByRole("region", { name: "Wrapped player card preview" }),
+			).toHaveClass(WRAPPED_UNKNOWN_TO_DEFAULT_CARD_OVERLAY_CLASS_NAME);
+		});
 		await waitFor(() => {
 			expect(
 				screen.getByRole("region", { name: "Wrapped player card preview" }),

--- a/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
@@ -38,7 +38,9 @@ type WrappedAuthCardFlight = {
 	from: WrappedAuthCardFlightRect;
 	key: number;
 	targetMode: WrappedAuthMode;
+	targetRect?: WrappedAuthCardFlightRect;
 	to?: WrappedAuthCardFlightRect;
+	transitionDurationMs: number;
 };
 
 const WRAPPED_AUTH_INTRO_TITLE_LABEL = "Your Claude Wrapped";
@@ -48,10 +50,14 @@ const WRAPPED_AUTH_LAYOUT_EASE = [0.32, 0.72, 0, 1] as const;
 const WRAPPED_AUTH_CARD_FLIGHT_CARD_WIDTH = 233;
 const WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS = 720;
 const WRAPPED_AUTH_CARD_FLIGHT_SETTLE_MS = 90;
+const WRAPPED_AUTH_CARD_FLIGHT_RETARGET_DELAYS_MS = [120, 260, 420] as const;
+const WRAPPED_AUTH_CARD_FLIGHT_MIN_RETARGET_DURATION_MS = 180;
 const WRAPPED_AUTH_CARD_FLIGHT_TRANSITION = {
 	duration: WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS / 1_000,
 	ease: WRAPPED_AUTH_LAYOUT_EASE,
 };
+const WRAPPED_AUTH_CARD_APPEARANCE_DURATION_MS = 480;
+const WRAPPED_AUTH_CARD_APPEARANCE_SETTLE_MS = 80;
 const WRAPPED_AUTH_FORM_TRANSITION_DURATION = 0.32;
 const WRAPPED_AUTH_LAYOUT_DURATION = 0.6;
 const WRAPPED_AUTH_FORM_CARD_SCALE = 1;
@@ -77,12 +83,14 @@ interface WrappedAuthStageProps {
 	authFormCardScale?: number;
 	authIntroCardScale?: number;
 	cardAppearance: WrappedAuthCardAppearance;
+	cardAppearanceOverlay: WrappedAuthCardAppearance | null;
 	cardStageRef: Ref<HTMLDivElement>;
 	isCardFlightActive: boolean;
 	mode: WrappedAuthMode;
 	onEmailPasswordPreviewSubmit?: (email: string) => void;
 	onModeChange: (mode: WrappedAuthMode) => void;
 	previewProfile: WrappedGuestPreviewProfile | null;
+	suppressIntroCardEnter: boolean;
 }
 
 function WrappedAuthStage(props: WrappedAuthStageProps) {
@@ -90,12 +98,14 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 		authFormCardScale,
 		authIntroCardScale,
 		cardAppearance,
+		cardAppearanceOverlay,
 		cardStageRef,
 		isCardFlightActive,
 		mode,
 		onEmailPasswordPreviewSubmit,
 		onModeChange,
 		previewProfile,
+		suppressIntroCardEnter,
 	} = props;
 	const shouldReduceMotion = useReducedMotion() ?? false;
 	const isIntro = mode === null;
@@ -169,6 +179,9 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 					isCardFlightActive
 						? "mymind-wrapped-auth-panel--card-flight-active"
 						: null,
+					suppressIntroCardEnter && isIntro
+						? "mymind-wrapped-auth-panel--suppress-intro-card-enter"
+						: null,
 				)}
 			>
 				<motion.div
@@ -191,6 +204,7 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 					>
 						<WrappedGuestPreviewCard
 							appearance={cardAppearance}
+							appearanceOverlay={cardAppearanceOverlay}
 							cardStageRef={cardStageRef}
 							enableAppearanceOverlay
 							profile={previewProfile}
@@ -269,11 +283,19 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 	const [mode, setMode] = useState<WrappedAuthMode>(null);
 	const [cardAppearance, setCardAppearance] =
 		useState<WrappedAuthCardAppearance>("default");
+	const [cardAppearanceOverlay, setCardAppearanceOverlay] =
+		useState<WrappedAuthCardAppearance | null>(null);
 	const [authCardFlight, setAuthCardFlight] =
 		useState<WrappedAuthCardFlight | null>(null);
+	const [suppressIntroCardEnter, setSuppressIntroCardEnter] = useState(false);
 	const authCardHandoffRef = useRef<HTMLDivElement | null>(null);
+	const authIntroCardFlightRectRef = useRef<WrappedAuthCardFlightRect | null>(
+		null,
+	);
 	const cardAppearanceTimeoutRef = useRef<number | null>(null);
+	const cardAppearanceOverlayTimeoutRef = useRef<number | null>(null);
 	const authCardFlightMeasureRef = useRef<number | null>(null);
+	const authCardFlightRetargetTimersRef = useRef<readonly number[]>([]);
 	const authCardFlightTimerRef = useRef<number | null>(null);
 	const [introTool, setIntroTool] = useState<WrappedAuthIntroTool>("Claude");
 	const shouldReduceMotion = useReducedMotion() ?? false;
@@ -303,54 +325,132 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 
 	useMountEffect(() => () => {
 		clearCardAppearanceTimeout();
+		clearCardAppearanceOverlayTimeout();
 		clearWrappedAuthCardFlightAnimationFrame(authCardFlightMeasureRef);
+		clearWrappedAuthCardFlightRetargetTimers(authCardFlightRetargetTimersRef);
 		clearWrappedAuthCardFlightTimer(authCardFlightTimerRef);
 	});
 
+	const activeAuthCardFlightAppearance = authCardFlight?.appearance;
+	const activeAuthCardFlightKey = authCardFlight?.key ?? null;
+	const activeAuthCardFlightTargetRect = authCardFlight?.targetRect;
+	const activeAuthCardFlightTargetMode = authCardFlight?.targetMode;
+	const transitionCardAppearance = useEffectEvent(
+		(
+			nextAppearance: WrappedAuthCardAppearance,
+			previousAppearance: WrappedAuthCardAppearance,
+		) => {
+			clearCardAppearanceOverlayTimeout();
+			setCardAppearance(nextAppearance);
+
+			if (nextAppearance === previousAppearance || shouldReduceMotion) {
+				setCardAppearanceOverlay(null);
+				return;
+			}
+
+			setCardAppearanceOverlay(previousAppearance);
+			cardAppearanceOverlayTimeoutRef.current = window.setTimeout(() => {
+				cardAppearanceOverlayTimeoutRef.current = null;
+				startTransition(() => {
+					setCardAppearanceOverlay(null);
+				});
+			}, WRAPPED_AUTH_CARD_APPEARANCE_DURATION_MS +
+				WRAPPED_AUTH_CARD_APPEARANCE_SETTLE_MS);
+		},
+	);
+
 	useEffect(() => {
 		if (
-			!authCardFlight ||
-			authCardFlight.to ||
-			mode !== authCardFlight.targetMode
+			activeAuthCardFlightKey === null ||
+			activeAuthCardFlightAppearance === undefined ||
+			activeAuthCardFlightTargetMode === undefined ||
+			mode !== activeAuthCardFlightTargetMode
 		) {
 			return;
 		}
 
-		clearWrappedAuthCardFlightAnimationFrame(authCardFlightMeasureRef);
-		authCardFlightMeasureRef.current = window.requestAnimationFrame(() => {
-			const nextRect = getWrappedAuthCardFlightRect(authCardHandoffRef.current);
+		const flightAppearance = activeAuthCardFlightAppearance;
+		const flightKey = activeAuthCardFlightKey;
+		const flightTargetMode = activeAuthCardFlightTargetMode;
+		const measurementStartTime = performance.now();
+		const shouldRetargetFlight = activeAuthCardFlightTargetRect === undefined;
+		let hasScheduledCompletion = false;
+
+		function completeCardFlight() {
+			setAuthCardFlight(null);
+			startTransition(() => {
+				transitionCardAppearance(
+					getWrappedAuthCardAppearance(flightTargetMode),
+					flightAppearance,
+				);
+			});
+		}
+
+		function scheduleCardFlightCompletion() {
+			if (hasScheduledCompletion) {
+				return;
+			}
+
+			hasScheduledCompletion = true;
+			clearWrappedAuthCardFlightTimer(authCardFlightTimerRef);
+			authCardFlightTimerRef.current = window.setTimeout(() => {
+				authCardFlightTimerRef.current = null;
+				completeCardFlight();
+			}, WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS +
+				WRAPPED_AUTH_CARD_FLIGHT_SETTLE_MS);
+		}
+
+		function getRetargetTransitionDuration() {
+			const elapsedMs = performance.now() - measurementStartTime;
+			return Math.max(
+				WRAPPED_AUTH_CARD_FLIGHT_MIN_RETARGET_DURATION_MS,
+				WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS - elapsedMs,
+			);
+		}
+
+		function measureCardFlightTarget(transitionDurationMs: number) {
+			const measuredRect = getWrappedAuthCardFlightRect(
+				authCardHandoffRef.current,
+			);
+			const nextRect = activeAuthCardFlightTargetRect ?? measuredRect;
 
 			if (!nextRect) {
-				setAuthCardFlight(null);
-				startTransition(() => {
-					setCardAppearance(
-						getWrappedAuthCardAppearance(authCardFlight.targetMode),
-					);
-				});
+				completeCardFlight();
 				return;
 			}
 
 			setAuthCardFlight((currentFlight) =>
-				currentFlight?.key === authCardFlight.key
-					? { ...currentFlight, to: nextRect }
+				currentFlight?.key === flightKey
+					? { ...currentFlight, to: nextRect, transitionDurationMs }
 					: currentFlight,
 			);
-			clearWrappedAuthCardFlightTimer(authCardFlightTimerRef);
-			authCardFlightTimerRef.current = window.setTimeout(() => {
-				setAuthCardFlight(null);
-				startTransition(() => {
-					setCardAppearance(
-						getWrappedAuthCardAppearance(authCardFlight.targetMode),
-					);
-				});
-			}, WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS +
-				WRAPPED_AUTH_CARD_FLIGHT_SETTLE_MS);
+			scheduleCardFlightCompletion();
+		}
+
+		clearWrappedAuthCardFlightAnimationFrame(authCardFlightMeasureRef);
+		authCardFlightMeasureRef.current = window.requestAnimationFrame(() => {
+			measureCardFlightTarget(WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS);
 		});
+		clearWrappedAuthCardFlightRetargetTimers(authCardFlightRetargetTimersRef);
+		authCardFlightRetargetTimersRef.current = shouldRetargetFlight
+			? WRAPPED_AUTH_CARD_FLIGHT_RETARGET_DELAYS_MS.map((delayMs) =>
+					window.setTimeout(() => {
+						measureCardFlightTarget(getRetargetTransitionDuration());
+					}, delayMs),
+				)
+			: [];
 
 		return () => {
 			clearWrappedAuthCardFlightAnimationFrame(authCardFlightMeasureRef);
+			clearWrappedAuthCardFlightRetargetTimers(authCardFlightRetargetTimersRef);
 		};
-	}, [authCardFlight, mode]);
+	}, [
+		activeAuthCardFlightAppearance,
+		activeAuthCardFlightKey,
+		activeAuthCardFlightTargetMode,
+		activeAuthCardFlightTargetRect,
+		mode,
+	]);
 
 	function clearCardAppearanceTimeout() {
 		if (cardAppearanceTimeoutRef.current === null) {
@@ -359,6 +459,15 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 
 		window.clearTimeout(cardAppearanceTimeoutRef.current);
 		cardAppearanceTimeoutRef.current = null;
+	}
+
+	function clearCardAppearanceOverlayTimeout() {
+		if (cardAppearanceOverlayTimeoutRef.current === null) {
+			return;
+		}
+
+		window.clearTimeout(cardAppearanceOverlayTimeoutRef.current);
+		cardAppearanceOverlayTimeoutRef.current = null;
 	}
 
 	function scheduleCardAppearanceForMode(
@@ -370,18 +479,19 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 		const nextAppearance = getWrappedAuthCardAppearance(nextMode);
 
 		if (nextAppearance === cardAppearance) {
+			setCardAppearanceOverlay(null);
 			return;
 		}
 
 		if (shouldReduceMotion || appearanceDelayMs === null) {
-			setCardAppearance(nextAppearance);
+			transitionCardAppearance(nextAppearance, cardAppearance);
 			return;
 		}
 
 		cardAppearanceTimeoutRef.current = window.setTimeout(() => {
 			cardAppearanceTimeoutRef.current = null;
 			startTransition(() => {
-				setCardAppearance(nextAppearance);
+				transitionCardAppearance(nextAppearance, cardAppearance);
 			});
 		}, appearanceDelayMs);
 	}
@@ -389,6 +499,7 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 	function handleAuthModeChange(nextMode: WrappedAuthMode) {
 		clearWrappedAuthCardFlightTimer(authCardFlightTimerRef);
 		clearWrappedAuthCardFlightAnimationFrame(authCardFlightMeasureRef);
+		clearWrappedAuthCardFlightRetargetTimers(authCardFlightRetargetTimersRef);
 
 		const shouldAnimateCardFlight =
 			mode !== nextMode &&
@@ -398,10 +509,18 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 			? getWrappedAuthCardFlightRect(authCardHandoffRef.current)
 			: null;
 		const shouldUseCardFlight = cardFlightFrom !== null;
+		const cardFlightTargetRect =
+			shouldUseCardFlight && nextMode === null
+				? (authIntroCardFlightRectRef.current ?? undefined)
+				: undefined;
 		const appearanceDelayMs =
 			mode === null || nextMode === null
 				? WRAPPED_AUTH_LAYOUT_DURATION * 1000
 				: null;
+
+		if (mode === null && cardFlightFrom !== null) {
+			authIntroCardFlightRectRef.current = cardFlightFrom;
+		}
 
 		if (shouldUseCardFlight) {
 			clearCardAppearanceTimeout();
@@ -415,11 +534,14 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 						from: cardFlightFrom,
 						key: Date.now(),
 						targetMode: nextMode,
+						targetRect: cardFlightTargetRect,
+						transitionDurationMs: WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS,
 					}
 				: null,
 		);
 		startTransition(() => {
 			setIntroTool("Claude");
+			setSuppressIntroCardEnter(nextMode === null);
 			setMode(nextMode);
 		});
 	}
@@ -446,12 +568,16 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 					authFormCardScale={authFormCardScale}
 					authIntroCardScale={authIntroCardScale}
 					cardAppearance={cardAppearance}
+					cardAppearanceOverlay={cardAppearanceOverlay}
 					cardStageRef={authCardHandoffRef}
 					isCardFlightActive={authCardFlight !== null}
 					mode={mode}
 					onEmailPasswordPreviewSubmit={onEmailPasswordPreviewSubmit}
 					onModeChange={handleAuthModeChange}
 					previewProfile={previewProfile}
+					suppressIntroCardEnter={
+						suppressIntroCardEnter || authCardFlight !== null
+					}
 				/>
 			}
 			overlay={
@@ -503,7 +629,10 @@ function WrappedAuthCardFlightOverlay(props: {
 				x: flight.from.left,
 				y: flight.from.top,
 			}}
-			transition={WRAPPED_AUTH_CARD_FLIGHT_TRANSITION}
+			transition={{
+				...WRAPPED_AUTH_CARD_FLIGHT_TRANSITION,
+				duration: flight.transitionDurationMs / 1_000,
+			}}
 		>
 			<div className="mymind-wrapped-auth-card-flight__card">
 				<WrappedGuestPreviewCard
@@ -536,6 +665,16 @@ function clearWrappedAuthCardFlightAnimationFrame(
 
 	window.cancelAnimationFrame(timerRef.current);
 	timerRef.current = null;
+}
+
+function clearWrappedAuthCardFlightRetargetTimers(
+	timerRef: MutableRefObject<readonly number[]>,
+) {
+	for (const timerId of timerRef.current) {
+		window.clearTimeout(timerId);
+	}
+
+	timerRef.current = [];
 }
 
 function getWrappedAuthCardFlightRect(

--- a/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
@@ -5,7 +5,7 @@ import {
 	useReducedMotion,
 } from "motion/react";
 import type { ReactNode } from "react";
-import { startTransition, useEffectEvent, useState } from "react";
+import { startTransition, useEffectEvent, useRef, useState } from "react";
 import { LoginForm } from "@/features/auth/LoginForm";
 import { SignupForm } from "@/features/auth/SignupForm";
 import {
@@ -19,6 +19,7 @@ import { WrappedGuestPreviewCard } from "./WrappedGuestPreviewCard";
 import type { WrappedGuestPreviewProfile } from "./wrapped-guest-preview";
 
 type WrappedAuthMode = "login" | "signup" | null;
+type WrappedAuthCardAppearance = "default" | "unknown";
 type WrappedAuthIntroTool = "Claude" | "Codex";
 
 const WRAPPED_AUTH_INTRO_TITLE_LABEL = "Your Claude Wrapped";
@@ -49,22 +50,22 @@ interface WrappedAuthFlowProps {
 interface WrappedAuthStageProps {
 	authFormCardScale?: number;
 	authIntroCardScale?: number;
+	cardAppearance: WrappedAuthCardAppearance;
 	mode: WrappedAuthMode;
 	onEmailPasswordPreviewSubmit?: (email: string) => void;
+	onModeChange: (mode: WrappedAuthMode) => void;
 	previewProfile: WrappedGuestPreviewProfile | null;
-	setIntroTool: (tool: WrappedAuthIntroTool) => void;
-	setMode: (mode: WrappedAuthMode) => void;
 }
 
 function WrappedAuthStage(props: WrappedAuthStageProps) {
 	const {
 		authFormCardScale,
 		authIntroCardScale,
+		cardAppearance,
 		mode,
 		onEmailPasswordPreviewSubmit,
+		onModeChange,
 		previewProfile,
-		setIntroTool,
-		setMode,
 	} = props;
 	const shouldReduceMotion = useReducedMotion() ?? false;
 	const isIntro = mode === null;
@@ -148,7 +149,7 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 						transition={cardScaleTransition}
 					>
 						<WrappedGuestPreviewCard
-							appearance={mode === "signup" ? "unknown" : "default"}
+							appearance={cardAppearance}
 							profile={previewProfile}
 							size="hero"
 						/>
@@ -168,17 +169,11 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 							<div className="mymind-wrapped-auth-panel__actions">
 								<WrappedPrimaryAction
 									kind="button"
-									onClick={() =>
-										transitionWrappedAuthMode(setMode, setIntroTool, "signup")
-									}
+									onClick={() => onModeChange("signup")}
 								>
 									Create account
 								</WrappedPrimaryAction>
-								<WrappedSecondaryAction
-									onClick={() =>
-										transitionWrappedAuthMode(setMode, setIntroTool, "login")
-									}
-								>
+								<WrappedSecondaryAction onClick={() => onModeChange("login")}>
 									Log in
 								</WrappedSecondaryAction>
 							</div>
@@ -196,17 +191,13 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 								<LoginForm
 									onEmailPasswordPreviewSubmit={onEmailPasswordPreviewSubmit}
 									variant="wrapped-story"
-									onSwitchToSignup={() =>
-										transitionWrappedAuthMode(setMode, setIntroTool, "signup")
-									}
+									onSwitchToSignup={() => onModeChange("signup")}
 								/>
 							) : (
 								<SignupForm
 									onEmailPasswordPreviewSubmit={onEmailPasswordPreviewSubmit}
 									variant="wrapped-story"
-									onSwitchToLogin={() =>
-										transitionWrappedAuthMode(setMode, setIntroTool, "login")
-									}
+									onSwitchToLogin={() => onModeChange("login")}
 								/>
 							)}
 						</motion.div>
@@ -233,6 +224,9 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 		previewProfile,
 	} = props;
 	const [mode, setMode] = useState<WrappedAuthMode>(null);
+	const [cardAppearance, setCardAppearance] =
+		useState<WrappedAuthCardAppearance>("default");
+	const cardAppearanceTimeoutRef = useRef<number | null>(null);
 	const [introTool, setIntroTool] = useState<WrappedAuthIntroTool>("Claude");
 	const shouldReduceMotion = useReducedMotion() ?? false;
 	const hasDebugControls =
@@ -259,6 +253,54 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 		};
 	});
 
+	useMountEffect(() => () => {
+		clearCardAppearanceTimeout();
+	});
+
+	function clearCardAppearanceTimeout() {
+		if (cardAppearanceTimeoutRef.current === null) {
+			return;
+		}
+
+		window.clearTimeout(cardAppearanceTimeoutRef.current);
+		cardAppearanceTimeoutRef.current = null;
+	}
+
+	function scheduleCardAppearanceForMode(
+		nextMode: WrappedAuthMode,
+		shouldDelayAppearance: boolean,
+	) {
+		clearCardAppearanceTimeout();
+
+		const nextAppearance = getWrappedAuthCardAppearance(nextMode);
+
+		if (nextAppearance === cardAppearance) {
+			return;
+		}
+
+		if (shouldReduceMotion || !shouldDelayAppearance) {
+			setCardAppearance(nextAppearance);
+			return;
+		}
+
+		cardAppearanceTimeoutRef.current = window.setTimeout(() => {
+			cardAppearanceTimeoutRef.current = null;
+			startTransition(() => {
+				setCardAppearance(nextAppearance);
+			});
+		}, WRAPPED_AUTH_LAYOUT_DURATION * 1000);
+	}
+
+	function handleAuthModeChange(nextMode: WrappedAuthMode) {
+		const shouldDelayAppearance = mode === null || nextMode === null;
+
+		scheduleCardAppearanceForMode(nextMode, shouldDelayAppearance);
+		startTransition(() => {
+			setIntroTool("Claude");
+			setMode(nextMode);
+		});
+	}
+
 	return (
 		<WrappedRouteStageShell
 			backLabel="Go back"
@@ -272,10 +314,7 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 				mode === null
 					? undefined
 					: () => {
-							startTransition(() => {
-								setIntroTool("Claude");
-								setMode(null);
-							});
+							handleAuthModeChange(null);
 						}
 			}
 			status={hasDebugControls ? debugControls : undefined}
@@ -283,11 +322,11 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 				<WrappedAuthStage
 					authFormCardScale={authFormCardScale}
 					authIntroCardScale={authIntroCardScale}
+					cardAppearance={cardAppearance}
 					mode={mode}
 					onEmailPasswordPreviewSubmit={onEmailPasswordPreviewSubmit}
+					onModeChange={handleAuthModeChange}
 					previewProfile={previewProfile}
-					setIntroTool={setIntroTool}
-					setMode={setMode}
 				/>
 			}
 			stageClassName={cn("mymind-wrapped-entry-stage--auth")}
@@ -434,6 +473,12 @@ function getWrappedAuthTitleText(mode: WrappedAuthMode) {
 	return mode === "login" ? "Log in" : "Create account";
 }
 
+function getWrappedAuthCardAppearance(
+	mode: WrappedAuthMode,
+): WrappedAuthCardAppearance {
+	return mode === "signup" ? "unknown" : "default";
+}
+
 function WrappedAuthIntroTerms() {
 	return (
 		<p className="mymind-wrapped-auth-form__terms">
@@ -458,15 +503,4 @@ function WrappedAuthIntroTerms() {
 			.
 		</p>
 	);
-}
-
-function transitionWrappedAuthMode(
-	setMode: (mode: WrappedAuthMode) => void,
-	setIntroTool: (tool: WrappedAuthIntroTool) => void,
-	mode: Exclude<WrappedAuthMode, null>,
-) {
-	startTransition(() => {
-		setIntroTool("Claude");
-		setMode(mode);
-	});
 }

--- a/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
@@ -37,7 +37,7 @@ type WrappedAuthCardFlight = {
 	appearance: WrappedAuthCardAppearance;
 	from: WrappedAuthCardFlightRect;
 	key: number;
-	targetMode: Exclude<WrappedAuthMode, null>;
+	targetMode: WrappedAuthMode;
 	to?: WrappedAuthCardFlightRect;
 };
 
@@ -391,29 +391,30 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 		clearWrappedAuthCardFlightAnimationFrame(authCardFlightMeasureRef);
 
 		const shouldAnimateCardFlight =
-			mode === null && nextMode !== null && !shouldReduceMotion;
+			mode !== nextMode &&
+			(mode === null || nextMode === null) &&
+			!shouldReduceMotion;
 		const cardFlightFrom = shouldAnimateCardFlight
 			? getWrappedAuthCardFlightRect(authCardHandoffRef.current)
 			: null;
-		const cardFlightTargetMode =
-			cardFlightFrom !== null && nextMode !== null ? nextMode : null;
+		const shouldUseCardFlight = cardFlightFrom !== null;
 		const appearanceDelayMs =
 			mode === null || nextMode === null
 				? WRAPPED_AUTH_LAYOUT_DURATION * 1000
 				: null;
 
-		if (cardFlightTargetMode) {
+		if (shouldUseCardFlight) {
 			clearCardAppearanceTimeout();
 		} else {
 			scheduleCardAppearanceForMode(nextMode, appearanceDelayMs);
 		}
 		setAuthCardFlight(
-			cardFlightFrom && cardFlightTargetMode
+			cardFlightFrom
 				? {
 						appearance: cardAppearance,
 						from: cardFlightFrom,
 						key: Date.now(),
-						targetMode: cardFlightTargetMode,
+						targetMode: nextMode,
 					}
 				: null,
 		);

--- a/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
@@ -2,6 +2,7 @@ import {
 	AnimatePresence,
 	LayoutGroup,
 	motion,
+	useIsPresent,
 	useReducedMotion,
 } from "motion/react";
 import type { ReactNode } from "react";
@@ -28,6 +29,8 @@ const WRAPPED_AUTH_EXIT_EASE = [0.4, 0, 0.2, 1] as const;
 const WRAPPED_AUTH_LAYOUT_EASE = [0.32, 0.72, 0, 1] as const;
 const WRAPPED_AUTH_FORM_TRANSITION_DURATION = 0.32;
 const WRAPPED_AUTH_LAYOUT_DURATION = 0.6;
+const WRAPPED_AUTH_CARD_APPEARANCE_ENTER_DURATION = 0.3;
+const WRAPPED_AUTH_CARD_APPEARANCE_EXIT_DURATION = 0.22;
 const WRAPPED_AUTH_FORM_CARD_SCALE = 1;
 const WRAPPED_AUTH_INTRO_REDUCED_DURATION = 0.14;
 const WRAPPED_AUTH_INTRO_CARD_SCALE = 1;
@@ -127,6 +130,30 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 				duration: WRAPPED_AUTH_FORM_TRANSITION_DURATION,
 				ease: WRAPPED_AUTH_INTRO_EASE,
 			};
+	const cardAppearanceEnterTransition = shouldReduceMotion
+		? {
+				duration: WRAPPED_AUTH_INTRO_REDUCED_DURATION,
+				ease: "linear" as const,
+			}
+		: {
+				duration: WRAPPED_AUTH_CARD_APPEARANCE_ENTER_DURATION,
+				ease: WRAPPED_AUTH_INTRO_EASE,
+			};
+	const cardAppearanceExit = shouldReduceMotion
+		? {
+				opacity: 0,
+				transition: {
+					duration: WRAPPED_AUTH_INTRO_REDUCED_DURATION,
+					ease: "linear" as const,
+				},
+			}
+		: {
+				opacity: 0,
+				transition: {
+					duration: WRAPPED_AUTH_CARD_APPEARANCE_EXIT_DURATION,
+					ease: WRAPPED_AUTH_EXIT_EASE,
+				},
+			};
 
 	return (
 		<LayoutGroup id="wrapped-auth-panel">
@@ -148,11 +175,23 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 						className="mymind-wrapped-auth-panel__card-scale-shell"
 						transition={cardScaleTransition}
 					>
-						<WrappedGuestPreviewCard
-							appearance={cardAppearance}
-							profile={previewProfile}
-							size="hero"
-						/>
+						<div className="mymind-wrapped-auth-card-appearance-stack">
+							<AnimatePresence initial={false} mode="sync">
+								<motion.div
+									key={cardAppearance}
+									animate={{ opacity: 1 }}
+									className="mymind-wrapped-auth-card-appearance-stack__item"
+									exit={cardAppearanceExit}
+									initial={{ opacity: shouldReduceMotion ? 1 : 0 }}
+									transition={cardAppearanceEnterTransition}
+								>
+									<WrappedAuthCardAppearanceLayer
+										appearance={cardAppearance}
+										previewProfile={previewProfile}
+									/>
+								</motion.div>
+							</AnimatePresence>
+						</div>
 					</motion.div>
 				</motion.div>
 
@@ -205,6 +244,32 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 				</AnimatePresence>
 			</div>
 		</LayoutGroup>
+	);
+}
+
+interface WrappedAuthCardAppearanceLayerProps {
+	appearance: WrappedAuthCardAppearance;
+	previewProfile: WrappedGuestPreviewProfile | null;
+}
+
+function WrappedAuthCardAppearanceLayer(
+	props: WrappedAuthCardAppearanceLayerProps,
+) {
+	const { appearance, previewProfile } = props;
+	const isPresent = useIsPresent();
+
+	return (
+		<div
+			aria-hidden={!isPresent}
+			className="mymind-wrapped-auth-card-appearance-stack__content"
+			style={{ pointerEvents: isPresent ? "auto" : "none" }}
+		>
+			<WrappedGuestPreviewCard
+				appearance={appearance}
+				profile={previewProfile}
+				size="hero"
+			/>
+		</div>
 	);
 }
 

--- a/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
@@ -4,8 +4,15 @@ import {
 	motion,
 	useReducedMotion,
 } from "motion/react";
-import type { ReactNode } from "react";
-import { startTransition, useEffectEvent, useRef, useState } from "react";
+import type { MutableRefObject, ReactNode, Ref } from "react";
+import {
+	startTransition,
+	// biome-ignore lint/style/noRestrictedImports: auth-card flight measurement is an imperative storyboard bridge for this wrapped surface.
+	useEffect,
+	useEffectEvent,
+	useRef,
+	useState,
+} from "react";
 import { LoginForm } from "@/features/auth/LoginForm";
 import { SignupForm } from "@/features/auth/SignupForm";
 import {
@@ -21,11 +28,30 @@ import type { WrappedGuestPreviewProfile } from "./wrapped-guest-preview";
 type WrappedAuthMode = "login" | "signup" | null;
 type WrappedAuthCardAppearance = "default" | "unknown";
 type WrappedAuthIntroTool = "Claude" | "Codex";
+type WrappedAuthCardFlightRect = {
+	left: number;
+	scale: number;
+	top: number;
+};
+type WrappedAuthCardFlight = {
+	appearance: WrappedAuthCardAppearance;
+	from: WrappedAuthCardFlightRect;
+	key: number;
+	targetMode: Exclude<WrappedAuthMode, null>;
+	to?: WrappedAuthCardFlightRect;
+};
 
 const WRAPPED_AUTH_INTRO_TITLE_LABEL = "Your Claude Wrapped";
 const WRAPPED_AUTH_INTRO_EASE = [0.22, 1, 0.36, 1] as const;
 const WRAPPED_AUTH_EXIT_EASE = [0.4, 0, 0.2, 1] as const;
 const WRAPPED_AUTH_LAYOUT_EASE = [0.32, 0.72, 0, 1] as const;
+const WRAPPED_AUTH_CARD_FLIGHT_CARD_WIDTH = 233;
+const WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS = 720;
+const WRAPPED_AUTH_CARD_FLIGHT_SETTLE_MS = 90;
+const WRAPPED_AUTH_CARD_FLIGHT_TRANSITION = {
+	duration: WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS / 1_000,
+	ease: WRAPPED_AUTH_LAYOUT_EASE,
+};
 const WRAPPED_AUTH_FORM_TRANSITION_DURATION = 0.32;
 const WRAPPED_AUTH_LAYOUT_DURATION = 0.6;
 const WRAPPED_AUTH_FORM_CARD_SCALE = 1;
@@ -51,6 +77,8 @@ interface WrappedAuthStageProps {
 	authFormCardScale?: number;
 	authIntroCardScale?: number;
 	cardAppearance: WrappedAuthCardAppearance;
+	cardStageRef: Ref<HTMLDivElement>;
+	isCardFlightActive: boolean;
 	mode: WrappedAuthMode;
 	onEmailPasswordPreviewSubmit?: (email: string) => void;
 	onModeChange: (mode: WrappedAuthMode) => void;
@@ -62,6 +90,8 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 		authFormCardScale,
 		authIntroCardScale,
 		cardAppearance,
+		cardStageRef,
+		isCardFlightActive,
 		mode,
 		onEmailPasswordPreviewSubmit,
 		onModeChange,
@@ -136,20 +166,32 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 					isIntro
 						? "mymind-wrapped-auth-panel--intro"
 						: "mymind-wrapped-auth-panel--form",
+					isCardFlightActive
+						? "mymind-wrapped-auth-panel--card-flight-active"
+						: null,
 				)}
 			>
 				<motion.div
-					layout="position"
+					layout={isCardFlightActive ? false : "position"}
 					className="mymind-wrapped-auth-panel__card"
-					transition={{ layout: panelLayoutTransition }}
+					transition={
+						isCardFlightActive ? undefined : { layout: panelLayoutTransition }
+					}
 				>
 					<motion.div
 						animate={{ scale: activeCardScale }}
 						className="mymind-wrapped-auth-panel__card-scale-shell"
-						transition={cardScaleTransition}
+						transition={
+							isCardFlightActive
+								? {
+										duration: 0,
+									}
+								: cardScaleTransition
+						}
 					>
 						<WrappedGuestPreviewCard
 							appearance={cardAppearance}
+							cardStageRef={cardStageRef}
 							enableAppearanceOverlay
 							profile={previewProfile}
 							size="hero"
@@ -227,7 +269,12 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 	const [mode, setMode] = useState<WrappedAuthMode>(null);
 	const [cardAppearance, setCardAppearance] =
 		useState<WrappedAuthCardAppearance>("default");
+	const [authCardFlight, setAuthCardFlight] =
+		useState<WrappedAuthCardFlight | null>(null);
+	const authCardHandoffRef = useRef<HTMLDivElement | null>(null);
 	const cardAppearanceTimeoutRef = useRef<number | null>(null);
+	const authCardFlightMeasureRef = useRef<number | null>(null);
+	const authCardFlightTimerRef = useRef<number | null>(null);
 	const [introTool, setIntroTool] = useState<WrappedAuthIntroTool>("Claude");
 	const shouldReduceMotion = useReducedMotion() ?? false;
 	const hasDebugControls =
@@ -256,7 +303,54 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 
 	useMountEffect(() => () => {
 		clearCardAppearanceTimeout();
+		clearWrappedAuthCardFlightAnimationFrame(authCardFlightMeasureRef);
+		clearWrappedAuthCardFlightTimer(authCardFlightTimerRef);
 	});
+
+	useEffect(() => {
+		if (
+			!authCardFlight ||
+			authCardFlight.to ||
+			mode !== authCardFlight.targetMode
+		) {
+			return;
+		}
+
+		clearWrappedAuthCardFlightAnimationFrame(authCardFlightMeasureRef);
+		authCardFlightMeasureRef.current = window.requestAnimationFrame(() => {
+			const nextRect = getWrappedAuthCardFlightRect(authCardHandoffRef.current);
+
+			if (!nextRect) {
+				setAuthCardFlight(null);
+				startTransition(() => {
+					setCardAppearance(
+						getWrappedAuthCardAppearance(authCardFlight.targetMode),
+					);
+				});
+				return;
+			}
+
+			setAuthCardFlight((currentFlight) =>
+				currentFlight?.key === authCardFlight.key
+					? { ...currentFlight, to: nextRect }
+					: currentFlight,
+			);
+			clearWrappedAuthCardFlightTimer(authCardFlightTimerRef);
+			authCardFlightTimerRef.current = window.setTimeout(() => {
+				setAuthCardFlight(null);
+				startTransition(() => {
+					setCardAppearance(
+						getWrappedAuthCardAppearance(authCardFlight.targetMode),
+					);
+				});
+			}, WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS +
+				WRAPPED_AUTH_CARD_FLIGHT_SETTLE_MS);
+		});
+
+		return () => {
+			clearWrappedAuthCardFlightAnimationFrame(authCardFlightMeasureRef);
+		};
+	}, [authCardFlight, mode]);
 
 	function clearCardAppearanceTimeout() {
 		if (cardAppearanceTimeoutRef.current === null) {
@@ -269,7 +363,7 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 
 	function scheduleCardAppearanceForMode(
 		nextMode: WrappedAuthMode,
-		shouldDelayAppearance: boolean,
+		appearanceDelayMs: number | null,
 	) {
 		clearCardAppearanceTimeout();
 
@@ -279,7 +373,7 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 			return;
 		}
 
-		if (shouldReduceMotion || !shouldDelayAppearance) {
+		if (shouldReduceMotion || appearanceDelayMs === null) {
 			setCardAppearance(nextAppearance);
 			return;
 		}
@@ -289,13 +383,40 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 			startTransition(() => {
 				setCardAppearance(nextAppearance);
 			});
-		}, WRAPPED_AUTH_LAYOUT_DURATION * 1000);
+		}, appearanceDelayMs);
 	}
 
 	function handleAuthModeChange(nextMode: WrappedAuthMode) {
-		const shouldDelayAppearance = mode === null || nextMode === null;
+		clearWrappedAuthCardFlightTimer(authCardFlightTimerRef);
+		clearWrappedAuthCardFlightAnimationFrame(authCardFlightMeasureRef);
 
-		scheduleCardAppearanceForMode(nextMode, shouldDelayAppearance);
+		const shouldAnimateCardFlight =
+			mode === null && nextMode !== null && !shouldReduceMotion;
+		const cardFlightFrom = shouldAnimateCardFlight
+			? getWrappedAuthCardFlightRect(authCardHandoffRef.current)
+			: null;
+		const cardFlightTargetMode =
+			cardFlightFrom !== null && nextMode !== null ? nextMode : null;
+		const appearanceDelayMs =
+			mode === null || nextMode === null
+				? WRAPPED_AUTH_LAYOUT_DURATION * 1000
+				: null;
+
+		if (cardFlightTargetMode) {
+			clearCardAppearanceTimeout();
+		} else {
+			scheduleCardAppearanceForMode(nextMode, appearanceDelayMs);
+		}
+		setAuthCardFlight(
+			cardFlightFrom && cardFlightTargetMode
+				? {
+						appearance: cardAppearance,
+						from: cardFlightFrom,
+						key: Date.now(),
+						targetMode: cardFlightTargetMode,
+					}
+				: null,
+		);
 		startTransition(() => {
 			setIntroTool("Claude");
 			setMode(nextMode);
@@ -324,9 +445,17 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 					authFormCardScale={authFormCardScale}
 					authIntroCardScale={authIntroCardScale}
 					cardAppearance={cardAppearance}
+					cardStageRef={authCardHandoffRef}
+					isCardFlightActive={authCardFlight !== null}
 					mode={mode}
 					onEmailPasswordPreviewSubmit={onEmailPasswordPreviewSubmit}
 					onModeChange={handleAuthModeChange}
+					previewProfile={previewProfile}
+				/>
+			}
+			overlay={
+				<WrappedAuthCardFlightOverlay
+					flight={authCardFlight}
 					previewProfile={previewProfile}
 				/>
 			}
@@ -342,6 +471,89 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 			useReferenceTopChrome={mode !== null}
 		/>
 	);
+}
+
+function WrappedAuthCardFlightOverlay(props: {
+	flight: WrappedAuthCardFlight | null;
+	previewProfile: WrappedGuestPreviewProfile | null;
+}) {
+	const { flight, previewProfile } = props;
+
+	if (!flight) {
+		return null;
+	}
+
+	const targetRect = flight.to ?? flight.from;
+
+	return (
+		<motion.div
+			key={flight.key}
+			aria-hidden="true"
+			animate={{
+				opacity: 1,
+				scale: targetRect.scale,
+				x: targetRect.left,
+				y: targetRect.top,
+			}}
+			className="mymind-wrapped-auth-card-flight"
+			initial={{
+				opacity: 1,
+				scale: flight.from.scale,
+				x: flight.from.left,
+				y: flight.from.top,
+			}}
+			transition={WRAPPED_AUTH_CARD_FLIGHT_TRANSITION}
+		>
+			<div className="mymind-wrapped-auth-card-flight__card">
+				<WrappedGuestPreviewCard
+					appearance={flight.appearance}
+					profile={previewProfile}
+					size="hero"
+				/>
+			</div>
+		</motion.div>
+	);
+}
+
+function clearWrappedAuthCardFlightTimer(
+	timerRef: MutableRefObject<number | null>,
+) {
+	if (timerRef.current === null) {
+		return;
+	}
+
+	window.clearTimeout(timerRef.current);
+	timerRef.current = null;
+}
+
+function clearWrappedAuthCardFlightAnimationFrame(
+	timerRef: MutableRefObject<number | null>,
+) {
+	if (timerRef.current === null) {
+		return;
+	}
+
+	window.cancelAnimationFrame(timerRef.current);
+	timerRef.current = null;
+}
+
+function getWrappedAuthCardFlightRect(
+	node: HTMLDivElement | null,
+): WrappedAuthCardFlightRect | null {
+	if (!node) {
+		return null;
+	}
+
+	const rect = node.getBoundingClientRect();
+	if (rect.width <= 0 || rect.height <= 0) {
+		return null;
+	}
+
+	return {
+		left: rect.left,
+		scale: rect.width / WRAPPED_AUTH_CARD_FLIGHT_CARD_WIDTH,
+		top: rect.top,
+	};
 }
 
 interface WrappedAuthTitleProps {

--- a/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
@@ -2,7 +2,6 @@ import {
 	AnimatePresence,
 	LayoutGroup,
 	motion,
-	useIsPresent,
 	useReducedMotion,
 } from "motion/react";
 import type { ReactNode } from "react";
@@ -29,8 +28,6 @@ const WRAPPED_AUTH_EXIT_EASE = [0.4, 0, 0.2, 1] as const;
 const WRAPPED_AUTH_LAYOUT_EASE = [0.32, 0.72, 0, 1] as const;
 const WRAPPED_AUTH_FORM_TRANSITION_DURATION = 0.32;
 const WRAPPED_AUTH_LAYOUT_DURATION = 0.6;
-const WRAPPED_AUTH_CARD_APPEARANCE_ENTER_DURATION = 0.3;
-const WRAPPED_AUTH_CARD_APPEARANCE_EXIT_DURATION = 0.22;
 const WRAPPED_AUTH_FORM_CARD_SCALE = 1;
 const WRAPPED_AUTH_INTRO_REDUCED_DURATION = 0.14;
 const WRAPPED_AUTH_INTRO_CARD_SCALE = 1;
@@ -130,30 +127,6 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 				duration: WRAPPED_AUTH_FORM_TRANSITION_DURATION,
 				ease: WRAPPED_AUTH_INTRO_EASE,
 			};
-	const cardAppearanceEnterTransition = shouldReduceMotion
-		? {
-				duration: WRAPPED_AUTH_INTRO_REDUCED_DURATION,
-				ease: "linear" as const,
-			}
-		: {
-				duration: WRAPPED_AUTH_CARD_APPEARANCE_ENTER_DURATION,
-				ease: WRAPPED_AUTH_INTRO_EASE,
-			};
-	const cardAppearanceExit = shouldReduceMotion
-		? {
-				opacity: 0,
-				transition: {
-					duration: WRAPPED_AUTH_INTRO_REDUCED_DURATION,
-					ease: "linear" as const,
-				},
-			}
-		: {
-				opacity: 0,
-				transition: {
-					duration: WRAPPED_AUTH_CARD_APPEARANCE_EXIT_DURATION,
-					ease: WRAPPED_AUTH_EXIT_EASE,
-				},
-			};
 
 	return (
 		<LayoutGroup id="wrapped-auth-panel">
@@ -175,23 +148,12 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 						className="mymind-wrapped-auth-panel__card-scale-shell"
 						transition={cardScaleTransition}
 					>
-						<div className="mymind-wrapped-auth-card-appearance-stack">
-							<AnimatePresence initial={false} mode="sync">
-								<motion.div
-									key={cardAppearance}
-									animate={{ opacity: 1 }}
-									className="mymind-wrapped-auth-card-appearance-stack__item"
-									exit={cardAppearanceExit}
-									initial={{ opacity: shouldReduceMotion ? 1 : 0 }}
-									transition={cardAppearanceEnterTransition}
-								>
-									<WrappedAuthCardAppearanceLayer
-										appearance={cardAppearance}
-										previewProfile={previewProfile}
-									/>
-								</motion.div>
-							</AnimatePresence>
-						</div>
+						<WrappedGuestPreviewCard
+							appearance={cardAppearance}
+							enableAppearanceOverlay
+							profile={previewProfile}
+							size="hero"
+						/>
 					</motion.div>
 				</motion.div>
 
@@ -244,32 +206,6 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 				</AnimatePresence>
 			</div>
 		</LayoutGroup>
-	);
-}
-
-interface WrappedAuthCardAppearanceLayerProps {
-	appearance: WrappedAuthCardAppearance;
-	previewProfile: WrappedGuestPreviewProfile | null;
-}
-
-function WrappedAuthCardAppearanceLayer(
-	props: WrappedAuthCardAppearanceLayerProps,
-) {
-	const { appearance, previewProfile } = props;
-	const isPresent = useIsPresent();
-
-	return (
-		<div
-			aria-hidden={!isPresent}
-			className="mymind-wrapped-auth-card-appearance-stack__content"
-			style={{ pointerEvents: isPresent ? "auto" : "none" }}
-		>
-			<WrappedGuestPreviewCard
-				appearance={appearance}
-				profile={previewProfile}
-				size="hero"
-			/>
-		</div>
 	);
 }
 

--- a/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
+++ b/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
@@ -2,6 +2,7 @@ import { useReducedMotion } from "motion/react";
 import {
 	type CSSProperties,
 	type ReactNode,
+	type Ref,
 	// biome-ignore lint/style/noRestrictedImports: auto-select focuses the editable name input after React commits it.
 	useEffect,
 	useRef,
@@ -31,6 +32,7 @@ interface WrappedGuestPreviewCardProps {
 		placeholder?: string;
 		value: string;
 	};
+	cardStageRef?: Ref<HTMLDivElement>;
 	enableAppearanceOverlay?: boolean;
 	mediaOverlayContent?: ReactNode;
 	profile: WrappedGuestPreviewProfile | null;
@@ -40,6 +42,7 @@ interface WrappedGuestPreviewCardProps {
 export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 	const {
 		appearance = "default",
+		cardStageRef,
 		disablePerspective = false,
 		editableDisplayName,
 		enableAppearanceOverlay = false,
@@ -253,7 +256,10 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 						: "mymind-wrapped-auth-card-preview--hero",
 			)}
 		>
-			<div className="team-lineup-card-tilt-stage mymind-wrapped-auth-card-preview__tilt-stage">
+			<div
+				ref={cardStageRef}
+				className="team-lineup-card-tilt-stage mymind-wrapped-auth-card-preview__tilt-stage"
+			>
 				<div
 					ref={tiltController.cardTiltRef}
 					className="team-lineup-card-tilt-shell mymind-wrapped-auth-card-preview__tilt mymind-wrapped-final-stage__tilt-shell"

--- a/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
+++ b/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
@@ -57,6 +57,9 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 	const appearanceOverlayClassName = enableAppearanceOverlay
 		? "mymind-wrapped-auth-card-preview__appearance-overlay"
 		: undefined;
+	const backAppearanceOverlayClassName = isUnknownCard
+		? undefined
+		: appearanceOverlayClassName;
 	const hasInteractiveFrontControls = Boolean(
 		editableDisplayName || mediaOverlayContent,
 	);
@@ -218,7 +221,7 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 			back={
 				<div className="grid justify-center">
 					<WrappedTeamMemberCardBack
-						backgroundOverlayClassName={appearanceOverlayClassName}
+						backgroundOverlayClassName={backAppearanceOverlayClassName}
 						disableOuterShadow
 						metrics={visibleBackMetrics}
 						shellClassName={activePreset.shellClassName}
@@ -246,6 +249,7 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 				enableAppearanceOverlay && isUnknownCard
 					? "mymind-wrapped-auth-card-preview--unknown-overlay"
 					: null,
+				isUnknownCard ? "mymind-wrapped-auth-card-preview--unknown" : null,
 				shouldRenderStaticFront
 					? "mymind-wrapped-auth-card-preview--static"
 					: null,

--- a/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
+++ b/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
@@ -31,6 +31,7 @@ interface WrappedGuestPreviewCardProps {
 		placeholder?: string;
 		value: string;
 	};
+	enableAppearanceOverlay?: boolean;
 	mediaOverlayContent?: ReactNode;
 	profile: WrappedGuestPreviewProfile | null;
 	size?: "hero" | "compact" | "profile";
@@ -41,6 +42,7 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 		appearance = "default",
 		disablePerspective = false,
 		editableDisplayName,
+		enableAppearanceOverlay = false,
 		mediaOverlayContent,
 		profile,
 		size = "hero",
@@ -49,6 +51,9 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 	const activePreset = isUnknownCard
 		? UNKNOWN_GUEST_CARD_PRESET
 		: RICK_PLACEHOLDER_GUEST_CARD_PRESET;
+	const appearanceOverlayClassName = enableAppearanceOverlay
+		? "mymind-wrapped-auth-card-preview__appearance-overlay"
+		: undefined;
 	const hasInteractiveFrontControls = Boolean(
 		editableDisplayName || mediaOverlayContent,
 	);
@@ -185,6 +190,7 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 	const frontCardContent = (
 		<div className="grid justify-center">
 			<WrappedTeamMemberCard
+				backgroundOverlayClassName={appearanceOverlayClassName}
 				disableOuterShadow
 				headerLeftMetric={activePreset.headerLeftMetric}
 				headerRightMetric={activePreset.headerRightMetric}
@@ -209,6 +215,7 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 			back={
 				<div className="grid justify-center">
 					<WrappedTeamMemberCardBack
+						backgroundOverlayClassName={appearanceOverlayClassName}
 						disableOuterShadow
 						metrics={visibleBackMetrics}
 						shellClassName={activePreset.shellClassName}
@@ -229,6 +236,12 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 				"mymind-wrapped-auth-card-preview team-lineup-surface-scope",
 				hasInteractiveFrontControls
 					? "mymind-wrapped-auth-card-preview--editable"
+					: null,
+				enableAppearanceOverlay
+					? "mymind-wrapped-auth-card-preview--appearance-overlay"
+					: null,
+				enableAppearanceOverlay && isUnknownCard
+					? "mymind-wrapped-auth-card-preview--unknown-overlay"
 					: null,
 				shouldRenderStaticFront
 					? "mymind-wrapped-auth-card-preview--static"

--- a/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
+++ b/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
@@ -24,6 +24,7 @@ import type { WrappedGuestPreviewProfile } from "./wrapped-guest-preview";
 
 interface WrappedGuestPreviewCardProps {
 	appearance?: "default" | "unknown";
+	appearanceOverlay?: "default" | "unknown" | null;
 	disablePerspective?: boolean;
 	editableDisplayName?: {
 		autoSelect?: boolean;
@@ -42,6 +43,7 @@ interface WrappedGuestPreviewCardProps {
 export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 	const {
 		appearance = "default",
+		appearanceOverlay,
 		cardStageRef,
 		disablePerspective = false,
 		editableDisplayName,
@@ -54,12 +56,17 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 	const activePreset = isUnknownCard
 		? UNKNOWN_GUEST_CARD_PRESET
 		: RICK_PLACEHOLDER_GUEST_CARD_PRESET;
-	const appearanceOverlayClassName = enableAppearanceOverlay
+	const resolvedAppearanceOverlay =
+		enableAppearanceOverlay && appearanceOverlay !== null
+			? (appearanceOverlay ?? (isUnknownCard ? "default" : null))
+			: null;
+	const appearanceOverlayClassName = resolvedAppearanceOverlay
 		? "mymind-wrapped-auth-card-preview__appearance-overlay"
 		: undefined;
-	const backAppearanceOverlayClassName = isUnknownCard
-		? undefined
-		: appearanceOverlayClassName;
+	const backAppearanceOverlayClassName =
+		isUnknownCard && resolvedAppearanceOverlay === "default"
+			? undefined
+			: appearanceOverlayClassName;
 	const hasInteractiveFrontControls = Boolean(
 		editableDisplayName || mediaOverlayContent,
 	);
@@ -246,8 +253,14 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 				enableAppearanceOverlay
 					? "mymind-wrapped-auth-card-preview--appearance-overlay"
 					: null,
-				enableAppearanceOverlay && isUnknownCard
+				resolvedAppearanceOverlay === "default" && isUnknownCard
 					? "mymind-wrapped-auth-card-preview--unknown-overlay"
+					: null,
+				resolvedAppearanceOverlay === "default"
+					? "mymind-wrapped-auth-card-preview--default-appearance-overlay"
+					: null,
+				resolvedAppearanceOverlay === "unknown"
+					? "mymind-wrapped-auth-card-preview--unknown-appearance-overlay"
 					: null,
 				isUnknownCard ? "mymind-wrapped-auth-card-preview--unknown" : null,
 				shouldRenderStaticFront

--- a/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
+++ b/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
@@ -290,6 +290,7 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 							tiltController.handlePointerMove(event);
 						}
 					}}
+					onPointerEnter={tiltController.handlePointerEnter}
 					onPointerLeave={tiltController.handlePointerLeave}
 					onPointerCancel={tiltController.handlePointerLeave}
 					style={

--- a/apps/web/src/features/wrapped/route-stage-shell.tsx
+++ b/apps/web/src/features/wrapped/route-stage-shell.tsx
@@ -27,6 +27,7 @@ interface WrappedRouteStageShellProps {
 	leadingControl?: ReactNode | null;
 	objectClassName?: string;
 	onBack?: () => void;
+	overlay?: ReactNode;
 	progressStepId?: WrappedOnboardingProgressStepId;
 	status?: ReactNode;
 	stageClassName?: string;
@@ -95,6 +96,7 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 		leadingControl,
 		objectClassName,
 		onBack,
+		overlay,
 		progressStepId,
 		stageClassName,
 		stage,
@@ -313,6 +315,7 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 					) : null}
 				</div>
 			</div>
+			{overlay}
 		</main>
 	);
 }

--- a/apps/web/src/features/wrapped/team-card/card-back.tsx
+++ b/apps/web/src/features/wrapped/team-card/card-back.tsx
@@ -11,6 +11,7 @@ export interface WrappedTeamMemberCardBackMetric {
 export type WrappedTeamMemberCardBackVariant = "default" | "gradient-only";
 
 export function WrappedTeamMemberCardBack(props: {
+	backgroundOverlayClassName?: string;
 	disableOuterShadow?: boolean;
 	metrics: readonly WrappedTeamMemberCardBackMetric[];
 	shellClassName?: string;
@@ -19,6 +20,7 @@ export function WrappedTeamMemberCardBack(props: {
 	variant?: WrappedTeamMemberCardBackVariant;
 }) {
 	const {
+		backgroundOverlayClassName,
 		disableOuterShadow = false,
 		metrics,
 		shellClassName,
@@ -68,6 +70,9 @@ export function WrappedTeamMemberCardBack(props: {
 			)}
 			style={{ ...cardBackStyle, ...shellStyle, ...outerShadowStyle }}
 		>
+			{backgroundOverlayClassName ? (
+				<div aria-hidden="true" className={backgroundOverlayClassName} />
+			) : null}
 			<div aria-hidden="true" className="mymind-wrapped-team-card-back__wash" />
 			{shouldRenderContent ? (
 				<div className="mymind-wrapped-team-card-back__content">

--- a/apps/web/src/features/wrapped/team-card/card.tsx
+++ b/apps/web/src/features/wrapped/team-card/card.tsx
@@ -251,6 +251,9 @@ export function WrappedTeamMemberCard(props: {
 	const portraitPanelStyle = {
 		"--wrapped-card-image-edit-inset": scaleLength(6),
 		"--wrapped-card-image-panel-radius": portraitPanelRadius,
+		"--wrapped-card-portrait-shadow-opacity": shouldRenderPortraitImage
+			? undefined
+			: "0.48",
 		borderRadius: portraitPanelRadius,
 		paddingBottom: scaleLength(10),
 		paddingLeft: scaleLength(12),

--- a/apps/web/src/features/wrapped/team-card/card.tsx
+++ b/apps/web/src/features/wrapped/team-card/card.tsx
@@ -117,6 +117,7 @@ const DEFAULT_STAT_LAYER_OPACITIES: WrappedTeamMemberCardStatLayerOpacities = {
 };
 
 export function WrappedTeamMemberCard(props: {
+	backgroundOverlayClassName?: string;
 	disableOuterShadow?: boolean;
 	headerLeftMetric?: WrappedTeamMemberCardHeaderMetric;
 	headerRightMetric?: WrappedTeamMemberCardHeaderMetric;
@@ -135,6 +136,7 @@ export function WrappedTeamMemberCard(props: {
 	theme?: WrappedTeamMemberCardTheme;
 }) {
 	const {
+		backgroundOverlayClassName,
 		disableOuterShadow = false,
 		headerLeftMetric,
 		headerRightMetric,
@@ -336,6 +338,9 @@ export function WrappedTeamMemberCard(props: {
 			)}
 			style={{ ...cardShellLayoutStyle, ...shellStyle }}
 		>
+			{backgroundOverlayClassName ? (
+				<div aria-hidden="true" className={backgroundOverlayClassName} />
+			) : null}
 			<div className="relative z-10 flex h-full flex-col">
 				<div
 					className={cn(

--- a/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
@@ -148,6 +148,7 @@ const tiltController: WrappedCardTiltController = {
 	enableGyroscope: vi.fn(async () => {}),
 	gyroscopeState: "idle",
 	gyroscopeStatusMessage: null,
+	handlePointerEnter: vi.fn(),
 	handlePointerLeave: vi.fn(),
 	handlePointerMove: vi.fn(),
 	isGyroscopePromptVisible: false,

--- a/apps/web/src/features/wrapped/team-card/final-stages.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.tsx
@@ -630,6 +630,7 @@ export function WrappedTeamCardRevealStage(
 										tiltController.handlePointerMove(event);
 									}
 								}}
+								onPointerEnter={tiltController.handlePointerEnter}
 								onPointerLeave={tiltController.handlePointerLeave}
 								onPointerCancel={tiltController.handlePointerLeave}
 							>

--- a/apps/web/src/features/wrapped/team-card/tilt/types.ts
+++ b/apps/web/src/features/wrapped/team-card/tilt/types.ts
@@ -27,6 +27,7 @@ export interface WrappedCardTiltController {
 	enableGyroscope: () => Promise<void>;
 	gyroscopeState: WrappedCardGyroscopeState;
 	gyroscopeStatusMessage: string | null;
+	handlePointerEnter: (event: ReactPointerEvent<HTMLDivElement>) => void;
 	handlePointerLeave: () => void;
 	handlePointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
 	isGyroscopePromptVisible: boolean;

--- a/apps/web/src/features/wrapped/team-card/tilt/use-card-tilt.ts
+++ b/apps/web/src/features/wrapped/team-card/tilt/use-card-tilt.ts
@@ -6,17 +6,56 @@ import { useWrappedCardGyroscope } from "./use-card-gyroscope";
 
 export type { WrappedCardTiltController } from "./types";
 
+const POINTER_TILT_ACTIVATION_DISTANCE_PX = 2;
+
 export function useWrappedCardTilt(): WrappedCardTiltController {
 	const cardTiltRef = useRef<HTMLDivElement | null>(null);
+	const pointerActivationOriginRef = useRef<{
+		x: number;
+		y: number;
+	} | null>(null);
 	const pointerActiveRef = useRef(false);
 	const gyroscope = useWrappedCardGyroscope({
 		cardTiltRef,
 		pointerActiveRef,
 	});
 
+	function handlePointerEnter(event: ReactPointerEvent<HTMLDivElement>) {
+		if (gyroscope.prefersReducedMotion || event.pointerType !== "mouse") {
+			return;
+		}
+
+		pointerActivationOriginRef.current = {
+			x: event.clientX,
+			y: event.clientY,
+		};
+	}
+
 	function handlePointerMove(event: ReactPointerEvent<HTMLDivElement>) {
 		if (gyroscope.prefersReducedMotion || event.pointerType !== "mouse") {
 			return;
+		}
+
+		const activationOrigin = pointerActivationOriginRef.current;
+		if (!activationOrigin && !pointerActiveRef.current) {
+			pointerActivationOriginRef.current = {
+				x: event.clientX,
+				y: event.clientY,
+			};
+			return;
+		}
+
+		if (activationOrigin) {
+			const movedDistance = Math.hypot(
+				event.clientX - activationOrigin.x,
+				event.clientY - activationOrigin.y,
+			);
+
+			if (movedDistance < POINTER_TILT_ACTIVATION_DISTANCE_PX) {
+				return;
+			}
+
+			pointerActivationOriginRef.current = null;
 		}
 
 		pointerActiveRef.current = true;
@@ -35,6 +74,7 @@ export function useWrappedCardTilt(): WrappedCardTiltController {
 	}
 
 	function handlePointerLeave() {
+		pointerActivationOriginRef.current = null;
 		pointerActiveRef.current = false;
 
 		if (gyroscope.isGyroscopeActive) {
@@ -50,6 +90,7 @@ export function useWrappedCardTilt(): WrappedCardTiltController {
 		enableGyroscope: gyroscope.enableGyroscope,
 		gyroscopeState: gyroscope.gyroscopeState,
 		gyroscopeStatusMessage: gyroscope.gyroscopeStatusMessage,
+		handlePointerEnter,
 		handlePointerLeave,
 		handlePointerMove,
 		isGyroscopePromptVisible: gyroscope.isGyroscopePromptVisible,

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -633,6 +633,36 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	transform: translateZ(0);
 }
 
+.mymind-wrapped-auth-card-flight {
+	position: fixed;
+	top: 0;
+	left: 0;
+	z-index: 60;
+	width: 233px;
+	height: 358px;
+	pointer-events: none;
+	transform-origin: top left;
+	will-change: transform, opacity;
+}
+
+.mymind-wrapped-auth-card-flight__card {
+	--wrapped-card-render-scale: 1;
+	--wrapped-short-card-scale: 1;
+	display: grid;
+	width: 233px;
+	height: 358px;
+	place-items: center;
+	filter: drop-shadow(0 18px 28px rgb(15 23 42 / 0.12));
+	transform: translateZ(0);
+}
+
+.mymind-wrapped-auth-card-flight .mymind-wrapped-auth-card-preview,
+.mymind-wrapped-auth-card-flight .mymind-wrapped-auth-card-preview__tilt-stage,
+.mymind-wrapped-auth-card-flight .mymind-wrapped-auth-card-preview__tilt {
+	width: 233px;
+	height: 358px;
+}
+
 .mymind-wrapped-intro-stage {
 	display: flex;
 	flex: 1;
@@ -4611,6 +4641,11 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	will-change: transform;
 }
 
+.mymind-wrapped-auth-panel--card-flight-active
+	.mymind-wrapped-auth-panel__card-scale-shell {
+	opacity: 0;
+}
+
 .mymind-wrapped-auth-intro-title,
 .mymind-wrapped-auth-intro-title__line {
 	will-change: opacity, transform, filter;
@@ -4826,6 +4861,10 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		.mymind-wrapped-auth-card-preview__tilt {
 		--wrapped-card-render-scale: 1.28;
 	}
+}
+
+.mymind-wrapped-auth-card-flight .mymind-wrapped-auth-card-preview__tilt {
+	--wrapped-card-render-scale: 1;
 }
 
 @keyframes wrapped-auth-intro-card-enter {

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -4667,6 +4667,11 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		both;
 }
 
+.mymind-wrapped-auth-panel--suppress-intro-card-enter.mymind-wrapped-auth-panel--intro
+	.mymind-wrapped-auth-panel__card {
+	animation: none;
+}
+
 .mymind-wrapped-auth-panel--form .mymind-wrapped-auth-panel__card {
 	padding-top: clamp(0.15rem, 1.6svh, 0.9rem);
 }
@@ -4753,6 +4758,13 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		#f05267 50%,
 		#f8d558 100%
 	);
+	--wrapped-auth-card-unknown-background: linear-gradient(
+		180deg,
+		#ffffff 0%,
+		#fbfcfe 48%,
+		#eef2f7 100%
+	);
+	--wrapped-auth-card-appearance-overlay-background: transparent;
 	--wrapped-auth-card-appearance-duration: 480ms;
 	--wrapped-auth-card-appearance-ease: cubic-bezier(0.4, 0, 1, 1);
 }
@@ -4762,15 +4774,28 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	inset: -1px;
 	z-index: 0;
 	border-radius: 0;
-	background: var(--wrapped-auth-card-default-background);
+	background: var(--wrapped-auth-card-appearance-overlay-background);
 	opacity: 0;
 	pointer-events: none;
 	will-change: opacity;
 }
 
-.mymind-wrapped-auth-card-preview--unknown-overlay
+.mymind-wrapped-auth-card-preview--default-appearance-overlay
 	.mymind-wrapped-auth-card-preview__appearance-overlay {
-	animation: wrapped-auth-card-default-overlay-exit
+	--wrapped-auth-card-appearance-overlay-background: var(
+		--wrapped-auth-card-default-background
+	);
+	animation: wrapped-auth-card-previous-overlay-exit
+		var(--wrapped-auth-card-appearance-duration)
+		var(--wrapped-auth-card-appearance-ease) both;
+}
+
+.mymind-wrapped-auth-card-preview--unknown-appearance-overlay
+	.mymind-wrapped-auth-card-preview__appearance-overlay {
+	--wrapped-auth-card-appearance-overlay-background: var(
+		--wrapped-auth-card-unknown-background
+	);
+	animation: wrapped-auth-card-previous-overlay-exit
 		var(--wrapped-auth-card-appearance-duration)
 		var(--wrapped-auth-card-appearance-ease) both;
 }
@@ -4900,7 +4925,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	}
 }
 
-@keyframes wrapped-auth-card-default-overlay-exit {
+@keyframes wrapped-auth-card-previous-overlay-exit {
 	from {
 		opacity: 1;
 	}

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -7264,7 +7264,27 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	}
 }
 
-@media (max-width: 47.999rem) and (min-height: 721px) and (max-height: 820px) {
+@media (min-height: 821px) and (max-height: 900px) {
+	.mymind-wrapped-auth-panel--form {
+		--wrapped-auth-form-overlap: clamp(1.15rem, 2.8svh, 1.55rem);
+	}
+
+	.mymind-wrapped-auth-panel--form .mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-card-render-scale: 1;
+	}
+
+	.mymind-wrapped-auth-form .mymind-wrapped-auth-form__scene-action {
+		height: 48px;
+		min-height: 48px;
+	}
+
+	.mymind-wrapped-auth-form[data-email-auth-stage="choice"]
+		.mymind-wrapped-auth-form__choice-footer {
+		margin-bottom: 0;
+	}
+}
+
+@media (min-height: 761px) and (max-height: 820px) {
 	.mymind-wrapped-auth-panel--form {
 		--wrapped-auth-form-overlap: clamp(0.9rem, 2.4svh, 1.25rem);
 	}
@@ -7272,13 +7292,43 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	.mymind-wrapped-auth-panel--form .mymind-wrapped-auth-card-preview__tilt {
 		--wrapped-card-render-scale: 0.94;
 	}
+
+	.mymind-wrapped-auth-form .mymind-wrapped-auth-form__scene-action {
+		height: 44px;
+		min-height: 44px;
+	}
+
+	.mymind-wrapped-auth-form[data-email-auth-stage="choice"]
+		.mymind-wrapped-auth-form__choice-footer {
+		margin-bottom: 0;
+	}
+}
+
+@media (min-height: 721px) and (max-height: 760px) {
+	.mymind-wrapped-auth-panel--form {
+		--wrapped-auth-form-overlap: clamp(0.75rem, 2.2svh, 1.2rem);
+	}
+
+	.mymind-wrapped-auth-panel--form .mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-card-render-scale: 0.84;
+	}
+
+	.mymind-wrapped-auth-form .mymind-wrapped-auth-form__scene-action {
+		height: 44px;
+		min-height: 44px;
+	}
+
+	.mymind-wrapped-auth-form[data-email-auth-stage="choice"]
+		.mymind-wrapped-auth-form__choice-footer {
+		margin-bottom: 0;
+	}
 }
 
 @media (max-height: 720px) {
 	.mymind-wrapped-shell {
 		--wrapped-shell-top-inset: 20px;
 		--wrapped-shell-inline-inset: 20px;
-		--wrapped-shell-bottom-inset: 8px;
+		--wrapped-shell-bottom-inset: 12px;
 		--wrapped-shell-stage-gap: 0.8rem;
 	}
 
@@ -7297,6 +7347,10 @@ body.mymind-wrapped-body #cw-bubble-holder {
 
 	.mymind-wrapped-auth-panel--intro {
 		gap: 0.8rem;
+	}
+
+	.mymind-wrapped-auth-panel--form {
+		--wrapped-auth-form-overlap: clamp(0.45rem, 1.5svh, 0.75rem);
 	}
 
 	.mymind-wrapped-auth-card-preview__tilt {
@@ -7318,6 +7372,16 @@ body.mymind-wrapped-body #cw-bubble-holder {
 			calc(env(safe-area-inset-bottom, 0px) + 0.9rem)
 		);
 		padding-top: clamp(0.35rem, 1.4svh, 0.75rem);
+	}
+
+	.mymind-wrapped-auth-form .mymind-wrapped-auth-form__scene-action {
+		height: 44px;
+		min-height: 44px;
+	}
+
+	.mymind-wrapped-auth-form[data-email-auth-stage="choice"]
+		.mymind-wrapped-auth-form__choice-footer {
+		margin-bottom: 0;
 	}
 
 	.mymind-wrapped-auth-panel--form:has(
@@ -7446,7 +7510,10 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	}
 
 	.mymind-wrapped-final-stage__tilt-shell {
-		--wrapped-card-render-scale: 0.66 !important;
+		--wrapped-card-render-scale: var(
+			--wrapped-short-card-scale,
+			0.66
+		) !important;
 	}
 
 	.mymind-wrapped-action-stack {
@@ -7456,6 +7523,20 @@ body.mymind-wrapped-body #cw-bubble-holder {
 
 	.mymind-wrapped-action-stack--single-action {
 		min-height: 44px;
+	}
+}
+
+@media (max-height: 600px) {
+	.mymind-wrapped-entry-stage--auth {
+		gap: 0.45rem;
+	}
+
+	.mymind-wrapped-auth-panel--form .mymind-wrapped-auth-panel__card {
+		padding-top: 0;
+	}
+
+	.mymind-wrapped-auth-panel--form .mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-short-card-scale: 0.48;
 	}
 }
 

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -4611,6 +4611,28 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	will-change: transform;
 }
 
+.mymind-wrapped-auth-card-appearance-stack {
+	isolation: isolate;
+	display: grid;
+	justify-items: center;
+	width: 100%;
+}
+
+.mymind-wrapped-auth-card-appearance-stack__item {
+	grid-area: 1 / 1;
+	display: grid;
+	justify-items: center;
+	width: 100%;
+	pointer-events: none;
+	will-change: opacity;
+}
+
+.mymind-wrapped-auth-card-appearance-stack__content {
+	display: grid;
+	justify-items: center;
+	width: 100%;
+}
+
 .mymind-wrapped-auth-intro-title,
 .mymind-wrapped-auth-intro-title__line {
 	will-change: opacity, transform, filter;

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -4775,6 +4775,22 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		var(--wrapped-auth-card-appearance-ease) both;
 }
 
+.mymind-wrapped-auth-card-preview--unknown .mymind-wrapped-team-card-back {
+	background: linear-gradient(180deg, #ffffff 0%, #fbfcfe 48%, #eef2f7 100%);
+}
+
+.mymind-wrapped-auth-card-preview--unknown
+	.mymind-wrapped-team-card-back__wash {
+	background: linear-gradient(
+		180deg,
+		rgb(255 255 255 / 0.18) 0%,
+		rgb(255 255 255 / 0) 54%,
+		rgb(148 163 184 / 0.08) 100%
+	);
+	mix-blend-mode: normal;
+	opacity: 1;
+}
+
 .mymind-wrapped-auth-card-preview__tilt-stage {
 	width: fit-content;
 	max-width: none;

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -7264,6 +7264,16 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	}
 }
 
+@media (max-width: 47.999rem) and (min-height: 721px) and (max-height: 820px) {
+	.mymind-wrapped-auth-panel--form {
+		--wrapped-auth-form-overlap: clamp(0.9rem, 2.4svh, 1.25rem);
+	}
+
+	.mymind-wrapped-auth-panel--form .mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-card-render-scale: 0.94;
+	}
+}
+
 @media (max-height: 720px) {
 	.mymind-wrapped-shell {
 		--wrapped-shell-top-inset: 20px;

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -4611,28 +4611,6 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	will-change: transform;
 }
 
-.mymind-wrapped-auth-card-appearance-stack {
-	isolation: isolate;
-	display: grid;
-	justify-items: center;
-	width: 100%;
-}
-
-.mymind-wrapped-auth-card-appearance-stack__item {
-	grid-area: 1 / 1;
-	display: grid;
-	justify-items: center;
-	width: 100%;
-	pointer-events: none;
-	will-change: opacity;
-}
-
-.mymind-wrapped-auth-card-appearance-stack__content {
-	display: grid;
-	justify-items: center;
-	width: 100%;
-}
-
 .mymind-wrapped-auth-intro-title,
 .mymind-wrapped-auth-intro-title__line {
 	will-change: opacity, transform, filter;
@@ -4731,6 +4709,35 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	display: grid;
 	justify-items: center;
 	width: 100%;
+}
+
+.mymind-wrapped-auth-card-preview--appearance-overlay {
+	--wrapped-auth-card-default-background: linear-gradient(
+		180deg,
+		#f05267 0%,
+		#f05267 50%,
+		#f8d558 100%
+	);
+	--wrapped-auth-card-appearance-duration: 480ms;
+	--wrapped-auth-card-appearance-ease: cubic-bezier(0.4, 0, 1, 1);
+}
+
+.mymind-wrapped-auth-card-preview__appearance-overlay {
+	position: absolute;
+	inset: -1px;
+	z-index: 0;
+	border-radius: 0;
+	background: var(--wrapped-auth-card-default-background);
+	opacity: 0;
+	pointer-events: none;
+	will-change: opacity;
+}
+
+.mymind-wrapped-auth-card-preview--unknown-overlay
+	.mymind-wrapped-auth-card-preview__appearance-overlay {
+	animation: wrapped-auth-card-default-overlay-exit
+		var(--wrapped-auth-card-appearance-duration)
+		var(--wrapped-auth-card-appearance-ease) both;
 }
 
 .mymind-wrapped-auth-card-preview__tilt-stage {
@@ -4835,6 +4842,16 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	to {
 		opacity: 1;
 		transform: translateY(0) scale(1);
+	}
+}
+
+@keyframes wrapped-auth-card-default-overlay-exit {
+	from {
+		opacity: 1;
+	}
+
+	to {
+		opacity: 0;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Keeps wrapped auth card/forms inside short browser viewports while preserving bottom inset spacing.
- Replaces the auth card mode switch with a measured flight so login, signup, and back transitions land smoothly before the card color eases.
- Softens the placeholder portrait inset shadow and gates hover tilt until the mouse deliberately moves on the landed card.

## Test plan
- `bun run verify`
- `bun run lint:wrapped:hig`
- Focused wrapped auth and final-stage tests
- Chromium/WebKit screenshot and pointer-tilt checks across mobile and desktop viewports