### PR TITLE
fix: purge retired wrapped archetype names

### DIFF
--- a/apps/web/src/features/wrapped/onboarding/config.test.ts
+++ b/apps/web/src/features/wrapped/onboarding/config.test.ts
@@ -39,7 +39,7 @@ describe("wrapped saturday story visibility", () => {
 
 	it("keeps decimal product-only by leaving the card beat as a theme picker", () => {
 		expect(WRAPPED_BEAT_CONTRACTS.card.whatWeShowNow).toContain(
-			"Decimal VIP special edition",
+			"VIP special-edition card theme",
 		);
 		expect(WRAPPED_BEAT_CONTRACTS.card.productNote).toContain("theme picker");
 	});

--- a/apps/web/src/features/wrapped/onboarding/config.ts
+++ b/apps/web/src/features/wrapped/onboarding/config.ts
@@ -244,8 +244,8 @@ export const WRAPPED_BEAT_CONTRACTS: Record<
 		saturdayStoryVisibility: "show_in_saturday_story",
 		whatWeShowNow: [
 			"User-picked theme carousel",
-			"Core k9 archetype set",
-			"Decimal VIP special edition",
+			"Core product archetype set",
+			"VIP special-edition card theme",
 		],
 		metricBasis:
 			"User-picked archetype theme. Classifier lands later; no automatic assignment yet.",
@@ -253,7 +253,7 @@ export const WRAPPED_BEAT_CONTRACTS: Record<
 		referenceClass: "User browses the full archetype set.",
 		eligibility: "Always shown.",
 		infraRequirement:
-			"Needs the snapshot-based archetype pipeline from docs/archetype-clickhouse-pipeline.md. Do not replace this with an incremental MV. Decimal stays product-only even after the classifier lands.",
+			"Needs the snapshot-based archetype pipeline from docs/archetype-clickhouse-pipeline.md. Do not replace this with an incremental MV. Special-edition card themes stay product-only even after the classifier lands.",
 		productNote:
 			"Today this is a theme picker, not a truth claim. The card can show Smooth Operator and other product labels, but only classifier-backed themes should ever be called computed archetypes.",
 	},

--- a/apps/web/src/features/wrapped/team-card/archetypes.test.ts
+++ b/apps/web/src/features/wrapped/team-card/archetypes.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+	WRAPPED_ARCHETYPE_CARD_THEMES,
+	WRAPPED_PRODUCT_ARCHETYPE_CARD_THEMES,
+} from "./archetypes";
+
+describe("wrapped archetype catalog", () => {
+	it("keeps the canonical product archetype labels isolated from special editions", () => {
+		expect(
+			WRAPPED_PRODUCT_ARCHETYPE_CARD_THEMES.map((theme) => theme.displayLabel),
+		).toEqual([
+			"Roadrunner",
+			"Hit and Runner",
+			"ADHD Brain",
+			"Cheapskate",
+			"Company Card",
+			"Tourist",
+			"Smooth Operator",
+			"Obsessed",
+			"Maniac",
+		]);
+	});
+
+	it("uses current product slugs for classifier-backed archetypes", () => {
+		expect(
+			WRAPPED_PRODUCT_ARCHETYPE_CARD_THEMES.map((theme) => theme.classifierKey),
+		).toEqual([
+			"roadrunner",
+			"hit_and_runner",
+			"adhd_brain",
+			"cheapskate",
+			"company_card",
+			"tourist",
+			"smooth_operator",
+			"obsessed",
+			"maniac",
+		]);
+	});
+
+	it("does not include special-edition card themes in the product archetype set", () => {
+		expect(
+			WRAPPED_ARCHETYPE_CARD_THEMES.map((theme) => theme.displayLabel),
+		).toContain("Decimal");
+		expect(
+			WRAPPED_PRODUCT_ARCHETYPE_CARD_THEMES.map((theme) => theme.displayLabel),
+		).not.toContain("Decimal");
+	});
+});

