### PR TITLE
fix: make wrapped card fully clickable

### DIFF
--- a/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
+++ b/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
@@ -278,7 +278,9 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 				className="team-lineup-card-tilt-stage mymind-wrapped-auth-card-preview__tilt-stage"
 			>
 				<div
-					ref={tiltController.cardTiltRef}
+					ref={(node) => {
+						tiltController.cardTiltRef.current = node;
+					}}
 					className="team-lineup-card-tilt-shell mymind-wrapped-auth-card-preview__tilt mymind-wrapped-final-stage__tilt-shell"
 					data-flip-active={isCardFlipAnimating ? "true" : "false"}
 					onPointerMove={(event) => {

--- a/apps/web/src/features/wrapped/WrappedPublicCardScreen.tsx
+++ b/apps/web/src/features/wrapped/WrappedPublicCardScreen.tsx
@@ -1,0 +1,189 @@
+import { ChevronRight } from "lucide-react";
+import type { CSSProperties, ReactNode } from "react";
+import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
+import {
+	WRAPPED_SATURDAY_STEPS,
+	type WrappedPrimaryStep,
+} from "@/features/wrapped/onboarding/config";
+import { WrappedOnboardingFooter } from "@/features/wrapped/onboarding/controls";
+import {
+	getWrappedArchetypeCardBackgroundValue,
+	type WrappedArchetypeCardTheme,
+} from "@/features/wrapped/team-card/archetypes";
+import type {
+	WrappedTeamMemberCardHeaderMetric,
+	WrappedTeamMemberCardStatItem,
+	WrappedTeamMemberCardStatLayerOpacities,
+	WrappedTeamMemberCardTheme,
+} from "@/features/wrapped/team-card/card";
+import type { WrappedTeamMemberCardBackMetric } from "@/features/wrapped/team-card/card-back";
+import { WrappedTeamCardPublicStage } from "@/features/wrapped/team-card/final-stages";
+import { useWrappedCardTilt } from "@/features/wrapped/team-card/tilt/use-card-tilt";
+import { WrappedProgress } from "@/features/wrapped/WrappedProgress";
+import { getWrappedOnboardingProgressView } from "@/features/wrapped/wrapped-onboarding-progress";
+import { cn } from "@/lib/utils";
+
+interface WrappedPublicCardScreenProps {
+	action: ReactNode;
+	activeArchetype: WrappedArchetypeCardTheme;
+	backMetrics?: readonly WrappedTeamMemberCardBackMetric[];
+	debugControls?: ReactNode;
+	headerLeftMetric?: WrappedTeamMemberCardHeaderMetric;
+	headerRightMetric?: WrappedTeamMemberCardHeaderMetric;
+	row: TeamPageMemberRow;
+	shellClassName: string;
+	shellStyle: CSSProperties;
+	statItems: readonly WrappedTeamMemberCardStatItem[];
+	statLayerOpacities?: WrappedTeamMemberCardStatLayerOpacities;
+	theme: WrappedTeamMemberCardTheme;
+}
+
+export function WrappedPublicCardScreen(props: WrappedPublicCardScreenProps) {
+	const {
+		action,
+		activeArchetype,
+		backMetrics,
+		debugControls,
+		headerLeftMetric,
+		headerRightMetric,
+		row,
+		shellClassName,
+		shellStyle,
+		statItems,
+		statLayerOpacities,
+		theme,
+	} = props;
+	const cardStep = getWrappedPublicCardStep();
+	const rewardCardBackground =
+		getWrappedArchetypeCardBackgroundValue(activeArchetype) ?? undefined;
+	const tiltController = useWrappedCardTilt();
+
+	return (
+		<main className="mymind-wrapped-route mymind-wrapped-route--onboarding mymind-wrapped-route--step-card mymind-wrapped-route--public-card">
+			<div className="mymind-wrapped-shell mymind-wrapped-shell--reference-top-chrome relative z-[1] mx-auto flex w-full flex-1 flex-col text-foreground">
+				<div
+					className={cn(
+						"mymind-wrapped-shell__frame",
+						debugControls ? null : "mymind-wrapped-shell__frame--no-footer",
+					)}
+				>
+					<WrappedPublicCardHeader
+						activeStep={cardStep}
+						rewardCardBackground={rewardCardBackground}
+					/>
+
+					<div className="mymind-wrapped-stage-area">
+						<div className="mymind-wrapped-stage-slot">
+							<div className="flex w-full flex-1">
+								<WrappedTeamCardPublicStage
+									action={action}
+									activeArchetype={activeArchetype}
+									backMetrics={backMetrics}
+									headerLeftMetric={headerLeftMetric}
+									headerRightMetric={headerRightMetric}
+									row={row}
+									shellClassName={shellClassName}
+									shellStyle={shellStyle}
+									statItems={statItems}
+									statLayerOpacities={statLayerOpacities}
+									theme={theme}
+									tiltController={tiltController}
+								/>
+							</div>
+						</div>
+					</div>
+
+					{debugControls ? (
+						<WrappedOnboardingFooter
+							activePreviewOptions={null}
+							activePreviewState="auto"
+							activePreviewStepId={null}
+							activeStep={cardStep}
+							finalFooter={false}
+							generalDebugControls={debugControls}
+							isContinueVisible
+							isDebugControlsVisible
+							isStepTransitioning={false}
+							onContinue={handlePublicContinue}
+							onPreviewStateChange={handlePublicPreviewStateChange}
+						/>
+					) : null}
+				</div>
+			</div>
+		</main>
+	);
+}
+
+export function WrappedPublicCardAction(props: {
+	children: ReactNode;
+	className?: string;
+	href: string;
+	onClick?: () => void;
+}) {
+	const { children, className, href, onClick } = props;
+
+	return (
+		<a
+			className={cn(
+				"mymind-wrapped-primary-action h-11 rounded-full px-7 [font-family:var(--app-font-heading)] text-[1.0625rem] font-semibold",
+				className,
+			)}
+			href={href}
+			onClick={onClick}
+		>
+			<span>{children}</span>
+			<span className="mymind-wrapped-primary-action__icon">
+				<ChevronRight className="size-4" />
+			</span>
+		</a>
+	);
+}
+
+function WrappedPublicCardHeader(props: {
+	activeStep: WrappedPrimaryStep;
+	rewardCardBackground?: string;
+}) {
+	const { activeStep, rewardCardBackground } = props;
+	const progressView = getWrappedOnboardingProgressView(activeStep.id);
+
+	return (
+		<header className="mymind-wrapped-top-tray mymind-wrapped-public-card-header">
+			<div className="mymind-wrapped-top-tray__row">
+				<div className="mymind-wrapped-top-tray__slot mymind-wrapped-top-tray__slot--start">
+					<span className="mymind-wrapped-top-tray__utility-placeholder" />
+				</div>
+				<div className="mymind-wrapped-top-tray__center">
+					<WrappedProgress
+						ariaLabel="Wrapped public card progress"
+						disabled
+						items={progressView.items.map((item) => ({
+							ariaLabel: `Wrapped step ${item.stepNumber}: ${item.label}`,
+							id: item.id,
+							isActive: item.isActive,
+						}))}
+						rewardCardBackground={rewardCardBackground}
+					/>
+				</div>
+				<div className="mymind-wrapped-top-tray__slot mymind-wrapped-top-tray__slot--end">
+					<span className="mymind-wrapped-top-tray__utility-placeholder" />
+				</div>
+			</div>
+		</header>
+	);
+}
+
+function getWrappedPublicCardStep() {
+	const step = WRAPPED_SATURDAY_STEPS.find(
+		(candidate) => candidate.id === "card",
+	);
+
+	if (!step) {
+		throw new Error("Wrapped public card step is missing.");
+	}
+
+	return step;
+}
+
+function handlePublicContinue() {}
+
+function handlePublicPreviewStateChange() {}

--- a/apps/web/src/features/wrapped/WrappedPublicMockPage.tsx
+++ b/apps/web/src/features/wrapped/WrappedPublicMockPage.tsx
@@ -1,28 +1,19 @@
-import { LayoutGroup, MotionConfig, motion } from "motion/react";
-import { type CSSProperties, type ReactNode, useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { appRoutes } from "@/app/routes";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
-import {
-	type PreviewableWrappedStepId,
-	WRAPPED_SATURDAY_STEPS,
-} from "@/features/wrapped/onboarding/config";
-import {
-	WrappedOnboardingFooter,
-	WrappedOnboardingHeader,
-} from "@/features/wrapped/onboarding/controls";
 import type { WrappedOnboardingMetrics } from "@/features/wrapped/onboarding/types";
-import {
-	getWrappedArchetypeCardBackgroundValue,
-	WRAPPED_ARCHETYPE_CARD_THEMES,
-} from "@/features/wrapped/team-card/archetypes";
+import { WRAPPED_ARCHETYPE_CARD_THEMES } from "@/features/wrapped/team-card/archetypes";
+import { buildWrappedTeamCardBackMetrics } from "@/features/wrapped/team-card/back-metrics";
 import type {
 	WrappedTeamMemberCardHeaderMetric,
 	WrappedTeamMemberCardStatItem,
 	WrappedTeamMemberCardStatLayerOpacities,
 } from "@/features/wrapped/team-card/card";
-import { WrappedTeamCardRevealStage } from "@/features/wrapped/team-card/final-stages";
-import { useWrappedCardTilt } from "@/features/wrapped/team-card/tilt/use-card-tilt";
+import {
+	WrappedPublicCardAction,
+	WrappedPublicCardScreen,
+} from "@/features/wrapped/WrappedPublicCardScreen";
 import { useMountEffect } from "@/hooks/useMountEffect";
 import "@/features/wrapped/wrapped.css";
 
@@ -110,11 +101,6 @@ const MOCK_PUBLIC_SHARE_STAT_LAYER_OPACITIES = {
 	textureOpacity: 0.76,
 } satisfies WrappedTeamMemberCardStatLayerOpacities;
 
-const MOCK_PUBLIC_SHARE_SHELL_STYLE: WrappedPublicMockCardShellStyle = {
-	"--team-lineup-card-grain-opacity": "0.18",
-	"--team-lineup-card-grain-size": "38px",
-};
-
 const MOCK_PUBLIC_SHARE_ONBOARDING_METRICS = {
 	activeDays: 42,
 	avgSessionMin: 18,
@@ -186,19 +172,22 @@ const MOCK_PUBLIC_SHARE_ONBOARDING_METRICS = {
 	totalTokens: 5_068_300,
 } satisfies WrappedOnboardingMetrics;
 
+const MOCK_PUBLIC_SHARE_BACK_METRICS = buildWrappedTeamCardBackMetrics({
+	onboardingMetrics: MOCK_PUBLIC_SHARE_ONBOARDING_METRICS,
+	row: MOCK_PUBLIC_SHARE_ROW,
+	shareCardCreatedAtLabel: "Apr 28, 2026",
+});
+
+const MOCK_PUBLIC_SHARE_SHELL_STYLE: WrappedPublicMockCardShellStyle = {
+	"--team-lineup-card-grain-opacity": "0.18",
+	"--team-lineup-card-grain-size": "38px",
+};
+
 const MOCK_PUBLIC_SHARE_ARCHETYPE = getMockPublicShareArchetype();
-const MOCK_PUBLIC_SHARE_CARD_STEP = getMockPublicShareCardStep();
-const MOCK_PUBLIC_SHARE_CARD_STEP_INDEX = getMockPublicShareCardStepIndex();
-const MOCK_PUBLIC_SHARE_REWARD_CARD_BACKGROUND =
-	getWrappedArchetypeCardBackgroundValue(MOCK_PUBLIC_SHARE_ARCHETYPE) ??
-	undefined;
 
 export function WrappedPublicMockPage(props: WrappedPublicMockPageProps) {
 	const { debugControls } = props;
 	const navigate = useNavigate();
-	const tiltController = useWrappedCardTilt();
-	const [isRevealSequenceComplete, setIsRevealSequenceComplete] =
-		useState(false);
 
 	useMountEffect(() => {
 		document.body.classList.add("mymind-wrapped-body");
@@ -208,86 +197,32 @@ export function WrappedPublicMockPage(props: WrappedPublicMockPageProps) {
 		};
 	});
 
-	function handleGoToStep(nextStepIndex: number) {
-		const nextStep = WRAPPED_SATURDAY_STEPS[nextStepIndex];
-
-		if (!nextStep) {
-			return;
-		}
-
-		navigate(`/dev/wrapped?stage=story&step=${nextStep.id}`);
-	}
-
 	function handleMakeYours() {
 		navigate(appRoutes.wrappedTeamCard());
 	}
 
 	return (
-		<MotionConfig reducedMotion="user">
-			<LayoutGroup>
-				<main className="mymind-wrapped-route mymind-wrapped-route--onboarding mymind-wrapped-route--step-card">
-					<motion.div
-						layout
-						className="mymind-wrapped-shell mymind-wrapped-shell--reference-top-chrome relative z-[1] mx-auto flex w-full flex-1 flex-col text-foreground"
-					>
-						<motion.div layout className="mymind-wrapped-shell__frame">
-							<WrappedOnboardingHeader
-								activeStep={MOCK_PUBLIC_SHARE_CARD_STEP}
-								activeStepIndex={MOCK_PUBLIC_SHARE_CARD_STEP_INDEX}
-								isStepTransitioning={false}
-								onBack={() => navigate("/dev/wrapped?stage=story")}
-								onGoToStep={handleGoToStep}
-								rewardCardBackground={MOCK_PUBLIC_SHARE_REWARD_CARD_BACKGROUND}
-							/>
-
-							<div className="mymind-wrapped-stage-area">
-								<div className="mymind-wrapped-stage-slot">
-									<div className="flex w-full flex-1">
-										<WrappedTeamCardRevealStage
-											activeArchetype={MOCK_PUBLIC_SHARE_ARCHETYPE}
-											footerActionLabel="Reveal card"
-											headerLeftMetric={MOCK_PUBLIC_SHARE_HEADER_LEFT_METRIC}
-											headerRightMetric={MOCK_PUBLIC_SHARE_HEADER_RIGHT_METRIC}
-											isPreviewPostVisible={isRevealSequenceComplete}
-											onboardingMetrics={MOCK_PUBLIC_SHARE_ONBOARDING_METRICS}
-											onPreviewPost={handleMakeYours}
-											onRevealComplete={() => setIsRevealSequenceComplete(true)}
-											revealedFooterActionLabel="Make yours"
-											row={MOCK_PUBLIC_SHARE_ROW}
-											shareCardCreatedAtLabel="Apr 28, 2026"
-											shellClassName={
-												MOCK_PUBLIC_SHARE_ARCHETYPE.shellClassName
-											}
-											shellStyle={MOCK_PUBLIC_SHARE_SHELL_STYLE}
-											statItems={MOCK_PUBLIC_SHARE_STAT_ITEMS}
-											statLayerOpacities={
-												MOCK_PUBLIC_SHARE_STAT_LAYER_OPACITIES
-											}
-											theme={MOCK_PUBLIC_SHARE_ARCHETYPE.theme}
-											tiltController={tiltController}
-										/>
-									</div>
-								</div>
-							</div>
-
-							<WrappedOnboardingFooter
-								activePreviewOptions={null}
-								activePreviewState="auto"
-								activePreviewStepId={null}
-								activeStep={MOCK_PUBLIC_SHARE_CARD_STEP}
-								finalFooter={false}
-								generalDebugControls={debugControls}
-								isContinueVisible
-								isDebugControlsVisible={Boolean(debugControls)}
-								isStepTransitioning={false}
-								onContinue={handleMakeYours}
-								onPreviewStateChange={handleMockPreviewStateChange}
-							/>
-						</motion.div>
-					</motion.div>
-				</main>
-			</LayoutGroup>
-		</MotionConfig>
+		<WrappedPublicCardScreen
+			action={
+				<WrappedPublicCardAction
+					href={appRoutes.wrappedTeamCard()}
+					onClick={handleMakeYours}
+				>
+					Make yours
+				</WrappedPublicCardAction>
+			}
+			activeArchetype={MOCK_PUBLIC_SHARE_ARCHETYPE}
+			backMetrics={MOCK_PUBLIC_SHARE_BACK_METRICS}
+			debugControls={debugControls}
+			headerLeftMetric={MOCK_PUBLIC_SHARE_HEADER_LEFT_METRIC}
+			headerRightMetric={MOCK_PUBLIC_SHARE_HEADER_RIGHT_METRIC}
+			row={MOCK_PUBLIC_SHARE_ROW}
+			shellClassName={MOCK_PUBLIC_SHARE_ARCHETYPE.shellClassName}
+			shellStyle={MOCK_PUBLIC_SHARE_SHELL_STYLE}
+			statItems={MOCK_PUBLIC_SHARE_STAT_ITEMS}
+			statLayerOpacities={MOCK_PUBLIC_SHARE_STAT_LAYER_OPACITIES}
+			theme={MOCK_PUBLIC_SHARE_ARCHETYPE.theme}
+		/>
 	);
 }
 
@@ -302,32 +237,3 @@ function getMockPublicShareArchetype() {
 
 	return archetype;
 }
-
-function getMockPublicShareCardStep() {
-	const step = WRAPPED_SATURDAY_STEPS.find(
-		(candidate) => candidate.id === "card",
-	);
-
-	if (!step) {
-		throw new Error("Wrapped public mock card step is missing.");
-	}
-
-	return step;
-}
-
-function getMockPublicShareCardStepIndex() {
-	const stepIndex = WRAPPED_SATURDAY_STEPS.findIndex(
-		(candidate) => candidate.id === "card",
-	);
-
-	if (stepIndex < 0) {
-		throw new Error("Wrapped public mock card step index is missing.");
-	}
-
-	return stepIndex;
-}
-
-function handleMockPreviewStateChange(
-	_stepId: PreviewableWrappedStepId,
-	_value: string,
-) {}

--- a/apps/web/src/features/wrapped/WrappedPublicPage.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedPublicPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WrappedPublicPage } from "@/features/wrapped/WrappedPublicPage";
 
@@ -25,8 +26,34 @@ vi.mock("@/features/analytics/tracking/useAnalyticsTracking", () => ({
 	}),
 }));
 
-vi.mock("@/features/wrapped/team-card/share-preview", () => ({
-	WrappedTeamCardSharePreview: () => <div>Wrapped share card</div>,
+vi.mock("@/features/wrapped/WrappedPublicCardScreen", () => ({
+	WrappedPublicCardAction: ({
+		children,
+		href,
+		onClick,
+	}: {
+		children: ReactNode;
+		href: string;
+		onClick?: () => void;
+	}) => (
+		<a href={href} onClick={onClick}>
+			{children}
+		</a>
+	),
+	WrappedPublicCardScreen: ({
+		action,
+		activeArchetype,
+		row,
+	}: {
+		action: ReactNode;
+		activeArchetype: { displayLabel: string };
+		row: { displayName: string };
+	}) => (
+		<div>
+			<h1>{`${row.displayName} is a ${activeArchetype.displayLabel}`}</h1>
+			{action}
+		</div>
+	),
 }));
 
 describe("WrappedPublicPage", () => {
@@ -43,6 +70,7 @@ describe("WrappedPublicPage", () => {
 				id: "11111111-1111-4111-8111-111111111111",
 				snapshot: {
 					archetypeLabel: "Calm operator",
+					backMetrics: [],
 					headerLeftMetric: { label: "Sessions", value: "12" },
 					headerRightMetric: { label: "Days", value: "6" },
 					row: {
@@ -72,7 +100,7 @@ describe("WrappedPublicPage", () => {
 	it("routes make yours into /wrapped with the share_id attribution", () => {
 		render(<WrappedPublicPage publicId="share-123" />);
 
-		expect(screen.getByText("Wrapped share card")).toBeInTheDocument();
+		expect(screen.getByText("Ada is a Calm operator")).toBeInTheDocument();
 		expect(screen.getByRole("link", { name: "Make yours" })).toHaveAttribute(
 			"href",
 			"/wrapped?share_id=share-123",

--- a/apps/web/src/features/wrapped/WrappedPublicPage.tsx
+++ b/apps/web/src/features/wrapped/WrappedPublicPage.tsx
@@ -4,9 +4,15 @@ import { appRoutes } from "@/app/routes";
 import { buttonVariants } from "@/app/ui/button";
 import { useAnalyticsTracking } from "@/features/analytics/tracking/useAnalyticsTracking";
 import { getSessionUserId } from "@/features/auth/auth-route-utils";
+import {
+	WRAPPED_ARCHETYPE_CARD_THEMES,
+	type WrappedArchetypeCardTheme,
+} from "@/features/wrapped/team-card/archetypes";
 import { getWrappedShareSafeImageUrl } from "@/features/wrapped/team-card/share-media";
-import { WrappedTeamCardSharePreview } from "@/features/wrapped/team-card/share-preview";
-import { formatShareCardCreatedAt } from "@/features/wrapped/team-card/utils";
+import {
+	WrappedPublicCardAction,
+	WrappedPublicCardScreen,
+} from "@/features/wrapped/WrappedPublicCardScreen";
 import { useEffectOnceWhen } from "@/hooks/useEffectOnceWhen";
 import { useMountEffect } from "@/hooks/useMountEffect";
 import { authClient } from "@/lib/auth-client";
@@ -111,58 +117,29 @@ function PublicShareReadyState(props: {
 	share: PublicWrappedShare;
 }) {
 	const { makeYoursHref, onMakeYoursClick, share } = props;
-	const shareDateLabel = formatShareDateLabel(share.created_at);
+	const activeArchetype = getPublicPageArchetype(share);
 	const publicRow = buildPublicPageRow(share.snapshot.row);
 
 	return (
-		<section className="min-h-screen bg-[#f8f4ef] text-[#22201f]">
-			<div className="mx-auto flex min-h-screen w-full max-w-[28rem] flex-col items-center justify-center px-6 py-10 text-center">
-				<p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-[#8f887f]">
-					Rudel Wrapped
-				</p>
-				<h1 className="mt-3 max-w-[12ch] text-balance font-[var(--app-font-heading)] text-[2.5rem] font-semibold tracking-[-0.07em] text-[#22201f]">
-					{share.snapshot.row.displayName}&apos;s card
-				</h1>
-				<p className="mt-3 max-w-[28ch] text-pretty text-sm leading-6 text-[#6c6761]">
-					{share.snapshot.archetypeLabel} is the theme they picked for this
-					card. Make your own from your uploaded Rudel history.
-				</p>
-
-				<div className="team-lineup-surface-scope mt-8 w-full">
-					<div className="grid justify-center">
-						<WrappedTeamCardSharePreview
-							appearance={share.snapshot.appearance}
-							backMetrics={share.snapshot.backMetrics}
-							headerLeftMetric={share.snapshot.headerLeftMetric}
-							headerRightMetric={share.snapshot.headerRightMetric}
-							row={publicRow}
-							shareCardCreatedAtLabel={shareDateLabel}
-							shellClassName={share.snapshot.shellClassName}
-							shellStyle={PUBLIC_SHARE_CARD_SHELL_STYLE}
-							statItems={share.snapshot.statItems}
-							theme={share.snapshot.theme}
-						/>
-					</div>
-				</div>
-
-				<p className="mt-5 text-[0.75rem] font-medium tracking-[-0.02em] text-[#7b746d]">
-					Shared {shareDateLabel}
-				</p>
-
-				<div className="mt-8 flex w-full flex-col gap-3">
-					<a
-						className={cn(
-							buttonVariants({ size: "lg" }),
-							"min-h-11 rounded-full bg-[#4f7cff] text-white shadow-[0_16px_28px_rgba(79,124,255,0.24)] hover:bg-[#4472f4]",
-						)}
-						href={makeYoursHref}
-						onClick={onMakeYoursClick}
-					>
-						Make yours
-					</a>
-				</div>
-			</div>
-		</section>
+		<WrappedPublicCardScreen
+			action={
+				<WrappedPublicCardAction
+					href={makeYoursHref}
+					onClick={onMakeYoursClick}
+				>
+					Make yours
+				</WrappedPublicCardAction>
+			}
+			activeArchetype={activeArchetype}
+			backMetrics={share.snapshot.backMetrics ?? []}
+			headerLeftMetric={share.snapshot.headerLeftMetric}
+			headerRightMetric={share.snapshot.headerRightMetric}
+			row={publicRow}
+			shellClassName={share.snapshot.shellClassName}
+			shellStyle={PUBLIC_SHARE_CARD_SHELL_STYLE}
+			statItems={share.snapshot.statItems}
+			theme={share.snapshot.theme}
+		/>
 	);
 }
 
@@ -232,14 +209,21 @@ function buildPublicPageRow(row: WrappedShareRow) {
 	};
 }
 
-// Shared cards store raw ISO timestamps. The public page formats them here so
-// the persistence layer stays neutral and UI-friendly wording lives at the edge.
-function formatShareDateLabel(createdAt: string) {
-	const parsedDate = new Date(createdAt);
+function getPublicPageArchetype(share: PublicWrappedShare) {
+	const existingArchetype = WRAPPED_ARCHETYPE_CARD_THEMES.find(
+		(candidate) => candidate.displayLabel === share.snapshot.archetypeLabel,
+	);
 
-	if (Number.isNaN(parsedDate.getTime())) {
-		return createdAt;
+	if (existingArchetype) {
+		return existingArchetype;
 	}
 
-	return formatShareCardCreatedAt(parsedDate);
+	return {
+		classifierKey: undefined,
+		displayLabel: share.snapshot.archetypeLabel,
+		id: "public-share-snapshot",
+		kind: "special_edition",
+		shellClassName: share.snapshot.shellClassName,
+		theme: share.snapshot.theme,
+	} satisfies WrappedArchetypeCardTheme;
 }

--- a/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
@@ -5,6 +5,7 @@ import type { WrappedOnboardingMetrics } from "@/features/wrapped/onboarding/typ
 import { WRAPPED_ARCHETYPE_CARD_THEMES } from "@/features/wrapped/team-card/archetypes";
 import { buildWrappedTeamCardBackMetrics } from "@/features/wrapped/team-card/back-metrics";
 import {
+	WrappedTeamCardPublicStage,
 	WrappedTeamCardRevealStage,
 	WrappedTeamCardShareStage,
 } from "@/features/wrapped/team-card/final-stages";
@@ -182,6 +183,7 @@ function finishRevealCardDrop() {
 }
 
 afterEach(() => {
+	vi.clearAllMocks();
 	vi.clearAllTimers();
 	vi.useRealTimers();
 });
@@ -548,7 +550,7 @@ describe("WrappedTeamCardRevealStage", () => {
 
 		expect(tiltController.handlePointerLeave).toHaveBeenCalledTimes(1);
 		const revealedButton = screen.getByRole("button", {
-			name: "Card revealed",
+			name: "Show back of card",
 		});
 		expect(revealedButton).toHaveAttribute("data-card-face", "front");
 		expect(revealedButton).toBeDisabled();
@@ -557,6 +559,11 @@ describe("WrappedTeamCardRevealStage", () => {
 			vi.advanceTimersByTime(REVEAL_CARD_FLIP_DURATION_MS);
 		});
 
+		expect(
+			screen.getByRole("button", {
+				name: "Show back of card",
+			}),
+		).toBeEnabled();
 		expect(
 			screen.getByRole("heading", {
 				name: "Avery Chen, you're a Smooth Operator",
@@ -567,6 +574,19 @@ describe("WrappedTeamCardRevealStage", () => {
 				"For the steady hand who keeps the machine moving without asking for attention on every pass.",
 			),
 		).toBeInTheDocument();
+
+		fireEvent.click(
+			screen.getByRole("button", {
+				name: "Show back of card",
+			}),
+		);
+
+		expect(tiltController.handlePointerLeave).toHaveBeenCalledTimes(2);
+		expect(
+			screen.getByRole("button", {
+				name: "Show front of card",
+			}),
+		).toHaveAttribute("data-card-face", "back");
 	});
 
 	it("uses the footer action to turn the card around before continuing", () => {
@@ -625,7 +645,7 @@ describe("WrappedTeamCardRevealStage", () => {
 		expect(onPreviewPost).not.toHaveBeenCalled();
 		expect(
 			screen.getByRole("button", {
-				name: "Card revealed",
+				name: "Show back of card",
 			}),
 		).toHaveAttribute("data-card-face", "front");
 
@@ -715,14 +735,9 @@ describe("WrappedTeamCardRevealStage", () => {
 
 		expect(
 			screen.getByRole("button", {
-				name: "Card revealed",
-			}),
-		).toBeDisabled();
-		expect(
-			screen.queryByRole("button", {
 				name: "Show back of card",
 			}),
-		).not.toBeInTheDocument();
+		).toBeEnabled();
 		expect(
 			screen.getByRole("button", {
 				name: "Continue",
@@ -733,6 +748,22 @@ describe("WrappedTeamCardRevealStage", () => {
 				name: "Turn around",
 			}),
 		).not.toBeInTheDocument();
+
+		fireEvent.click(
+			screen.getByRole("button", {
+				name: "Show back of card",
+			}),
+		);
+
+		expect(
+			screen.getByRole("button", {
+				name: "Show front of card",
+			}),
+		).toHaveAttribute("data-card-face", "back");
+
+		act(() => {
+			vi.advanceTimersByTime(REVEAL_CARD_FLIP_DURATION_MS);
+		});
 
 		fireEvent.click(
 			screen.getByRole("button", {
@@ -747,5 +778,80 @@ describe("WrappedTeamCardRevealStage", () => {
 		});
 
 		expect(onPreviewPost).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("WrappedTeamCardPublicStage", () => {
+	it("starts on the public front and lets the viewer flip to the back", () => {
+		vi.useFakeTimers();
+		const activeArchetype = {
+			displayLabel: "Smooth Operator",
+			id: "smooth_operator",
+			kind: "taxonomy",
+			classifierKey: "smooth_operator",
+			shellClassName: "bg-sky-200",
+			theme: "light",
+		} as const;
+
+		render(
+			<WrappedTeamCardPublicStage
+				action={<button type="button">Make yours</button>}
+				activeArchetype={activeArchetype}
+				backMetrics={buildWrappedTeamCardBackMetrics({
+					onboardingMetrics,
+					row,
+					shareCardCreatedAtLabel: "04/24/2026",
+				})}
+				headerLeftMetric={{ title: "$42 estimated spend", value: "$42" }}
+				headerRightMetric={{
+					title: "Smooth Operator",
+					value: "Smooth Operator",
+				}}
+				row={row}
+				shellClassName="bg-sky-200"
+				shellStyle={{}}
+				statItems={[]}
+				statLayerOpacities={{
+					rainbowShineOpacity: 0.3,
+					textureOpacity: 1,
+					tileBorderOpacity: 1,
+					tileFillOpacity: 0.08,
+					tileInsetShadowOpacity: 0.5,
+					tileTopStrokeOpacity: 0.08,
+				}}
+				theme="light"
+				tiltController={tiltController}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("heading", {
+				name: "Avery Chen is a Smooth Operator",
+			}),
+		).toBeInTheDocument();
+
+		const showBackButton = screen.getByRole("button", {
+			name: "Show back of card",
+		});
+		expect(showBackButton).toHaveAttribute("data-card-face", "front");
+
+		fireEvent.click(showBackButton);
+
+		expect(tiltController.handlePointerLeave).toHaveBeenCalledTimes(1);
+		expect(
+			screen.getByRole("button", {
+				name: "Show front of card",
+			}),
+		).toHaveAttribute("data-card-face", "back");
+
+		act(() => {
+			vi.advanceTimersByTime(REVEAL_CARD_FLIP_DURATION_MS);
+		});
+
+		expect(
+			screen.getByRole("button", {
+				name: "Show front of card",
+			}),
+		).toBeEnabled();
 	});
 });

--- a/apps/web/src/features/wrapped/team-card/final-stages.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.tsx
@@ -9,6 +9,7 @@ import {
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
 	type CSSProperties,
+	type ReactNode,
 	type RefObject,
 	// biome-ignore lint/style/noRestrictedImports: reveal-stage timers are an imperative storyboard bridge for this wrapped surface.
 	useEffect,
@@ -83,6 +84,45 @@ interface WrappedTeamCardRevealStageProps
 	tiltController: WrappedCardTiltController;
 }
 
+interface WrappedTeamCardPublicStageProps {
+	action: ReactNode;
+	activeArchetype: WrappedArchetypeCardTheme;
+	backMetrics?: readonly WrappedTeamMemberCardBackMetric[];
+	headerLeftMetric?: WrappedTeamMemberCardHeaderMetric;
+	headerRightMetric?: WrappedTeamMemberCardHeaderMetric;
+	row: TeamPageMemberRow;
+	shellClassName: string;
+	shellStyle: CSSProperties;
+	statItems: readonly WrappedTeamMemberCardStatItem[];
+	statLayerOpacities?: WrappedTeamMemberCardStatLayerOpacities;
+	theme: WrappedTeamMemberCardTheme;
+	tiltController: WrappedCardTiltController;
+}
+
+interface WrappedTeamCardFlipSurfaceProps {
+	backMetrics: readonly WrappedTeamMemberCardBackMetric[];
+	buttonLabel: string;
+	cardVisualStageClassName?: string;
+	headerLeftMetric?: WrappedTeamMemberCardHeaderMetric;
+	headerRightMetric?: WrappedTeamMemberCardHeaderMetric;
+	isDisabled: boolean;
+	isFlipAnimating: boolean;
+	isFrontVisible: boolean;
+	isTiltEnabled: boolean;
+	morphShellRef?: RefObject<HTMLDivElement | null>;
+	onFlip: () => void;
+	printedCardCaptureKey: string;
+	reduceMotion: boolean;
+	row: TeamPageMemberRow;
+	shellClassName: string;
+	shellStyle: CSSProperties;
+	statItems: readonly WrappedTeamMemberCardStatItem[];
+	statLayerOpacities?: WrappedTeamMemberCardStatLayerOpacities;
+	theme: WrappedTeamMemberCardTheme;
+	tiltController: WrappedCardTiltController;
+	tiltShellClassName?: string;
+}
+
 interface WrappedRevealArchetypeTitleStyle extends CSSProperties {
 	"--wrapped-reveal-archetype-accent": string;
 	"--wrapped-reveal-archetype-gt-direction": string;
@@ -96,6 +136,10 @@ const WRAPPED_REVEAL_TEXT_DARK = "#17161c";
 const WRAPPED_REVEAL_GRADIENT_COLOR_PATTERN = /#[\da-fA-F]{3,8}\b/g;
 const WRAPPED_REVEAL_LINEAR_GRADIENT_PATTERN =
 	/^linear-gradient\(([^,]+),\s*(.+)\)$/;
+const WRAPPED_REVEAL_GRADIENT_DARK_HOLD_STOP = 60;
+const WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_START = 68;
+const WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_END = 100;
+const WRAPPED_REVEAL_GRADIENT_COLOR_INSET_STOP = 15;
 
 interface WrappedRevealTextGradient {
 	accent: string;
@@ -107,29 +151,48 @@ function formatWrappedRevealGradientStopPosition(position: number) {
 	return position.toFixed(2).replace(/\.?0+$/, "");
 }
 
+function resolveWrappedRevealGradientColorStop(position: number) {
+	const colorRange =
+		WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_END -
+		WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_START;
+
+	return (
+		WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_START + (colorRange * position) / 100
+	);
+}
+
 function buildWrappedRevealTextGradientStops(colors: readonly string[]) {
 	if (colors.length === 0) {
 		return `${WRAPPED_REVEAL_TEXT_DARK} 0%, ${WRAPPED_REVEAL_TEXT_DARK} 100%`;
 	}
 
 	if (colors.length === 1) {
-		return `${WRAPPED_REVEAL_TEXT_DARK} 0%, ${WRAPPED_REVEAL_TEXT_DARK} 40%, ${colors[0]} 48%, ${colors[0]} 100%`;
+		return `${WRAPPED_REVEAL_TEXT_DARK} 0%, ${WRAPPED_REVEAL_TEXT_DARK} ${WRAPPED_REVEAL_GRADIENT_DARK_HOLD_STOP}%, ${colors[0]} ${WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_START}%, ${colors[0]} ${WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_END}%`;
 	}
 
-	const colorRangeStart = 48;
-	const colorRangeEnd = 100;
-	const colorRange = colorRangeEnd - colorRangeStart;
-	const colorDenominator = Math.max(colors.length - 1, 1);
-	const colorStops = colors
+	const firstColor = colors[0];
+	const lastColor = colors[colors.length - 1];
+	const interiorColors = colors.slice(1, -1);
+	const interiorDenominator = Math.max(interiorColors.length + 1, 1);
+	const interiorStops = interiorColors
 		.map((color, index) => {
 			const stopPosition =
-				colorRangeStart + (colorRange * index) / colorDenominator;
+				WRAPPED_REVEAL_GRADIENT_COLOR_INSET_STOP +
+				((100 - WRAPPED_REVEAL_GRADIENT_COLOR_INSET_STOP * 2) * (index + 1)) /
+					interiorDenominator;
 
-			return `${color} ${formatWrappedRevealGradientStopPosition(stopPosition)}%`;
+			return `${color} ${formatWrappedRevealGradientStopPosition(resolveWrappedRevealGradientColorStop(stopPosition))}%`;
 		})
 		.join(", ");
+	const edgeStops = [
+		`${firstColor} ${formatWrappedRevealGradientStopPosition(resolveWrappedRevealGradientColorStop(0))}%`,
+		`${firstColor} ${formatWrappedRevealGradientStopPosition(resolveWrappedRevealGradientColorStop(WRAPPED_REVEAL_GRADIENT_COLOR_INSET_STOP))}%`,
+		interiorStops,
+		`${lastColor} ${formatWrappedRevealGradientStopPosition(resolveWrappedRevealGradientColorStop(100 - WRAPPED_REVEAL_GRADIENT_COLOR_INSET_STOP))}%`,
+		`${lastColor} ${formatWrappedRevealGradientStopPosition(resolveWrappedRevealGradientColorStop(100))}%`,
+	].filter(Boolean);
 
-	return `${WRAPPED_REVEAL_TEXT_DARK} 0%, ${WRAPPED_REVEAL_TEXT_DARK} 40%, ${colorStops}`;
+	return `${WRAPPED_REVEAL_TEXT_DARK} 0%, ${WRAPPED_REVEAL_TEXT_DARK} ${WRAPPED_REVEAL_GRADIENT_DARK_HOLD_STOP}%, ${edgeStops.join(", ")}`;
 }
 
 function buildWrappedRevealTextAccentGradient(input: {
@@ -645,6 +708,268 @@ function useWrappedShareStageObjectSize() {
 	return shareObjectShellRef;
 }
 
+function WrappedTeamCardFlipSurface(props: WrappedTeamCardFlipSurfaceProps) {
+	const {
+		backMetrics,
+		buttonLabel,
+		cardVisualStageClassName,
+		headerLeftMetric,
+		headerRightMetric,
+		isDisabled,
+		isFlipAnimating,
+		isFrontVisible,
+		isTiltEnabled,
+		morphShellRef,
+		onFlip,
+		printedCardCaptureKey,
+		reduceMotion,
+		row,
+		shellClassName,
+		shellStyle,
+		statItems,
+		statLayerOpacities,
+		theme,
+		tiltController,
+		tiltShellClassName,
+	} = props;
+	const cardFace = isFrontVisible ? "front" : "back";
+	const cardVisualStageClassNames = `team-lineup-card-tilt-stage mymind-wrapped-final-stage__card-visual-stage w-full max-w-[16rem] min-[360px]:max-w-[16.75rem] sm:max-w-none${
+		cardVisualStageClassName ? ` ${cardVisualStageClassName}` : ""
+	}`;
+	const cardScaleClassNames =
+		"[--wrapped-card-render-scale:1] min-[360px]:[--wrapped-card-render-scale:1.08] sm:[--wrapped-card-render-scale:1.42] lg:[--wrapped-card-render-scale:1.56]";
+	const hitShellClassNames = `mymind-wrapped-final-stage__card-hit-shell ${cardScaleClassNames}`;
+	const tiltShellClassNames = `team-lineup-card-tilt-shell mymind-wrapped-final-stage__tilt-shell${
+		tiltShellClassName ? ` ${tiltShellClassName}` : ""
+	}`;
+
+	return (
+		<div className={cardVisualStageClassNames}>
+			<button
+				aria-label={buttonLabel}
+				aria-pressed={isFrontVisible}
+				className={hitShellClassNames}
+				data-card-face={cardFace}
+				disabled={isDisabled}
+				onClick={onFlip}
+				onPointerMove={(event) => {
+					if (isTiltEnabled && !isFlipAnimating) {
+						tiltController.handlePointerMove(event);
+					}
+				}}
+				onPointerEnter={tiltController.handlePointerEnter}
+				onPointerLeave={tiltController.handlePointerLeave}
+				onPointerCancel={tiltController.handlePointerLeave}
+				type="button"
+			>
+				<div
+					ref={morphShellRef}
+					className="mymind-wrapped-final-stage__card-morph-shell"
+				>
+					<div
+						ref={(node) => {
+							tiltController.cardTiltRef.current = node;
+						}}
+						className={tiltShellClassNames}
+						data-flip-active={isFlipAnimating ? "true" : "false"}
+						data-tilt-active="false"
+						style={
+							{
+								"--wrapped-card-flip-rotate-y": isFrontVisible
+									? "0deg"
+									: "180deg",
+							} as CSSProperties
+						}
+					>
+						<div
+							className="mymind-wrapped-final-stage__flip-control"
+							data-card-face={cardFace}
+						>
+							<WrappedPrintedCardFlip
+								captureKey={printedCardCaptureKey}
+								front={
+									<div className="grid justify-center">
+										<WrappedTeamMemberCard
+											disableOuterShadow
+											headerLeftMetric={headerLeftMetric}
+											headerRightMetric={headerRightMetric}
+											hideHeaderLogo
+											layoutPreset="team-card-preview"
+											mediaPanelClassName="mx-auto"
+											row={row}
+											shellClassName={shellClassName}
+											shellStyle={shellStyle}
+											statItems={statItems}
+											statLayerOpacities={statLayerOpacities}
+											statTileClassName=""
+											theme={theme}
+										/>
+									</div>
+								}
+								back={
+									<div className="grid justify-center">
+										<WrappedTeamMemberCardBack
+											disableOuterShadow
+											metrics={backMetrics}
+											shellClassName={shellClassName}
+											shellStyle={shellStyle}
+											theme={theme}
+										/>
+									</div>
+								}
+								isFrontVisible={isFrontVisible}
+								reduceMotion={reduceMotion}
+							/>
+						</div>
+					</div>
+				</div>
+			</button>
+		</div>
+	);
+}
+
+export function WrappedTeamCardPublicStage(
+	props: WrappedTeamCardPublicStageProps,
+) {
+	const {
+		action,
+		activeArchetype,
+		backMetrics = [],
+		headerLeftMetric,
+		headerRightMetric,
+		row,
+		shellClassName,
+		shellStyle,
+		statItems,
+		statLayerOpacities,
+		theme,
+		tiltController,
+	} = props;
+	const shouldReduceMotion = useReducedMotion();
+	const reduceMotion = shouldReduceMotion ?? false;
+	const [isCardFrontVisible, setIsCardFrontVisible] = useState(true);
+	const [isCardFlipAnimating, setIsCardFlipAnimating] = useState(false);
+	const revealCopy = getWrappedRevealCopy(activeArchetype);
+	const printedCardCaptureKey = [
+		activeArchetype.id,
+		row.userId,
+		row.displayName,
+		row.imageUrl ?? "",
+		theme,
+		shellClassName,
+		headerLeftMetric?.value ?? "",
+		headerRightMetric?.value ?? "",
+		...statItems.map((item) => `${item.key}:${item.value}`),
+		...backMetrics.map((metric) => `${metric.label}:${metric.value}`),
+	].join("|");
+
+	useEffect(() => {
+		if (!isCardFlipAnimating || reduceMotion) {
+			return;
+		}
+
+		const timeoutId = window.setTimeout(() => {
+			setIsCardFlipAnimating(false);
+		}, REVEAL_STAGE_CARD_FLIP_DURATION_MS);
+
+		return () => {
+			window.clearTimeout(timeoutId);
+		};
+	}, [isCardFlipAnimating, reduceMotion]);
+
+	function handlePublicCardFlipToggle() {
+		if (isCardFlipAnimating) {
+			return;
+		}
+
+		tiltController.handlePointerLeave();
+
+		if (reduceMotion) {
+			setIsCardFrontVisible((currentValue) => !currentValue);
+			return;
+		}
+
+		setIsCardFlipAnimating(true);
+		setIsCardFrontVisible((currentValue) => !currentValue);
+	}
+
+	return (
+		<WrappedStageFrame
+			className="mymind-wrapped-final-stage mymind-wrapped-final-stage--reveal mymind-wrapped-final-stage--public-card"
+			objectClassName="mymind-wrapped-final-stage__object mymind-wrapped-final-stage__object--canvas"
+			supportClassName="mymind-wrapped-final-stage__support"
+			object={
+				<div className="mymind-wrapped-final-stage__canvas mymind-wrapped-public-card-stage__canvas">
+					<div
+						className="mymind-wrapped-final-stage__card-drop-layer mymind-wrapped-public-card-stage__card-layer"
+						data-card-state="dropped"
+					>
+						<div
+							className="mymind-wrapped-final-stage__reveal-stage mymind-wrapped-public-card-stage__composition"
+							data-companion-state="visible"
+							data-motion={reduceMotion ? "reduced" : "standard"}
+						>
+							<div className="mymind-wrapped-final-stage__slide-card-slot">
+								<WrappedTeamCardFlipSurface
+									backMetrics={backMetrics}
+									buttonLabel={
+										isCardFrontVisible
+											? "Show back of card"
+											: "Show front of card"
+									}
+									cardVisualStageClassName="mymind-wrapped-public-card-stage__card-visual-stage"
+									headerLeftMetric={headerLeftMetric}
+									headerRightMetric={headerRightMetric}
+									isDisabled={isCardFlipAnimating}
+									isFlipAnimating={isCardFlipAnimating}
+									isFrontVisible={isCardFrontVisible}
+									isTiltEnabled
+									onFlip={handlePublicCardFlipToggle}
+									printedCardCaptureKey={printedCardCaptureKey}
+									reduceMotion={reduceMotion}
+									row={row}
+									shellClassName={shellClassName}
+									shellStyle={shellStyle}
+									statItems={statItems}
+									statLayerOpacities={statLayerOpacities}
+									theme={theme}
+									tiltController={tiltController}
+									tiltShellClassName="mymind-wrapped-public-card-stage__tilt"
+								/>
+							</div>
+
+							<aside className="mymind-wrapped-final-stage__archetype-copy mymind-wrapped-public-card-stage__copy">
+								<h1 className="mymind-wrapped-final-stage__archetype-title">
+									<span className="mymind-wrapped-final-stage__archetype-name">
+										{row.displayName}
+									</span>
+									<span className="mymind-wrapped-final-stage__archetype-line">
+										is a{" "}
+										<WrappedArchetypeGradientText
+											activeArchetype={activeArchetype}
+											className="mymind-wrapped-final-stage__archetype-accent"
+											isHoverReplayEnabled
+											state="active"
+										/>
+									</span>
+								</h1>
+								<p className="mymind-wrapped-final-stage__archetype-description">
+									{revealCopy.description}
+								</p>
+							</aside>
+						</div>
+					</div>
+				</div>
+			}
+			support={
+				<div className="mymind-wrapped-action-stack mymind-wrapped-action-stack--single-action mymind-wrapped-public-card-stage__action">
+					{action}
+				</div>
+			}
+		/>
+	);
+}
+
 function getWrappedShareChromeMotion(input: {
 	delay: number;
 	reduceMotion: boolean;
@@ -729,7 +1054,6 @@ export function WrappedTeamCardRevealStage(
 		!isCardDropped && shouldShowRevealIntroDescription;
 	const shouldShowArchetypeCompanion =
 		isCardDropped &&
-		isCardFrontVisible &&
 		hasCardFrontBeenRevealed &&
 		!isCardFlipAnimating &&
 		!isRevealExitPending;
@@ -738,9 +1062,14 @@ export function WrappedTeamCardRevealStage(
 		: isRevealExitPending
 			? "exiting"
 			: "hidden";
-	const revealFooterLabel = shouldShowArchetypeCompanion
+	const revealFooterLabel = hasCardFrontBeenRevealed
 		? (revealedFooterActionLabel ?? footerActionLabel)
 		: footerActionLabel;
+	const cardFlipButtonLabel = !hasCardFrontBeenRevealed
+		? "Reveal front of card"
+		: isCardFrontVisible
+			? "Show back of card"
+			: "Show front of card";
 	const shouldShowRevealFooter =
 		shouldShowRevealIntroContinue || (isCardDropped && isPreviewPostVisible);
 	const printedCardCaptureKey = [
@@ -864,7 +1193,7 @@ export function WrappedTeamCardRevealStage(
 			!isCardDropped ||
 			isCardFlipAnimating ||
 			isRevealExitPending ||
-			hasCardFrontBeenRevealed
+			isPostHandoffPreparing
 		) {
 			return;
 		}
@@ -873,12 +1202,12 @@ export function WrappedTeamCardRevealStage(
 		setHasCardFrontBeenRevealed(true);
 
 		if (reduceMotion) {
-			setIsCardFrontVisible(true);
+			setIsCardFrontVisible((currentValue) => !currentValue);
 			return;
 		}
 
 		setIsCardFlipAnimating(true);
-		setIsCardFrontVisible(true);
+		setIsCardFrontVisible((currentValue) => !currentValue);
 	}
 
 	function handleRevealFooterAction() {
@@ -891,7 +1220,7 @@ export function WrappedTeamCardRevealStage(
 			return;
 		}
 
-		if (!hasCardFrontBeenRevealed || !isCardFrontVisible) {
+		if (!hasCardFrontBeenRevealed) {
 			handleCardFlipToggle();
 			return;
 		}
@@ -1008,92 +1337,34 @@ export function WrappedTeamCardRevealStage(
 							data-motion={reduceMotion ? "reduced" : "standard"}
 						>
 							<div className="mymind-wrapped-final-stage__slide-card-slot">
-								<div className="team-lineup-card-tilt-stage mymind-wrapped-final-stage__card-visual-stage w-full max-w-[16rem] min-[360px]:max-w-[16.75rem] sm:max-w-none">
-									<div
-										ref={handoffCardRef}
-										className="mymind-wrapped-final-stage__card-morph-shell"
-										onPointerMove={(event) => {
-											if (
-												!isCardFlipAnimating &&
-												!isPostHandoffPreparing &&
-												!isRevealExitPending
-											) {
-												tiltController.handlePointerMove(event);
-											}
-										}}
-										onPointerEnter={tiltController.handlePointerEnter}
-										onPointerLeave={tiltController.handlePointerLeave}
-										onPointerCancel={tiltController.handlePointerLeave}
-									>
-										<div
-											ref={tiltController.cardTiltRef}
-											className="team-lineup-card-tilt-shell mymind-wrapped-final-stage__tilt-shell [--wrapped-card-render-scale:1] min-[360px]:[--wrapped-card-render-scale:1.08] sm:[--wrapped-card-render-scale:1.42] lg:[--wrapped-card-render-scale:1.56]"
-											data-flip-active={isCardFlipAnimating ? "true" : "false"}
-											style={
-												{
-													"--wrapped-card-flip-rotate-y": isCardFrontVisible
-														? "0deg"
-														: "180deg",
-												} as CSSProperties
-											}
-										>
-											<button
-												aria-label={
-													isCardFrontVisible
-														? "Card revealed"
-														: "Reveal front of card"
-												}
-												aria-pressed={isCardFrontVisible}
-												className="mymind-wrapped-final-stage__flip-control"
-												data-card-face={isCardFrontVisible ? "front" : "back"}
-												disabled={
-													!isCardDropped ||
-													isCardFrontVisible ||
-													isPostHandoffPreparing ||
-													isRevealExitPending
-												}
-												onClick={handleCardFlipToggle}
-												type="button"
-											>
-												<WrappedPrintedCardFlip
-													captureKey={printedCardCaptureKey}
-													front={
-														<div className="grid justify-center">
-															<WrappedTeamMemberCard
-																disableOuterShadow
-																headerLeftMetric={headerLeftMetric}
-																headerRightMetric={headerRightMetric}
-																hideHeaderLogo
-																layoutPreset="team-card-preview"
-																mediaPanelClassName="mx-auto"
-																row={row}
-																shellClassName={shellClassName}
-																shellStyle={shellStyle}
-																statItems={statItems}
-																statLayerOpacities={statLayerOpacities}
-																statTileClassName=""
-																theme={theme}
-															/>
-														</div>
-													}
-													back={
-														<div className="grid justify-center">
-															<WrappedTeamMemberCardBack
-																disableOuterShadow
-																metrics={revealBackMetrics}
-																shellClassName={shellClassName}
-																shellStyle={shellStyle}
-																theme={theme}
-															/>
-														</div>
-													}
-													isFrontVisible={isCardFrontVisible}
-													reduceMotion={reduceMotion}
-												/>
-											</button>
-										</div>
-									</div>
-								</div>
+								<WrappedTeamCardFlipSurface
+									backMetrics={revealBackMetrics}
+									buttonLabel={cardFlipButtonLabel}
+									headerLeftMetric={headerLeftMetric}
+									headerRightMetric={headerRightMetric}
+									isDisabled={
+										!isCardDropped ||
+										isCardFlipAnimating ||
+										isPostHandoffPreparing ||
+										isRevealExitPending
+									}
+									isFlipAnimating={isCardFlipAnimating}
+									isFrontVisible={isCardFrontVisible}
+									isTiltEnabled={
+										!isPostHandoffPreparing && !isRevealExitPending
+									}
+									morphShellRef={handoffCardRef}
+									onFlip={handleCardFlipToggle}
+									printedCardCaptureKey={printedCardCaptureKey}
+									reduceMotion={reduceMotion}
+									row={row}
+									shellClassName={shellClassName}
+									shellStyle={shellStyle}
+									statItems={statItems}
+									statLayerOpacities={statLayerOpacities}
+									theme={theme}
+									tiltController={tiltController}
+								/>
 							</div>
 
 							<AnimatePresence>

--- a/apps/web/src/features/wrapped/team-card/printed-card-flip.tsx
+++ b/apps/web/src/features/wrapped/team-card/printed-card-flip.tsx
@@ -23,6 +23,7 @@ interface WrappedPrintedCardFlipProps {
 	front: ReactNode;
 	isFrontVisible: boolean;
 	reduceMotion?: boolean;
+	shouldCaptureBackSurface?: boolean;
 }
 
 interface PrintedCardVisualStyle extends CSSProperties {
@@ -40,6 +41,7 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 		front,
 		isFrontVisible,
 		reduceMotion = false,
+		shouldCaptureBackSurface = true,
 	} = props;
 	const backSourceRef = useRef<HTMLDivElement | null>(null);
 	const flipShellRef = useRef<HTMLDivElement | null>(null);
@@ -56,9 +58,13 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 	useEffect(() => {
 		let isCancelled = false;
 
-		async function captureBackSurface() {
-			setBackUrl(null);
+		setBackUrl(null);
 
+		if (!shouldCaptureBackSurface) {
+			return;
+		}
+
+		async function captureBackSurface() {
 			const backSource = backSourceRef.current;
 			if (!backSource) {
 				return;
@@ -83,7 +89,7 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 		return () => {
 			isCancelled = true;
 		};
-	}, [captureKey]);
+	}, [captureKey, shouldCaptureBackSurface]);
 
 	useEffect(() => {
 		const targetAngle = isFrontVisible ? 0 : 180;
@@ -146,18 +152,20 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 
 	return (
 		<>
-			<div
-				aria-hidden="true"
-				className="mymind-wrapped-printed-card-flip__source-stage"
-			>
+			{shouldCaptureBackSurface ? (
 				<div
-					ref={backSourceRef}
-					className="mymind-wrapped-printed-card-flip__source-side"
-					data-card-back-texture-source=""
+					aria-hidden="true"
+					className="mymind-wrapped-printed-card-flip__source-stage"
 				>
-					{back}
+					<div
+						ref={backSourceRef}
+						className="mymind-wrapped-printed-card-flip__source-side"
+						data-card-back-texture-source=""
+					>
+						{back}
+					</div>
 				</div>
-			</div>
+			) : null}
 
 			<div
 				ref={flipShellRef}
@@ -177,6 +185,10 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 								draggable={false}
 								src={backUrl}
 							/>
+						) : !shouldCaptureBackSurface ? (
+							<div className="mymind-wrapped-printed-card-flip__live-back">
+								{back}
+							</div>
 						) : (
 							<div
 								aria-label="Rudel"

--- a/apps/web/src/features/wrapped/team-card/tilt/dom.ts
+++ b/apps/web/src/features/wrapped/team-card/tilt/dom.ts
@@ -14,7 +14,7 @@ import {
 import type { WrappedCardTiltValues } from "./types";
 
 export function applyTilt(
-	node: HTMLDivElement | null,
+	node: HTMLElement | null,
 	values: WrappedCardTiltValues,
 ) {
 	if (!node) {
@@ -130,7 +130,7 @@ export function applyTilt(
 	);
 }
 
-export function resetTilt(node: HTMLDivElement | null) {
+export function resetTilt(node: HTMLElement | null) {
 	if (!node) {
 		return;
 	}

--- a/apps/web/src/features/wrapped/team-card/tilt/types.ts
+++ b/apps/web/src/features/wrapped/team-card/tilt/types.ts
@@ -23,13 +23,13 @@ export interface WrappedCardTiltValues {
 }
 
 export interface WrappedCardTiltController {
-	cardTiltRef: RefObject<HTMLDivElement | null>;
+	cardTiltRef: RefObject<HTMLElement | null>;
 	enableGyroscope: () => Promise<void>;
 	gyroscopeState: WrappedCardGyroscopeState;
 	gyroscopeStatusMessage: string | null;
-	handlePointerEnter: (event: ReactPointerEvent<HTMLDivElement>) => void;
+	handlePointerEnter: (event: ReactPointerEvent<HTMLElement>) => void;
 	handlePointerLeave: () => void;
-	handlePointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
+	handlePointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
 	isGyroscopePromptVisible: boolean;
 	isGyroscopeSupported: boolean;
 }

--- a/apps/web/src/features/wrapped/team-card/tilt/use-card-gyroscope.ts
+++ b/apps/web/src/features/wrapped/team-card/tilt/use-card-gyroscope.ts
@@ -8,7 +8,7 @@ import type {
 } from "./types";
 
 interface UseWrappedCardGyroscopeParams {
-	cardTiltRef: RefObject<HTMLDivElement | null>;
+	cardTiltRef: RefObject<HTMLElement | null>;
 	pointerActiveRef: MutableRefObject<boolean>;
 }
 

--- a/apps/web/src/features/wrapped/team-card/tilt/use-card-tilt.ts
+++ b/apps/web/src/features/wrapped/team-card/tilt/use-card-tilt.ts
@@ -9,7 +9,7 @@ export type { WrappedCardTiltController } from "./types";
 const POINTER_TILT_ACTIVATION_DISTANCE_PX = 2;
 
 export function useWrappedCardTilt(): WrappedCardTiltController {
-	const cardTiltRef = useRef<HTMLDivElement | null>(null);
+	const cardTiltRef = useRef<HTMLElement | null>(null);
 	const pointerActivationOriginRef = useRef<{
 		x: number;
 		y: number;
@@ -20,7 +20,7 @@ export function useWrappedCardTilt(): WrappedCardTiltController {
 		pointerActiveRef,
 	});
 
-	function handlePointerEnter(event: ReactPointerEvent<HTMLDivElement>) {
+	function handlePointerEnter(event: ReactPointerEvent<HTMLElement>) {
 		if (gyroscope.prefersReducedMotion || event.pointerType !== "mouse") {
 			return;
 		}
@@ -31,7 +31,7 @@ export function useWrappedCardTilt(): WrappedCardTiltController {
 		};
 	}
 
-	function handlePointerMove(event: ReactPointerEvent<HTMLDivElement>) {
+	function handlePointerMove(event: ReactPointerEvent<HTMLElement>) {
 		if (gyroscope.prefersReducedMotion || event.pointerType !== "mouse") {
 			return;
 		}

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -6518,6 +6518,10 @@ body.mymind-wrapped-body #cw-bubble-holder {
 .mymind-wrapped-final-stage__intro-accent,
 .mymind-wrapped-final-stage__archetype-accent {
 	display: inline-block;
+	padding: 0.07em 0.08em 0.08em;
+	font-weight: 800;
+	line-height: 1.08;
+	overflow: visible;
 }
 
 .mymind-wrapped-final-stage__gradient-text {
@@ -6673,7 +6677,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 			var(--wrapped-reveal-intro-gt-height);
 	}
 
-	99% {
+	100% {
 		background-color: var(--wrapped-reveal-intro-gt-color);
 		background-image: linear-gradient(
 			var(--wrapped-reveal-archetype-gt-direction, 184deg),
@@ -6683,14 +6687,6 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		background-repeat: no-repeat;
 		background-size: var(--wrapped-reveal-intro-gt-width)
 			var(--wrapped-reveal-intro-gt-height);
-	}
-
-	100% {
-		background-color: transparent;
-		background-image: var(--wrapped-reveal-archetype-accent);
-		background-position: 0% 0%;
-		background-repeat: repeat;
-		background-size: auto;
 	}
 }
 
@@ -6817,6 +6813,57 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	transform-style: preserve-3d;
 	transform-origin: center center;
 	will-change: transform;
+}
+
+.mymind-wrapped-final-stage__card-hit-shell {
+	position: relative;
+	display: grid;
+	width: calc(var(--wrapped-card-render-scale, 1) * 233px);
+	height: calc(var(--wrapped-card-render-scale, 1) * 358px);
+	place-items: center;
+	border: 0;
+	border-radius: calc(var(--wrapped-card-render-scale, 1) * 18px);
+	padding: 0;
+	overflow: visible;
+	background: transparent;
+	color: inherit;
+	cursor: pointer;
+	font: inherit;
+	opacity: 1;
+	text-align: inherit;
+	transform: none;
+	appearance: none;
+	touch-action: manipulation;
+	-webkit-appearance: none;
+}
+
+.mymind-wrapped-final-stage__card-hit-shell:disabled {
+	cursor: default;
+}
+
+.mymind-wrapped-public-card-header .mymind-wrapped-progress {
+	width: min(100%, 14rem);
+}
+
+.mymind-wrapped-final-stage--public-card {
+	width: 100%;
+}
+
+.mymind-wrapped-public-card-stage__canvas,
+.mymind-wrapped-public-card-stage__card-layer {
+	min-height: clamp(24rem, 58svh, 35rem);
+}
+
+.mymind-wrapped-public-card-stage__card-layer {
+	padding-top: clamp(2.2rem, 6svh, 3.8rem);
+}
+
+.mymind-wrapped-public-card-stage__copy {
+	pointer-events: none;
+}
+
+.mymind-wrapped-public-card-stage__action {
+	max-width: min(100%, 30rem);
 }
 
 @media (min-width: 360px) {
@@ -6978,6 +7025,8 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		box-shadow 220ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+.mymind-wrapped-final-stage__card-hit-shell:focus-visible,
+.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell:focus-visible,
 .mymind-wrapped-final-stage__flip-control:focus-visible {
 	box-shadow:
 		inset 0 0 0 calc(var(--wrapped-card-render-scale, 1) * 2px)
@@ -7097,6 +7146,13 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	-webkit-user-drag: none;
 }
 
+.mymind-wrapped-printed-card-flip__live-back {
+	display: grid;
+	width: 100%;
+	height: 100%;
+	place-items: center;
+}
+
 .mymind-wrapped-printed-card-flip__placeholder {
 	grid-area: 1 / 1;
 	width: 100%;
@@ -7121,11 +7177,18 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	--wrapped-card-base-rotate-y: -11deg;
 	width: calc(var(--wrapped-card-render-scale, 1) * 233px);
 	height: calc(var(--wrapped-card-render-scale, 1) * 358px);
+	border: 0;
+	padding: 0;
 	overflow: visible;
+	background: transparent;
 	backface-visibility: visible;
 	box-shadow: none;
+	color: inherit;
+	cursor: pointer;
+	font: inherit;
 	perspective: calc(1120px + var(--wrapped-card-render-scale, 1) * 180px);
 	perspective-origin: center 44%;
+	text-align: inherit;
 	transform: rotateX(
 			calc(
 				var(--wrapped-card-base-rotate-x) +
@@ -7140,7 +7203,10 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		)
 		scale(var(--wrapped-card-tilt-scale));
 	transform-style: preserve-3d;
+	appearance: none;
+	touch-action: manipulation;
 	-webkit-backface-visibility: visible;
+	-webkit-appearance: none;
 }
 
 .mymind-wrapped-final-stage--handoff-preparing
@@ -7156,6 +7222,10 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	transition:
 		transform 240ms cubic-bezier(0.22, 1, 0.36, 1),
 		filter 240ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell:disabled {
+	cursor: default;
 }
 
 .mymind-wrapped-final-stage--handoff-preparing


### PR DESCRIPTION
## Summary
- replace the transformed card shell click target with a flat hit shell so the full wrapped card box flips reliably
- reuse the shared reveal card surface for the public card page and keep public copy in third person
- let both public and normal revealed cards flip front/back by click, with public back metrics matching the normal card density
- remove the temporary card debug borders

## Test plan
- [x] bun ./node_modules/.bin/biome check --diagnostic-level=error apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx apps/web/src/features/wrapped/WrappedPublicCardScreen.tsx apps/web/src/features/wrapped/WrappedPublicMockPage.tsx apps/web/src/features/wrapped/WrappedPublicPage.tsx apps/web/src/features/wrapped/WrappedPublicPage.test.tsx apps/web/src/features/wrapped/team-card/final-stages.tsx apps/web/src/features/wrapped/team-card/final-stages.test.tsx apps/web/src/features/wrapped/team-card/printed-card-flip.tsx apps/web/src/features/wrapped/team-card/tilt/dom.ts apps/web/src/features/wrapped/team-card/tilt/types.ts apps/web/src/features/wrapped/team-card/tilt/use-card-gyroscope.ts apps/web/src/features/wrapped/team-card/tilt/use-card-tilt.ts apps/web/src/features/wrapped/wrapped.css
- [x] bun run lint:wrapped:hig
- [x] bun run check-types
- [x] bun run test team-card/final-stages.test.tsx WrappedPublicPage.test.tsx
- [x] bun run verify