### PR TITLE
fix: tighten wrapped card layouts

### DIFF
--- a/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
@@ -23,6 +23,12 @@ import { useMountEffect } from "@/hooks/useMountEffect";
 import { cn } from "@/lib/utils";
 import { WrappedRouteStageShell } from "./route-stage-shell";
 import { WrappedGuestPreviewCard } from "./WrappedGuestPreviewCard";
+import {
+	getWrappedAuthFormCardOffsetY,
+	useWrappedAuthViewportSize,
+	WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS,
+	type WrappedAuthFormCardYValues,
+} from "./wrapped-auth-card-position";
 import type { WrappedGuestPreviewProfile } from "./wrapped-guest-preview";
 
 type WrappedAuthMode = "login" | "signup" | null;
@@ -38,7 +44,6 @@ type WrappedAuthCardFlight = {
 	from: WrappedAuthCardFlightRect;
 	key: number;
 	targetMode: WrappedAuthMode;
-	targetRect?: WrappedAuthCardFlightRect;
 	to?: WrappedAuthCardFlightRect;
 	transitionDurationMs: number;
 };
@@ -73,6 +78,7 @@ const WRAPPED_AUTH_TITLE_MICRO_DURATION = 0.2;
 
 interface WrappedAuthFlowProps {
 	authFormCardScale?: number;
+	authFormCardYValues?: WrappedAuthFormCardYValues;
 	authIntroCardScale?: number;
 	debugControls?: ReactNode;
 	onEmailPasswordPreviewSubmit?: (email: string) => void;
@@ -81,6 +87,7 @@ interface WrappedAuthFlowProps {
 
 interface WrappedAuthStageProps {
 	authFormCardScale?: number;
+	authFormCardOffsetY?: number;
 	authIntroCardScale?: number;
 	cardAppearance: WrappedAuthCardAppearance;
 	cardAppearanceOverlay: WrappedAuthCardAppearance | null;
@@ -96,6 +103,7 @@ interface WrappedAuthStageProps {
 function WrappedAuthStage(props: WrappedAuthStageProps) {
 	const {
 		authFormCardScale,
+		authFormCardOffsetY = 0,
 		authIntroCardScale,
 		cardAppearance,
 		cardAppearanceOverlay,
@@ -114,6 +122,7 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 			? (authIntroCardScale ?? WRAPPED_AUTH_INTRO_CARD_SCALE)
 			: (authFormCardScale ?? WRAPPED_AUTH_FORM_CARD_SCALE),
 	);
+	const activeCardOffsetY = isIntro ? 0 : authFormCardOffsetY;
 	const panelLayoutTransition = shouldReduceMotion
 		? {
 				duration: WRAPPED_AUTH_INTRO_REDUCED_DURATION,
@@ -192,7 +201,7 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 					}
 				>
 					<motion.div
-						animate={{ scale: activeCardScale }}
+						animate={{ scale: activeCardScale, y: activeCardOffsetY }}
 						className="mymind-wrapped-auth-panel__card-scale-shell"
 						transition={
 							isCardFlightActive
@@ -274,6 +283,7 @@ function clampWrappedAuthCardScale(scale: number) {
 
 export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 	const {
+		authFormCardYValues,
 		authFormCardScale,
 		authIntroCardScale,
 		debugControls,
@@ -289,9 +299,6 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 		useState<WrappedAuthCardFlight | null>(null);
 	const [suppressIntroCardEnter, setSuppressIntroCardEnter] = useState(false);
 	const authCardHandoffRef = useRef<HTMLDivElement | null>(null);
-	const authIntroCardFlightRectRef = useRef<WrappedAuthCardFlightRect | null>(
-		null,
-	);
 	const cardAppearanceTimeoutRef = useRef<number | null>(null);
 	const cardAppearanceOverlayTimeoutRef = useRef<number | null>(null);
 	const authCardFlightMeasureRef = useRef<number | null>(null);
@@ -299,6 +306,11 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 	const authCardFlightTimerRef = useRef<number | null>(null);
 	const [introTool, setIntroTool] = useState<WrappedAuthIntroTool>("Claude");
 	const shouldReduceMotion = useReducedMotion() ?? false;
+	const authViewportSize = useWrappedAuthViewportSize();
+	const authFormCardOffsetY = getWrappedAuthFormCardOffsetY({
+		values: authFormCardYValues ?? WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS,
+		viewportSize: authViewportSize,
+	});
 	const hasDebugControls =
 		debugControls !== undefined && debugControls !== null;
 	const rotateIntroTool = useEffectEvent(() => {
@@ -333,7 +345,6 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 
 	const activeAuthCardFlightAppearance = authCardFlight?.appearance;
 	const activeAuthCardFlightKey = authCardFlight?.key ?? null;
-	const activeAuthCardFlightTargetRect = authCardFlight?.targetRect;
 	const activeAuthCardFlightTargetMode = authCardFlight?.targetMode;
 	const transitionCardAppearance = useEffectEvent(
 		(
@@ -373,7 +384,6 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 		const flightKey = activeAuthCardFlightKey;
 		const flightTargetMode = activeAuthCardFlightTargetMode;
 		const measurementStartTime = performance.now();
-		const shouldRetargetFlight = activeAuthCardFlightTargetRect === undefined;
 		let hasScheduledCompletion = false;
 
 		function completeCardFlight() {
@@ -412,16 +422,15 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 			const measuredRect = getWrappedAuthCardFlightRect(
 				authCardHandoffRef.current,
 			);
-			const nextRect = activeAuthCardFlightTargetRect ?? measuredRect;
 
-			if (!nextRect) {
+			if (!measuredRect) {
 				completeCardFlight();
 				return;
 			}
 
 			setAuthCardFlight((currentFlight) =>
 				currentFlight?.key === flightKey
-					? { ...currentFlight, to: nextRect, transitionDurationMs }
+					? { ...currentFlight, to: measuredRect, transitionDurationMs }
 					: currentFlight,
 			);
 			scheduleCardFlightCompletion();
@@ -432,13 +441,12 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 			measureCardFlightTarget(WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS);
 		});
 		clearWrappedAuthCardFlightRetargetTimers(authCardFlightRetargetTimersRef);
-		authCardFlightRetargetTimersRef.current = shouldRetargetFlight
-			? WRAPPED_AUTH_CARD_FLIGHT_RETARGET_DELAYS_MS.map((delayMs) =>
-					window.setTimeout(() => {
-						measureCardFlightTarget(getRetargetTransitionDuration());
-					}, delayMs),
-				)
-			: [];
+		authCardFlightRetargetTimersRef.current =
+			WRAPPED_AUTH_CARD_FLIGHT_RETARGET_DELAYS_MS.map((delayMs) =>
+				window.setTimeout(() => {
+					measureCardFlightTarget(getRetargetTransitionDuration());
+				}, delayMs),
+			);
 
 		return () => {
 			clearWrappedAuthCardFlightAnimationFrame(authCardFlightMeasureRef);
@@ -448,7 +456,6 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 		activeAuthCardFlightAppearance,
 		activeAuthCardFlightKey,
 		activeAuthCardFlightTargetMode,
-		activeAuthCardFlightTargetRect,
 		mode,
 	]);
 
@@ -509,18 +516,10 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 			? getWrappedAuthCardFlightRect(authCardHandoffRef.current)
 			: null;
 		const shouldUseCardFlight = cardFlightFrom !== null;
-		const cardFlightTargetRect =
-			shouldUseCardFlight && nextMode === null
-				? (authIntroCardFlightRectRef.current ?? undefined)
-				: undefined;
 		const appearanceDelayMs =
 			mode === null || nextMode === null
 				? WRAPPED_AUTH_LAYOUT_DURATION * 1000
 				: null;
-
-		if (mode === null && cardFlightFrom !== null) {
-			authIntroCardFlightRectRef.current = cardFlightFrom;
-		}
 
 		if (shouldUseCardFlight) {
 			clearCardAppearanceTimeout();
@@ -534,7 +533,6 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 						from: cardFlightFrom,
 						key: Date.now(),
 						targetMode: nextMode,
-						targetRect: cardFlightTargetRect,
 						transitionDurationMs: WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS,
 					}
 				: null,
@@ -566,6 +564,7 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 			stage={
 				<WrappedAuthStage
 					authFormCardScale={authFormCardScale}
+					authFormCardOffsetY={authFormCardOffsetY}
 					authIntroCardScale={authIntroCardScale}
 					cardAppearance={cardAppearance}
 					cardAppearanceOverlay={cardAppearanceOverlay}

--- a/apps/web/src/features/wrapped/WrappedDevPage.tsx
+++ b/apps/web/src/features/wrapped/WrappedDevPage.tsx
@@ -14,6 +14,10 @@ import {
 	type WrappedUploadedRepoRow,
 } from "@/features/wrapped/WrappedSetupCompletePage";
 import { WrappedSetupPage } from "@/features/wrapped/WrappedSetupPage";
+import {
+	WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS,
+	type WrappedAuthFormCardYValues,
+} from "@/features/wrapped/wrapped-auth-card-position";
 
 type WrappedDevStage = "auth" | "setup" | "mobile" | "story";
 type WrappedDevSetupView = "guide" | "uploaded";
@@ -92,6 +96,14 @@ export function WrappedDevPage() {
 		card: {
 			_collapsed: true,
 			formScale: [1, 0.88, 1.08, 0.01],
+			formCardY: {
+				_collapsed: false,
+				compact: [WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS.compact, -120, 120, 1],
+				medium: [WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS.medium, -120, 120, 1],
+				short: [WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS.short, -120, 120, 1],
+				tall: [WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS.tall, -120, 120, 1],
+				wideTall: [WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS.wideTall, -120, 120, 1],
+			},
 			introScale: [1, 0.88, 1.08, 0.01],
 		},
 	});
@@ -165,6 +177,7 @@ export function WrappedDevPage() {
 		<>
 			{activeStage === "auth" ? (
 				<WrappedDevAuthStage
+					authFormCardYValues={dialValues.card.formCardY}
 					authFormCardScale={dialValues.card.formScale}
 					authIntroCardScale={dialValues.card.introScale}
 					debugControls={
@@ -284,12 +297,14 @@ function WrappedDevToolbar(props: {
 }
 
 function WrappedDevAuthStage(props: {
+	authFormCardYValues: WrappedAuthFormCardYValues;
 	authFormCardScale: number;
 	authIntroCardScale: number;
 	debugControls: ReactNode;
 }) {
 	return (
 		<WrappedGuestPage
+			authFormCardYValues={props.authFormCardYValues}
 			authFormCardScale={props.authFormCardScale}
 			authIntroCardScale={props.authIntroCardScale}
 			debugControls={props.debugControls}

--- a/apps/web/src/features/wrapped/WrappedGuestPage.tsx
+++ b/apps/web/src/features/wrapped/WrappedGuestPage.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { WrappedAuthFlow } from "./WrappedAuthFlow";
+import type { WrappedAuthFormCardYValues } from "./wrapped-auth-card-position";
 import {
 	readWrappedGuestPreviewSnapshot,
 	type WrappedGuestPreviewProfile,
@@ -8,16 +9,23 @@ import {
 
 export function WrappedGuestPage(props: {
 	authFormCardScale?: number;
+	authFormCardYValues?: WrappedAuthFormCardYValues;
 	authIntroCardScale?: number;
 	debugControls?: ReactNode;
 }) {
-	const { authFormCardScale, authIntroCardScale, debugControls } = props;
+	const {
+		authFormCardYValues,
+		authFormCardScale,
+		authIntroCardScale,
+		debugControls,
+	} = props;
 	const [previewProfile] = useState<WrappedGuestPreviewProfile | null>(
 		() => readWrappedGuestPreviewSnapshot()?.profile ?? null,
 	);
 
 	return (
 		<WrappedAuthFlow
+			authFormCardYValues={authFormCardYValues}
 			authFormCardScale={authFormCardScale}
 			authIntroCardScale={authIntroCardScale}
 			debugControls={debugControls}

--- a/apps/web/src/features/wrapped/onboarding/models/tools.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/tools.ts
@@ -3,7 +3,6 @@ import { formatPercent } from "../format";
 import type { WrappedSkillUsageItem } from "../types";
 
 interface ToolsStageEntry {
-	kindLabel: string;
 	id: string;
 	isPlaceholder: boolean;
 	name: string;
@@ -188,14 +187,14 @@ export function resolveToolsPreviewInput(
 
 export function getToolsStackHeightRem(entryCount: number) {
 	if (entryCount >= 3) {
-		return 17.4;
+		return 14.4;
 	}
 
 	if (entryCount === 2) {
-		return 11.4;
+		return 9.8;
 	}
 
-	return 6.9;
+	return 6.5;
 }
 
 export function getToolsEntryStyle(
@@ -232,7 +231,7 @@ export function getToolsEntryStyle(
 							rotate: "3deg",
 							scale: 0.985,
 							translateX: "-49.5%",
-							translateY: "4rem",
+							translateY: "3.55rem",
 							zIndex: 10,
 						}
 				: stackLayer === 0
@@ -248,14 +247,14 @@ export function getToolsEntryStyle(
 								rotate: "3deg",
 								scale: 0.988,
 								translateX: "-49.2%",
-								translateY: "4.2rem",
+								translateY: "3.65rem",
 								zIndex: 20,
 							}
 						: {
 								rotate: "-3.25deg",
 								scale: 0.976,
 								translateX: "-50.8%",
-								translateY: "8.2rem",
+								translateY: "7.1rem",
 								zIndex: 10,
 							};
 
@@ -361,9 +360,6 @@ function buildToolsStageEntries(input: {
 		)
 		.slice(0, 3)
 		.map((item) => ({
-			kindLabel: item.id.startsWith("slash-command-")
-				? "Slash command"
-				: "Subagent",
 			id: item.id,
 			isPlaceholder: false,
 			name: item.name,
@@ -377,7 +373,6 @@ function buildToolsStageEntries(input: {
 function buildToolsPlaceholderEntries(): readonly ToolsStageEntry[] {
 	return [
 		{
-			kindLabel: "Base model",
 			id: "tools-placeholder-1",
 			isPlaceholder: true,
 			name: "Solo mode",

--- a/apps/web/src/features/wrapped/onboarding/stages/tools.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/tools.tsx
@@ -381,15 +381,12 @@ function WrappedOnboardingToolsRegularStage(props: {
 											type="button"
 										>
 											<span className="mymind-wrapped-tools-stage__entry-top">
-												<span className="mymind-wrapped-tools-stage__entry-kind">
-													{entry.kindLabel}
+												<span className="mymind-wrapped-tools-stage__entry-name">
+													{entry.name}
 												</span>
 												<span className="mymind-wrapped-tools-stage__entry-usage">
 													{entry.usageLabel}
 												</span>
-											</span>
-											<span className="mymind-wrapped-tools-stage__entry-name">
-												{entry.name}
 											</span>
 											<span
 												aria-hidden="true"

--- a/apps/web/src/features/wrapped/wrapped-auth-card-position.ts
+++ b/apps/web/src/features/wrapped/wrapped-auth-card-position.ts
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import { useMountEffect } from "@/hooks/useMountEffect";
+
+export interface WrappedAuthViewportSize {
+	height: number;
+	width: number;
+}
+
+export interface WrappedAuthFormCardYValues {
+	compact: number;
+	medium: number;
+	short: number;
+	tall: number;
+	wideTall: number;
+}
+
+const WRAPPED_AUTH_NARROW_DESKTOP_MIN_WIDTH = 1024;
+const WRAPPED_AUTH_NARROW_DESKTOP_TARGET_WIDTH = 1077;
+const WRAPPED_AUTH_NARROW_DESKTOP_FULL_WIDTH = 1120;
+const WRAPPED_AUTH_NARROW_DESKTOP_MAX_WIDTH = 1200;
+const WRAPPED_AUTH_SHORT_MAX_HEIGHT = 760;
+const WRAPPED_AUTH_MEDIUM_MAX_HEIGHT = 820;
+const WRAPPED_AUTH_TALL_TARGET_HEIGHT = 1025;
+
+const WRAPPED_AUTH_DEFAULT_VIEWPORT_SIZE: WrappedAuthViewportSize = {
+	height: WRAPPED_AUTH_MEDIUM_MAX_HEIGHT,
+	width: WRAPPED_AUTH_NARROW_DESKTOP_MIN_WIDTH,
+};
+
+export const WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS: WrappedAuthFormCardYValues = {
+	compact: 0,
+	medium: 0,
+	short: -5,
+	tall: 48,
+	wideTall: 0,
+};
+
+export function useWrappedAuthViewportSize() {
+	const [viewportSize, setViewportSize] = useState<WrappedAuthViewportSize>(
+		() => getWrappedAuthViewportSize(),
+	);
+
+	useMountEffect(() => {
+		function updateViewportSize() {
+			setViewportSize(getWrappedAuthViewportSize());
+		}
+
+		window.addEventListener("resize", updateViewportSize);
+		window.visualViewport?.addEventListener("resize", updateViewportSize);
+
+		return () => {
+			window.removeEventListener("resize", updateViewportSize);
+			window.visualViewport?.removeEventListener("resize", updateViewportSize);
+		};
+	});
+
+	return viewportSize;
+}
+
+export function getWrappedAuthFormCardOffsetY(input: {
+	values: WrappedAuthFormCardYValues;
+	viewportSize: WrappedAuthViewportSize;
+}) {
+	const { height, width } = input.viewportSize;
+
+	if (height <= 720) {
+		return input.values.compact;
+	}
+
+	if (height <= WRAPPED_AUTH_SHORT_MAX_HEIGHT) {
+		return input.values.short * getWrappedAuthNarrowDesktopWeight(width);
+	}
+
+	if (height <= WRAPPED_AUTH_MEDIUM_MAX_HEIGHT) {
+		return input.values.medium;
+	}
+
+	if (width < WRAPPED_AUTH_NARROW_DESKTOP_MIN_WIDTH) {
+		return 0;
+	}
+
+	const narrowDesktopWeight = getWrappedAuthNarrowDesktopWeight(width);
+	const tallHeightWeight = getClampedProgress({
+		max: WRAPPED_AUTH_TALL_TARGET_HEIGHT,
+		min: WRAPPED_AUTH_MEDIUM_MAX_HEIGHT,
+		value: height,
+	});
+	const tallOffset =
+		input.values.tall * narrowDesktopWeight +
+		input.values.wideTall * (1 - narrowDesktopWeight);
+
+	return tallOffset * tallHeightWeight;
+}
+
+function getWrappedAuthViewportSize(): WrappedAuthViewportSize {
+	if (typeof window === "undefined") {
+		return WRAPPED_AUTH_DEFAULT_VIEWPORT_SIZE;
+	}
+
+	const viewport = window.visualViewport;
+
+	return {
+		height: viewport?.height ?? window.innerHeight,
+		width: viewport?.width ?? window.innerWidth,
+	};
+}
+
+function getWrappedAuthNarrowDesktopWeight(width: number) {
+	if (
+		width < WRAPPED_AUTH_NARROW_DESKTOP_MIN_WIDTH ||
+		width >= WRAPPED_AUTH_NARROW_DESKTOP_MAX_WIDTH
+	) {
+		return 0;
+	}
+
+	if (width < WRAPPED_AUTH_NARROW_DESKTOP_TARGET_WIDTH) {
+		return getClampedProgress({
+			max: WRAPPED_AUTH_NARROW_DESKTOP_TARGET_WIDTH,
+			min: WRAPPED_AUTH_NARROW_DESKTOP_MIN_WIDTH,
+			value: width,
+		});
+	}
+
+	if (width <= WRAPPED_AUTH_NARROW_DESKTOP_FULL_WIDTH) {
+		return 1;
+	}
+
+	return (
+		1 -
+		getClampedProgress({
+			max: WRAPPED_AUTH_NARROW_DESKTOP_MAX_WIDTH,
+			min: WRAPPED_AUTH_NARROW_DESKTOP_FULL_WIDTH,
+			value: width,
+		})
+	);
+}
+
+function getClampedProgress(input: {
+	max: number;
+	min: number;
+	value: number;
+}) {
+	const range = input.max - input.min;
+
+	if (range <= 0) {
+		return 0;
+	}
+
+	return Math.max(0, Math.min(1, (input.value - input.min) / range));
+}

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -4621,10 +4621,19 @@ body.mymind-wrapped-body #cw-bubble-holder {
 
 .mymind-wrapped-auth-panel--form {
 	--wrapped-auth-form-overlap: clamp(2.4rem, 7.5vw, 3.5rem);
-	grid-template-rows: auto minmax(0, 1fr);
+	--wrapped-auth-form-surplus-card-space: 0px;
+	grid-template-rows:
+		minmax(0, var(--wrapped-auth-form-surplus-card-space)) auto
+		minmax(0, 1fr);
 	align-content: stretch;
 	gap: 0;
 	min-height: 100%;
+}
+
+.mymind-wrapped-auth-panel--form::before {
+	content: "";
+	display: block;
+	min-height: 0;
 }
 
 .mymind-wrapped-auth-panel--profile {
@@ -4686,7 +4695,12 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 .mymind-wrapped-auth-panel--form .mymind-wrapped-auth-panel__card {
+	grid-row: 2;
 	padding-top: clamp(0.15rem, 1.6svh, 0.9rem);
+}
+
+.mymind-wrapped-auth-panel--form .mymind-wrapped-auth-panel__body--form {
+	grid-row: 3;
 }
 
 .mymind-wrapped-auth-panel__card--compact {
@@ -4750,6 +4764,17 @@ body.mymind-wrapped-body #cw-bubble-holder {
 .mymind-wrapped-auth-panel--form .mymind-wrapped-auth-panel__body--form {
 	margin-top: 0;
 	padding-top: var(--wrapped-auth-form-overlap);
+}
+
+@media (min-width: 64rem) and (min-height: 64.0625rem) {
+	.mymind-wrapped-auth-panel--form {
+		/* Spend surplus height as real grid space so the card and form controls move together. */
+		--wrapped-auth-form-surplus-card-space: calc(
+			(100svh - 64.0625rem) *
+			0.5 +
+			min(6.75rem, (100svh - 64.0625rem) * 0.617142857)
+		);
+	}
 }
 
 .mymind-wrapped-auth-panel__footer {
@@ -4896,7 +4921,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 @media (min-width: 40rem) {
 	.mymind-wrapped-auth-card-preview--hero
 		.mymind-wrapped-auth-card-preview__tilt {
-		--wrapped-card-render-scale: 1.42;
+		--wrapped-card-render-scale: 1.2;
 	}
 
 	.mymind-wrapped-auth-card-preview--profile
@@ -4914,6 +4939,14 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	.mymind-wrapped-auth-card-preview--profile
 		.mymind-wrapped-auth-card-preview__tilt {
 		--wrapped-card-render-scale: 1.28;
+	}
+}
+
+@media (max-width: 63.999rem) {
+	.mymind-wrapped-auth-form__scene--email,
+	.mymind-wrapped-auth-form__scene--credentials {
+		/* Keep the form steps within the clipped mobile/tablet auth viewport. */
+		padding-top: clamp(1rem, 4svh, 2rem);
 	}
 }
 
@@ -5242,8 +5275,9 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		calc(env(safe-area-inset-bottom, 0px) + 1.1rem)
 	);
 	box-sizing: border-box;
-	justify-content: flex-end;
-	padding-top: clamp(0.6rem, 2.2svh, 1.25rem);
+	justify-content: flex-start;
+	/* Keep the password action inside short auth stages without moving the card. */
+	padding-top: clamp(1.4rem, 4.8svh, 2.35rem);
 	padding-bottom: var(--wrapped-auth-credentials-bottom-space);
 }
 
@@ -7480,6 +7514,12 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		--wrapped-auth-form-overlap: clamp(0.9rem, 2.4svh, 1.25rem);
 	}
 
+	.mymind-wrapped-auth-panel--intro
+		.mymind-wrapped-auth-card-preview--hero
+		.mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-card-render-scale: 1.04;
+	}
+
 	.mymind-wrapped-auth-panel--form .mymind-wrapped-auth-card-preview__tilt {
 		--wrapped-card-render-scale: 0.94;
 	}
@@ -7498,6 +7538,12 @@ body.mymind-wrapped-body #cw-bubble-holder {
 @media (min-height: 721px) and (max-height: 760px) {
 	.mymind-wrapped-auth-panel--form {
 		--wrapped-auth-form-overlap: clamp(0.75rem, 2.2svh, 1.2rem);
+	}
+
+	.mymind-wrapped-auth-panel--intro
+		.mymind-wrapped-auth-card-preview--hero
+		.mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-card-render-scale: 1.04;
 	}
 
 	.mymind-wrapped-auth-panel--form .mymind-wrapped-auth-card-preview__tilt {
@@ -7544,6 +7590,12 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		--wrapped-auth-form-overlap: clamp(0.45rem, 1.5svh, 0.75rem);
 	}
 
+	.mymind-wrapped-auth-panel--intro
+		.mymind-wrapped-auth-card-preview--hero
+		.mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-card-render-scale: 1.04;
+	}
+
 	.mymind-wrapped-auth-card-preview__tilt {
 		--wrapped-card-render-scale: 0.84;
 	}
@@ -7562,7 +7614,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 			1.25rem,
 			calc(env(safe-area-inset-bottom, 0px) + 0.9rem)
 		);
-		padding-top: clamp(0.35rem, 1.4svh, 0.75rem);
+		padding-top: clamp(1.4rem, 4.8svh, 2.35rem);
 	}
 
 	.mymind-wrapped-auth-form .mymind-wrapped-auth-form__scene-action {
@@ -7573,19 +7625,6 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	.mymind-wrapped-auth-form[data-email-auth-stage="choice"]
 		.mymind-wrapped-auth-form__choice-footer {
 		margin-bottom: 0;
-	}
-
-	.mymind-wrapped-auth-panel--form:has(
-			.mymind-wrapped-auth-form__scene--credentials
-		) {
-		--wrapped-auth-form-overlap: clamp(0.75rem, 2.2svh, 1.2rem);
-	}
-
-	.mymind-wrapped-auth-panel--form:has(
-			.mymind-wrapped-auth-form__scene--credentials
-		)
-		.mymind-wrapped-auth-card-preview__tilt {
-		--wrapped-card-render-scale: 0.82;
 	}
 
 	.mymind-wrapped-final-stage {


### PR DESCRIPTION
## Summary
- Keep the wrapped auth card/form layout responsive across short, tall, and oversized viewports without unnecessary large-screen card travel.
- Add DialKit-tunable wrapped auth card Y offsets and retarget the card flight animation against the live layout.
- Tighten the wrapped tools card stack rows so tool entries use less vertical space.

## Test plan
- `bun run verify`
- `bun run lint:wrapped:hig`
- Playwright auth layout sweep: 109 viewport cases, 0 measured failures

Generated with Codex.