### PR TITLE
fix: remove signup name field

### DIFF
--- a/apps/web/src/components/auth/signup-form.tsx
+++ b/apps/web/src/components/auth/signup-form.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useAnalyticsTracking } from "../../hooks/useDashboardAnalytics";
 import { authClient } from "../../lib/auth-client";
+import { getInitialSignupName } from "../../lib/auth-signup-name";
 import {
 	captureSignUpFailed,
 	normalizeWebErrorCode,
@@ -67,7 +68,6 @@ export function SignupForm({
 }: {
 	onSwitchToLogin: () => void;
 }) {
-	const [name, setName] = useState("");
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	const [error, setError] = useState("");
@@ -80,6 +80,7 @@ export function SignupForm({
 		e.preventDefault();
 		setError("");
 		setLoading(true);
+		const signupEmail = email.trim();
 		const signupContext = getSignupContext();
 		trackAuthenticationAction({
 			actionName: "sign_up",
@@ -88,8 +89,8 @@ export function SignupForm({
 			entrypoint: signupContext.entryPoint,
 		});
 		const { error } = await authClient.signUp.email({
-			name,
-			email,
+			name: getInitialSignupName(signupEmail),
+			email: signupEmail,
 			password,
 		});
 		setLoading(false);
@@ -140,17 +141,6 @@ export function SignupForm({
 			</CardHeader>
 			<CardContent className="flex flex-col gap-4">
 				<form onSubmit={handleSubmit} className="flex flex-col gap-4">
-					<div className="flex flex-col gap-2">
-						<Label htmlFor="name">Name</Label>
-						<Input
-							id="name"
-							type="text"
-							placeholder="Your name"
-							value={name}
-							onChange={(e) => setName(e.target.value)}
-							required
-						/>
-					</div>
 					<div className="flex flex-col gap-2">
 						<Label htmlFor="email">Email</Label>
 						<Input

--- a/apps/web/src/features/auth/AuthStateRefresh.test.tsx
+++ b/apps/web/src/features/auth/AuthStateRefresh.test.tsx
@@ -213,8 +213,8 @@ describe("auth state refresh", () => {
 		await user.click(
 			screen.getByRole("button", { name: "Create account with Email" }),
 		);
-		await user.type(screen.getByLabelText("Name"), "Ada Lovelace");
-		await user.type(screen.getByLabelText("Email"), "ada@example.com");
+		expect(screen.queryByLabelText("Name")).not.toBeInTheDocument();
+		await user.type(screen.getByLabelText("Email"), "ada.lovelace@example.com");
 		await user.type(screen.getByLabelText("Password"), "supersecure");
 		await user.click(screen.getByRole("button", { name: "Sign up" }));
 
@@ -222,7 +222,7 @@ describe("auth state refresh", () => {
 			expect(mockSignUpEmail).toHaveBeenCalledWith(
 				expect.objectContaining({
 					name: "Ada Lovelace",
-					email: "ada@example.com",
+					email: "ada.lovelace@example.com",
 					password: "supersecure",
 					callbackURL: appRoutes.wrappedSessionsLanded(),
 					fetchOptions: expect.objectContaining({
@@ -254,7 +254,6 @@ describe("auth state refresh", () => {
 		await user.click(
 			screen.getByRole("button", { name: "Create account with Email" }),
 		);
-		await user.type(screen.getByLabelText("Name"), "Ada Lovelace");
 		await user.type(screen.getByLabelText("Email"), "ada@example.com");
 		await user.type(screen.getByLabelText("Password"), "supersecure");
 		await user.click(screen.getByRole("button", { name: "Sign up" }));
@@ -276,7 +275,6 @@ describe("auth state refresh", () => {
 		await user.click(
 			screen.getByRole("button", { name: "Create account with Email" }),
 		);
-		await user.type(screen.getByLabelText("Name"), "Ada Lovelace");
 		await user.type(screen.getByLabelText("Email"), "ada@example.com");
 		await user.type(screen.getByLabelText("Password"), "supersecure");
 		await user.click(screen.getByRole("button", { name: "Sign up" }));
@@ -299,7 +297,6 @@ describe("auth state refresh", () => {
 		await user.click(
 			screen.getByRole("button", { name: "Create account with Email" }),
 		);
-		await user.type(screen.getByLabelText("Name"), "Ada Lovelace");
 		await user.type(screen.getByLabelText("Email"), "ada@example.com");
 		await user.type(screen.getByLabelText("Password"), "supersecure");
 		await user.click(screen.getByRole("button", { name: "Sign up" }));

--- a/apps/web/src/features/auth/SignupForm.tsx
+++ b/apps/web/src/features/auth/SignupForm.tsx
@@ -6,6 +6,7 @@ import { Label } from "@/app/ui/label";
 import { Separator } from "@/app/ui/separator";
 import { useAnalyticsTracking } from "@/features/analytics/tracking/useAnalyticsTracking";
 import { authClient } from "@/lib/auth-client";
+import { getInitialSignupName } from "@/lib/auth-signup-name";
 import {
 	captureSignUpFailed,
 	normalizeWebErrorCode,
@@ -71,7 +72,6 @@ export function SignupForm(props: SignupFormProps) {
 		onSwitchToLogin,
 		variant = "default",
 	} = props;
-	const [name, setName] = useState("");
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	const [error, setError] = useState("");
@@ -110,6 +110,7 @@ export function SignupForm(props: SignupFormProps) {
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
 		setError("");
+		const signupEmail = email.trim();
 
 		if (usesWrappedEmailPreview) {
 			if (!hasValidEmail) {
@@ -130,7 +131,7 @@ export function SignupForm(props: SignupFormProps) {
 				return;
 			}
 
-			onEmailPasswordPreviewSubmit(email.trim());
+			onEmailPasswordPreviewSubmit(signupEmail);
 			return;
 		}
 
@@ -154,8 +155,8 @@ export function SignupForm(props: SignupFormProps) {
 			entrypoint: signupContext.entryPoint,
 		});
 		const { error } = await authClient.signUp.email({
-			name,
-			email,
+			name: getInitialSignupName(signupEmail),
+			email: signupEmail,
 			password,
 			callbackURL: verificationCallbackURL,
 			fetchOptions: {
@@ -421,28 +422,9 @@ export function SignupForm(props: SignupFormProps) {
 									initial={wrappedSceneMotion.initial}
 									transition={wrappedSceneMotion.transition}
 								>
-									{usesWrappedEmailPreview ? null : (
-										<div className="mymind-wrapped-auth-form__field">
-											<Label
-												className="mymind-wrapped-auth-form__label"
-												htmlFor="name"
-											>
-												Name
-											</Label>
-											<Input
-												id="name"
-												type="text"
-												placeholder="Your name"
-												value={name}
-												onChange={(e) => setName(e.target.value)}
-												className="mymind-wrapped-auth-form__input"
-												required
-											/>
-										</div>
-									)}
 									<div className="mymind-wrapped-auth-form__field">
 										<Input
-											autoFocus={usesWrappedEmailPreview}
+											autoFocus
 											aria-label="Password"
 											id="password"
 											type="password"
@@ -556,17 +538,6 @@ export function SignupForm(props: SignupFormProps) {
 
 				{showEmailForm ? (
 					<form onSubmit={handleSubmit} className="flex flex-col gap-4">
-						<div className="flex flex-col gap-2">
-							<Label htmlFor="name">Name</Label>
-							<Input
-								id="name"
-								type="text"
-								placeholder="Your name"
-								value={name}
-								onChange={(e) => setName(e.target.value)}
-								required
-							/>
-						</div>
 						<div className="flex flex-col gap-2">
 							<Label htmlFor="email">Email</Label>
 							<Input

--- a/apps/web/src/lib/auth-signup-name.ts
+++ b/apps/web/src/lib/auth-signup-name.ts
@@ -1,0 +1,18 @@
+export function getInitialSignupName(email: string): string {
+	const localPart = email.split("@")[0]?.trim();
+	if (!localPart) {
+		return "Rudel User";
+	}
+
+	const words = localPart
+		.split(/[._-]+/)
+		.map((word) => word.trim())
+		.filter(Boolean);
+	if (words.length === 0) {
+		return localPart;
+	}
+
+	return words
+		.map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+		.join(" ");
+}


### PR DESCRIPTION
## Summary
- remove the explicit Name field from signup forms
- derive the submitted signup name from the email local part
- update auth flow tests for the name-free signup path

## Test plan
- [x] bun run test src/features/auth/AuthStateRefresh.test.tsx (from apps/web)
- [x] bun run verify