--- a/apps/web/src/features/wrapped/team-card/archetypes.ts
+++ b/apps/web/src/features/wrapped/team-card/archetypes.ts
@@ -1,47 +1,46 @@
 import type { WrappedTeamMemberCardTheme } from "./card";
 
-export interface WrappedArchetypeCardTheme {
-	// id is the stable local key used by the wrapped card UI.
-	id: string;
-	// kind makes it explicit whether a card belongs to the core classifier-backed
-	// archetype set or is a hand-picked product-only edition.
-	kind: "taxonomy" | "special_edition";
-	// classifierKey intentionally matches the ClickHouse archetype key from the
-	// pipeline reference for taxonomy-backed cards. Special editions leave this
-	// undefined on purpose because there is no classifier output behind them.
-	classifierKey?: string;
-	// taxonomyLabel is the canonical archetype name used in the data docs and
-	// snapshot pipeline. Special editions can leave this empty because they are
-	// not part of the core k9 taxonomy.
-	taxonomyLabel?: string;
-	// displayLabel is what the wrapped card shows to users today.
+export type WrappedProductArchetypeId =
+	| "roadrunner"
+	| "hit_and_runner"
+	| "adhd_brain"
+	| "cheapskate"
+	| "company_card"
+	| "tourist"
+	| "smooth_operator"
+	| "obsessed"
+	| "maniac";
+
+interface WrappedArchetypeCardThemeBase {
 	displayLabel: string;
 	shellClassName: string;
 	theme: WrappedTeamMemberCardTheme;
 }
 
+export interface WrappedProductArchetypeCardTheme
+	extends WrappedArchetypeCardThemeBase {
+	classifierKey: WrappedProductArchetypeId;
+	id: WrappedProductArchetypeId;
+	kind: "taxonomy";
+}
+
+export interface WrappedSpecialEditionCardTheme
+	extends WrappedArchetypeCardThemeBase {
+	classifierKey: undefined;
+	id: string;
+	kind: "special_edition";
+}
+
+export type WrappedArchetypeCardTheme =
+	| WrappedProductArchetypeCardTheme
+	| WrappedSpecialEditionCardTheme;
+
 const WRAPPED_SHELL_BACKGROUND_VALUE_PATTERN = /bg-\[(.+?)\]/;
 
-// This is the Saturday wrapped card archetype catalog.
-//
-// Product rule:
-// - keep the canonical archetype set aligned with docs/archetype-taxonomy.md
-// - keep the classifier keys aligned with .context/archetype-clickhouse-reference.sql
-// - allow a small number of display aliases where the card copy should read more
-//   human than the raw taxonomy label
-//
-// This means:
-// - `npc` is rendered as "Smooth Operator"
-// - `papas_credit_card` is rendered as "Company Card"
-// - `needs_to_touch_grass` stays keyed to the pipeline, but the visible product
-//   label remains "Obsessed"
-//
-// Decimal stays in the carousel as a VIP special edition. It is intentionally
-// separate from the classifier-backed k9 set so nobody mistakes it for a real
-// archetype emitted by the pipeline.
+// The product archetype catalog. Classifier keys, local ids, docs, and labels
+// intentionally use the same current product names so older names cannot leak
+// into dev simulations or user-visible card copy.
 export const WRAPPED_ARCHETYPE_CARD_THEMES = [
-	// Core classifier-backed k9 set in the order we want people to browse it in
-	// the final card carousel.
 	{
 		classifierKey: "roadrunner",
 		displayLabel: "Roadrunner",
@@ -49,7 +48,6 @@ export const WRAPPED_ARCHETYPE_CARD_THEMES = [
 		kind: "taxonomy",
 		shellClassName:
 			"bg-[linear-gradient(161.01deg,_#28D0FF_4.98%,_#FFCA0D_99.99%)]",
-		taxonomyLabel: "Roadrunner",
 		theme: "light",
 	},
 	{
@@ -59,7 +57,6 @@ export const WRAPPED_ARCHETYPE_CARD_THEMES = [
 		kind: "taxonomy",
 		shellClassName:
 			"bg-[linear-gradient(180deg,_#EE9BEB_0%,_#F29BBB_44.71%,_#EFB09C_100%)]",
-		taxonomyLabel: "Hit and Runner",
 		theme: "light",
 	},
 	{
@@ -69,31 +66,26 @@ export const WRAPPED_ARCHETYPE_CARD_THEMES = [
 		kind: "taxonomy",
 		shellClassName:
 			"bg-[linear-gradient(180deg,_#FF7567_0%,_#F8D558_48.08%,_#A4F554_100%)]",
-		taxonomyLabel: "ADHD Brain",
 		theme: "light",
 	},
 	{
-		classifierKey: "window_shopper",
+		classifierKey: "cheapskate",
 		displayLabel: "Cheapskate",
-		id: "window_shopper",
+		id: "cheapskate",
 		kind: "taxonomy",
 		shellClassName: "bg-[linear-gradient(180deg,_#00E4E7_0%,_#00EAAE_100%)]",
-		taxonomyLabel: "Cheapskate",
 		theme: "light",
 	},
 	{
-		classifierKey: "papas_credit_card",
+		classifierKey: "company_card",
 		displayLabel: "Company Card",
-		id: "papas_credit_card",
+		id: "company_card",
 		kind: "taxonomy",
 		shellClassName: "bg-[linear-gradient(180deg,_#E5F221_0%,_#DFEC1C_100%)]",
-		taxonomyLabel: "Papa's Credit Card",
 		theme: "light",
 	},
-	// Decimal is intentionally kept in the same carousel because product wants it
-	// available, but `kind: "special_edition"` makes it impossible to confuse
-	// this VIP card with a classifier-backed result later.
 	{
+		classifierKey: undefined,
 		displayLabel: "Decimal",
 		id: "decimal",
 		kind: "special_edition",
@@ -108,26 +100,23 @@ export const WRAPPED_ARCHETYPE_CARD_THEMES = [
 		kind: "taxonomy",
 		shellClassName:
 			"bg-[linear-gradient(180deg,_#39E5E7_0%,_#35E895_50.96%,_#7AE762_100%)]",
-		taxonomyLabel: "Tourist",
 		theme: "light",
 	},
 	{
-		classifierKey: "npc",
+		classifierKey: "smooth_operator",
 		displayLabel: "Smooth Operator",
-		id: "npc",
+		id: "smooth_operator",
 		kind: "taxonomy",
 		shellClassName: "bg-[linear-gradient(180deg,_#8ED9F8_0%,_#69B8D9_100%)]",
-		taxonomyLabel: "NPC",
 		theme: "light",
 	},
 	{
-		classifierKey: "needs_to_touch_grass",
+		classifierKey: "obsessed",
 		displayLabel: "Obsessed",
-		id: "needs_to_touch_grass",
+		id: "obsessed",
 		kind: "taxonomy",
 		shellClassName:
 			"border-white/10 bg-[linear-gradient(180deg,_#191919_0%,_#000000_100%)]",
-		taxonomyLabel: "Obsessed",
 		theme: "dark",
 	},
 	{
@@ -137,10 +126,12 @@ export const WRAPPED_ARCHETYPE_CARD_THEMES = [
 		kind: "taxonomy",
 		shellClassName:
 			"bg-[linear-gradient(180deg,_#F05267_0%,_#F05267_50%,_#F8D558_100%)]",
-		taxonomyLabel: "Maniac",
 		theme: "light",
 	},
 ] as const satisfies readonly WrappedArchetypeCardTheme[];
+
+export const WRAPPED_PRODUCT_ARCHETYPE_CARD_THEMES =
+	WRAPPED_ARCHETYPE_CARD_THEMES.filter(isWrappedProductArchetypeCardTheme);
 
 export function getWrappedArchetypeCardBackgroundValue(
 	theme: WrappedArchetypeCardTheme,
@@ -150,4 +141,22 @@ export function getWrappedArchetypeCardBackgroundValue(
 	);
 
 	return backgroundMatch?.[1].replaceAll("_", " ") ?? null;
+}
+
+export function resolveWrappedArchetypeCardThemeByClassifierKey(
+	classifierKey: string | undefined,
+) {
+	if (!classifierKey) {
+		return undefined;
+	}
+
+	return WRAPPED_PRODUCT_ARCHETYPE_CARD_THEMES.find(
+		(theme) => theme.classifierKey === classifierKey,
+	);
+}
+
+function isWrappedProductArchetypeCardTheme(
+	theme: WrappedArchetypeCardTheme,
+): theme is WrappedProductArchetypeCardTheme {
+	return theme.kind === "taxonomy";
 }

--- a/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
@@ -399,10 +399,10 @@ describe("WrappedTeamCardRevealStage", () => {
 			<WrappedTeamCardRevealStage
 				activeArchetype={{
 					displayLabel: "Smooth Operator",
-					id: "npc",
+					id: "smooth_operator",
 					kind: "taxonomy",
+					classifierKey: "smooth_operator",
 					shellClassName: "bg-sky-200",
-					taxonomyLabel: "NPC",
 					theme: "light",
 				}}
 				headerLeftMetric={{
@@ -577,10 +577,10 @@ describe("WrappedTeamCardRevealStage", () => {
 			<WrappedTeamCardRevealStage
 				activeArchetype={{
 					displayLabel: "Smooth Operator",
-					id: "npc",
+					id: "smooth_operator",
 					kind: "taxonomy",
+					classifierKey: "smooth_operator",
 					shellClassName: "bg-sky-200",
-					taxonomyLabel: "NPC",
 					theme: "light",
 				}}
 				headerLeftMetric={{
@@ -657,10 +657,10 @@ describe("WrappedTeamCardRevealStage", () => {
 			<WrappedTeamCardRevealStage
 				activeArchetype={{
 					displayLabel: "Smooth Operator",
-					id: "npc",
+					id: "smooth_operator",
 					kind: "taxonomy",
+					classifierKey: "smooth_operator",
 					shellClassName: "bg-sky-200",
-					taxonomyLabel: "NPC",
 					theme: "light",
 				}}
 				headerLeftMetric={{

--- a/apps/web/src/features/wrapped/team-card/final-stages.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.tsx
@@ -200,7 +200,7 @@ function WrappedArchetypeGradientText(props: {
 		"--wrapped-reveal-archetype-gt-gradient": gradient.stops,
 	};
 	const classNames = `mymind-wrapped-final-stage__gradient-text ${className}${
-		activeArchetype.id === "needs_to_touch_grass" ? " is-obsession" : ""
+		activeArchetype.id === "obsessed" ? " is-obsession" : ""
 	}`;
 
 	return (
@@ -1260,13 +1260,13 @@ function getWrappedRevealCopy(archetype: WrappedArchetypeCardTheme): {
 					"For the mind that keeps five tabs alive, three ideas moving, and the pace somehow intact.",
 				title: "Every tab had a job.",
 			};
-		case "window_shopper":
+		case "cheapskate":
 			return {
 				description:
 					"For the selective one who keeps the spend light and still finds the exact tool worth using.",
 				title: "Low spend, sharp eye.",
 			};
-		case "papas_credit_card":
+		case "company_card":
 			return {
 				description:
 					"For the teammate who never thinks small when the work calls for a heavier swing.",
@@ -1284,13 +1284,13 @@ function getWrappedRevealCopy(archetype: WrappedArchetypeCardTheme): {
 					"For the wanderer who touched every corner of the work and kept moving between scenes.",
 				title: "Every repo got a visit.",
 			};
-		case "npc":
+		case "smooth_operator":
 			return {
 				description:
 					"For the steady hand who keeps the machine moving without asking for attention on every pass.",
 				title: "Smooth by default.",
 			};
-		case "needs_to_touch_grass":
+		case "obsessed":
 			return {
 				description:
 					"For the one who locked in so hard the sessions started stacking on top of each other.",

--- a/apps/web/src/features/wrapped/team-card/page.tsx
+++ b/apps/web/src/features/wrapped/team-card/page.tsx
@@ -157,9 +157,7 @@ export function WrappedTeamCardPage(props: {
 	);
 	const headerRightMetric = useMemo<WrappedTeamMemberCardHeaderMetric>(
 		() => ({
-			// The card shows product-facing labels here, not raw classifier names.
-			// Example: the taxonomy says "NPC", while the visible card says
-			// "Smooth Operator".
+			// The card shows only the current product-facing archetype label.
 			title: activeArchetype.displayLabel,
 			value: activeArchetype.displayLabel,
 		}),

--- a/apps/web/src/features/wrapped/team-card/use-page-data.ts
+++ b/apps/web/src/features/wrapped/team-card/use-page-data.ts
@@ -11,6 +11,7 @@ import { MAX_ANALYTICS_DAYS } from "@/lib/analytics-date-range";
 import { authClient } from "@/lib/auth-client";
 import { orpc } from "@/lib/orpc";
 import {
+	resolveWrappedArchetypeCardThemeByClassifierKey,
 	WRAPPED_ARCHETYPE_CARD_THEMES,
 	type WrappedArchetypeCardTheme,
 } from "./archetypes";
@@ -189,10 +190,8 @@ function resolveLiveArchetype(
 	if (!classifierKey) {
 		return DEFAULT_LIVE_ARCHETYPE;
 	}
-	const matched = WRAPPED_ARCHETYPE_CARD_THEMES.find(
-		(theme) =>
-			theme.kind === "taxonomy" && theme.classifierKey === classifierKey,
-	);
+	const matched =
+		resolveWrappedArchetypeCardThemeByClassifierKey(classifierKey);
 	return matched ?? DEFAULT_LIVE_ARCHETYPE;
 }
 

--- a/apps/web/src/features/wrapped/wrapped-x-share.ts
+++ b/apps/web/src/features/wrapped/wrapped-x-share.ts
@@ -44,17 +44,9 @@ const WRAPPED_X_SHARE_COPY_BY_ARCHETYPE: Record<string, WrappedXShareCopy> = {
 	maniac: {
 		traits: "high session count, heavy token burn, no visible off switch",
 	},
-	npc: {
-		traits:
-			"keeps sessions steady, follows the quest log, somehow makes repetition useful",
-	},
 	obsessed: {
 		traits:
 			"keeps coming back, keeps digging deeper, probably knows the repo's floor plan",
-	},
-	"papas credit card": {
-		traits:
-			"pushes usage hard, trusts the budget line, treats the meter like someone else's problem",
 	},
 	roadrunner: {
 		traits:
@@ -67,10 +59,6 @@ const WRAPPED_X_SHARE_COPY_BY_ARCHETYPE: Record<string, WrappedXShareCopy> = {
 	tourist: {
 		traits:
 			"wanders across repos, samples every corner, collects project stamps",
-	},
-	"window shopper": {
-		traits:
-			"watches token spend, stretches each prompt, gets the answer without lighting money on fire",
 	},
 };
 

--- a/docs/archetype-clickhouse-pipeline.md
+++ b/docs/archetype-clickhouse-pipeline.md
@@ -19,8 +19,8 @@ The current label family is:
 
 - Roadrunner
 - Cheapskate
-- NPC
-- Papa's Credit Card
+- Smooth Operator
+- Company Card
 - Hit and Runner
 - ADHD Brain
 - Obsessed
@@ -352,7 +352,7 @@ Create:
 - `wrapped_user_archetype_snapshots_v1`
 - `wrapped_user_archetype_runs_v1`
 
-Seed the centroid table with the current empirical `k=9` centers for the active taxonomy above.
+Seed the centroid table with the current nine product archetype centers for the active taxonomy above.
 
 ### Phase 2: backfill the first snapshot
 

--- a/docs/archetype-taxonomy.md
+++ b/docs/archetype-taxonomy.md
@@ -6,8 +6,8 @@ The product-facing label set is:
 
 - Roadrunner
 - Cheapskate
-- NPC
-- Papa's Credit Card
+- Smooth Operator
+- Company Card
 - Hit and Runner
 - ADHD Brain
 - Obsessed
@@ -50,7 +50,7 @@ Reads like:
 - experiments more than they commit
 - keeps the relationship light
 
-### NPC
+### Smooth Operator
 
 High consistency, high intensity, strong session shape, low cost intensity, and balanced breadth.
 
@@ -59,7 +59,7 @@ Reads like:
 - gets real work done
 - converts time into output without waste
 
-### Papa's Credit Card
+### Company Card
 
 Low consistency and low output, but a surprisingly high cost footprint relative to the amount of work completed.
 

--- a/packages/ch-schema/scripts/rebuild-wrapped-user-archetypes.ts
+++ b/packages/ch-schema/scripts/rebuild-wrapped-user-archetypes.ts
@@ -39,7 +39,7 @@ const CENTROIDS: readonly Centroid[] = [
 	},
 	{
 		archetype_id: 1,
-		archetype_key: "window_shopper",
+		archetype_key: "cheapskate",
 		archetype_name: "Cheapskate",
 		consistency: 0.2693,
 		intensity: 0.1741,
@@ -51,8 +51,8 @@ const CENTROIDS: readonly Centroid[] = [
 	},
 	{
 		archetype_id: 2,
-		archetype_key: "npc",
-		archetype_name: "NPC",
+		archetype_key: "smooth_operator",
+		archetype_name: "Smooth Operator",
 		consistency: 0.62,
 		intensity: 0.7758,
 		session_shape: 0.8591,
@@ -63,8 +63,8 @@ const CENTROIDS: readonly Centroid[] = [
 	},
 	{
 		archetype_id: 3,
-		archetype_key: "papas_credit_card",
-		archetype_name: "Papa's Credit Card",
+		archetype_key: "company_card",
+		archetype_name: "Company Card",
 		consistency: 0.3061,
 		intensity: 0.1582,
 		session_shape: 0.1786,
@@ -99,7 +99,7 @@ const CENTROIDS: readonly Centroid[] = [
 	},
 	{
 		archetype_id: 6,
-		archetype_key: "needs_to_touch_grass",
+		archetype_key: "obsessed",
 		archetype_name: "Obsessed",
 		consistency: 0.5778,
 		intensity: 0.5037,

--- a/packages/ch-schema/src/wrapped-archetype-constants.ts
+++ b/packages/ch-schema/src/wrapped-archetype-constants.ts
@@ -1,6 +1,7 @@
 export const WRAPPED_ARCHETYPE_SCOPE = "active_organization_all_time" as const;
 
-export const WRAPPED_ARCHETYPE_PIPELINE_VERSION = "2026_04_25_launch" as const;
+export const WRAPPED_ARCHETYPE_PIPELINE_VERSION =
+	"2026_04_28_product_names" as const;
 
 export const WRAPPED_ARCHETYPE_CENTROID_VERSION =
-	"empirical_k9_2026_04_19" as const;
+	"product_archetypes_2026_04_28" as const;


### PR DESCRIPTION
## Summary
- replace retired wrapped archetype slugs/names with the current product set: Cheapskate, Company Card, Smooth Operator, Obsessed, and the existing current labels
- make the web card catalog expose a strict classifier-backed product archetype set separate from special-edition card themes
- update the ClickHouse rebuild constants/script and archetype docs to use the current product names only
- add a catalog contract test to prevent retired names or special editions from entering the product archetype set

## Test plan
- [x] `rg -n "NPC|Papa's Credit Card|papas_credit_card|needs_to_touch_grass|touch grass|window_shopper|\\bnpc\\b|Core k9|Decimal VIP special edition|k=9|taxonomyLabel" . --glob '!**/node_modules/**' --glob '!**/.next/**' --glob '!**/.git/**'`
- [x] `bun run test src/features/wrapped/team-card/archetypes.test.ts src/features/wrapped/onboarding/config.test.ts src/features/wrapped/team-card/final-stages.test.tsx`
- [x] `bun run check-types` in `apps/web`
- [x] `bun run check-types` in `packages/ch-schema`
- [x] `bun run lint:wrapped:hig`
- [x] GitHub CI `verify`