### PR TITLE
fix: show maintenance page during outage

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,7 +11,13 @@
     <title>Rudel</title>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <main style="min-height: 100svh; display: flex; align-items: center; justify-content: center; box-sizing: border-box; padding: 3rem 1.5rem; background: #fff; color: #171717; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;">
+        <h1 style="max-width: 36rem; margin: 0; text-align: center; font-size: clamp(1.875rem, 4vw, 2.25rem); line-height: 1.1; font-weight: 600; letter-spacing: 0;">
+          We are experiencing techical difficulties. Sorry for that. We are working on it!
+        </h1>
+      </main>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/src/app/system/MaintenancePage.tsx
+++ b/apps/web/src/app/system/MaintenancePage.tsx
@@ -1,0 +1,18 @@
+export function MaintenancePage() {
+	return (
+		<main className="flex min-h-[100svh] items-center justify-center bg-background px-6 py-12 text-foreground">
+			<section
+				aria-labelledby="maintenance-message"
+				className="mx-auto flex max-w-xl flex-col items-center text-center"
+			>
+				<h1
+					id="maintenance-message"
+					className="text-balance text-3xl font-semibold leading-tight tracking-tight sm:text-4xl"
+				>
+					We are experiencing techical difficulties. Sorry for that. We are
+					working on it!
+				</h1>
+			</section>
+		</main>
+	);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,85 +1,11 @@
-import { DialRoot } from "dialkit";
-import { lazy, StrictMode, Suspense } from "react";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { useLocation } from "react-router-dom";
-import { AppProviders } from "@/app/providers/AppProviders";
-import App from "./App.tsx";
-import { useIsMobile } from "./app/hooks/use-mobile";
-import { useMountEffect } from "./app/hooks/useMountEffect";
+import { MaintenancePage } from "@/app/system/MaintenancePage";
 import "./index.css";
-import "dialkit/styles.css";
-import { initProductAnalytics } from "./lib/product-analytics";
-
-const DevTools = import.meta.env.DEV
-	? lazy(async () => {
-			const module = await import("./DevTools.tsx");
-			return {
-				default: module.DevTools,
-			};
-		})
-	: null;
-
-function GlobalLumaScope() {
-	useMountEffect(() => {
-		document.body.classList.add("style-luma");
-
-		return () => {
-			document.body.classList.remove("style-luma");
-		};
-	});
-
-	return null;
-}
-
-function DevControls() {
-	const { pathname } = useLocation();
-	const isMobile = useIsMobile();
-	const isWrappedMobile = isMobile && pathname.startsWith("/wrapped");
-
-	if (isWrappedMobile) {
-		return null;
-	}
-
-	return (
-		<>
-			<DialRoot defaultOpen={false} position="bottom-right" />
-			{DevTools ? (
-				<Suspense fallback={null}>
-					<DevTools />
-				</Suspense>
-			) : null}
-		</>
-	);
-}
-
-function deferProductAnalyticsInit() {
-	if (typeof window === "undefined") {
-		return;
-	}
-
-	if ("requestIdleCallback" in window) {
-		window.requestIdleCallback(() => {
-			initProductAnalytics();
-		});
-		return;
-	}
-
-	setTimeout(() => {
-		initProductAnalytics();
-	}, 0);
-}
 
 // biome-ignore lint/style/noNonNullAssertion: root element always exists
 createRoot(document.getElementById("root")!).render(
 	<StrictMode>
-		<AppProviders>
-			<GlobalLumaScope />
-			<div className="h-full">
-				<App />
-				{import.meta.env.DEV ? <DevControls /> : null}
-			</div>
-		</AppProviders>
+		<MaintenancePage />
 	</StrictMode>,
 );
-
-deferProductAnalyticsInit();


### PR DESCRIPTION
## Summary
- Replace the web app boot path with a standalone maintenance page for all app routes.
- Add a matching no-JavaScript fallback in `index.html` so the outage message appears before React loads.
- Keep the message copy exactly as requested.

## Test plan
- `bun run verify`
- Checked arbitrary Vite routes returned the maintenance message before committing.