### PR TITLE
fix: return wrapped auth to uploaded sessions

### DIFF
--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -13,6 +13,8 @@ const CARD_REFERENCE_PATH = "/card-reference";
 const WRAPPED_TEAM_CARD_PATH = "/wrapped";
 const DEV_WRAPPED_PATH = "/dev/wrapped";
 const WRAPPED_RESUME_PATH = "/resume";
+export const WRAPPED_ROUTE_FLOW_QUERY_PARAM = "flow";
+export const WRAPPED_ROUTE_SESSIONS_LANDED_FLOW = "sessions-landed";
 
 // These helpers are the canonical route surface for the Saturday wrapped loop.
 // We keep them centralized so design, auth, analytics, and public sharing all
@@ -29,6 +31,8 @@ export const appRoutes = {
 	presetBaseline: () => PRESET_BASELINE_PATH,
 	cardReference: () => CARD_REFERENCE_PATH,
 	wrappedTeamCard: () => WRAPPED_TEAM_CARD_PATH,
+	wrappedSessionsLanded: (search?: string) =>
+		getWrappedSessionsLandedPath(search),
 	devWrapped: () => DEV_WRAPPED_PATH,
 	wrappedPublic: (publicId: string) =>
 		`${WRAPPED_TEAM_CARD_PATH}/${encodeURIComponent(publicId)}`,
@@ -41,6 +45,16 @@ export const appRoutes = {
 	settingsAccount: () => SETTINGS_ACCOUNT_PATH,
 	settingsCreateWorkspace: () => SETTINGS_CREATE_WORKSPACE_PATH,
 };
+
+export function getWrappedSessionsLandedPath(search?: string) {
+	const searchParams = new URLSearchParams(search);
+	searchParams.set(
+		WRAPPED_ROUTE_FLOW_QUERY_PARAM,
+		WRAPPED_ROUTE_SESSIONS_LANDED_FLOW,
+	);
+
+	return `${WRAPPED_TEAM_CARD_PATH}?${searchParams.toString()}`;
+}
 
 // Public wrapped pages live at /wrapped/:id in this pass. The id is still the
 // existing UUID-backed share id even though the route shape is changing.

--- a/apps/web/src/features/auth/AuthStateRefresh.test.tsx
+++ b/apps/web/src/features/auth/AuthStateRefresh.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { appRoutes } from "@/app/routes";
 import {
 	clearPendingSignupRedirect,
+	getAuthCallbackURL,
 	getEmailLoginSuccessDestination,
 	getEmailSignupSuccessDestination,
 	getEmailSignupVerificationCallbackURL,
@@ -76,13 +77,13 @@ describe("auth state refresh", () => {
 
 	it("routes homepage email signups to the wrapped entry", () => {
 		expect(getEmailSignupSuccessDestination("/", "")).toBe(
-			appRoutes.wrappedTeamCard(),
+			appRoutes.wrappedSessionsLanded(),
 		);
 	});
 
 	it("uses the direct redirect destination for homepage email verification callbacks", () => {
 		expect(getEmailSignupVerificationCallbackURL("/", "")).toBe(
-			appRoutes.wrappedTeamCard(),
+			appRoutes.wrappedSessionsLanded(),
 		);
 	});
 
@@ -158,13 +159,32 @@ describe("auth state refresh", () => {
 	});
 
 	it("preserves direct wrapped destinations for email login", () => {
-		expect(getEmailLoginSuccessDestination("/wrapped", "")).toBe("/wrapped");
+		expect(getEmailLoginSuccessDestination("/wrapped", "")).toBe(
+			appRoutes.wrappedSessionsLanded(),
+		);
+	});
+
+	it("returns wrapped auth redirects to uploaded sessions with share attribution", () => {
+		expect(
+			getEmailLoginSuccessDestination(
+				"/wrapped",
+				"?share_id=share-123&flow=story",
+			),
+		).toBe("/wrapped?share_id=share-123&flow=sessions-landed");
+	});
+
+	it("builds social login callbacks that return wrapped auth to uploaded sessions", () => {
+		expect(getAuthCallbackURL("/wrapped", "?share_id=share-123")).toBe(
+			`/?redirect=${encodeURIComponent(
+				"/wrapped?share_id=share-123&flow=sessions-landed",
+			)}`,
+		);
 	});
 
 	it("uses a separate new-user social signup destination on the homepage", () => {
 		expect(getSocialSignupRedirectOptions("/", "")).toEqual({
 			callbackURL: "/",
-			newUserCallbackURL: appRoutes.wrappedTeamCard(),
+			newUserCallbackURL: appRoutes.wrappedSessionsLanded(),
 		});
 	});
 
@@ -204,7 +224,7 @@ describe("auth state refresh", () => {
 					name: "Ada Lovelace",
 					email: "ada@example.com",
 					password: "supersecure",
-					callbackURL: "/wrapped",
+					callbackURL: appRoutes.wrappedSessionsLanded(),
 					fetchOptions: expect.objectContaining({
 						disableSignal: true,
 						onSuccess: expect.any(Function),
@@ -214,11 +234,13 @@ describe("auth state refresh", () => {
 		});
 
 		await waitFor(() => {
-			expect(mockNavigateToDestination).toHaveBeenCalledWith("/wrapped");
+			expect(mockNavigateToDestination).toHaveBeenCalledWith(
+				appRoutes.wrappedSessionsLanded(),
+			);
 		});
 
 		expect(window.location.search).toBe(
-			`?signup_redirect=${encodeURIComponent(appRoutes.wrappedTeamCard())}`,
+			`?signup_redirect=${encodeURIComponent(appRoutes.wrappedSessionsLanded())}`,
 		);
 	});
 
@@ -303,7 +325,7 @@ describe("auth state refresh", () => {
 			expect(mockSignInSocial).toHaveBeenCalledWith({
 				provider: "google",
 				callbackURL: "/",
-				newUserCallbackURL: "/wrapped",
+				newUserCallbackURL: appRoutes.wrappedSessionsLanded(),
 			});
 		});
 	});
@@ -379,7 +401,9 @@ describe("auth state refresh", () => {
 		await user.click(screen.getByRole("button", { name: "Sign in" }));
 
 		await waitFor(() => {
-			expect(mockNavigateToDestination).toHaveBeenCalledWith("/wrapped");
+			expect(mockNavigateToDestination).toHaveBeenCalledWith(
+				appRoutes.wrappedSessionsLanded(),
+			);
 		});
 		expect(mockRefreshAuthClientState).toHaveBeenCalledTimes(1);
 	});

--- a/apps/web/src/features/auth/DeviceAuthorizationApp.test.tsx
+++ b/apps/web/src/features/auth/DeviceAuthorizationApp.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { appRoutes } from "@/app/routes";
 import { DeviceAuthorizationApp } from "./DeviceAuthorizationApp";
@@ -37,6 +37,12 @@ const session = {
 	},
 };
 
+function WrappedLocation() {
+	const location = useLocation();
+
+	return <div>Wrapped: {location.search}</div>;
+}
+
 describe("DeviceAuthorizationApp", () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
@@ -63,7 +69,7 @@ describe("DeviceAuthorizationApp", () => {
 					/>
 					<Route
 						path={appRoutes.wrappedTeamCard()}
-						element={<div>Wrapped</div>}
+						element={<WrappedLocation />}
 					/>
 				</Routes>
 			</MemoryRouter>,
@@ -72,7 +78,9 @@ describe("DeviceAuthorizationApp", () => {
 		await user.click(screen.getByRole("button", { name: "Approve" }));
 
 		await waitFor(() => {
-			expect(screen.getByText("Wrapped")).toBeInTheDocument();
+			expect(
+				screen.getByText("Wrapped: ?flow=sessions-landed"),
+			).toBeInTheDocument();
 		});
 
 		expect(fetchMock).toHaveBeenCalledWith("/api/auth/device/approve", {
@@ -105,7 +113,7 @@ describe("DeviceAuthorizationApp", () => {
 					/>
 					<Route
 						path={appRoutes.wrappedTeamCard()}
-						element={<div>Wrapped</div>}
+						element={<WrappedLocation />}
 					/>
 					<Route path={appRoutes.dashboard()} element={<div>Dashboard</div>} />
 				</Routes>
@@ -115,7 +123,9 @@ describe("DeviceAuthorizationApp", () => {
 		await user.click(screen.getByRole("button", { name: "Approve" }));
 
 		await waitFor(() => {
-			expect(screen.getByText("Wrapped")).toBeInTheDocument();
+			expect(
+				screen.getByText("Wrapped: ?flow=sessions-landed"),
+			).toBeInTheDocument();
 		});
 		expect(screen.queryByText("Dashboard")).toBeNull();
 	});

--- a/apps/web/src/features/auth/DeviceAuthorizationApp.tsx
+++ b/apps/web/src/features/auth/DeviceAuthorizationApp.tsx
@@ -11,7 +11,7 @@ import {
 import { GuestApp } from "@/features/auth/GuestApp";
 
 function ApprovedDeviceSetupPage() {
-	return <Navigate replace to={appRoutes.wrappedTeamCard()} />;
+	return <Navigate replace to={appRoutes.wrappedSessionsLanded()} />;
 }
 
 export function DeviceAuthorizationApp({

--- a/apps/web/src/features/auth/LoginForm.tsx
+++ b/apps/web/src/features/auth/LoginForm.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils";
 import { navigateToDestination } from "./auth-navigation";
 import {
 	clearPendingSignupRedirect,
+	getAuthCallbackURL,
 	getEmailLoginSuccessDestination,
 } from "./auth-route-utils";
 import {
@@ -33,24 +34,6 @@ interface LoginFormProps {
 	onEmailPasswordPreviewSubmit?: (email: string) => void;
 	onSwitchToSignup: () => void;
 	variant?: "default" | "wrapped-story";
-}
-
-function getCallbackURL(): string {
-	const params = new URLSearchParams(window.location.search);
-	const userCode = params.get("user_code");
-	if (userCode) {
-		return `/?user_code=${encodeURIComponent(userCode)}`;
-	}
-	const redirect = params.get("redirect");
-	if (redirect) {
-		return `/?redirect=${encodeURIComponent(redirect)}`;
-	}
-	const path = window.location.pathname;
-	const search = window.location.search;
-	if (path !== "/" && path !== "") {
-		return `/?redirect=${encodeURIComponent(`${path}${search}`)}`;
-	}
-	return "/";
 }
 
 export function LoginForm(props: LoginFormProps) {
@@ -199,7 +182,7 @@ export function LoginForm(props: LoginFormProps) {
 			sourceComponent: "login_form",
 			authMethod: provider,
 		});
-		const callbackURL = getCallbackURL();
+		const callbackURL = getAuthCallbackURL();
 		recordOAuthRedirectStart({
 			callbackURL,
 			provider,

--- a/apps/web/src/features/auth/auth-route-utils.ts
+++ b/apps/web/src/features/auth/auth-route-utils.ts
@@ -3,6 +3,7 @@ import type { authClient } from "@/lib/auth-client";
 
 export type AppSession = ReturnType<typeof authClient.useSession>["data"];
 const PENDING_SIGNUP_REDIRECT_PARAM = "signup_redirect";
+const RELATIVE_URL_BASE = "https://rudel.local";
 
 function normalizeValidRedirect(redirect: string | null): string | null {
 	if (!redirect) {
@@ -13,7 +14,21 @@ function normalizeValidRedirect(redirect: string | null): string | null {
 		return null;
 	}
 
-	return redirect;
+	return normalizeWrappedAuthRedirect(redirect);
+}
+
+function normalizeWrappedAuthRedirect(redirect: string): string {
+	try {
+		const url = new URL(redirect, RELATIVE_URL_BASE);
+
+		if (url.pathname !== appRoutes.wrappedTeamCard()) {
+			return redirect;
+		}
+
+		return `${appRoutes.wrappedSessionsLanded(url.search)}${url.hash}`;
+	} catch {
+		return redirect;
+	}
 }
 
 export function getDeviceUserCode(search?: string): string | null {
@@ -57,7 +72,7 @@ function getDirectAuthDestination(
 	}
 
 	if (pathname !== "/" && pathname !== "") {
-		return `${pathname}${search}`;
+		return normalizeWrappedAuthRedirect(`${pathname}${search}`);
 	}
 
 	return null;
@@ -68,7 +83,8 @@ export function getEmailSignupSuccessDestination(
 	search = window.location.search,
 ): string {
 	return (
-		getDirectAuthDestination(pathname, search) ?? appRoutes.wrappedTeamCard()
+		getDirectAuthDestination(pathname, search) ??
+		appRoutes.wrappedSessionsLanded()
 	);
 }
 
@@ -77,6 +93,23 @@ export function getEmailLoginSuccessDestination(
 	search = window.location.search,
 ): string {
 	return getDirectAuthDestination(pathname, search) ?? "/";
+}
+
+export function getAuthCallbackURL(
+	pathname = window.location.pathname,
+	search = window.location.search,
+): string {
+	const directDestination = getDirectAuthDestination(pathname, search);
+
+	if (!directDestination) {
+		return "/";
+	}
+
+	if (directDestination.startsWith("/?user_code=")) {
+		return directDestination;
+	}
+
+	return `/?redirect=${encodeURIComponent(directDestination)}`;
 }
 
 export function getEmailSignupVerificationCallbackURL(
@@ -103,7 +136,7 @@ export function getSocialSignupRedirectOptions(
 
 	return {
 		callbackURL: "/",
-		newUserCallbackURL: appRoutes.wrappedTeamCard(),
+		newUserCallbackURL: appRoutes.wrappedSessionsLanded(),
 	};
 }
 

--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -247,6 +247,29 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByText("Wrapped story")).toBeInTheDocument();
 	});
 
+	it("honors the sessions-landed flow even after setup completion was acknowledged", () => {
+		const storageKey = getWrappedSetupCompletionStorageKey(session.user.id);
+
+		if (storageKey === null) {
+			throw new Error("Expected wrapped setup completion storage key");
+		}
+
+		window.localStorage.setItem(storageKey, "true");
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 3,
+		});
+
+		render(
+			<MemoryRouter initialEntries={["/wrapped?flow=sessions-landed"]}>
+				<WrappedRouteGate isPending={false} publicId={null} session={session} />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
+	});
+
 	it("returns from the first story page to the upload screen", async () => {
 		const user = userEvent.setup();
 		const storageKey = getWrappedSetupCompletionStorageKey(session.user.id);

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -1,7 +1,11 @@
 import { type ReactNode, startTransition, useState } from "react";
 import { useLocation, useSearchParams } from "react-router-dom";
 import { useIsMobile } from "@/app/hooks/use-mobile";
-import { getWrappedShareIdFromSearch } from "@/app/routes";
+import {
+	getWrappedShareIdFromSearch,
+	WRAPPED_ROUTE_FLOW_QUERY_PARAM,
+	WRAPPED_ROUTE_SESSIONS_LANDED_FLOW,
+} from "@/app/routes";
 import { useAnalyticsTracking } from "@/features/analytics/tracking/useAnalyticsTracking";
 import {
 	type AppSession,
@@ -34,8 +38,6 @@ interface WrappedRouteGateProps {
 }
 
 type WrappedRouteFlowStage = "desktop-ready" | "sessions-landed" | "story";
-
-const WRAPPED_ROUTE_FLOW_QUERY_PARAM = "flow";
 
 export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const { isPending, publicId, session } = props;
@@ -219,7 +221,7 @@ function getWrappedRouteFlowStage(
 	flowStage: string | null,
 ): WrappedRouteFlowStage | null {
 	return flowStage === "desktop-ready" ||
-		flowStage === "sessions-landed" ||
+		flowStage === WRAPPED_ROUTE_SESSIONS_LANDED_FLOW ||
 		flowStage === "story"
 		? flowStage
 		: null;


### PR DESCRIPTION
## Summary
- Add a canonical wrapped sessions-landed route helper.
- Normalize wrapped post-auth destinations to `/wrapped?flow=sessions-landed`, preserving attribution query params such as `share_id`.
- Align email auth, OAuth callback URLs, and CLI device approval with the uploaded-sessions return path.
- Cover the route helper behavior and wrapped route gate regression with tests.

## Test plan
- `bun run verify`
- `bun --filter @rudel/web test -- AuthStateRefresh.test.tsx WrappedRouteGate.test.tsx DeviceAuthorizationApp.test.tsx`
- `bun --filter @rudel/web check-types`
- `bunx --no-install biome check apps/web/src/app/routes.ts apps/web/src/features/auth/auth-route-utils.ts apps/web/src/features/auth/LoginForm.tsx apps/web/src/features/auth/DeviceAuthorizationApp.tsx apps/web/src/features/auth/AuthStateRefresh.test.tsx apps/web/src/features/auth/DeviceAuthorizationApp.test.tsx apps/web/src/features/wrapped/WrappedRouteGate.tsx apps/web/src/features/wrapped/WrappedRouteGate.test.tsx`