### PR TITLE
fix: align wrapped tools card rows

### DIFF
--- a/apps/web/src/features/wrapped/onboarding/models/tools.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/tools.ts
@@ -3,7 +3,6 @@ import { formatPercent } from "../format";
 import type { WrappedSkillUsageItem } from "../types";
 
 interface ToolsStageEntry {
-	kindLabel: string;
 	id: string;
 	isPlaceholder: boolean;
 	name: string;
@@ -188,14 +187,14 @@ export function resolveToolsPreviewInput(
 
 export function getToolsStackHeightRem(entryCount: number) {
 	if (entryCount >= 3) {
-		return 17.4;
+		return 14.4;
 	}
 
 	if (entryCount === 2) {
-		return 11.4;
+		return 9.8;
 	}
 
-	return 6.9;
+	return 6.5;
 }
 
 export function getToolsEntryStyle(
@@ -232,7 +231,7 @@ export function getToolsEntryStyle(
 							rotate: "3deg",
 							scale: 0.985,
 							translateX: "-49.5%",
-							translateY: "4rem",
+							translateY: "3.55rem",
 							zIndex: 10,
 						}
 				: stackLayer === 0
@@ -248,14 +247,14 @@ export function getToolsEntryStyle(
 								rotate: "3deg",
 								scale: 0.988,
 								translateX: "-49.2%",
-								translateY: "4.2rem",
+								translateY: "3.65rem",
 								zIndex: 20,
 							}
 						: {
 								rotate: "-3.25deg",
 								scale: 0.976,
 								translateX: "-50.8%",
-								translateY: "8.2rem",
+								translateY: "7.1rem",
 								zIndex: 10,
 							};
 
@@ -361,9 +360,6 @@ function buildToolsStageEntries(input: {
 		)
 		.slice(0, 3)
 		.map((item) => ({
-			kindLabel: item.id.startsWith("slash-command-")
-				? "Slash command"
-				: "Subagent",
 			id: item.id,
 			isPlaceholder: false,
 			name: item.name,
@@ -377,7 +373,6 @@ function buildToolsStageEntries(input: {
 function buildToolsPlaceholderEntries(): readonly ToolsStageEntry[] {
 	return [
 		{
-			kindLabel: "Base model",
 			id: "tools-placeholder-1",
 			isPlaceholder: true,
 			name: "Solo mode",

--- a/apps/web/src/features/wrapped/onboarding/stages/tools.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/tools.tsx
@@ -381,15 +381,12 @@ function WrappedOnboardingToolsRegularStage(props: {
 											type="button"
 										>
 											<span className="mymind-wrapped-tools-stage__entry-top">
-												<span className="mymind-wrapped-tools-stage__entry-kind">
-													{entry.kindLabel}
+												<span className="mymind-wrapped-tools-stage__entry-name">
+													{entry.name}
 												</span>
 												<span className="mymind-wrapped-tools-stage__entry-usage">
 													{entry.usageLabel}
 												</span>
-											</span>
-											<span className="mymind-wrapped-tools-stage__entry-name">
-												{entry.name}
 											</span>
 											<span
 												aria-hidden="true"


### PR DESCRIPTION
## Summary
- remove the repeated tool kind label from wrapped tools cards
- place the tool name and usage metric on the same row
- relax the card stack overlap after the cards became thinner

## Test plan
- [x] bun run lint:wrapped:hig
- [x] bun ./node_modules/.bin/biome check apps/web/src/features/wrapped/onboarding/models/tools.ts apps/web/src/features/wrapped/onboarding/stages/tools.tsx
- [x] bun --filter @rudel/web test src/features/wrapped/onboarding/stages/tools.test.tsx
- [x] bun run verify in a clean temp worktree with only this patch applied