### PR TITLE
fix: correct maintenance page spelling

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -14,7 +14,7 @@
     <div id="root">
       <main style="min-height: 100svh; display: flex; align-items: center; justify-content: center; box-sizing: border-box; padding: 3rem 1.5rem; background: #fff; color: #171717; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;">
         <h1 style="max-width: 36rem; margin: 0; text-align: center; font-size: clamp(1.875rem, 4vw, 2.25rem); line-height: 1.1; font-weight: 600; letter-spacing: 0;">
-          We are experiencing techical difficulties. Sorry for that. We are working on it!
+          We are experiencing technical difficulties. Sorry for that. We are working on it!
         </h1>
       </main>
     </div>

--- a/apps/web/src/app/system/MaintenancePage.tsx
+++ b/apps/web/src/app/system/MaintenancePage.tsx
@@ -9,7 +9,7 @@ export function MaintenancePage() {
 					id="maintenance-message"
 					className="text-balance text-3xl font-semibold leading-tight tracking-tight sm:text-4xl"
 				>
-					We are experiencing techical difficulties. Sorry for that. We are
+					We are experiencing technical difficulties. Sorry for that. We are
 					working on it!
 				</h1>
 			</section>


### PR DESCRIPTION
## Summary
- Correct the outage page copy from `techical` to `technical`.
- Update both the React maintenance page and the no-JavaScript HTML fallback.

## Test plan
- `bun run verify`