### PR TITLE
fix: polish wrapped onboarding flow

### DIFF
--- a/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
@@ -23,6 +23,12 @@ import { useMountEffect } from "@/hooks/useMountEffect";
 import { cn } from "@/lib/utils";
 import { WrappedRouteStageShell } from "./route-stage-shell";
 import { WrappedGuestPreviewCard } from "./WrappedGuestPreviewCard";
+import {
+	getWrappedAuthFormCardOffsetY,
+	useWrappedAuthViewportSize,
+	WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS,
+	type WrappedAuthFormCardYValues,
+} from "./wrapped-auth-card-position";
 import type { WrappedGuestPreviewProfile } from "./wrapped-guest-preview";
 
 type WrappedAuthMode = "login" | "signup" | null;
@@ -38,7 +44,6 @@ type WrappedAuthCardFlight = {
 	from: WrappedAuthCardFlightRect;
 	key: number;
 	targetMode: WrappedAuthMode;
-	targetRect?: WrappedAuthCardFlightRect;
 	to?: WrappedAuthCardFlightRect;
 	transitionDurationMs: number;
 };
@@ -73,6 +78,7 @@ const WRAPPED_AUTH_TITLE_MICRO_DURATION = 0.2;
 
 interface WrappedAuthFlowProps {
 	authFormCardScale?: number;
+	authFormCardYValues?: WrappedAuthFormCardYValues;
 	authIntroCardScale?: number;
 	debugControls?: ReactNode;
 	onEmailPasswordPreviewSubmit?: (email: string) => void;
@@ -81,6 +87,7 @@ interface WrappedAuthFlowProps {
 
 interface WrappedAuthStageProps {
 	authFormCardScale?: number;
+	authFormCardOffsetY?: number;
 	authIntroCardScale?: number;
 	cardAppearance: WrappedAuthCardAppearance;
 	cardAppearanceOverlay: WrappedAuthCardAppearance | null;
@@ -96,6 +103,7 @@ interface WrappedAuthStageProps {
 function WrappedAuthStage(props: WrappedAuthStageProps) {
 	const {
 		authFormCardScale,
+		authFormCardOffsetY = 0,
 		authIntroCardScale,
 		cardAppearance,
 		cardAppearanceOverlay,
@@ -114,6 +122,7 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 			? (authIntroCardScale ?? WRAPPED_AUTH_INTRO_CARD_SCALE)
 			: (authFormCardScale ?? WRAPPED_AUTH_FORM_CARD_SCALE),
 	);
+	const activeCardOffsetY = isIntro ? 0 : authFormCardOffsetY;
 	const panelLayoutTransition = shouldReduceMotion
 		? {
 				duration: WRAPPED_AUTH_INTRO_REDUCED_DURATION,
@@ -192,7 +201,7 @@ function WrappedAuthStage(props: WrappedAuthStageProps) {
 					}
 				>
 					<motion.div
-						animate={{ scale: activeCardScale }}
+						animate={{ scale: activeCardScale, y: activeCardOffsetY }}
 						className="mymind-wrapped-auth-panel__card-scale-shell"
 						transition={
 							isCardFlightActive
@@ -274,6 +283,7 @@ function clampWrappedAuthCardScale(scale: number) {
 
 export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 	const {
+		authFormCardYValues,
 		authFormCardScale,
 		authIntroCardScale,
 		debugControls,
@@ -289,9 +299,6 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 		useState<WrappedAuthCardFlight | null>(null);
 	const [suppressIntroCardEnter, setSuppressIntroCardEnter] = useState(false);
 	const authCardHandoffRef = useRef<HTMLDivElement | null>(null);
-	const authIntroCardFlightRectRef = useRef<WrappedAuthCardFlightRect | null>(
-		null,
-	);
 	const cardAppearanceTimeoutRef = useRef<number | null>(null);
 	const cardAppearanceOverlayTimeoutRef = useRef<number | null>(null);
 	const authCardFlightMeasureRef = useRef<number | null>(null);
@@ -299,6 +306,11 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 	const authCardFlightTimerRef = useRef<number | null>(null);
 	const [introTool, setIntroTool] = useState<WrappedAuthIntroTool>("Claude");
 	const shouldReduceMotion = useReducedMotion() ?? false;
+	const authViewportSize = useWrappedAuthViewportSize();
+	const authFormCardOffsetY = getWrappedAuthFormCardOffsetY({
+		values: authFormCardYValues ?? WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS,
+		viewportSize: authViewportSize,
+	});
 	const hasDebugControls =
 		debugControls !== undefined && debugControls !== null;
 	const rotateIntroTool = useEffectEvent(() => {
@@ -333,7 +345,6 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 
 	const activeAuthCardFlightAppearance = authCardFlight?.appearance;
 	const activeAuthCardFlightKey = authCardFlight?.key ?? null;
-	const activeAuthCardFlightTargetRect = authCardFlight?.targetRect;
 	const activeAuthCardFlightTargetMode = authCardFlight?.targetMode;
 	const transitionCardAppearance = useEffectEvent(
 		(
@@ -373,7 +384,6 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 		const flightKey = activeAuthCardFlightKey;
 		const flightTargetMode = activeAuthCardFlightTargetMode;
 		const measurementStartTime = performance.now();
-		const shouldRetargetFlight = activeAuthCardFlightTargetRect === undefined;
 		let hasScheduledCompletion = false;
 
 		function completeCardFlight() {
@@ -412,16 +422,15 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 			const measuredRect = getWrappedAuthCardFlightRect(
 				authCardHandoffRef.current,
 			);
-			const nextRect = activeAuthCardFlightTargetRect ?? measuredRect;
 
-			if (!nextRect) {
+			if (!measuredRect) {
 				completeCardFlight();
 				return;
 			}
 
 			setAuthCardFlight((currentFlight) =>
 				currentFlight?.key === flightKey
-					? { ...currentFlight, to: nextRect, transitionDurationMs }
+					? { ...currentFlight, to: measuredRect, transitionDurationMs }
 					: currentFlight,
 			);
 			scheduleCardFlightCompletion();
@@ -432,13 +441,12 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 			measureCardFlightTarget(WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS);
 		});
 		clearWrappedAuthCardFlightRetargetTimers(authCardFlightRetargetTimersRef);
-		authCardFlightRetargetTimersRef.current = shouldRetargetFlight
-			? WRAPPED_AUTH_CARD_FLIGHT_RETARGET_DELAYS_MS.map((delayMs) =>
-					window.setTimeout(() => {
-						measureCardFlightTarget(getRetargetTransitionDuration());
-					}, delayMs),
-				)
-			: [];
+		authCardFlightRetargetTimersRef.current =
+			WRAPPED_AUTH_CARD_FLIGHT_RETARGET_DELAYS_MS.map((delayMs) =>
+				window.setTimeout(() => {
+					measureCardFlightTarget(getRetargetTransitionDuration());
+				}, delayMs),
+			);
 
 		return () => {
 			clearWrappedAuthCardFlightAnimationFrame(authCardFlightMeasureRef);
@@ -448,7 +456,6 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 		activeAuthCardFlightAppearance,
 		activeAuthCardFlightKey,
 		activeAuthCardFlightTargetMode,
-		activeAuthCardFlightTargetRect,
 		mode,
 	]);
 
@@ -509,18 +516,10 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 			? getWrappedAuthCardFlightRect(authCardHandoffRef.current)
 			: null;
 		const shouldUseCardFlight = cardFlightFrom !== null;
-		const cardFlightTargetRect =
-			shouldUseCardFlight && nextMode === null
-				? (authIntroCardFlightRectRef.current ?? undefined)
-				: undefined;
 		const appearanceDelayMs =
 			mode === null || nextMode === null
 				? WRAPPED_AUTH_LAYOUT_DURATION * 1000
 				: null;
-
-		if (mode === null && cardFlightFrom !== null) {
-			authIntroCardFlightRectRef.current = cardFlightFrom;
-		}
 
 		if (shouldUseCardFlight) {
 			clearCardAppearanceTimeout();
@@ -534,7 +533,6 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 						from: cardFlightFrom,
 						key: Date.now(),
 						targetMode: nextMode,
-						targetRect: cardFlightTargetRect,
 						transitionDurationMs: WRAPPED_AUTH_CARD_FLIGHT_DURATION_MS,
 					}
 				: null,
@@ -566,6 +564,7 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 			stage={
 				<WrappedAuthStage
 					authFormCardScale={authFormCardScale}
+					authFormCardOffsetY={authFormCardOffsetY}
 					authIntroCardScale={authIntroCardScale}
 					cardAppearance={cardAppearance}
 					cardAppearanceOverlay={cardAppearanceOverlay}

--- a/apps/web/src/features/wrapped/WrappedDevPage.tsx
+++ b/apps/web/src/features/wrapped/WrappedDevPage.tsx
@@ -14,6 +14,10 @@ import {
 	type WrappedUploadedRepoRow,
 } from "@/features/wrapped/WrappedSetupCompletePage";
 import { WrappedSetupPage } from "@/features/wrapped/WrappedSetupPage";
+import {
+	WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS,
+	type WrappedAuthFormCardYValues,
+} from "@/features/wrapped/wrapped-auth-card-position";
 
 type WrappedDevStage = "auth" | "setup" | "mobile" | "story";
 type WrappedDevSetupView = "guide" | "uploaded";
@@ -92,6 +96,14 @@ export function WrappedDevPage() {
 		card: {
 			_collapsed: true,
 			formScale: [1, 0.88, 1.08, 0.01],
+			formCardY: {
+				_collapsed: false,
+				compact: [WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS.compact, -120, 120, 1],
+				medium: [WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS.medium, -120, 120, 1],
+				short: [WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS.short, -120, 120, 1],
+				tall: [WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS.tall, -120, 120, 1],
+				wideTall: [WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS.wideTall, -120, 120, 1],
+			},
 			introScale: [1, 0.88, 1.08, 0.01],
 		},
 	});
@@ -165,6 +177,7 @@ export function WrappedDevPage() {
 		<>
 			{activeStage === "auth" ? (
 				<WrappedDevAuthStage
+					authFormCardYValues={dialValues.card.formCardY}
 					authFormCardScale={dialValues.card.formScale}
 					authIntroCardScale={dialValues.card.introScale}
 					debugControls={
@@ -284,12 +297,14 @@ function WrappedDevToolbar(props: {
 }
 
 function WrappedDevAuthStage(props: {
+	authFormCardYValues: WrappedAuthFormCardYValues;
 	authFormCardScale: number;
 	authIntroCardScale: number;
 	debugControls: ReactNode;
 }) {
 	return (
 		<WrappedGuestPage
+			authFormCardYValues={props.authFormCardYValues}
 			authFormCardScale={props.authFormCardScale}
 			authIntroCardScale={props.authIntroCardScale}
 			debugControls={props.debugControls}

--- a/apps/web/src/features/wrapped/WrappedGuestPage.tsx
+++ b/apps/web/src/features/wrapped/WrappedGuestPage.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { WrappedAuthFlow } from "./WrappedAuthFlow";
+import type { WrappedAuthFormCardYValues } from "./wrapped-auth-card-position";
 import {
 	readWrappedGuestPreviewSnapshot,
 	type WrappedGuestPreviewProfile,
@@ -8,16 +9,23 @@ import {
 
 export function WrappedGuestPage(props: {
 	authFormCardScale?: number;
+	authFormCardYValues?: WrappedAuthFormCardYValues;
 	authIntroCardScale?: number;
 	debugControls?: ReactNode;
 }) {
-	const { authFormCardScale, authIntroCardScale, debugControls } = props;
+	const {
+		authFormCardYValues,
+		authFormCardScale,
+		authIntroCardScale,
+		debugControls,
+	} = props;
 	const [previewProfile] = useState<WrappedGuestPreviewProfile | null>(
 		() => readWrappedGuestPreviewSnapshot()?.profile ?? null,
 	);
 
 	return (
 		<WrappedAuthFlow
+			authFormCardYValues={authFormCardYValues}
 			authFormCardScale={authFormCardScale}
 			authIntroCardScale={authIntroCardScale}
 			debugControls={debugControls}

--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, useSearchParams } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliSetupStepId } from "@/components/analytics/CliSetupHint";
 import type { AppSession } from "@/features/auth/auth-route-utils";
 import { WrappedRouteGate } from "@/features/wrapped/WrappedRouteGate";
 import { getWrappedSetupCompletionStorageKey } from "@/features/wrapped/wrapped-setup-state";
@@ -44,7 +45,24 @@ vi.mock("@/features/wrapped/WrappedDesktopResumePromptPage", () => ({
 }));
 
 vi.mock("@/features/wrapped/WrappedSetupPage", () => ({
-	WrappedSetupPage: () => <div>Wrapped setup page</div>,
+	WrappedSetupPage: ({
+		completedStepIdsOverride,
+		currentStepIdOverride,
+		initialStepId,
+	}: {
+		completedStepIdsOverride?: readonly CliSetupStepId[];
+		currentStepIdOverride?: CliSetupStepId | null;
+		initialStepId?: CliSetupStepId;
+	}) => (
+		<div>
+			<div>Wrapped setup page</div>
+			<div>Setup initial step: {initialStepId ?? "none"}</div>
+			<div>Setup current step: {currentStepIdOverride ?? "none"}</div>
+			<div>
+				Setup completed steps: {completedStepIdsOverride?.join(",") ?? "none"}
+			</div>
+		</div>
+	),
 }));
 
 vi.mock("@/features/wrapped/WrappedSetupCompletePage", () => ({
@@ -124,6 +142,10 @@ describe("WrappedRouteGate", () => {
 		});
 	});
 
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("renders the public page before auth branching when a public id exists", () => {
 		render(
 			<MemoryRouter initialEntries={["/wrapped/share-123"]}>
@@ -185,9 +207,15 @@ describe("WrappedRouteGate", () => {
 		);
 
 		expect(screen.getByText("Wrapped setup page")).toBeInTheDocument();
+		expect(
+			screen.getByText("Setup current step: enable-auto-upload"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Setup completed steps: install-and-login"),
+		).toBeInTheDocument();
 	});
 
-	it("shows a checking state while uploaded sessions are still being checked", () => {
+	it("keeps showing setup while uploaded sessions are still being checked", () => {
 		mockUseSetupProgress.mockReturnValue({
 			hasUploadedSessions: false,
 			isLoading: true,
@@ -200,11 +228,12 @@ describe("WrappedRouteGate", () => {
 			</MemoryRouter>,
 		);
 
-		expect(screen.getByText("Checking your sessions")).toBeInTheDocument();
+		expect(screen.getByText("Wrapped setup page")).toBeInTheDocument();
 		expect(
-			screen.getByText(
-				"Looking for uploaded sessions and any in-flight desktop handoff.",
-			),
+			screen.getByText("Setup current step: enable-auto-upload"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Setup completed steps: install-and-login"),
 		).toBeInTheDocument();
 	});
 
@@ -220,6 +249,55 @@ describe("WrappedRouteGate", () => {
 				<WrappedRouteGate isPending={false} publicId={null} session={session} />
 			</MemoryRouter>,
 		);
+
+		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
+	});
+
+	it("briefly marks upload complete before showing uploaded sessions when sessions land during setup", async () => {
+		vi.useFakeTimers();
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: false,
+			isLoading: false,
+			totalSessionCount: 0,
+		});
+
+		const { rerender } = render(
+			<MemoryRouter initialEntries={["/wrapped?flow=sessions-landed"]}>
+				<WrappedRouteGate isPending={false} publicId={null} session={session} />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Wrapped setup page")).toBeInTheDocument();
+		expect(
+			screen.getByText("Setup current step: enable-auto-upload"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Setup completed steps: install-and-login"),
+		).toBeInTheDocument();
+
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 1,
+		});
+
+		rerender(
+			<MemoryRouter initialEntries={["/wrapped?flow=sessions-landed"]}>
+				<WrappedRouteGate isPending={false} publicId={null} session={session} />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Wrapped setup page")).toBeInTheDocument();
+		expect(screen.getByText("Setup current step: none")).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"Setup completed steps: install-and-login,enable-auto-upload",
+			),
+		).toBeInTheDocument();
+
+		await act(async () => {
+			vi.advanceTimersByTime(900);
+		});
 
 		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
 	});
@@ -296,6 +374,12 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
 		await user.click(screen.getByRole("button", { name: "Back to setup" }));
 		expect(screen.getByText("Wrapped setup page")).toBeInTheDocument();
+		expect(
+			screen.getByText("Setup current step: enable-auto-upload"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Setup completed steps: install-and-login"),
+		).toBeInTheDocument();
 	});
 
 	it("restarts the story from scale when continuing from sessions landed", async () => {

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, startTransition, useState } from "react";
+import { type ReactNode, startTransition, useRef, useState } from "react";
 import { useLocation, useSearchParams } from "react-router-dom";
 import { useIsMobile } from "@/app/hooks/use-mobile";
 import {
@@ -39,6 +39,14 @@ interface WrappedRouteGateProps {
 
 type WrappedRouteFlowStage = "desktop-ready" | "sessions-landed" | "story";
 
+const WRAPPED_SETUP_UPLOAD_STEP_ID = "enable-auto-upload";
+const WRAPPED_SETUP_AUTH_COMPLETED_STEP_IDS = ["install-and-login"] as const;
+const WRAPPED_SETUP_ALL_COMPLETED_STEP_IDS = [
+	"install-and-login",
+	"enable-auto-upload",
+] as const;
+const WRAPPED_SETUP_UPLOAD_COMPLETE_HOLD_MS = 900;
+
 export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const { isPending, publicId, session } = props;
 	const location = useLocation();
@@ -58,6 +66,12 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const [completedSetupUserIds, setCompletedSetupUserIds] = useState<
 		Record<string, true>
 	>({});
+	const [uploadSetupSeenUserIds, setUploadSetupSeenUserIds] = useState<
+		Record<string, true>
+	>({});
+	const [uploadCompletionShownUserIds, setUploadCompletionShownUserIds] =
+		useState<Record<string, true>>({});
+	const uploadCompletionTimeoutRef = useRef<number | null>(null);
 	const forcedFlowStage = getWrappedRouteFlowStage(
 		searchParams.get(WRAPPED_ROUTE_FLOW_QUERY_PARAM),
 	);
@@ -66,6 +80,21 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 			? false
 			: completedSetupUserIds[sessionUserId] === true ||
 				hasCompletedWrappedSetup(sessionUserId);
+	const hasSeenUploadSetup =
+		sessionUserId === null
+			? false
+			: uploadSetupSeenUserIds[sessionUserId] === true;
+	const hasShownUploadCompletion =
+		sessionUserId === null
+			? false
+			: uploadCompletionShownUserIds[sessionUserId] === true;
+	const shouldShowUploadCompletionStep =
+		sessionUserId !== null &&
+		setupProgress.hasUploadedSessions &&
+		!hasCompletedSetup &&
+		hasSeenUploadSetup &&
+		!hasShownUploadCompletion &&
+		forcedFlowStage !== "story";
 	const shouldForceSessionsLanded =
 		forcedFlowStage === "sessions-landed" && setupProgress.hasUploadedSessions;
 	const shouldForceDesktopReady =
@@ -124,8 +153,55 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		document.body.classList.add("mymind-wrapped-body");
 
 		return () => {
+			if (uploadCompletionTimeoutRef.current !== null) {
+				window.clearTimeout(uploadCompletionTimeoutRef.current);
+			}
 			document.body.classList.remove("mymind-wrapped-body");
 		};
+	});
+
+	useEffectOnceWhen({
+		effect: () => {
+			if (!sessionUserId) {
+				return;
+			}
+
+			setUploadSetupSeenUserIds((currentState) => ({
+				...currentState,
+				[sessionUserId]: true,
+			}));
+		},
+		isReady:
+			!publicId &&
+			!isPending &&
+			!!sessionUserId &&
+			!!session &&
+			!setupProgress.isLoading &&
+			!setupProgress.hasUploadedSessions &&
+			!(isMobile && sessionUserEmail),
+		key: sessionUserId,
+	});
+
+	useEffectOnceWhen({
+		effect: () => {
+			if (!sessionUserId) {
+				return;
+			}
+
+			uploadCompletionTimeoutRef.current = window.setTimeout(() => {
+				uploadCompletionTimeoutRef.current = null;
+				setUploadCompletionShownUserIds((currentState) => ({
+					...currentState,
+					[sessionUserId]: true,
+				}));
+				setWrappedRouteFlowStage("sessions-landed");
+			}, WRAPPED_SETUP_UPLOAD_COMPLETE_HOLD_MS);
+		},
+		isReady: shouldShowUploadCompletionStep,
+		key:
+			sessionUserId === null
+				? null
+				: `${sessionUserId}:wrapped-upload-complete`,
 	});
 
 	useEffectOnceWhen({
@@ -164,7 +240,8 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 			!isPending &&
 			!!sessionUserId &&
 			setupProgress.hasUploadedSessions &&
-			!hasCompletedSetup,
+			!hasCompletedSetup &&
+			!shouldShowUploadCompletionStep,
 		key: sessionUserId,
 	});
 
@@ -178,10 +255,10 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		);
 	} else if (!session) {
 		content = <WrappedGuestPage />;
-	} else if (setupProgress.isLoading) {
-		content = <WrappedSetupLoadingState />;
 	} else if (shouldForceDesktopReady) {
-		content = <WrappedSetupPage />;
+		content = <WrappedUploadSetupPage />;
+	} else if (shouldShowUploadCompletionStep) {
+		content = <WrappedUploadSetupPage isUploadComplete />;
 	} else if (
 		sessionUserId &&
 		(shouldForceSessionsLanded ||
@@ -211,10 +288,25 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 			/>
 		);
 	} else {
-		content = <WrappedSetupPage />;
+		content = <WrappedUploadSetupPage />;
 	}
 
 	return content;
+}
+
+function WrappedUploadSetupPage(props: { isUploadComplete?: boolean }) {
+	return (
+		<WrappedSetupPage
+			completedStepIdsOverride={
+				props.isUploadComplete
+					? WRAPPED_SETUP_ALL_COMPLETED_STEP_IDS
+					: WRAPPED_SETUP_AUTH_COMPLETED_STEP_IDS
+			}
+			currentStepIdOverride={
+				props.isUploadComplete ? null : WRAPPED_SETUP_UPLOAD_STEP_ID
+			}
+		/>
+	);
 }
 
 function getWrappedRouteFlowStage(
@@ -242,24 +334,6 @@ function WrappedRouteLoadingState(props: { body: string }) {
 				</div>
 			}
 			title="Loading wrapped"
-		/>
-	);
-}
-
-function WrappedSetupLoadingState() {
-	return (
-		<WrappedRouteStageShell
-			description="Checking whether your first Rudel sessions are already ready."
-			progressStepId="desktop-ready"
-			stage={
-				<div className="mymind-wrapped-entry-card mymind-wrapped-entry-card--status">
-					<div className="mymind-wrapped-entry-card__status-dot" />
-					<p className="mymind-wrapped-entry-card__status-copy">
-						Looking for uploaded sessions and any in-flight desktop handoff.
-					</p>
-				</div>
-			}
-			title="Checking your sessions"
 		/>
 	);
 }

--- a/apps/web/src/features/wrapped/WrappedSetupPage.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedSetupPage.test.tsx
@@ -1,8 +1,20 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { WrappedSetupPage } from "@/features/wrapped/WrappedSetupPage";
+
+const { mockOpenChatwoot, mockSetChatwootBubbleVisibility } = vi.hoisted(
+	() => ({
+		mockOpenChatwoot: vi.fn(),
+		mockSetChatwootBubbleVisibility: vi.fn(),
+	}),
+);
+
+vi.mock("@/lib/chatwoot", () => ({
+	openChatwoot: mockOpenChatwoot,
+	setChatwootBubbleVisibility: mockSetChatwootBubbleVisibility,
+}));
 
 Object.defineProperty(window, "matchMedia", {
 	writable: true,
@@ -16,6 +28,13 @@ Object.defineProperty(window, "matchMedia", {
 		removeEventListener: vi.fn(),
 		removeListener: vi.fn(),
 	})),
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	window.sessionStorage.clear();
+	mockOpenChatwoot.mockClear();
+	mockSetChatwootBubbleVisibility.mockClear();
 });
 
 function hasExactTextContent(expectedText: string) {
@@ -206,5 +225,76 @@ describe("WrappedSetupPage", () => {
 		expect(
 			screen.getAllByRole("button", { name: "Copy to clipboard" }),
 		).toHaveLength(2);
+	});
+
+	it("reveals upload support after one minute and opens support chat", () => {
+		vi.useFakeTimers();
+
+		render(
+			<MemoryRouter>
+				<WrappedSetupPage initialStepId="enable-auto-upload" />
+			</MemoryRouter>,
+		);
+
+		expect(
+			screen.queryByRole("button", {
+				name: "Trouble uploading sessions?",
+			}),
+		).toBeNull();
+
+		act(() => {
+			vi.advanceTimersByTime(59_999);
+		});
+
+		expect(
+			screen.queryByRole("button", {
+				name: "Trouble uploading sessions?",
+			}),
+		).toBeNull();
+
+		act(() => {
+			vi.advanceTimersByTime(1);
+		});
+
+		const supportButton = screen.getByRole("button", {
+			name: "Trouble uploading sessions?",
+		});
+		fireEvent.click(supportButton);
+
+		expect(mockOpenChatwoot).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps upload support visible after it has appeared once", () => {
+		vi.useFakeTimers();
+
+		const firstRender = render(
+			<MemoryRouter>
+				<WrappedSetupPage initialStepId="enable-auto-upload" />
+			</MemoryRouter>,
+		);
+
+		act(() => {
+			vi.advanceTimersByTime(60_000);
+		});
+
+		expect(
+			screen.getByRole("button", {
+				name: "Trouble uploading sessions?",
+			}),
+		).toBeInTheDocument();
+
+		firstRender.unmount();
+
+		render(
+			<MemoryRouter>
+				<WrappedSetupPage initialStepId="enable-auto-upload" />
+			</MemoryRouter>,
+		);
+
+		expect(
+			screen.getByRole("button", {
+				name: "Trouble uploading sessions?",
+			}),
+		).toBeInTheDocument();
 	});
 });

--- a/apps/web/src/features/wrapped/WrappedSetupPage.tsx
+++ b/apps/web/src/features/wrapped/WrappedSetupPage.tsx
@@ -1,15 +1,21 @@
 import { MotionConfig } from "motion/react";
 import type { ReactNode } from "react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
 	CliSetupHint,
 	type CliSetupStepId,
 	cliSetupCommands,
 } from "@/components/analytics/CliSetupHint";
+import { useMountEffect } from "@/hooks/useMountEffect";
+import { openChatwoot } from "@/lib/chatwoot";
 import {
 	WrappedDebugControlStack,
 	WrappedRouteStageShell,
 } from "./route-stage-shell";
+
+const WRAPPED_SETUP_SUPPORT_PROMPT_DELAY_MS = 60_000;
+const WRAPPED_SETUP_SUPPORT_PROMPT_STORAGE_KEY =
+	"wrapped:setup-support-prompt-shown";
 
 interface WrappedSetupPageProps {
 	completedStepIdsOverride?: readonly CliSetupStepId[];
@@ -43,6 +49,7 @@ export function WrappedSetupPage(props: WrappedSetupPageProps) {
 			? derivedCurrentStepId
 			: currentStepIdOverride;
 	const completedStepIds = completedStepIdsOverride ?? derivedCompletedStepIds;
+	const shouldOfferUploadSupport = currentStepId === "enable-auto-upload";
 
 	return (
 		<MotionConfig reducedMotion="user">
@@ -62,17 +69,82 @@ export function WrappedSetupPage(props: WrappedSetupPageProps) {
 				progressStepId="desktop-ready"
 				stageClassName="mymind-wrapped-entry-stage--setup"
 				stage={
-					<CliSetupHint
-						completedStepIds={completedStepIds}
-						currentStepId={currentStepId}
-						hideAlternateCommandCaption
-						variant="wrapped-story"
-					/>
+					<div className="mymind-wrapped-setup-guide">
+						{shouldOfferUploadSupport ? <WrappedSetupSupportPrompt /> : null}
+						<CliSetupHint
+							completedStepIds={completedStepIds}
+							currentStepId={currentStepId}
+							hideAlternateCommandCaption
+							variant="wrapped-story"
+						/>
+					</div>
 				}
 				title="Set up Rudel"
 			/>
 		</MotionConfig>
 	);
+}
+
+function WrappedSetupSupportPrompt() {
+	const [isVisible, setIsVisible] = useState(hasShownWrappedSetupSupportPrompt);
+
+	useMountEffect(() => {
+		if (isVisible) {
+			return;
+		}
+
+		const timeoutId = window.setTimeout(() => {
+			markWrappedSetupSupportPromptShown();
+			setIsVisible(true);
+		}, WRAPPED_SETUP_SUPPORT_PROMPT_DELAY_MS);
+
+		return () => {
+			window.clearTimeout(timeoutId);
+		};
+	});
+
+	if (!isVisible) {
+		return null;
+	}
+
+	return (
+		<button
+			type="button"
+			className="mymind-wrapped-setup-support-prompt"
+			onClick={() => void openChatwoot()}
+		>
+			Trouble uploading sessions?
+		</button>
+	);
+}
+
+function hasShownWrappedSetupSupportPrompt() {
+	if (typeof window === "undefined") {
+		return false;
+	}
+
+	try {
+		return (
+			window.sessionStorage.getItem(
+				WRAPPED_SETUP_SUPPORT_PROMPT_STORAGE_KEY,
+			) === "true"
+		);
+	} catch {
+		return false;
+	}
+}
+
+function markWrappedSetupSupportPromptShown() {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	try {
+		window.sessionStorage.setItem(
+			WRAPPED_SETUP_SUPPORT_PROMPT_STORAGE_KEY,
+			"true",
+		);
+	} catch {}
 }
 
 function getInitialStepIndex(

--- a/apps/web/src/features/wrapped/onboarding/models/tools.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/tools.ts
@@ -3,7 +3,6 @@ import { formatPercent } from "../format";
 import type { WrappedSkillUsageItem } from "../types";
 
 interface ToolsStageEntry {
-	kindLabel: string;
 	id: string;
 	isPlaceholder: boolean;
 	name: string;
@@ -188,14 +187,14 @@ export function resolveToolsPreviewInput(
 
 export function getToolsStackHeightRem(entryCount: number) {
 	if (entryCount >= 3) {
-		return 17.4;
+		return 14.4;
 	}
 
 	if (entryCount === 2) {
-		return 11.4;
+		return 9.8;
 	}
 
-	return 6.9;
+	return 6.5;
 }
 
 export function getToolsEntryStyle(
@@ -232,7 +231,7 @@ export function getToolsEntryStyle(
 							rotate: "3deg",
 							scale: 0.985,
 							translateX: "-49.5%",
-							translateY: "4rem",
+							translateY: "3.55rem",
 							zIndex: 10,
 						}
 				: stackLayer === 0
@@ -248,14 +247,14 @@ export function getToolsEntryStyle(
 								rotate: "3deg",
 								scale: 0.988,
 								translateX: "-49.2%",
-								translateY: "4.2rem",
+								translateY: "3.65rem",
 								zIndex: 20,
 							}
 						: {
 								rotate: "-3.25deg",
 								scale: 0.976,
 								translateX: "-50.8%",
-								translateY: "8.2rem",
+								translateY: "7.1rem",
 								zIndex: 10,
 							};
 
@@ -361,9 +360,6 @@ function buildToolsStageEntries(input: {
 		)
 		.slice(0, 3)
 		.map((item) => ({
-			kindLabel: item.id.startsWith("slash-command-")
-				? "Slash command"
-				: "Subagent",
 			id: item.id,
 			isPlaceholder: false,
 			name: item.name,
@@ -377,7 +373,6 @@ function buildToolsStageEntries(input: {
 function buildToolsPlaceholderEntries(): readonly ToolsStageEntry[] {
 	return [
 		{
-			kindLabel: "Base model",
 			id: "tools-placeholder-1",
 			isPlaceholder: true,
 			name: "Solo mode",

--- a/apps/web/src/features/wrapped/onboarding/stages/skills.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/skills.tsx
@@ -82,10 +82,31 @@ const SKILLS_STAGE_INTRO_TOKENS =
 const SKILLS_STAGE_DEAL_FINAL_HOLD_MS = 280;
 const SKILLS_STAGE_INTRO_TOKEN_STAGGER_S = 0.055;
 
+function getSkillsDebugLayoutClassName() {
+	if (typeof window === "undefined") {
+		return null;
+	}
+
+	const debugValue = new URLSearchParams(window.location.search).get(
+		"debugSkillsLayout",
+	);
+
+	if (debugValue === "purple" || debugValue === "bottom-gradient") {
+		return "mymind-wrapped-skills-stage--debug-purple-gradient";
+	}
+
+	if (debugValue === "1" || debugValue === "true") {
+		return "mymind-wrapped-skills-stage--debug-layout";
+	}
+
+	return null;
+}
+
 export function WrappedOnboardingSkillsStage(props: SkillsStageProps) {
 	const { onboardingMetrics, previewState } = props;
 	const shouldReduceMotion = useReducedMotion();
 	const reduceMotion = shouldReduceMotion ?? false;
+	const debugLayoutClassName = getSkillsDebugLayoutClassName();
 	const [replayNonce, setReplayNonce] = useState(0);
 	const model = resolveSkillsStageModel(
 		resolveSkillsPreviewInput(
@@ -294,6 +315,7 @@ export function WrappedOnboardingSkillsStage(props: SkillsStageProps) {
 				isIntroCopyVisible && "mymind-wrapped-skills-stage--intro-copy",
 				isComponentOnly && "mymind-wrapped-skills-stage--component-only",
 				isOverlayCopyVisible && "mymind-wrapped-skills-stage--overlay-copy",
+				debugLayoutClassName,
 			)}
 			copy={
 				isEmptySkillsBoard ? (
@@ -318,6 +340,8 @@ export function WrappedOnboardingSkillsStage(props: SkillsStageProps) {
 							<motion.div
 								key="skills-intro-copy"
 								animate={{ filter: "blur(0px)", opacity: 1, scale: 1, y: 0 }}
+								className="mymind-wrapped-skills-stage__debug-copy-shell"
+								data-debug-label="intro copy motion"
 								exit={{ filter: "blur(6px)", opacity: 0, scale: 0.992, y: -8 }}
 								initial={false}
 								transition={SKILLS_STAGE_COPY_TRANSITION}
@@ -338,6 +362,8 @@ export function WrappedOnboardingSkillsStage(props: SkillsStageProps) {
 							scale: 1,
 							y: 0,
 						}}
+						className="mymind-wrapped-skills-stage__debug-copy-shell"
+						data-debug-label="overlay copy motion"
 						initial={{
 							filter: "blur(10px)",
 							opacity: 0,
@@ -355,10 +381,14 @@ export function WrappedOnboardingSkillsStage(props: SkillsStageProps) {
 			}
 			object={
 				isEmptySkillsBoard ? (
-					<div className="mymind-wrapped-skills-stage__empty-state">
+					<div
+						className="mymind-wrapped-skills-stage__empty-state"
+						data-debug-label="empty state"
+					>
 						<div
 							aria-hidden="true"
 							className="mymind-wrapped-skills-stage__empty-icon-shell"
+							data-debug-label="empty icon shell"
 						>
 							<span className="mymind-wrapped-skills-stage__empty-code">
 								404
@@ -386,17 +416,20 @@ export function WrappedOnboardingSkillsStage(props: SkillsStageProps) {
 					<motion.div
 						animate={{ filter: "blur(0px)", opacity: 1, y: 0 }}
 						className="mymind-wrapped-skills-stage__object-shell"
+						data-debug-label="object shell"
 						initial={{ filter: "blur(10px)", opacity: 0, y: 14 }}
 						transition={SKILLS_STAGE_OBJECT_TRANSITION}
 					>
 						<div
 							className="mymind-wrapped-skills-stage__stack-frame"
+							data-debug-label="stack frame"
 							data-scrollable={model.isScrollable ? "true" : "false"}
 							data-stack-stage={skillsEntranceStage}
 						>
 							<section
 								aria-label="Skill rankings"
 								className="mymind-wrapped-skills-stage__stack"
+								data-debug-label="scroll stack"
 								data-scrollable={model.isScrollable ? "true" : "false"}
 								data-stack-stage={skillsEntranceStage}
 								onScroll={handleSkillsStackScroll}
@@ -406,6 +439,7 @@ export function WrappedOnboardingSkillsStage(props: SkillsStageProps) {
 							>
 								<div
 									className="mymind-wrapped-skills-stage__stack-track"
+									data-debug-label="stack track"
 									style={stackStyle}
 								>
 									{model.cards.map((card, cardIndex) => {
@@ -441,6 +475,7 @@ export function WrappedOnboardingSkillsStage(props: SkillsStageProps) {
 															cardIndex === frontDealCardIndex)) &&
 														"is-front",
 												)}
+												data-debug-label={`card ${card.item.rank}`}
 												data-card-stage={skillsEntranceStage}
 												style={cardStyle}
 											>
@@ -449,15 +484,28 @@ export function WrappedOnboardingSkillsStage(props: SkillsStageProps) {
 														"mymind-wrapped-skills-stage__card-item",
 														card.item.isPlaceholder && "is-placeholder",
 													)}
+													data-debug-label={`card ${card.item.rank} item grid`}
 												>
-													<span className="mymind-wrapped-skills-stage__item-rank">
+													<span
+														className="mymind-wrapped-skills-stage__item-rank"
+														data-debug-label={`rank ${card.item.rank}`}
+													>
 														{card.item.rank}
 													</span>
-													<div className="mymind-wrapped-skills-stage__item-copy">
-														<p className="mymind-wrapped-skills-stage__item-name">
+													<div
+														className="mymind-wrapped-skills-stage__item-copy"
+														data-debug-label={`card ${card.item.rank} copy`}
+													>
+														<p
+															className="mymind-wrapped-skills-stage__item-name"
+															data-debug-label={`card ${card.item.rank} name`}
+														>
 															{card.item.name}
 														</p>
-														<p className="mymind-wrapped-skills-stage__item-meta">
+														<p
+															className="mymind-wrapped-skills-stage__item-meta"
+															data-debug-label={`card ${card.item.rank} meta`}
+														>
 															{card.item.meta}
 														</p>
 													</div>
@@ -479,7 +527,10 @@ function WrappedSkillsIntroLine(props: { reduceMotion: boolean }) {
 	const { reduceMotion } = props;
 
 	return (
-		<span className="mymind-wrapped-skills-stage__intro-line">
+		<span
+			className="mymind-wrapped-skills-stage__intro-line"
+			data-debug-label="intro line"
+		>
 			{SKILLS_STAGE_INTRO_TOKENS.map((token, tokenIndex) => (
 				<motion.span
 					key={token}
@@ -489,6 +540,7 @@ function WrappedSkillsIntroLine(props: { reduceMotion: boolean }) {
 							: { filter: "blur(0px)", opacity: 1, y: 0 }
 					}
 					className="mymind-wrapped-skills-stage__intro-token"
+					data-debug-label={`intro token: ${token}`}
 					initial={
 						reduceMotion
 							? { opacity: 0 }

--- a/apps/web/src/features/wrapped/onboarding/stages/tools.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/tools.tsx
@@ -381,15 +381,12 @@ function WrappedOnboardingToolsRegularStage(props: {
 											type="button"
 										>
 											<span className="mymind-wrapped-tools-stage__entry-top">
-												<span className="mymind-wrapped-tools-stage__entry-kind">
-													{entry.kindLabel}
+												<span className="mymind-wrapped-tools-stage__entry-name">
+													{entry.name}
 												</span>
 												<span className="mymind-wrapped-tools-stage__entry-usage">
 													{entry.usageLabel}
 												</span>
-											</span>
-											<span className="mymind-wrapped-tools-stage__entry-name">
-												{entry.name}
 											</span>
 											<span
 												aria-hidden="true"

--- a/apps/web/src/features/wrapped/wrapped-auth-card-position.ts
+++ b/apps/web/src/features/wrapped/wrapped-auth-card-position.ts
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import { useMountEffect } from "@/hooks/useMountEffect";
+
+export interface WrappedAuthViewportSize {
+	height: number;
+	width: number;
+}
+
+export interface WrappedAuthFormCardYValues {
+	compact: number;
+	medium: number;
+	short: number;
+	tall: number;
+	wideTall: number;
+}
+
+const WRAPPED_AUTH_NARROW_DESKTOP_MIN_WIDTH = 1024;
+const WRAPPED_AUTH_NARROW_DESKTOP_TARGET_WIDTH = 1077;
+const WRAPPED_AUTH_NARROW_DESKTOP_FULL_WIDTH = 1120;
+const WRAPPED_AUTH_NARROW_DESKTOP_MAX_WIDTH = 1200;
+const WRAPPED_AUTH_SHORT_MAX_HEIGHT = 760;
+const WRAPPED_AUTH_MEDIUM_MAX_HEIGHT = 820;
+const WRAPPED_AUTH_TALL_TARGET_HEIGHT = 1025;
+
+const WRAPPED_AUTH_DEFAULT_VIEWPORT_SIZE: WrappedAuthViewportSize = {
+	height: WRAPPED_AUTH_MEDIUM_MAX_HEIGHT,
+	width: WRAPPED_AUTH_NARROW_DESKTOP_MIN_WIDTH,
+};
+
+export const WRAPPED_AUTH_FORM_CARD_Y_DEFAULTS: WrappedAuthFormCardYValues = {
+	compact: 0,
+	medium: 0,
+	short: -5,
+	tall: 48,
+	wideTall: 0,
+};
+
+export function useWrappedAuthViewportSize() {
+	const [viewportSize, setViewportSize] = useState<WrappedAuthViewportSize>(
+		() => getWrappedAuthViewportSize(),
+	);
+
+	useMountEffect(() => {
+		function updateViewportSize() {
+			setViewportSize(getWrappedAuthViewportSize());
+		}
+
+		window.addEventListener("resize", updateViewportSize);
+		window.visualViewport?.addEventListener("resize", updateViewportSize);
+
+		return () => {
+			window.removeEventListener("resize", updateViewportSize);
+			window.visualViewport?.removeEventListener("resize", updateViewportSize);
+		};
+	});
+
+	return viewportSize;
+}
+
+export function getWrappedAuthFormCardOffsetY(input: {
+	values: WrappedAuthFormCardYValues;
+	viewportSize: WrappedAuthViewportSize;
+}) {
+	const { height, width } = input.viewportSize;
+
+	if (height <= 720) {
+		return input.values.compact;
+	}
+
+	if (height <= WRAPPED_AUTH_SHORT_MAX_HEIGHT) {
+		return input.values.short * getWrappedAuthNarrowDesktopWeight(width);
+	}
+
+	if (height <= WRAPPED_AUTH_MEDIUM_MAX_HEIGHT) {
+		return input.values.medium;
+	}
+
+	if (width < WRAPPED_AUTH_NARROW_DESKTOP_MIN_WIDTH) {
+		return 0;
+	}
+
+	const narrowDesktopWeight = getWrappedAuthNarrowDesktopWeight(width);
+	const tallHeightWeight = getClampedProgress({
+		max: WRAPPED_AUTH_TALL_TARGET_HEIGHT,
+		min: WRAPPED_AUTH_MEDIUM_MAX_HEIGHT,
+		value: height,
+	});
+	const tallOffset =
+		input.values.tall * narrowDesktopWeight +
+		input.values.wideTall * (1 - narrowDesktopWeight);
+
+	return tallOffset * tallHeightWeight;
+}
+
+function getWrappedAuthViewportSize(): WrappedAuthViewportSize {
+	if (typeof window === "undefined") {
+		return WRAPPED_AUTH_DEFAULT_VIEWPORT_SIZE;
+	}
+
+	const viewport = window.visualViewport;
+
+	return {
+		height: viewport?.height ?? window.innerHeight,
+		width: viewport?.width ?? window.innerWidth,
+	};
+}
+
+function getWrappedAuthNarrowDesktopWeight(width: number) {
+	if (
+		width < WRAPPED_AUTH_NARROW_DESKTOP_MIN_WIDTH ||
+		width >= WRAPPED_AUTH_NARROW_DESKTOP_MAX_WIDTH
+	) {
+		return 0;
+	}
+
+	if (width < WRAPPED_AUTH_NARROW_DESKTOP_TARGET_WIDTH) {
+		return getClampedProgress({
+			max: WRAPPED_AUTH_NARROW_DESKTOP_TARGET_WIDTH,
+			min: WRAPPED_AUTH_NARROW_DESKTOP_MIN_WIDTH,
+			value: width,
+		});
+	}
+
+	if (width <= WRAPPED_AUTH_NARROW_DESKTOP_FULL_WIDTH) {
+		return 1;
+	}
+
+	return (
+		1 -
+		getClampedProgress({
+			max: WRAPPED_AUTH_NARROW_DESKTOP_MAX_WIDTH,
+			min: WRAPPED_AUTH_NARROW_DESKTOP_FULL_WIDTH,
+			value: width,
+		})
+	);
+}
+
+function getClampedProgress(input: {
+	max: number;
+	min: number;
+	value: number;
+}) {
+	const range = input.max - input.min;
+
+	if (range <= 0) {
+		return 0;
+	}
+
+	return Math.max(0, Math.min(1, (input.value - input.min) / range));
+}

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -4621,10 +4621,19 @@ body.mymind-wrapped-body #cw-bubble-holder {
 
 .mymind-wrapped-auth-panel--form {
 	--wrapped-auth-form-overlap: clamp(2.4rem, 7.5vw, 3.5rem);
-	grid-template-rows: auto minmax(0, 1fr);
+	--wrapped-auth-form-surplus-card-space: 0px;
+	grid-template-rows:
+		minmax(0, var(--wrapped-auth-form-surplus-card-space)) auto
+		minmax(0, 1fr);
 	align-content: stretch;
 	gap: 0;
 	min-height: 100%;
+}
+
+.mymind-wrapped-auth-panel--form::before {
+	content: "";
+	display: block;
+	min-height: 0;
 }
 
 .mymind-wrapped-auth-panel--profile {
@@ -4686,7 +4695,12 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 .mymind-wrapped-auth-panel--form .mymind-wrapped-auth-panel__card {
+	grid-row: 2;
 	padding-top: clamp(0.15rem, 1.6svh, 0.9rem);
+}
+
+.mymind-wrapped-auth-panel--form .mymind-wrapped-auth-panel__body--form {
+	grid-row: 3;
 }
 
 .mymind-wrapped-auth-panel__card--compact {
@@ -4750,6 +4764,17 @@ body.mymind-wrapped-body #cw-bubble-holder {
 .mymind-wrapped-auth-panel--form .mymind-wrapped-auth-panel__body--form {
 	margin-top: 0;
 	padding-top: var(--wrapped-auth-form-overlap);
+}
+
+@media (min-width: 64rem) and (min-height: 64.0625rem) {
+	.mymind-wrapped-auth-panel--form {
+		/* Spend surplus height as real grid space so the card and form controls move together. */
+		--wrapped-auth-form-surplus-card-space: calc(
+			(100svh - 64.0625rem) *
+			0.5 +
+			min(6.75rem, (100svh - 64.0625rem) * 0.617142857)
+		);
+	}
 }
 
 .mymind-wrapped-auth-panel__footer {
@@ -4896,7 +4921,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 @media (min-width: 40rem) {
 	.mymind-wrapped-auth-card-preview--hero
 		.mymind-wrapped-auth-card-preview__tilt {
-		--wrapped-card-render-scale: 1.42;
+		--wrapped-card-render-scale: 1.2;
 	}
 
 	.mymind-wrapped-auth-card-preview--profile
@@ -4914,6 +4939,14 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	.mymind-wrapped-auth-card-preview--profile
 		.mymind-wrapped-auth-card-preview__tilt {
 		--wrapped-card-render-scale: 1.28;
+	}
+}
+
+@media (max-width: 63.999rem) {
+	.mymind-wrapped-auth-form__scene--email,
+	.mymind-wrapped-auth-form__scene--credentials {
+		/* Keep the form steps within the clipped mobile/tablet auth viewport. */
+		padding-top: clamp(1rem, 4svh, 2rem);
 	}
 }
 
@@ -5242,8 +5275,9 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		calc(env(safe-area-inset-bottom, 0px) + 1.1rem)
 	);
 	box-sizing: border-box;
-	justify-content: flex-end;
-	padding-top: clamp(0.6rem, 2.2svh, 1.25rem);
+	justify-content: flex-start;
+	/* Keep the password action inside short auth stages without moving the card. */
+	padding-top: clamp(1.4rem, 4.8svh, 2.35rem);
 	padding-bottom: var(--wrapped-auth-credentials-bottom-space);
 }
 
@@ -7480,6 +7514,12 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		--wrapped-auth-form-overlap: clamp(0.9rem, 2.4svh, 1.25rem);
 	}
 
+	.mymind-wrapped-auth-panel--intro
+		.mymind-wrapped-auth-card-preview--hero
+		.mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-card-render-scale: 1.04;
+	}
+
 	.mymind-wrapped-auth-panel--form .mymind-wrapped-auth-card-preview__tilt {
 		--wrapped-card-render-scale: 0.94;
 	}
@@ -7498,6 +7538,12 @@ body.mymind-wrapped-body #cw-bubble-holder {
 @media (min-height: 721px) and (max-height: 760px) {
 	.mymind-wrapped-auth-panel--form {
 		--wrapped-auth-form-overlap: clamp(0.75rem, 2.2svh, 1.2rem);
+	}
+
+	.mymind-wrapped-auth-panel--intro
+		.mymind-wrapped-auth-card-preview--hero
+		.mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-card-render-scale: 1.04;
 	}
 
 	.mymind-wrapped-auth-panel--form .mymind-wrapped-auth-card-preview__tilt {
@@ -7544,6 +7590,12 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		--wrapped-auth-form-overlap: clamp(0.45rem, 1.5svh, 0.75rem);
 	}
 
+	.mymind-wrapped-auth-panel--intro
+		.mymind-wrapped-auth-card-preview--hero
+		.mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-card-render-scale: 1.04;
+	}
+
 	.mymind-wrapped-auth-card-preview__tilt {
 		--wrapped-card-render-scale: 0.84;
 	}
@@ -7562,7 +7614,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 			1.25rem,
 			calc(env(safe-area-inset-bottom, 0px) + 0.9rem)
 		);
-		padding-top: clamp(0.35rem, 1.4svh, 0.75rem);
+		padding-top: clamp(1.4rem, 4.8svh, 2.35rem);
 	}
 
 	.mymind-wrapped-auth-form .mymind-wrapped-auth-form__scene-action {
@@ -7573,19 +7625,6 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	.mymind-wrapped-auth-form[data-email-auth-stage="choice"]
 		.mymind-wrapped-auth-form__choice-footer {
 		margin-bottom: 0;
-	}
-
-	.mymind-wrapped-auth-panel--form:has(
-			.mymind-wrapped-auth-form__scene--credentials
-		) {
-		--wrapped-auth-form-overlap: clamp(0.75rem, 2.2svh, 1.2rem);
-	}
-
-	.mymind-wrapped-auth-panel--form:has(
-			.mymind-wrapped-auth-form__scene--credentials
-		)
-		.mymind-wrapped-auth-card-preview__tilt {
-		--wrapped-card-render-scale: 0.82;
 	}
 
 	.mymind-wrapped-final-stage {

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -1380,23 +1380,14 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 .mymind-wrapped-tools-stage__entry-top {
-	display: flex;
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
 	align-items: center;
-	justify-content: space-between;
-	gap: 0.6rem;
-}
-
-.mymind-wrapped-tools-stage__entry-kind {
-	margin: 0;
-	color: rgb(58 61 70 / 0.68);
-	font-size: 0.72rem;
-	font-weight: 700;
-	letter-spacing: 0.06em;
-	line-height: 1.2;
-	text-transform: uppercase;
+	gap: 0.75rem;
 }
 
 .mymind-wrapped-tools-stage__entry-usage {
+	justify-self: end;
 	margin: 0;
 	color: rgb(58 61 70 / 0.66);
 	font-size: 0.76rem;
@@ -1404,11 +1395,12 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	line-height: 1.3;
 	text-align: right;
 	text-wrap: balance;
+	white-space: nowrap;
 }
 
 .mymind-wrapped-tools-stage__entry-name {
 	margin: 0;
-	max-width: 14ch;
+	min-width: 0;
 	color: #17161c;
 	font-size: 1.08rem;
 	font-family: "Nunito", var(--font-sans);
@@ -1435,8 +1427,6 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	background: #17161c;
 }
 
-.mymind-wrapped-tools-stage__entry.is-placeholder
-	.mymind-wrapped-tools-stage__entry-kind,
 .mymind-wrapped-tools-stage__entry.is-placeholder
 	.mymind-wrapped-tools-stage__entry-name,
 .mymind-wrapped-tools-stage__entry.is-placeholder
@@ -1578,6 +1568,14 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	list-style: none;
 }
 
+.mymind-wrapped-repo-pulse-stage__stack:has(
+		> .mymind-wrapped-repo-pulse-stage__empty:only-child
+	) {
+	min-height: clamp(12rem, 34svh, 18rem);
+	align-content: center;
+	justify-items: center;
+}
+
 .mymind-wrapped-repo-pulse-stage__row {
 	display: grid;
 	align-items: start;
@@ -1661,14 +1659,17 @@ body.mymind-wrapped-body #cw-bubble-holder {
 .mymind-wrapped-repo-pulse-stage__empty {
 	display: grid;
 	place-items: center;
-	min-height: 7rem;
-	margin: 0;
-	border-radius: 1.2rem;
-	background: rgb(247 249 252 / 0.88);
-	box-shadow: inset 0 0 0 1px rgb(23 22 28 / 0.04);
-	color: rgb(58 61 70 / 0.66);
-	font-size: 0.92rem;
-	font-weight: 700;
+	width: min(100%, 22rem);
+	min-height: clamp(5.75rem, 13svh, 7.5rem);
+	margin: 0 auto;
+	padding: 0.95rem 1.05rem;
+	border: 1px solid rgb(23 22 28 / 0.06);
+	border-radius: 1rem;
+	background: rgb(255 255 255 / 0.58);
+	box-shadow: 0 0.8rem 2rem rgb(23 22 28 / 0.04);
+	color: rgb(58 61 70 / 0.6);
+	font-size: 0.9rem;
+	font-weight: 500;
 	line-height: 1.35;
 	text-align: center;
 	text-wrap: balance;
@@ -1889,6 +1890,14 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	align-content: end;
 }
 
+.mymind-wrapped-model-stage__chart-shell:has(
+		> .mymind-wrapped-model-stage__empty
+	) {
+	min-height: clamp(12rem, 34svh, 18rem);
+	align-content: center;
+	justify-items: center;
+}
+
 .mymind-wrapped-model-stage__chart-grid {
 	display: grid;
 	--model-stage-bar-gap: clamp(0.65rem, 2.4vw, 0.95rem);
@@ -1918,8 +1927,9 @@ body.mymind-wrapped-body #cw-bubble-holder {
 .mymind-wrapped-model-stage__chart-empty-state {
 	display: grid;
 	width: 100%;
-	min-height: inherit;
+	min-height: clamp(8rem, 22svh, 13rem);
 	align-content: center;
+	justify-items: center;
 }
 
 .mymind-wrapped-model-stage__legend-name,
@@ -2470,14 +2480,17 @@ body.mymind-wrapped-body #cw-bubble-holder {
 .mymind-wrapped-model-stage__empty {
 	display: grid;
 	place-items: center;
-	min-height: 7rem;
-	margin: 0;
-	border-radius: 1.2rem;
-	background: rgb(247 249 252 / 0.88);
-	box-shadow: inset 0 0 0 1px rgb(23 22 28 / 0.04);
-	color: rgb(58 61 70 / 0.66);
-	font-size: 0.92rem;
-	font-weight: 700;
+	width: min(100%, 24rem);
+	min-height: clamp(5.75rem, 13svh, 7.5rem);
+	margin: 0 auto;
+	padding: 0.95rem 1.05rem;
+	border: 1px solid rgb(23 22 28 / 0.06);
+	border-radius: 1rem;
+	background: rgb(255 255 255 / 0.58);
+	box-shadow: 0 0.8rem 2rem rgb(23 22 28 / 0.04);
+	color: rgb(58 61 70 / 0.6);
+	font-size: 0.9rem;
+	font-weight: 500;
 	line-height: 1.35;
 	text-align: center;
 	text-wrap: balance;
@@ -5579,6 +5592,33 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	text-underline-offset: 0.24rem;
 }
 
+.mymind-wrapped-setup-guide {
+	display: grid;
+	gap: 0.58rem;
+	justify-items: center;
+	width: min(100%, 25rem);
+}
+
+.mymind-wrapped-setup-support-prompt {
+	min-height: 44px;
+	padding: 0;
+	border: 0;
+	background: transparent;
+	color: rgb(37 34 32 / 0.62);
+	font-family: var(--font-sans);
+	font-size: 0.82rem;
+	font-weight: 400;
+	letter-spacing: 0;
+	line-height: 1.2;
+	text-decoration: none;
+	cursor: pointer;
+}
+
+.mymind-wrapped-setup-support-prompt:focus-visible {
+	outline: 2px solid rgb(59 130 246 / 0.28);
+	outline-offset: 3px;
+}
+
 .mymind-wrapped-setup-steps {
 	display: grid;
 	gap: 0.75rem;
@@ -6090,7 +6130,6 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 @media (min-width: 768px) {
-	.mymind-wrapped-entry-stage--setup,
 	.mymind-wrapped-entry-stage--mobile-handoff {
 		grid-template-rows: auto auto;
 		align-content: center;
@@ -8047,4 +8086,115 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	100% {
 		transform: translateZ(0) scale(1);
 	}
+}
+
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__object-shell {
+	--skills-debug-outline: #14b8a6;
+}
+
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__stack-frame {
+	--skills-debug-outline: #ef4444;
+}
+
+.mymind-wrapped-skills-stage--debug-layout .mymind-wrapped-skills-stage__stack {
+	--skills-debug-outline: #8b5cf6;
+}
+
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__stack-track {
+	--skills-debug-outline: #22c55e;
+}
+
+.mymind-wrapped-skills-stage--debug-layout .mymind-wrapped-skills-stage__card {
+	--skills-debug-outline: #0ea5e9;
+}
+
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__card-item,
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__item-copy {
+	--skills-debug-outline: #eab308;
+}
+
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__item-rank,
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__item-name,
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__item-meta {
+	--skills-debug-outline: #ec4899;
+}
+
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__object-shell,
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__object-shell
+	[data-debug-label] {
+	outline: 1.5px dashed var(--skills-debug-outline, #f43f5e);
+	outline-offset: 2px;
+}
+
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__object-shell,
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__card-item,
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__item-copy,
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__item-rank,
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__item-name,
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__item-meta {
+	position: relative;
+}
+
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__object-shell::after,
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__object-shell
+	[data-debug-label]:not(.mymind-wrapped-skills-stage__stack-frame)::after {
+	content: attr(data-debug-label);
+	position: absolute;
+	z-index: 90;
+	top: 0;
+	left: 0;
+	max-width: min(16rem, 72vw);
+	transform: translateY(calc(-100% - 3px));
+	border-radius: 0.35rem;
+	background: var(--skills-debug-outline, #f43f5e);
+	color: #fff;
+	font-family: var(--font-sans);
+	font-size: 0.625rem;
+	font-weight: 800;
+	letter-spacing: 0;
+	line-height: 1;
+	padding: 0.18rem 0.32rem;
+	pointer-events: none;
+	text-transform: none;
+	white-space: nowrap;
+}
+
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__stack-frame::before,
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__stack-frame::after {
+	outline: 1.5px dashed #06b6d4;
+	outline-offset: -2px;
+}
+
+.mymind-wrapped-skills-stage--debug-layout
+	.mymind-wrapped-skills-stage__stack-frame::after {
+	outline-color: #a855f7;
+}
+
+.mymind-wrapped-skills-stage--debug-purple-gradient
+	.mymind-wrapped-skills-stage__stack-frame::after {
+	outline: 2px solid #a855f7;
+	outline-offset: -2px;
+	box-shadow:
+		inset 0 0 0 1px rgb(168 85 247 / 0.32),
+		0 0 0 2px rgb(168 85 247 / 0.18);
 }


### PR DESCRIPTION
## Summary
- aligns the wrapped tools cards and removes the repeated tool-type label from each card
- keeps the wrapped auth card/form composition inside the stage frame
- replaces the extra sessions polling screen with the setup cards, adds the upload support text prompt, and briefly marks upload complete before showing uploaded repos
- adds wrapped skills debug layout borders behind a query param and gives repo/model empty states a minimal centered style

## Test plan
- bun --filter @rudel/web test src/features/wrapped/WrappedRouteGate.test.tsx
- bun --filter @rudel/web test src/features/wrapped/WrappedSetupPage.test.tsx
- bun ./node_modules/.bin/biome check apps/web/src/features/wrapped/WrappedRouteGate.tsx apps/web/src/features/wrapped/WrappedRouteGate.test.tsx apps/web/src/features/wrapped/WrappedSetupPage.tsx apps/web/src/features/wrapped/WrappedSetupPage.test.tsx
- bun run lint:wrapped:hig
- cd .context && ./node_modules/.bin/playwright test --config wrapped-real-playwright.config.ts

Note: full bun run verify was not completed in this dirty shared workspace.