### PR TITLE
fix: add maintenance feedback link

### DIFF
--- a/apps/web/src/app/system/MaintenancePage.tsx
+++ b/apps/web/src/app/system/MaintenancePage.tsx
@@ -12,6 +12,19 @@ export function MaintenancePage() {
 					We are experiencing technical difficulties. Sorry for that. We are
 					working on it!
 				</h1>
+				<p className="mt-6 max-w-md text-balance text-base leading-7 text-muted-foreground">
+					While we're out of service, we'd love to get some feedback about your
+					experience so far:{" "}
+					<a
+						href="https://tally.so/r/ob0v6M"
+						target="_blank"
+						rel="noreferrer"
+						className="font-medium text-foreground underline underline-offset-4"
+					>
+						https://tally.so/r/ob0v6M
+					</a>
+					.
+				</p>
 			</section>
 		</main>
 	);


### PR DESCRIPTION
## Summary
- Add feedback copy to the maintenance page.
- Render the Tally feedback URL as the literal visible link text.

## Test plan
- [x] bun run verify
- [x] ./node_modules/.bin/biome check apps/web/src/app/system/MaintenancePage.tsx