### PR TITLE
fix: use wrapped help button for mobile support

### DIFF
--- a/apps/web/src/app/hooks/use-mobile.ts
+++ b/apps/web/src/app/hooks/use-mobile.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 
-const MOBILE_BREAKPOINT = 768;
-const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
+export const MOBILE_BREAKPOINT = 768;
+export const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
 
 function subscribe(callback: () => void) {
 	const mediaQuery = window.matchMedia(MOBILE_QUERY);

--- a/apps/web/src/features/wrapped/mobile-chatwoot-bubble-controller.tsx
+++ b/apps/web/src/features/wrapped/mobile-chatwoot-bubble-controller.tsx
@@ -1,0 +1,30 @@
+import { MOBILE_QUERY } from "@/app/hooks/use-mobile";
+import { useMountEffect } from "@/app/hooks/useMountEffect";
+import { setChatwootBubbleVisibility } from "@/lib/chatwoot";
+
+export function WrappedMobileChatwootBubbleController() {
+	useMountEffect(() => {
+		if (
+			typeof window === "undefined" ||
+			typeof window.matchMedia !== "function"
+		) {
+			return;
+		}
+
+		const mediaQuery = window.matchMedia(MOBILE_QUERY);
+
+		function syncBubbleVisibility() {
+			void setChatwootBubbleVisibility(mediaQuery.matches ? "hide" : "show");
+		}
+
+		syncBubbleVisibility();
+		mediaQuery.addEventListener("change", syncBubbleVisibility);
+
+		return () => {
+			mediaQuery.removeEventListener("change", syncBubbleVisibility);
+			void setChatwootBubbleVisibility("show");
+		};
+	});
+
+	return null;
+}

--- a/apps/web/src/features/wrapped/onboarding/controls.tsx
+++ b/apps/web/src/features/wrapped/onboarding/controls.tsx
@@ -7,6 +7,7 @@ import { WrappedProgress } from "@/features/wrapped/WrappedProgress";
 import { getWrappedOnboardingProgressView } from "@/features/wrapped/wrapped-onboarding-progress";
 import { openChatwoot } from "@/lib/chatwoot";
 import { cn } from "@/lib/utils";
+import { WrappedMobileChatwootBubbleController } from "../mobile-chatwoot-bubble-controller";
 import { WrappedDebugControlStack } from "../route-stage-shell";
 import type {
 	PreviewableWrappedStepId,
@@ -75,62 +76,65 @@ export function WrappedOnboardingHeader(props: WrappedOnboardingHeaderProps) {
 	const progressView = getWrappedOnboardingProgressView(activeStep.id);
 
 	return (
-		<header className="mymind-wrapped-top-tray">
-			<div className="mymind-wrapped-top-tray__row">
-				<div className="mymind-wrapped-top-tray__slot mymind-wrapped-top-tray__slot--start">
-					{activeStepIndex > 0 ? (
-						<button
-							type="button"
-							aria-label="Go back"
+		<>
+			<WrappedMobileChatwootBubbleController />
+			<header className="mymind-wrapped-top-tray">
+				<div className="mymind-wrapped-top-tray__row">
+					<div className="mymind-wrapped-top-tray__slot mymind-wrapped-top-tray__slot--start">
+						{activeStepIndex > 0 ? (
+							<button
+								type="button"
+								aria-label="Go back"
+								disabled={isStepTransitioning}
+								className="mymind-wrapped-top-tray__edge-control"
+								onClick={() => onGoToStep(activeStepIndex - 1)}
+							>
+								<ChevronLeft className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--back" />
+							</button>
+						) : (
+							<button
+								type="button"
+								aria-label="Go back"
+								className="mymind-wrapped-top-tray__edge-control"
+								onClick={onBack}
+							>
+								<ChevronLeft className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--back" />
+							</button>
+						)}
+					</div>
+
+					<div className="mymind-wrapped-top-tray__center">
+						<WrappedProgress
+							ariaLabel="Wrapped onboarding progress"
 							disabled={isStepTransitioning}
-							className="mymind-wrapped-top-tray__edge-control"
-							onClick={() => onGoToStep(activeStepIndex - 1)}
-						>
-							<ChevronLeft className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--back" />
-						</button>
-					) : (
+							items={progressView.items.map((item) => {
+								const routeIndex = getWrappedSaturdayRouteIndex(item.id);
+
+								return {
+									ariaLabel: `Go to onboarding step ${item.stepNumber}: ${item.label}`,
+									id: item.id,
+									isActive: item.isActive,
+									onSelect:
+										routeIndex >= 0 ? () => onGoToStep(routeIndex) : undefined,
+								};
+							})}
+							rewardCardBackground={rewardCardBackground}
+						/>
+					</div>
+
+					<div className="mymind-wrapped-top-tray__slot mymind-wrapped-top-tray__slot--end">
 						<button
 							type="button"
-							aria-label="Go back"
+							aria-label="Open support"
 							className="mymind-wrapped-top-tray__edge-control"
-							onClick={onBack}
+							onClick={() => void openChatwoot()}
 						>
-							<ChevronLeft className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--back" />
+							<HelpCircle className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
 						</button>
-					)}
+					</div>
 				</div>
-
-				<div className="mymind-wrapped-top-tray__center">
-					<WrappedProgress
-						ariaLabel="Wrapped onboarding progress"
-						disabled={isStepTransitioning}
-						items={progressView.items.map((item) => {
-							const routeIndex = getWrappedSaturdayRouteIndex(item.id);
-
-							return {
-								ariaLabel: `Go to onboarding step ${item.stepNumber}: ${item.label}`,
-								id: item.id,
-								isActive: item.isActive,
-								onSelect:
-									routeIndex >= 0 ? () => onGoToStep(routeIndex) : undefined,
-							};
-						})}
-						rewardCardBackground={rewardCardBackground}
-					/>
-				</div>
-
-				<div className="mymind-wrapped-top-tray__slot mymind-wrapped-top-tray__slot--end">
-					<button
-						type="button"
-						aria-label="Open support"
-						className="mymind-wrapped-top-tray__edge-control"
-						onClick={() => void openChatwoot()}
-					>
-						<HelpCircle className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
-					</button>
-				</div>
-			</div>
-		</header>
+			</header>
+		</>
 	);
 }
 

--- a/apps/web/src/features/wrapped/route-stage-shell.tsx
+++ b/apps/web/src/features/wrapped/route-stage-shell.tsx
@@ -15,6 +15,7 @@ import {
 import { openChatwoot } from "@/lib/chatwoot";
 import { cn } from "@/lib/utils";
 import "@/features/wrapped/wrapped.css";
+import { WrappedMobileChatwootBubbleController } from "./mobile-chatwoot-bubble-controller";
 
 interface WrappedRouteStageShellProps {
 	backLabel?: string;
@@ -113,6 +114,8 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 		useReferenceTopChrome || progressView !== null;
 	const hasFooter = Boolean(footer) || Boolean(footerDebugControls);
 	const shouldAnimateSetupEntrance = entrancePreset === "setup";
+	const hasSupportButton =
+		!hideTopChromeControls && shouldUseReferenceTopChrome;
 	const hasTextStatus =
 		typeof status === "string" || typeof status === "number";
 	const animatedCopy = (
@@ -181,6 +184,7 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 
 	return (
 		<main className="mymind-wrapped-route mymind-wrapped-route--onboarding">
+			{hasSupportButton ? <WrappedMobileChatwootBubbleController /> : null}
 			<div
 				className={cn(
 					"mymind-wrapped-shell relative z-[1] mx-auto flex w-full flex-1 flex-col text-foreground",

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -25,6 +25,12 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	display: none !important;
 }
 
+@media only screen and (max-width: 767px) {
+	body.mymind-wrapped-body .woot-widget-bubble {
+		display: none !important;
+	}
+}
+
 @media only screen and (min-width: 667px) {
 	body.mymind-wrapped-body .woot-widget-holder,
 	body.mymind-wrapped-body .woot-widget-holder.has-unread-view {

--- a/apps/web/src/lib/chatwoot.ts
+++ b/apps/web/src/lib/chatwoot.ts
@@ -14,10 +14,13 @@ type ChatwootUser = {
 type ChatwootAPI = {
 	hasLoaded?: boolean;
 	toggle: (state?: "open" | "close") => void;
+	toggleBubbleVisibility?: (visibility: ChatwootBubbleVisibility) => void;
 	setUser: (identifier: string | number, user: ChatwootUser) => void;
 	setLabel: (label: string) => void;
 	reset: () => void;
 };
+
+type ChatwootBubbleVisibility = "show" | "hide";
 
 type ChatwootConfig = {
 	baseUrl: string;
@@ -171,6 +174,17 @@ export async function openChatwoot() {
 		window.$chatwoot?.toggle("open");
 	} catch {
 		// Ignore widget load failures so the dashboard remains functional.
+	}
+}
+
+export async function setChatwootBubbleVisibility(
+	visibility: ChatwootBubbleVisibility,
+) {
+	try {
+		await ensureChatwootLoaded();
+		window.$chatwoot?.toggleBubbleVisibility?.(visibility);
+	} catch {
+		// Keep the dashboard usable even if Chatwoot is unavailable.
 	}
 }
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,8 +1,10 @@
 import { DialRoot } from "dialkit";
 import { lazy, StrictMode, Suspense } from "react";
 import { createRoot } from "react-dom/client";
+import { useLocation } from "react-router-dom";
 import { AppProviders } from "@/app/providers/AppProviders";
 import App from "./App.tsx";
+import { useIsMobile } from "./app/hooks/use-mobile";
 import { useMountEffect } from "./app/hooks/useMountEffect";
 import "./index.css";
 import "dialkit/styles.css";
@@ -29,6 +31,27 @@ function GlobalLumaScope() {
 	return null;
 }
 
+function DevControls() {
+	const { pathname } = useLocation();
+	const isMobile = useIsMobile();
+	const isWrappedMobile = isMobile && pathname.startsWith("/wrapped");
+
+	if (isWrappedMobile) {
+		return null;
+	}
+
+	return (
+		<>
+			<DialRoot defaultOpen={false} position="bottom-right" />
+			{DevTools ? (
+				<Suspense fallback={null}>
+					<DevTools />
+				</Suspense>
+			) : null}
+		</>
+	);
+}
+
 function deferProductAnalyticsInit() {
 	if (typeof window === "undefined") {
 		return;
@@ -53,14 +76,7 @@ createRoot(document.getElementById("root")!).render(
 			<GlobalLumaScope />
 			<div className="h-full">
 				<App />
-				{import.meta.env.DEV ? (
-					<DialRoot defaultOpen={false} position="bottom-right" />
-				) : null}
-				{DevTools ? (
-					<Suspense fallback={null}>
-						<DevTools />
-					</Suspense>
-				) : null}
+				{import.meta.env.DEV ? <DevControls /> : null}
 			</div>
 		</AppProviders>
 	</StrictMode>,


### PR DESCRIPTION
## Summary
- Hide the Chatwoot launcher on mobile wrapped screens and keep the top-right question mark as the support entry point.
- Reuse the shared mobile media query for wrapped Chatwoot visibility handling.
- Hide dev-only floating controls on mobile wrapped routes so they do not overlap the story UI.

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig
- [x] Captured mobile wrapped screenshots in Chromium, Firefox, and WebKit.