### PR TITLE
fix: avoid generic wrapped URL in X shares

### DIFF
--- a/apps/web/src/features/wrapped/team-card/share.test.ts
+++ b/apps/web/src/features/wrapped/team-card/share.test.ts
@@ -117,7 +117,7 @@ describe("createWrappedTeamCardShareActions", () => {
 		expect(toast.success).toHaveBeenCalledWith("Post downloaded");
 	});
 
-	it("opens X with first-person copy and the wrapped landing URL", async () => {
+	it("opens X with first-person copy and only the resolved public card URL", async () => {
 		vi.clearAllMocks();
 		const pendingXWindow = {
 			closed: false,
@@ -155,6 +155,8 @@ describe("createWrappedTeamCardShareActions", () => {
 		await actions.handleSharePost();
 
 		expect(resolveShareUrl).toHaveBeenCalledTimes(1);
+		const initialIntentUrl = new URL(open.mock.calls[0]?.[0] ?? "");
+		expect(initialIntentUrl.searchParams.get("url")).toBeNull();
 		expect(captureElement).not.toHaveBeenCalled();
 		expect(copyToClipboard).not.toHaveBeenCalled();
 		expect(downloadAsImage).not.toHaveBeenCalled();
@@ -163,7 +165,7 @@ describe("createWrappedTeamCardShareActions", () => {
 			[
 				"According to my Codex usage, I'm a Maniac.",
 				"Traits: 1.9M tokens over 219 sessions; high session count, heavy token burn, no visible off switch.",
-				"Make yours: app.rudel.ai/wrapped",
+				"Make yours from the card.",
 			].join("\n\n"),
 		);
 		expect(intentUrl.searchParams.get("url")).toBe(

--- a/apps/web/src/features/wrapped/team-card/share.ts
+++ b/apps/web/src/features/wrapped/team-card/share.ts
@@ -2,10 +2,7 @@ import type { WrappedSourceSplit } from "@rudel/api-routes";
 import type { RefObject } from "react";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
 import { createWrappedImageShareActions } from "@/features/wrapped/share-image";
-import {
-	buildWrappedXShareText,
-	WRAPPED_X_MAKE_YOURS_URL,
-} from "@/features/wrapped/wrapped-x-share";
+import { buildWrappedXShareText } from "@/features/wrapped/wrapped-x-share";
 
 const TEAM_CARD_SHARE_IMAGE_FILE_NAME = "rudel-team-card-post.png";
 const TEAM_CARD_SHARE_CAPTURE_SIZE = 6144;
@@ -138,7 +135,7 @@ export function createWrappedTeamCardShareActions(
 		shareText,
 		shareTarget: "x",
 		shareTitle,
-		shareUrl: shareUrl ?? WRAPPED_X_MAKE_YOURS_URL,
+		shareUrl,
 		shareUrlLabel,
 	});
 

--- a/apps/web/src/features/wrapped/wrapped-x-share.test.ts
+++ b/apps/web/src/features/wrapped/wrapped-x-share.test.ts
@@ -17,7 +17,7 @@ describe("wrapped X share copy", () => {
 			[
 				"According to my Claude / Codex usage, I'm a Maniac.",
 				"Traits: 1.9M tokens over 219 sessions; high session count, heavy token burn, no visible off switch.",
-				"Make yours: app.rudel.ai/wrapped",
+				"Make yours from the card.",
 			].join("\n\n"),
 		);
 	});

--- a/apps/web/src/features/wrapped/wrapped-x-share.ts
+++ b/apps/web/src/features/wrapped/wrapped-x-share.ts
@@ -19,8 +19,6 @@ interface WrappedXShareCopy {
 }
 
 const WRAPPED_X_INTENT_URL = "https://twitter.com/intent/tweet";
-export const WRAPPED_X_MAKE_YOURS_LABEL = "app.rudel.ai/wrapped";
-export const WRAPPED_X_MAKE_YOURS_URL = `https://${WRAPPED_X_MAKE_YOURS_LABEL}`;
 
 const WRAPPED_X_SHARE_COPY_BY_ARCHETYPE: Record<string, WrappedXShareCopy> = {
 	"adhd brain": {
@@ -106,7 +104,7 @@ export function buildWrappedXShareText(input: BuildWrappedXShareTextInput) {
 	return [
 		`According to my ${usageSourceLabel} usage, I'm ${archetypeIdentity}.`,
 		`Traits: ${metrics}; ${copy.traits}.`,
-		`Make yours: ${WRAPPED_X_MAKE_YOURS_LABEL}`,
+		"Make yours from the card.",
 	].join("\n\n");
 }
 


### PR DESCRIPTION
## Summary
- Remove the generic `app.rudel.ai/wrapped` URL from X share copy so X only sees the resolved public card URL.
- Stop seeding the X intent with the generic wrapped fallback before a share record exists.
- Update share tests to assert the initial X intent has no fallback URL and the final intent uses the public card URL.

## Root cause
The generated tweet could contain both the generic wrapped entry URL and the per-user share URL. The generic entry page does not expose `twitter:image`/`og:image`, so X could crawl that URL and produce no image preview.

## Test plan
- `bun run verify`
- `bun run lint:wrapped:hig`