### PR TITLE
fix: align wrapped setup title

### DIFF
--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -6056,7 +6056,6 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 @media (min-width: 768px) {
-	.mymind-wrapped-entry-stage--setup,
 	.mymind-wrapped-entry-stage--mobile-handoff {
 		grid-template-rows: auto auto;
 		align-content: center;


### PR DESCRIPTION
## Summary
- Keep the wrapped setup screen out of the tablet/desktop centering rule used by the mobile handoff prompt.
- Restores the Set up Rudel title to the top-aligned wrapped page layout.

## Test plan
- `bun run lint:wrapped:hig`
- `bun run verify`