### PR TITLE
fix: handle zero slash commands in wrapped

### DIFF
--- a/apps/web/src/features/wrapped/onboarding/models.ts
+++ b/apps/web/src/features/wrapped/onboarding/models.ts
@@ -46,9 +46,7 @@ import {
 } from "./models/skills";
 import {
 	getToolsEntryStyle,
-	getToolsHeadline,
 	getToolsStackHeightRem,
-	getToolsSubline,
 	resolveToolsPreviewInput,
 	resolveToolsStageModel,
 } from "./models/tools";
@@ -148,21 +146,9 @@ export function buildStepContent(input: {
 				},
 				previewState,
 			);
+			const toolsStage = resolveToolsStageModel(toolsPreview);
 
-			return [
-				{
-					text: getToolsHeadline({
-						topSlashCommand: toolsPreview.topSlashCommand,
-						topSubagent: toolsPreview.topSubagent,
-					}),
-				},
-				{
-					text: getToolsSubline({
-						slashCommandsAdoptionRate: toolsPreview.slashCommandsAdoptionRate,
-						subagentsAdoptionRate: toolsPreview.subagentsAdoptionRate,
-					}),
-				},
-			];
+			return [{ text: toolsStage.headline }, { text: toolsStage.subline }];
 		}
 		case "lock-in": {
 			const lockInStage = resolveLockInStageModel(

--- a/apps/web/src/features/wrapped/onboarding/models/tools.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/tools.ts
@@ -11,6 +11,14 @@ interface ToolsStageEntry {
 	usageRate: number | null;
 }
 
+type ToolsStageMode =
+	| "base-model"
+	| "regular"
+	| "thin-slash-command"
+	| "zero-slash-command";
+
+const MIN_RECAP_SLASH_COMMAND_COUNT = 3;
+
 export function resolveToolsStageModel(input: {
 	slashCommandsAdoptionRate: number | null;
 	subagentsAdoptionRate: number | null;
@@ -22,34 +30,69 @@ export function resolveToolsStageModel(input: {
 	topSubagentCount: number | null;
 	totalSessions: number;
 }) {
+	const topSlashCommand = resolveRecapSlashCommand(input);
+	const mode = resolveToolsStageMode(input, topSlashCommand);
 	const liveEntries = buildToolsStageEntries(input);
 
-	if (input.topSlashCommand === null && input.topSubagent === null) {
+	if (mode === "zero-slash-command") {
+		return {
+			entries: buildToolsPlaceholderEntries(),
+			footnote: "No slash commands made the recap.",
+			headline: "You used no slash commands.",
+			mode,
+			subline: "No slash commands made the recap.",
+			topSlashCommand,
+			topSubagent: input.topSubagent,
+		};
+	}
+
+	if (mode === "thin-slash-command") {
+		return {
+			entries: buildToolsPlaceholderEntries(),
+			footnote: "Almost no slash commands made the recap.",
+			headline: "Almost no slash commands.",
+			mode,
+			subline: "Almost no slash commands made the recap.",
+			topSlashCommand,
+			topSubagent: input.topSubagent,
+		};
+	}
+
+	if (topSlashCommand === null && input.topSubagent === null) {
 		return {
 			entries: buildToolsPlaceholderEntries(),
 			footnote: "You should try them out tho: slash commands and subagents.",
 			headline: "Just vibes.",
+			mode,
 			subline: "You should try them out tho: slash commands and subagents.",
+			topSlashCommand,
+			topSubagent: input.topSubagent,
 		};
 	}
 
-	if (input.topSlashCommand !== null && input.topSubagent !== null) {
+	if (topSlashCommand !== null && input.topSubagent !== null) {
 		return {
 			entries: liveEntries,
 			footnote:
 				"These are session-share numbers: how often that layer appeared in a session at least once.",
 			headline: getToolsHeadline(input),
+			mode,
 			subline: getToolsSubline(input),
+			topSlashCommand,
+			topSubagent: input.topSubagent,
 		};
 	}
 
-	if (input.topSlashCommand !== null) {
+	if (topSlashCommand !== null) {
 		return {
 			entries: liveEntries,
 			footnote:
 				"Session share is based on whether the layer appeared in the session, not how many times it fired.",
 			headline: getToolsHeadline(input),
+			mode,
 			subline: getToolsSubline(input),
+			topSlashCommand,
+			topSubagent: input.topSubagent,
 		};
 	}
 
@@ -58,7 +101,10 @@ export function resolveToolsStageModel(input: {
 		footnote:
 			"Session share is based on whether the layer appeared in the session, not how many times it fired.",
 		headline: getToolsHeadline(input),
+		mode,
 		subline: getToolsSubline(input),
+		topSlashCommand,
+		topSubagent: input.topSubagent,
 	};
 }
 
@@ -224,9 +270,12 @@ export function getToolsEntryStyle(
 
 export function getToolsHeadline(input: {
 	topSlashCommand: string | null;
+	topSlashCommandCount: number | null;
+	topSlashCommands: readonly WrappedSkillUsageItem[];
 	topSubagent: string | null;
 }) {
-	const { topSlashCommand, topSubagent } = input;
+	const topSlashCommand = resolveRecapSlashCommand(input);
+	const { topSubagent } = input;
 
 	if (topSlashCommand && topSubagent) {
 		return `${topSlashCommand} led. ${topSubagent} backed it up.`;
@@ -246,18 +295,31 @@ export function getToolsHeadline(input: {
 export function getToolsSubline(input: {
 	slashCommandsAdoptionRate: number | null;
 	subagentsAdoptionRate: number | null;
+	topSlashCommand: string | null;
+	topSlashCommandCount: number | null;
+	topSlashCommands: readonly WrappedSkillUsageItem[];
+	topSubagent: string | null;
 }) {
 	const { slashCommandsAdoptionRate, subagentsAdoptionRate } = input;
+	const topSlashCommand = resolveRecapSlashCommand(input);
+	const hasLowSlashCommandSignal = isThinSlashCommandSignal(input);
+	const hasSubagent = input.topSubagent !== null;
 
-	if (slashCommandsAdoptionRate === null && subagentsAdoptionRate === null) {
-		return "You should try them out tho: slash commands and subagents.";
+	if (topSlashCommand === null && !hasSubagent) {
+		return hasLowSlashCommandSignal
+			? "Almost no slash commands made the recap."
+			: "You should try them out tho: slash commands and subagents.";
 	}
 
-	if (slashCommandsAdoptionRate === null) {
-		return `${formatPercent(subagentsAdoptionRate)} of sessions used a subagent. No slash command ranked yet.`;
+	if (topSlashCommand === null) {
+		const slashCommandLine = hasLowSlashCommandSignal
+			? "Almost no slash commands landed."
+			: "No slash command ranked yet.";
+
+		return `${formatPercent(subagentsAdoptionRate)} of sessions used a subagent. ${slashCommandLine}`;
 	}
 
-	if (subagentsAdoptionRate === null) {
+	if (!hasSubagent) {
 		return `${formatPercent(slashCommandsAdoptionRate)} of sessions used a slash command. No subagent ranked yet.`;
 	}
 
@@ -269,16 +331,21 @@ function getToolsUsageLabel(rate: number) {
 }
 
 function buildToolsStageEntries(input: {
+	topSlashCommand: string | null;
+	topSlashCommandCount: number | null;
 	topSlashCommands: readonly WrappedSkillUsageItem[];
 	topSubagents: readonly WrappedSkillUsageItem[];
 	totalSessions: number;
 }): readonly ToolsStageEntry[] {
 	const totalSessions = Math.max(input.totalSessions, 0);
-	const slashEntries = input.topSlashCommands.map((item, index) => ({
-		count: item.count,
-		id: `slash-command-${index}`,
-		name: item.name,
-	}));
+	const slashEntries =
+		resolveRecapSlashCommand(input) === null
+			? []
+			: input.topSlashCommands.map((item, index) => ({
+					count: item.count,
+					id: `slash-command-${index}`,
+					name: item.name,
+				}));
 	const subagentEntries = input.topSubagents.map((item, index) => ({
 		count: item.count,
 		id: `subagent-${index}`,
@@ -318,4 +385,99 @@ function buildToolsPlaceholderEntries(): readonly ToolsStageEntry[] {
 			usageRate: null,
 		},
 	] as const;
+}
+
+function resolveToolsStageMode(
+	input: {
+		slashCommandsAdoptionRate: number | null;
+		topSlashCommand: string | null;
+		topSlashCommandCount: number | null;
+		topSlashCommands: readonly WrappedSkillUsageItem[];
+		topSubagent: string | null;
+	},
+	topSlashCommand: string | null,
+): ToolsStageMode {
+	if (topSlashCommand !== null) {
+		return "regular";
+	}
+
+	if (isZeroSlashCommandSignal(input)) {
+		return "zero-slash-command";
+	}
+
+	if (isThinSlashCommandSignal(input)) {
+		return "thin-slash-command";
+	}
+
+	if (input.topSubagent !== null) {
+		return "regular";
+	}
+
+	return "base-model";
+}
+
+function resolveRecapSlashCommand(input: {
+	topSlashCommand: string | null;
+	topSlashCommandCount: number | null;
+	topSlashCommands: readonly WrappedSkillUsageItem[];
+}) {
+	if (input.topSlashCommand === null) {
+		return null;
+	}
+
+	const slashCommandCount = resolveSlashCommandSignalCount(input);
+
+	if (
+		slashCommandCount !== null &&
+		slashCommandCount < MIN_RECAP_SLASH_COMMAND_COUNT
+	) {
+		return null;
+	}
+
+	return input.topSlashCommand;
+}
+
+function isThinSlashCommandSignal(input: {
+	topSlashCommand: string | null;
+	topSlashCommandCount: number | null;
+	topSlashCommands: readonly WrappedSkillUsageItem[];
+}) {
+	const slashCommandCount = resolveSlashCommandSignalCount(input);
+
+	return (
+		input.topSlashCommand !== null &&
+		slashCommandCount !== null &&
+		slashCommandCount > 0 &&
+		slashCommandCount < MIN_RECAP_SLASH_COMMAND_COUNT
+	);
+}
+
+function isZeroSlashCommandSignal(input: {
+	slashCommandsAdoptionRate: number | null;
+	topSlashCommand: string | null;
+}) {
+	return (
+		input.topSlashCommand === null && input.slashCommandsAdoptionRate === 0
+	);
+}
+
+function resolveSlashCommandSignalCount(input: {
+	topSlashCommand: string | null;
+	topSlashCommandCount: number | null;
+	topSlashCommands: readonly WrappedSkillUsageItem[];
+}) {
+	const rankedCommandCount = input.topSlashCommands.reduce(
+		(totalCount, item) => totalCount + Math.max(0, item.count),
+		0,
+	);
+
+	if (rankedCommandCount > 0) {
+		return rankedCommandCount;
+	}
+
+	if (input.topSlashCommandCount !== null) {
+		return Math.max(0, input.topSlashCommandCount);
+	}
+
+	return input.topSlashCommand === null ? 0 : null;
 }

--- a/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
@@ -104,6 +104,75 @@ describe("WrappedOnboardingToolsStage", () => {
 		expect(onBaseModelSequenceComplete).toHaveBeenCalledTimes(1);
 	});
 
+	it("keeps tiny slash-command usage in the text-only recap", () => {
+		vi.useFakeTimers();
+		const onBaseModelSequenceComplete = vi.fn();
+
+		render(
+			<WrappedOnboardingToolsStage
+				onBaseModelSequenceComplete={onBaseModelSequenceComplete}
+				onboardingMetrics={{
+					...emptyToolsMetrics,
+					slashCommandsAdoptionRate: 5,
+					topSlashCommand: "/fix",
+					topSlashCommandCount: 1,
+					topSlashCommands: [{ count: 1, name: "/fix" }],
+					totalSessions: 20,
+				}}
+				previewState="live"
+			/>,
+		);
+
+		expect(
+			screen.getByRole("heading", { name: /almost no slash commands/i }),
+		).toBeInTheDocument();
+		expect(screen.getByText("No subagents.")).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "/fix. 5% of sessions" }),
+		).toBeNull();
+
+		act(() => {
+			vi.runAllTimers();
+		});
+
+		expect(onBaseModelSequenceComplete).toHaveBeenCalledTimes(1);
+	});
+
+	it("shows the zero slash-command recap before subagent-only copy", () => {
+		vi.useFakeTimers();
+		const onBaseModelSequenceComplete = vi.fn();
+
+		render(
+			<WrappedOnboardingToolsStage
+				onBaseModelSequenceComplete={onBaseModelSequenceComplete}
+				onboardingMetrics={{
+					...emptyToolsMetrics,
+					slashCommandsAdoptionRate: 0,
+					subagentsAdoptionRate: 20,
+					topSubagent: "Reviewer",
+					topSubagentCount: 4,
+					topSubagents: [{ count: 4, name: "Reviewer" }],
+					totalSessions: 20,
+				}}
+				previewState="live"
+			/>,
+		);
+
+		expect(
+			screen.getByRole("heading", { name: /you used no slash commands/i }),
+		).toBeInTheDocument();
+		expect(screen.getByText("Subagents did show up.")).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Reviewer. 20% of sessions" }),
+		).toBeNull();
+
+		act(() => {
+			vi.runAllTimers();
+		});
+
+		expect(onBaseModelSequenceComplete).toHaveBeenCalledTimes(1);
+	});
+
 	it("hands the regular tools sequence off to a separate final scene", () => {
 		vi.useFakeTimers();
 		const onBaseModelSequenceComplete = vi.fn();

--- a/apps/web/src/features/wrapped/onboarding/stages/tools.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/tools.tsx
@@ -35,11 +35,16 @@ type ToolsStageSequenceFrame = {
 };
 
 type ToolsStageScenePhase = "sequence" | "handoff" | "final";
-type ToolsStagePreviewInput = ReturnType<typeof resolveToolsPreviewInput>;
 type ToolsStageModel = ReturnType<typeof resolveToolsStageModel>;
+type ToolsTextOnlyMode = Exclude<ToolsStageModel["mode"], "regular">;
 
 const TOOLS_BASE_MODEL_LINES = [
 	"You used no slash commands.",
+	"No subagents.",
+	"Just vibes.",
+] as const;
+const TOOLS_THIN_SLASH_COMMAND_LINES = [
+	"Almost no slash commands.",
 	"No subagents.",
 	"Just vibes.",
 ] as const;
@@ -85,12 +90,13 @@ export function WrappedOnboardingToolsStage(props: ToolsStageProps) {
 		previewState,
 	);
 	const model = resolveToolsStageModel(previewInput);
-	const isBaseModelStage =
-		previewInput.topSlashCommand === null && previewInput.topSubagent === null;
+	const textOnlyMode = resolveToolsTextOnlyMode(model.mode);
 
-	if (isBaseModelStage) {
+	if (textOnlyMode !== null) {
 		return (
 			<WrappedOnboardingToolsBaseModelStage
+				hasSubagentSignal={model.topSubagent !== null}
+				mode={textOnlyMode}
 				onSequenceComplete={onBaseModelSequenceComplete}
 				reduceMotion={reduceMotion}
 			/>
@@ -101,7 +107,6 @@ export function WrappedOnboardingToolsStage(props: ToolsStageProps) {
 		<WrappedOnboardingToolsRegularStage
 			model={model}
 			onSequenceComplete={onBaseModelSequenceComplete}
-			previewInput={previewInput}
 			reduceMotion={reduceMotion}
 		/>
 	);
@@ -110,13 +115,12 @@ export function WrappedOnboardingToolsStage(props: ToolsStageProps) {
 function WrappedOnboardingToolsRegularStage(props: {
 	model: ToolsStageModel;
 	onSequenceComplete?: () => void;
-	previewInput: ToolsStagePreviewInput;
 	reduceMotion: boolean;
 }) {
-	const { model, onSequenceComplete, previewInput, reduceMotion } = props;
+	const { model, onSequenceComplete, reduceMotion } = props;
 	const sequenceFrames = resolveToolsStageSequenceFrames(
-		previewInput.topSlashCommand,
-		previewInput.topSubagent,
+		model.topSlashCommand,
+		model.topSubagent,
 	);
 	const [activeCardIndex, setActiveCardIndex] = useState(0);
 	const [sequenceIndex, setSequenceIndex] = useState(() =>
@@ -409,12 +413,15 @@ function WrappedOnboardingToolsRegularStage(props: {
 }
 
 function WrappedOnboardingToolsBaseModelStage(props: {
+	hasSubagentSignal: boolean;
+	mode: ToolsTextOnlyMode;
 	onSequenceComplete?: () => void;
 	reduceMotion: boolean;
 }) {
-	const { onSequenceComplete, reduceMotion } = props;
+	const { hasSubagentSignal, mode, onSequenceComplete, reduceMotion } = props;
+	const lines = resolveToolsTextOnlyLines(mode, hasSubagentSignal);
 	const [visibleLineCount, setVisibleLineCount] = useState(() =>
-		reduceMotion ? TOOLS_BASE_MODEL_LINES.length : 0,
+		reduceMotion ? lines.length : 0,
 	);
 	const [isDocsVisible, setIsDocsVisible] = useState(reduceMotion);
 	const timerRefs = useRef<number[]>([]);
@@ -442,7 +449,7 @@ function WrappedOnboardingToolsBaseModelStage(props: {
 		hasCompletedSequenceRef.current = false;
 
 		if (reduceMotion) {
-			setVisibleLineCount(TOOLS_BASE_MODEL_LINES.length);
+			setVisibleLineCount(lines.length);
 			setIsDocsVisible(true);
 			const timeoutId = window.setTimeout(() => {
 				completeSequence();
@@ -456,19 +463,19 @@ function WrappedOnboardingToolsBaseModelStage(props: {
 
 		setVisibleLineCount(0);
 		setIsDocsVisible(false);
-		const timeoutIds = TOOLS_BASE_MODEL_LINES.map((_line, lineIndex) =>
+		const timeoutIds = lines.map((_line, lineIndex) =>
 			window.setTimeout(() => {
 				setVisibleLineCount(lineIndex + 1);
 			}, lineIndex * TOOLS_BASE_MODEL_LINE_STAGGER_MS),
 		);
 		const docsTimerId = window.setTimeout(() => {
 			setIsDocsVisible(true);
-		}, TOOLS_BASE_MODEL_LINES.length * TOOLS_BASE_MODEL_LINE_STAGGER_MS);
+		}, lines.length * TOOLS_BASE_MODEL_LINE_STAGGER_MS);
 		const completeTimerId = window.setTimeout(
 			() => {
 				completeSequence();
 			},
-			TOOLS_BASE_MODEL_LINES.length * TOOLS_BASE_MODEL_LINE_STAGGER_MS +
+			lines.length * TOOLS_BASE_MODEL_LINE_STAGGER_MS +
 				TOOLS_BASE_MODEL_DOCS_REVEAL_MS +
 				TOOLS_BASE_MODEL_ADVANCE_HOLD_MS,
 		);
@@ -522,7 +529,7 @@ function WrappedOnboardingToolsBaseModelStage(props: {
 					descriptionClassName="mymind-wrapped-tools-stage__description-shell"
 					title={
 						<span className="mymind-wrapped-tools-stage__line-stack">
-							{TOOLS_BASE_MODEL_LINES.map((line, lineIndex) => {
+							{lines.map((line, lineIndex) => {
 								const isLineVisible = lineIndex < visibleLineCount;
 
 								return (
@@ -548,6 +555,35 @@ function WrappedOnboardingToolsBaseModelStage(props: {
 			}
 		/>
 	);
+}
+
+function resolveToolsTextOnlyLines(
+	mode: ToolsTextOnlyMode,
+	hasSubagentSignal: boolean,
+) {
+	if (mode === "zero-slash-command") {
+		return hasSubagentSignal
+			? ["You used no slash commands.", "Subagents did show up.", "Just vibes."]
+			: TOOLS_BASE_MODEL_LINES;
+	}
+
+	if (mode === "thin-slash-command") {
+		return hasSubagentSignal
+			? ["Almost no slash commands.", "Subagents did show up.", "Just vibes."]
+			: TOOLS_THIN_SLASH_COMMAND_LINES;
+	}
+
+	return TOOLS_BASE_MODEL_LINES;
+}
+
+function resolveToolsTextOnlyMode(
+	mode: ToolsStageModel["mode"],
+): ToolsTextOnlyMode | null {
+	if (mode === "regular") {
+		return null;
+	}
+
+	return mode;
 }
 
 function resolveToolsStageSequenceFrames(


### PR DESCRIPTION
## Summary
- route zero slash-command usage through the wrapped tools text-only recap, even when subagents exist
- keep tiny slash-command usage out of weak recap cards and show the almost-no-slash copy instead
- add tests for tiny slash-command and zero slash-command/subagent cases

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig