### PR TITLE
fix: ignore synthetic wrapped model rows

### DIFF
--- a/apps/web/src/features/wrapped/onboarding/models/model-mix.test.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/model-mix.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { resolveModelStageModel } from "./model-mix";
+
+describe("resolveModelStageModel", () => {
+	it("does not count synthetic model rows as Codex in the monthly chart", () => {
+		const model = resolveModelStageModel({
+			modelByMonth: [
+				{
+					model: "<synthetic>",
+					month: "2026-04",
+					session_count: 7,
+				},
+				{
+					model: "gpt-5.4",
+					month: "2026-04",
+					session_count: 3,
+				},
+				{
+					model: "claude-opus-4-6",
+					month: "2026-04",
+					session_count: 2,
+				},
+			],
+			sourceSplit: [
+				{
+					session_count: 9,
+					session_share_percent: 75,
+					source: "claude_code",
+				},
+				{
+					session_count: 3,
+					session_share_percent: 25,
+					source: "codex",
+				},
+			],
+		});
+		const aprilMonth = model.months.find(
+			(month) => month.id === "model-month-2026-04",
+		);
+
+		expect(aprilMonth?.totalSessions).toBe(5);
+		expect(aprilMonth?.segments).toEqual([
+			{
+				id: "2026-04:claude_code",
+				label: "Claude",
+				sessionCount: 2,
+				share: 40,
+				source: "claude_code",
+			},
+			{
+				id: "2026-04:codex",
+				label: "Codex",
+				sessionCount: 3,
+				share: 60,
+				source: "codex",
+			},
+		]);
+	});
+});

--- a/apps/web/src/features/wrapped/onboarding/models/model-mix.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/model-mix.ts
@@ -460,7 +460,15 @@ function resolveModelStageSource(
 		return null;
 	}
 
+	if (isSyntheticModelLabel(modelLabel)) {
+		return null;
+	}
+
 	return modelLabel.includes("claude") ? "claude_code" : "codex";
+}
+
+function isSyntheticModelLabel(modelLabel: string) {
+	return modelLabel.replaceAll(/[^a-z0-9]+/g, "").includes("synthetic");
 }
 
 function formatMonthTickLabel(month: string) {


### PR DESCRIPTION
## Summary
- ignore synthetic model labels when resolving wrapped MoM chart source buckets
- add a regression test proving synthetic rows are not counted as Codex

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig