### PR TITLE
fix: polish wrapped card sharing

### DIFF
--- a/apps/web/src/features/wrapped/share-image.test.ts
+++ b/apps/web/src/features/wrapped/share-image.test.ts
@@ -3,18 +3,21 @@ import { describe, expect, it, vi } from "vitest";
 import { createWrappedImageShareActions } from "@/features/wrapped/share-image";
 import {
 	captureElement,
+	copyPngToClipboardWhenReady,
 	copyToClipboard,
 	downloadAsImage,
 } from "@/lib/screenshot";
 
 const {
 	mockCaptureElement,
+	mockCopyPngToClipboardWhenReady,
 	mockCopyToClipboard,
 	mockDownloadAsImage,
 	mockToastError,
 	mockToastSuccess,
 } = vi.hoisted(() => ({
 	mockCaptureElement: vi.fn(),
+	mockCopyPngToClipboardWhenReady: vi.fn(),
 	mockCopyToClipboard: vi.fn(),
 	mockDownloadAsImage: vi.fn(),
 	mockToastError: vi.fn(),
@@ -23,6 +26,7 @@ const {
 
 vi.mock("@/lib/screenshot", () => ({
 	captureElement: mockCaptureElement,
+	copyPngToClipboardWhenReady: mockCopyPngToClipboardWhenReady,
 	copyToClipboard: mockCopyToClipboard,
 	downloadAsImage: mockDownloadAsImage,
 }));
@@ -114,19 +118,22 @@ describe("createWrappedImageShareActions", () => {
 
 	it("opens an X intent with the public share URL for card previews", async () => {
 		resetShareImageMocks();
+		const blob = new Blob(["png"], { type: "image/png" });
 		const imageRef = { current: document.createElement("div") };
-		const pendingXWindow = {
-			closed: false,
-			close: vi.fn(),
-			document: { title: "" },
-			location: { href: "" },
-			opener: null,
-		};
-		const open = vi.fn().mockReturnValue(pendingXWindow);
+		const open = vi.fn().mockReturnValue({ opener: null });
 		Object.defineProperty(window, "open", {
 			configurable: true,
 			value: open,
 		});
+		let copiedBlob: Blob | undefined;
+		vi.mocked(captureElement).mockResolvedValue(blob);
+		vi.mocked(copyPngToClipboardWhenReady).mockImplementation(
+			async (imageBlobPromise) => {
+				expect(open).not.toHaveBeenCalled();
+				copiedBlob = await imageBlobPromise;
+				return true;
+			},
+		);
 
 		const actions = createWrappedImageShareActions({
 			fileName: "card.png",
@@ -140,22 +147,60 @@ describe("createWrappedImageShareActions", () => {
 
 		await actions.handleShareImage();
 
+		expect(open).toHaveBeenCalledTimes(1);
 		expect(open).toHaveBeenCalledWith(
 			expect.stringContaining("https://twitter.com/intent/tweet"),
 			"_blank",
+			"noopener,noreferrer",
 		);
-		const intentUrl = new URL(pendingXWindow.location.href);
+		const intentUrl = new URL(open.mock.calls[0]?.[0] ?? "");
 		expect(`${intentUrl.origin}${intentUrl.pathname}`).toBe(
 			"https://twitter.com/intent/tweet",
 		);
 		expect(intentUrl.searchParams.get("text")).toBe("Share text");
 		expect(intentUrl.searchParams.get("url")).toBe("https://rudel.ai/wrapped");
-		expect(captureElement).not.toHaveBeenCalled();
+		expect(captureElement).toHaveBeenCalledWith(imageRef.current, undefined);
+		expect(copyPngToClipboardWhenReady).toHaveBeenCalledWith(
+			expect.any(Promise),
+		);
+		expect(copiedBlob).toBe(blob);
 		expect(copyToClipboard).not.toHaveBeenCalled();
 		expect(downloadAsImage).not.toHaveBeenCalled();
 		expect(toast.success).toHaveBeenCalledWith(
-			"X is open with your wrapped card preview.",
-			{ duration: 5000 },
+			"Image copied. X is open. Paste the image into the post; your card link is included.",
+			{ duration: 7000 },
+		);
+	});
+
+	it("does not open X when the image was not copied", async () => {
+		resetShareImageMocks();
+		const blob = new Blob(["png"], { type: "image/png" });
+		const imageRef = { current: document.createElement("div") };
+		const open = vi.fn().mockReturnValue({ opener: null });
+		Object.defineProperty(window, "open", {
+			configurable: true,
+			value: open,
+		});
+		vi.mocked(captureElement).mockResolvedValue(blob);
+		vi.mocked(copyPngToClipboardWhenReady).mockResolvedValue(false);
+
+		const actions = createWrappedImageShareActions({
+			fileName: "card.png",
+			imageRef,
+			shareTarget: "x",
+			shareText: "Share text",
+			shareTitle: "Share title",
+			shareUrl: "https://rudel.ai/wrapped",
+			shareUrlLabel: "rudel.ai/wrapped",
+		});
+
+		await actions.handleShareImage();
+
+		expect(open).not.toHaveBeenCalled();
+		expect(downloadAsImage).toHaveBeenCalledWith(blob, "card.png");
+		expect(toast.success).toHaveBeenCalledWith(
+			"Image downloaded. Share the PNG from your downloads.",
+			{ duration: 7000 },
 		);
 	});
 

--- a/apps/web/src/features/wrapped/share-image.ts
+++ b/apps/web/src/features/wrapped/share-image.ts
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import {
 	type CaptureElementOptions,
 	captureElement,
+	copyPngToClipboardWhenReady,
 	copyToClipboard,
 	downloadAsImage,
 } from "@/lib/screenshot";
@@ -21,7 +22,6 @@ interface WrappedImageShareMessages {
 	shareUrlError: string;
 	xShareCopiedSuccess: string;
 	xShareDownloadedSuccess: string;
-	xShareReadySuccess: string;
 }
 
 interface CreateWrappedImageShareActionsParams {
@@ -31,6 +31,7 @@ interface CreateWrappedImageShareActionsParams {
 	messages?: Partial<WrappedImageShareMessages>;
 	onShareActionTriggered?: (action: WrappedImageShareActionKind) => void;
 	resolveShareUrl?: () => Promise<string | undefined>;
+	shareCaptureOptions?: CaptureElementOptions;
 	shareText: string;
 	shareTarget?: WrappedImageShareTarget;
 	shareTitle: string;
@@ -56,10 +57,9 @@ const DEFAULT_WRAPPED_IMAGE_SHARE_MESSAGES: WrappedImageShareMessages = {
 	shareDownloadSuccess: "Image downloaded. Share the PNG from your downloads.",
 	shareUrlError: "Could not create a share link. Sharing the image without it.",
 	xShareCopiedSuccess:
-		"Image copied. X is open. Paste the image into the post.",
+		"Image copied. X is open. Paste the image into the post; your card link is included.",
 	xShareDownloadedSuccess:
 		"Image downloaded. X is open. Attach the PNG from your downloads.",
-	xShareReadySuccess: "X is open with your wrapped card preview.",
 };
 
 export function createWrappedImageShareActions(
@@ -72,6 +72,7 @@ export function createWrappedImageShareActions(
 		messages: inputMessages,
 		onShareActionTriggered,
 		resolveShareUrl,
+		shareCaptureOptions,
 		shareText,
 		shareTarget = "system",
 		shareTitle,
@@ -100,7 +101,7 @@ export function createWrappedImageShareActions(
 		}
 
 		const imageBlob = await captureShareImage({
-			captureOptions,
+			captureOptions: shareCaptureOptions ?? captureOptions,
 			imageRef,
 			messages,
 		});
@@ -148,66 +149,47 @@ export function createWrappedImageShareActions(
 	}
 
 	async function handleShareImageToX() {
-		const pendingXWindow = openPendingXWindow(
-			buildWrappedXIntentUrl({
-				text: shareText,
-				url: shareUrl,
+		const imageBlobPromise = requireCapturedShareImage(
+			captureShareImage({
+				captureOptions: shareCaptureOptions ?? captureOptions,
+				imageRef,
+				messages,
 			}),
 		);
-		const resolvedShareUrl = await getResolvedShareUrl({
-			messages,
-			resolveShareUrl,
-			shareUrl,
-		});
-
-		if (!resolvedShareUrl) {
-			await handleShareImageToXFallback(pendingXWindow);
-			return;
-		}
-
-		toast.success(messages.xShareReadySuccess, {
-			duration: 5000,
-		});
-		openXIntentWindow(
-			pendingXWindow,
-			buildWrappedXIntentUrl({
-				text: shareText,
-				url: resolvedShareUrl,
+		const [imageBlob, copied, resolvedShareUrl] = await Promise.all([
+			imageBlobPromise.catch(() => null),
+			copyPngToClipboardWhenReady(imageBlobPromise),
+			getResolvedShareUrl({
+				messages,
+				resolveShareUrl,
+				shareUrl,
 			}),
-		);
-	}
-
-	async function handleShareImageToXFallback(pendingXWindow: Window | null) {
-		const imageBlob = await captureShareImage({
-			captureOptions,
-			imageRef,
-			messages,
-		});
+		]);
 
 		if (!imageBlob) {
-			closePendingXWindow(pendingXWindow);
 			return;
 		}
 
-		const copied = await copyToClipboard(imageBlob);
-
-		if (copied) {
-			toast.success(messages.xShareCopiedSuccess, {
-				duration: 7000,
-			});
-		} else {
+		if (!copied) {
 			downloadAsImage(imageBlob, fileName);
-			toast.success(messages.xShareDownloadedSuccess, {
+			toast.success(messages.shareDownloadSuccess, {
 				duration: 7000,
 			});
+			return;
 		}
 
-		openXIntentWindow(
-			pendingXWindow,
+		const didOpenX = openXIntentWindow(
 			buildWrappedXIntentUrl({
 				text: shareText,
-				url: shareUrl,
+				url: resolvedShareUrl ?? shareUrl,
 			}),
+		);
+
+		toast.success(
+			didOpenX ? messages.xShareCopiedSuccess : messages.copyFallbackSuccess,
+			{
+				duration: 7000,
+			},
 		);
 	}
 
@@ -250,6 +232,18 @@ export function createWrappedImageShareActions(
 	}
 }
 
+async function requireCapturedShareImage(
+	imageBlobPromise: Promise<Blob | null>,
+): Promise<Blob> {
+	const imageBlob = await imageBlobPromise;
+
+	if (!imageBlob) {
+		throw new Error("Missing share image");
+	}
+
+	return imageBlob;
+}
+
 async function getResolvedShareUrl(options: {
 	messages: WrappedImageShareMessages;
 	resolveShareUrl?: () => Promise<string | undefined>;
@@ -275,6 +269,8 @@ async function captureShareImage(options: {
 	messages: WrappedImageShareMessages;
 }): Promise<Blob | null> {
 	const { captureOptions, imageRef, messages } = options;
+	await waitForCurrentRender();
+
 	const imageElement = imageRef.current;
 
 	if (!imageElement) {
@@ -290,6 +286,18 @@ async function captureShareImage(options: {
 	}
 }
 
+function waitForCurrentRender() {
+	if (typeof window === "undefined" || !window.requestAnimationFrame) {
+		return Promise.resolve();
+	}
+
+	return new Promise<void>((resolve) => {
+		window.requestAnimationFrame(() => {
+			window.requestAnimationFrame(() => resolve());
+		});
+	});
+}
+
 function canShareFiles(shareFile: File) {
 	if (!navigator.canShare) {
 		return true;
@@ -302,39 +310,19 @@ function canShareFiles(shareFile: File) {
 	}
 }
 
-function openPendingXWindow(initialXIntentUrl: string) {
+function openXIntentWindow(xIntentUrl: string) {
 	if (typeof window === "undefined") {
-		return null;
+		return false;
 	}
 
 	try {
-		const pendingXWindow = window.open(initialXIntentUrl, "_blank");
+		const xWindow = window.open(xIntentUrl, "_blank", "noopener,noreferrer");
 
-		if (pendingXWindow) {
-			pendingXWindow.opener = null;
+		if (xWindow) {
+			xWindow.opener = null;
+			return true;
 		}
-
-		return pendingXWindow;
-	} catch {
-		return null;
-	}
-}
-
-function openXIntentWindow(pendingXWindow: Window | null, xIntentUrl: string) {
-	if (pendingXWindow && !pendingXWindow.closed) {
-		pendingXWindow.location.href = xIntentUrl;
-		return;
-	}
-
-	window.open(xIntentUrl, "_blank", "noopener,noreferrer");
-}
-
-function closePendingXWindow(pendingXWindow: Window | null) {
-	if (!pendingXWindow || pendingXWindow.closed) {
-		return;
-	}
-
-	try {
-		pendingXWindow.close();
 	} catch {}
+
+	return false;
 }

--- a/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
@@ -347,6 +347,54 @@ describe("WrappedTeamCardShareStage", () => {
 		expect(downloadButton).toHaveAttribute("aria-busy", "true");
 		expect(downloadButton.querySelector(".animate-spin")).not.toBeNull();
 	});
+
+	it("shows a spinner in the X share button while copy is pending", () => {
+		render(
+			<WrappedTeamCardShareStage
+				appearance={{ layoutMode: "front_back", showArchetypeLabel: true }}
+				backMetrics={buildWrappedTeamCardBackMetrics({
+					onboardingMetrics,
+					row,
+					shareCardCreatedAtLabel: "04/24/2026",
+				})}
+				headerLeftMetric={{ title: "$42 estimated spend", value: "$42" }}
+				headerRightMetric={{
+					title: "Smooth Operator",
+					value: "Smooth Operator",
+				}}
+				isSharePending
+				onAppearanceChange={vi.fn()}
+				onBack={vi.fn()}
+				onContinueToDashboard={vi.fn()}
+				onCopy={vi.fn()}
+				onDownload={vi.fn()}
+				onShare={vi.fn()}
+				row={row}
+				shareCardCreatedAtLabel="04/24/2026"
+				sharePostRef={{ current: null }}
+				shellClassName="bg-sky-200"
+				shellStyle={{}}
+				statItems={[]}
+				statLayerOpacities={{
+					rainbowShineOpacity: 0.3,
+					textureOpacity: 1,
+					tileBorderOpacity: 1,
+					tileFillOpacity: 0.08,
+					tileInsetShadowOpacity: 0.5,
+					tileTopStrokeOpacity: 0.08,
+				}}
+				theme="light"
+			/>,
+		);
+
+		const shareButton = screen.getByRole("button", {
+			name: "Copying image...",
+		});
+
+		expect(shareButton).toBeDisabled();
+		expect(shareButton).toHaveAttribute("aria-busy", "true");
+		expect(shareButton.querySelector(".animate-spin")).not.toBeNull();
+	});
 });
 
 describe("WrappedTeamCardRevealStage", () => {
@@ -587,6 +635,16 @@ describe("WrappedTeamCardRevealStage", () => {
 				name: "Show front of card",
 			}),
 		).toHaveAttribute("data-card-face", "back");
+		expect(
+			screen.getByRole("heading", {
+				name: "Avery Chen, you're a Smooth Operator",
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"For the steady hand who keeps the machine moving without asking for attention on every pass.",
+			),
+		).toBeInTheDocument();
 	});
 
 	it("uses the footer action to turn the card around before continuing", () => {

--- a/apps/web/src/features/wrapped/team-card/final-stages.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.tsx
@@ -59,6 +59,7 @@ interface WrappedTeamCardShareStageProps extends WrappedTeamCardStageCardProps {
 	frontCardHandoffRef?: RefObject<HTMLDivElement | null>;
 	isFrontCardHandoffHidden?: boolean;
 	isDownloadPending?: boolean;
+	isSharePending?: boolean;
 	onBack: () => void;
 	onCopy: () => void | Promise<void>;
 	onContinueToDashboard: () => void;
@@ -404,6 +405,7 @@ export function WrappedTeamCardShareStage(
 		headerRightMetric,
 		isDownloadPending = false,
 		isFrontCardHandoffHidden = false,
+		isSharePending = false,
 		onBack,
 		onCopy,
 		onContinueToDashboard,
@@ -558,11 +560,17 @@ export function WrappedTeamCardShareStage(
 							<Button
 								type="button"
 								size="lg"
+								aria-busy={isSharePending ? "true" : undefined}
 								className="mymind-wrapped-share-actions__primary"
+								disabled={isSharePending}
 								onClick={onShare}
 							>
-								<Share2 className="size-4" />
-								Share to X
+								{isSharePending ? (
+									<Loader2 className="size-4 animate-spin" />
+								) : (
+									<Share2 className="size-4" />
+								)}
+								{isSharePending ? "Copying image..." : "Share to X"}
 							</Button>
 						</nav>
 					</motion.div>
@@ -752,19 +760,19 @@ function WrappedTeamCardFlipSurface(props: WrappedTeamCardFlipSurfaceProps) {
 				data-card-face={cardFace}
 				disabled={isDisabled}
 				onClick={onFlip}
-				onPointerMove={(event) => {
-					if (isTiltEnabled && !isFlipAnimating) {
-						tiltController.handlePointerMove(event);
-					}
-				}}
-				onPointerEnter={tiltController.handlePointerEnter}
-				onPointerLeave={tiltController.handlePointerLeave}
-				onPointerCancel={tiltController.handlePointerLeave}
 				type="button"
 			>
 				<div
 					ref={morphShellRef}
 					className="mymind-wrapped-final-stage__card-morph-shell"
+					onPointerMove={(event) => {
+						if (isTiltEnabled && !isFlipAnimating) {
+							tiltController.handlePointerMove(event);
+						}
+					}}
+					onPointerEnter={tiltController.handlePointerEnter}
+					onPointerLeave={tiltController.handlePointerLeave}
+					onPointerCancel={tiltController.handlePointerLeave}
 				>
 					<div
 						ref={(node) => {
@@ -1033,6 +1041,8 @@ export function WrappedTeamCardRevealStage(
 	const [isCardFrontVisible, setIsCardFrontVisible] = useState(false);
 	const [hasCardFrontBeenRevealed, setHasCardFrontBeenRevealed] =
 		useState(false);
+	const [hasInitialCardFlipSettled, setHasInitialCardFlipSettled] =
+		useState(false);
 	const [isCardFlipAnimating, setIsCardFlipAnimating] = useState(false);
 	const [isRevealExitPending, setIsRevealExitPending] = useState(false);
 	const revealTimerRefs = useRef<number[]>([]);
@@ -1055,7 +1065,7 @@ export function WrappedTeamCardRevealStage(
 	const shouldShowArchetypeCompanion =
 		isCardDropped &&
 		hasCardFrontBeenRevealed &&
-		!isCardFlipAnimating &&
+		(hasInitialCardFlipSettled || !isCardFlipAnimating) &&
 		!isRevealExitPending;
 	const revealCompanionState = shouldShowArchetypeCompanion
 		? "visible"
@@ -1110,6 +1120,7 @@ export function WrappedTeamCardRevealStage(
 			setIsCardDropped(false);
 			setIsCardFrontVisible(false);
 			setHasCardFrontBeenRevealed(false);
+			setHasInitialCardFlipSettled(false);
 			setIsCardFlipAnimating(false);
 			setIsRevealExitPending(false);
 			return;
@@ -1119,6 +1130,7 @@ export function WrappedTeamCardRevealStage(
 		setIsCardDropped(false);
 		setIsCardFrontVisible(false);
 		setHasCardFrontBeenRevealed(false);
+		setHasInitialCardFlipSettled(false);
 		setIsCardFlipAnimating(false);
 		setIsRevealExitPending(false);
 		const timeoutIds = [
@@ -1165,6 +1177,7 @@ export function WrappedTeamCardRevealStage(
 
 		const timeoutId = window.setTimeout(() => {
 			setIsCardFlipAnimating(false);
+			setHasInitialCardFlipSettled(true);
 		}, REVEAL_STAGE_CARD_FLIP_DURATION_MS);
 
 		return () => {
@@ -1202,6 +1215,7 @@ export function WrappedTeamCardRevealStage(
 		setHasCardFrontBeenRevealed(true);
 
 		if (reduceMotion) {
+			setHasInitialCardFlipSettled(true);
 			setIsCardFrontVisible((currentValue) => !currentValue);
 			return;
 		}

--- a/apps/web/src/features/wrapped/team-card/page.tsx
+++ b/apps/web/src/features/wrapped/team-card/page.tsx
@@ -290,6 +290,7 @@ function WrappedTeamCardPageContent(props: {
 	const [isRevealSequenceComplete, setIsRevealSequenceComplete] =
 		useState(false);
 	const [isDownloadPending, setIsDownloadPending] = useState(false);
+	const [isSharePending, setIsSharePending] = useState(false);
 	const finalCardHandoffTimerRef = useRef<number | null>(null);
 	const finalCardFlightTimerRef = useRef<number | null>(null);
 	const finalCardFlightMeasureRef = useRef<number | null>(null);
@@ -501,6 +502,20 @@ function WrappedTeamCardPageContent(props: {
 		}
 	}
 
+	async function handleSharePost() {
+		if (isSharePending) {
+			return;
+		}
+
+		setIsSharePending(true);
+
+		try {
+			await shareActions.handleSharePost();
+		} finally {
+			setIsSharePending(false);
+		}
+	}
+
 	const finalStage = (
 		<AnimatePresence initial={false} mode="popLayout">
 			{showShareStage ? (
@@ -521,6 +536,7 @@ function WrappedTeamCardPageContent(props: {
 						headerRightMetric={headerRightMetric}
 						isDownloadPending={isDownloadPending}
 						isFrontCardHandoffHidden={finalCardFlight !== null}
+						isSharePending={isSharePending}
 						onBack={() => {
 							clearFinalCardHandoffTimer(finalCardHandoffTimerRef);
 							clearFinalCardHandoffTimer(finalCardFlightTimerRef);
@@ -533,18 +549,14 @@ function WrappedTeamCardPageContent(props: {
 							});
 						}}
 						onAppearanceChange={(nextAppearance) => {
-							startTransition(() => {
-								setShareAppearance(
-									resolveWrappedShareAppearance(nextAppearance),
-								);
-							});
+							setShareAppearance(resolveWrappedShareAppearance(nextAppearance));
 						}}
 						onCopy={() => void shareActions.handleCopyPost()}
 						onContinueToDashboard={() =>
 							handleContinueToDashboard("wrapped_share_footer")
 						}
 						onDownload={() => void handleDownloadPost()}
-						onShare={() => void shareActions.handleSharePost()}
+						onShare={() => void handleSharePost()}
 						row={sharePreviewRow}
 						shareCardCreatedAtLabel={shareCardCreatedAtLabel}
 						sharePostRef={sharePostRef}

--- a/apps/web/src/features/wrapped/team-card/share.test.ts
+++ b/apps/web/src/features/wrapped/team-card/share.test.ts
@@ -4,17 +4,20 @@ import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
 import { createWrappedTeamCardShareActions } from "@/features/wrapped/team-card/share";
 import {
 	captureElement,
+	copyPngToClipboardWhenReady,
 	copyToClipboard,
 	downloadAsImage,
 } from "@/lib/screenshot";
 
 const {
 	mockCaptureElement,
+	mockCopyPngToClipboardWhenReady,
 	mockCopyToClipboard,
 	mockDownloadAsImage,
 	mockToastSuccess,
 } = vi.hoisted(() => ({
 	mockCaptureElement: vi.fn(),
+	mockCopyPngToClipboardWhenReady: vi.fn(),
 	mockCopyToClipboard: vi.fn(),
 	mockDownloadAsImage: vi.fn(),
 	mockToastSuccess: vi.fn(),
@@ -22,6 +25,7 @@ const {
 
 vi.mock("@/lib/screenshot", () => ({
 	captureElement: mockCaptureElement,
+	copyPngToClipboardWhenReady: mockCopyPngToClipboardWhenReady,
 	copyToClipboard: mockCopyToClipboard,
 	downloadAsImage: mockDownloadAsImage,
 }));
@@ -97,6 +101,14 @@ describe("createWrappedTeamCardShareActions", () => {
 				"--wrapped-share-preview-card-scale-base": "0.96",
 				"--wrapped-share-preview-export-scale": "13.241379",
 				"--wrapped-share-preview-meta-font-size": "0.82rem",
+				"--wrapped-share-preview-portrait-highlight-blur":
+					"calc(var(--wrapped-card-render-scale, 1) * 2.75px)",
+				"--wrapped-share-preview-portrait-highlight-y":
+					"calc(var(--wrapped-card-render-scale, 1) * 2.25px)",
+				"--wrapped-share-preview-portrait-shadow-blur":
+					"calc(var(--wrapped-card-render-scale, 1) * 3px)",
+				"--wrapped-share-preview-portrait-shadow-y":
+					"calc(var(--wrapped-card-render-scale, 1) * -2.5px)",
 				"--wrapped-share-preview-shell-padding-bottom": "1.05rem",
 				"--wrapped-share-preview-shell-padding-left": "1.15rem",
 				"--wrapped-share-preview-shell-padding-right": "1.15rem",
@@ -106,6 +118,8 @@ describe("createWrappedTeamCardShareActions", () => {
 				"--wrapped-share-preview-spread-scale-base": "0.72",
 				"--wrapped-share-preview-top-gap": "0.625rem",
 				"--wrapped-share-preview-top-logo-size": "1rem",
+				"--wrapped-team-card-edge-outline-opacity": "0",
+				"--wrapped-team-card-edge-top-opacity": "0",
 			},
 		});
 		expect(downloadAsImage).toHaveBeenCalledWith(
@@ -117,14 +131,8 @@ describe("createWrappedTeamCardShareActions", () => {
 
 	it("opens X with first-person copy and only the resolved public card URL", async () => {
 		vi.clearAllMocks();
-		const pendingXWindow = {
-			closed: false,
-			close: vi.fn(),
-			document: { title: "" },
-			location: { href: "" },
-			opener: null,
-		};
-		const open = vi.fn().mockReturnValue(pendingXWindow);
+		const imageBlob = new Blob(["png"], { type: "image/png" });
+		const open = vi.fn().mockReturnValue({ opener: null });
 		const resolveShareUrl = vi
 			.fn()
 			.mockResolvedValue("https://rudel.ai/wrapped/public-card");
@@ -133,6 +141,15 @@ describe("createWrappedTeamCardShareActions", () => {
 			configurable: true,
 			value: open,
 		});
+		let copiedBlob: Blob | undefined;
+		vi.mocked(captureElement).mockResolvedValue(imageBlob);
+		vi.mocked(copyPngToClipboardWhenReady).mockImplementation(
+			async (imageBlobPromise) => {
+				expect(open).not.toHaveBeenCalled();
+				copiedBlob = await imageBlobPromise;
+				return true;
+			},
+		);
 
 		const actions = createWrappedTeamCardShareActions({
 			archetypeLabel: "Maniac",
@@ -153,12 +170,63 @@ describe("createWrappedTeamCardShareActions", () => {
 		await actions.handleSharePost();
 
 		expect(resolveShareUrl).toHaveBeenCalledTimes(1);
-		const initialIntentUrl = new URL(open.mock.calls[0]?.[0] ?? "");
-		expect(initialIntentUrl.searchParams.get("url")).toBeNull();
-		expect(captureElement).not.toHaveBeenCalled();
+		expect(captureElement).toHaveBeenCalledWith(sharePostRef.current, {
+			captureHeight: 3000,
+			captureWidth: 3000,
+			layoutHeight: 3000,
+			layoutWidth: 3000,
+			padding: 0,
+			pixelRatio: 1,
+			style: {
+				border: "0",
+				borderRadius: "0",
+				boxShadow: "none",
+				height: "3000px",
+				maxWidth: "none",
+				width: "3000px",
+				"--wrapped-share-preview-body-padding-bottom": "0.56rem",
+				"--wrapped-share-preview-body-padding-left": "0.08rem",
+				"--wrapped-share-preview-body-padding-right": "0.08rem",
+				"--wrapped-share-preview-body-padding-top": "0.45rem",
+				"--wrapped-share-preview-card-glare-opacity": "0.2",
+				"--wrapped-share-preview-card-shadow-opacity": "0.16",
+				"--wrapped-share-preview-card-scale-base": "0.96",
+				"--wrapped-share-preview-export-scale": "6.465517",
+				"--wrapped-share-preview-meta-font-size": "0.82rem",
+				"--wrapped-share-preview-portrait-highlight-blur":
+					"calc(var(--wrapped-card-render-scale, 1) * 2.75px)",
+				"--wrapped-share-preview-portrait-highlight-y":
+					"calc(var(--wrapped-card-render-scale, 1) * 2.25px)",
+				"--wrapped-share-preview-portrait-shadow-blur":
+					"calc(var(--wrapped-card-render-scale, 1) * 3px)",
+				"--wrapped-share-preview-portrait-shadow-y":
+					"calc(var(--wrapped-card-render-scale, 1) * -2.5px)",
+				"--wrapped-share-preview-shell-padding-bottom": "1.05rem",
+				"--wrapped-share-preview-shell-padding-left": "1.15rem",
+				"--wrapped-share-preview-shell-padding-right": "1.15rem",
+				"--wrapped-share-preview-shell-padding-top": "1.05rem",
+				"--wrapped-share-preview-spread-gap": "0.42rem",
+				"--wrapped-share-preview-spread-shadow-opacity": "0.14",
+				"--wrapped-share-preview-spread-scale-base": "0.72",
+				"--wrapped-share-preview-top-gap": "0.625rem",
+				"--wrapped-share-preview-top-logo-size": "1rem",
+				"--wrapped-team-card-edge-outline-opacity": "0",
+				"--wrapped-team-card-edge-top-opacity": "0",
+			},
+		});
+		expect(copyPngToClipboardWhenReady).toHaveBeenCalledWith(
+			expect.any(Promise),
+		);
+		expect(copiedBlob).toBe(imageBlob);
 		expect(copyToClipboard).not.toHaveBeenCalled();
 		expect(downloadAsImage).not.toHaveBeenCalled();
-		const intentUrl = new URL(pendingXWindow.location.href);
+		expect(open).toHaveBeenCalledTimes(1);
+		expect(open).toHaveBeenCalledWith(
+			expect.stringContaining("https://twitter.com/intent/tweet"),
+			"_blank",
+			"noopener,noreferrer",
+		);
+		const intentUrl = new URL(open.mock.calls[0]?.[0] ?? "");
 		expect(intentUrl.searchParams.get("text")).toBe(
 			[
 				"According to my Codex usage, I'm a Maniac.",
@@ -170,8 +238,8 @@ describe("createWrappedTeamCardShareActions", () => {
 			"https://rudel.ai/wrapped/public-card",
 		);
 		expect(toast.success).toHaveBeenCalledWith(
-			"X is open with your Rudel Wrapped post preview.",
-			{ duration: 5000 },
+			"Post copied. X is open. Paste the image into the post; your card link is included.",
+			{ duration: 7000 },
 		);
 	});
 });

--- a/apps/web/src/features/wrapped/team-card/share.ts
+++ b/apps/web/src/features/wrapped/team-card/share.ts
@@ -3,57 +3,23 @@ import type { RefObject } from "react";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
 import { createWrappedImageShareActions } from "@/features/wrapped/share-image";
 import { buildWrappedXShareText } from "@/features/wrapped/wrapped-x-share";
+import type { CaptureElementOptions } from "@/lib/screenshot";
 
 const TEAM_CARD_SHARE_IMAGE_FILE_NAME = "rudel-team-card-post.png";
 const TEAM_CARD_SHARE_CAPTURE_SIZE = 6144;
+const TEAM_CARD_SHARE_CLIPBOARD_CAPTURE_SIZE = 3000;
 const TEAM_CARD_SHARE_OUTPUT_SIZE = 4096;
 const TEAM_CARD_SHARE_REFERENCE_SIZE = 464;
 const TEAM_CARD_SHARE_FRONT_CARD_SCALE = 0.96;
 const TEAM_CARD_SHARE_SPREAD_CARD_SCALE = 0.72;
-const TEAM_CARD_SHARE_EXPORT_SCALE =
-	TEAM_CARD_SHARE_CAPTURE_SIZE / TEAM_CARD_SHARE_REFERENCE_SIZE;
-const TEAM_CARD_SHARE_IMAGE_CAPTURE_OPTIONS = {
-	captureHeight: TEAM_CARD_SHARE_CAPTURE_SIZE,
-	captureWidth: TEAM_CARD_SHARE_CAPTURE_SIZE,
-	layoutHeight: TEAM_CARD_SHARE_CAPTURE_SIZE,
-	layoutWidth: TEAM_CARD_SHARE_CAPTURE_SIZE,
-	outputHeight: TEAM_CARD_SHARE_OUTPUT_SIZE,
-	outputWidth: TEAM_CARD_SHARE_OUTPUT_SIZE,
-	padding: 0,
-	pixelRatio: 1,
-	style: {
-		border: "0",
-		borderRadius: "0",
-		boxShadow: "none",
-		height: `${TEAM_CARD_SHARE_CAPTURE_SIZE}px`,
-		maxWidth: "none",
-		width: `${TEAM_CARD_SHARE_CAPTURE_SIZE}px`,
-		"--wrapped-share-preview-body-padding-bottom": "0.56rem",
-		"--wrapped-share-preview-body-padding-left": "0.08rem",
-		"--wrapped-share-preview-body-padding-right": "0.08rem",
-		"--wrapped-share-preview-body-padding-top": "0.45rem",
-		"--wrapped-share-preview-card-glare-opacity": "0.2",
-		"--wrapped-share-preview-card-shadow-opacity": "0.16",
-		"--wrapped-share-preview-card-scale-base": formatShareCaptureScale(
-			TEAM_CARD_SHARE_FRONT_CARD_SCALE,
-		),
-		"--wrapped-share-preview-export-scale": formatShareCaptureScale(
-			TEAM_CARD_SHARE_EXPORT_SCALE,
-		),
-		"--wrapped-share-preview-meta-font-size": "0.82rem",
-		"--wrapped-share-preview-shell-padding-bottom": "1.05rem",
-		"--wrapped-share-preview-shell-padding-left": "1.15rem",
-		"--wrapped-share-preview-shell-padding-right": "1.15rem",
-		"--wrapped-share-preview-shell-padding-top": "1.05rem",
-		"--wrapped-share-preview-spread-gap": "0.42rem",
-		"--wrapped-share-preview-spread-shadow-opacity": "0.14",
-		"--wrapped-share-preview-spread-scale-base": formatShareCaptureScale(
-			TEAM_CARD_SHARE_SPREAD_CARD_SCALE,
-		),
-		"--wrapped-share-preview-top-gap": "0.625rem",
-		"--wrapped-share-preview-top-logo-size": "1rem",
-	},
-};
+const TEAM_CARD_SHARE_VISIBLE_CAPTURE_OPTIONS =
+	buildTeamCardShareCaptureOptions({
+		captureSize: TEAM_CARD_SHARE_CLIPBOARD_CAPTURE_SIZE,
+	});
+const TEAM_CARD_SHARE_IMAGE_CAPTURE_OPTIONS = buildTeamCardShareCaptureOptions({
+	captureSize: TEAM_CARD_SHARE_CAPTURE_SIZE,
+	outputSize: TEAM_CARD_SHARE_OUTPUT_SIZE,
+});
 
 type WrappedShareActionKind = "copy" | "download" | "share";
 
@@ -117,13 +83,13 @@ export function createWrappedTeamCardShareActions(
 			shareUrlError:
 				"Could not create a share link. Sharing the image without it.",
 			xShareCopiedSuccess:
-				"Post copied. X is open. Paste the image into the post.",
+				"Post copied. X is open. Paste the image into the post; your card link is included.",
 			xShareDownloadedSuccess:
 				"Post downloaded. X is open. Attach the PNG from your downloads.",
-			xShareReadySuccess: "X is open with your Rudel Wrapped post preview.",
 		},
 		onShareActionTriggered,
 		resolveShareUrl,
+		shareCaptureOptions: TEAM_CARD_SHARE_VISIBLE_CAPTURE_OPTIONS,
 		shareText,
 		shareTarget: "x",
 		shareTitle,
@@ -142,4 +108,72 @@ export function createWrappedTeamCardShareActions(
 
 function formatShareCaptureScale(value: number) {
 	return value.toFixed(6).replace(/\.?0+$/, "");
+}
+
+function buildTeamCardShareCaptureOptions(options: {
+	captureSize: number;
+	outputSize?: number;
+}): CaptureElementOptions {
+	const { captureSize, outputSize } = options;
+
+	return {
+		captureHeight: captureSize,
+		captureWidth: captureSize,
+		layoutHeight: captureSize,
+		layoutWidth: captureSize,
+		...(outputSize
+			? {
+					outputHeight: outputSize,
+					outputWidth: outputSize,
+				}
+			: {}),
+		padding: 0,
+		pixelRatio: 1,
+		style: buildTeamCardShareCaptureStyle(captureSize),
+	};
+}
+
+function buildTeamCardShareCaptureStyle(captureSize: number) {
+	return {
+		border: "0",
+		borderRadius: "0",
+		boxShadow: "none",
+		height: `${captureSize}px`,
+		maxWidth: "none",
+		width: `${captureSize}px`,
+		"--wrapped-share-preview-body-padding-bottom": "0.56rem",
+		"--wrapped-share-preview-body-padding-left": "0.08rem",
+		"--wrapped-share-preview-body-padding-right": "0.08rem",
+		"--wrapped-share-preview-body-padding-top": "0.45rem",
+		"--wrapped-share-preview-card-glare-opacity": "0.2",
+		"--wrapped-share-preview-card-shadow-opacity": "0.16",
+		"--wrapped-share-preview-card-scale-base": formatShareCaptureScale(
+			TEAM_CARD_SHARE_FRONT_CARD_SCALE,
+		),
+		"--wrapped-share-preview-export-scale": formatShareCaptureScale(
+			captureSize / TEAM_CARD_SHARE_REFERENCE_SIZE,
+		),
+		"--wrapped-share-preview-meta-font-size": "0.82rem",
+		"--wrapped-share-preview-portrait-highlight-blur":
+			"calc(var(--wrapped-card-render-scale, 1) * 2.75px)",
+		"--wrapped-share-preview-portrait-highlight-y":
+			"calc(var(--wrapped-card-render-scale, 1) * 2.25px)",
+		"--wrapped-share-preview-portrait-shadow-blur":
+			"calc(var(--wrapped-card-render-scale, 1) * 3px)",
+		"--wrapped-share-preview-portrait-shadow-y":
+			"calc(var(--wrapped-card-render-scale, 1) * -2.5px)",
+		"--wrapped-share-preview-shell-padding-bottom": "1.05rem",
+		"--wrapped-share-preview-shell-padding-left": "1.15rem",
+		"--wrapped-share-preview-shell-padding-right": "1.15rem",
+		"--wrapped-share-preview-shell-padding-top": "1.05rem",
+		"--wrapped-share-preview-spread-gap": "0.42rem",
+		"--wrapped-share-preview-spread-shadow-opacity": "0.14",
+		"--wrapped-share-preview-spread-scale-base": formatShareCaptureScale(
+			TEAM_CARD_SHARE_SPREAD_CARD_SCALE,
+		),
+		"--wrapped-share-preview-top-gap": "0.625rem",
+		"--wrapped-share-preview-top-logo-size": "1rem",
+		"--wrapped-team-card-edge-outline-opacity": "0",
+		"--wrapped-team-card-edge-top-opacity": "0",
+	};
 }

--- a/apps/web/src/features/wrapped/team-card/tilt/constants.ts
+++ b/apps/web/src/features/wrapped/team-card/tilt/constants.ts
@@ -1,7 +1,7 @@
 export const ACTIVE_GLARE_OPACITY = 0.9;
 export const ACTIVE_SCALE = 1.018;
 export const MAX_GYRO_TILT_DEGREES = 9;
-export const MAX_POINTER_TILT_DEGREES = 8;
+export const MAX_POINTER_TILT_DEGREES = 14;
 export const RESTING_PORTRAIT_HIGHLIGHT_BLUR = "4px";
 export const RESTING_PORTRAIT_HIGHLIGHT_OPACITY = "0.52";
 export const RESTING_PORTRAIT_HIGHLIGHT_X = "0px";

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -4651,7 +4651,6 @@ body.mymind-wrapped-body #cw-bubble-holder {
 
 .mymind-wrapped-auth-panel--profile {
 	align-content: center;
-	gap: clamp(0.8rem, 2.6svh, 1.25rem);
 	min-height: 100%;
 }
 
@@ -6758,6 +6757,45 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	);
 }
 
+@media (max-width: 55.999rem) {
+	.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"] {
+		align-content: center;
+		grid-template-areas:
+			"copy"
+			"card";
+		grid-template-rows: auto auto;
+		row-gap: clamp(1rem, 3svh, 1.5rem);
+	}
+
+	.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-copy {
+		position: relative;
+		grid-area: copy;
+		top: auto;
+		inset-inline: auto;
+		width: min(100%, 24rem);
+		margin-inline: auto;
+	}
+
+	.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__slide-card-slot {
+		grid-area: card;
+		width: auto;
+		transform: none;
+	}
+
+	.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__card-visual-stage {
+		transform: none;
+	}
+
+	.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-base-rotate-x: 0deg;
+		--wrapped-card-base-rotate-y: 0deg;
+	}
+}
+
 .mymind-wrapped-final-stage__archetype-copy {
 	position: absolute;
 	z-index: 2;
@@ -6802,6 +6840,8 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 .mymind-wrapped-final-stage__card-visual-stage {
+	display: grid;
+	justify-items: center;
 	transform: translateY(var(--wrapped-reveal-card-visual-y));
 	transform-origin: center center;
 }
@@ -6813,6 +6853,78 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	transform-style: preserve-3d;
 	transform-origin: center center;
 	will-change: transform;
+}
+
+.mymind-wrapped-final-stage--reveal
+	.mymind-wrapped-final-stage__card-visual-stage {
+	width: max-content;
+	max-width: none;
+	justify-self: center;
+}
+
+.mymind-wrapped-final-stage--reveal
+	.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+	--wrapped-card-tilt-rotate-x: 0deg;
+	--wrapped-card-tilt-rotate-y: 0deg;
+	--wrapped-card-tilt-scale: 1;
+	transform: rotateX(0deg) rotateY(0deg) scale(1);
+}
+
+.mymind-wrapped-final-stage--reveal
+	.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell:not(
+		[data-flip-active="true"]
+	)
+	.mymind-wrapped-final-stage__flip-control[data-card-face="back"]
+	.mymind-wrapped-final-stage__flip-shell {
+	transform: none;
+	transform-style: flat;
+	will-change: auto;
+}
+
+.mymind-wrapped-final-stage--reveal
+	.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell:not(
+		[data-flip-active="true"]
+	)
+	.mymind-wrapped-final-stage__flip-control[data-card-face="back"]
+	.mymind-wrapped-final-stage__flip-shell::after {
+	display: none;
+}
+
+.mymind-wrapped-final-stage--reveal
+	.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell:not(
+		[data-flip-active="true"]
+	)
+	.mymind-wrapped-final-stage__flip-control[data-card-face="back"]
+	.mymind-wrapped-printed-card-flip__rotator,
+.mymind-wrapped-final-stage--reveal
+	.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell:not(
+		[data-flip-active="true"]
+	)
+	.mymind-wrapped-final-stage__flip-control[data-card-face="back"]
+	.mymind-wrapped-printed-card-flip__plane {
+	transform-style: flat;
+	-webkit-transform-style: flat;
+}
+
+.mymind-wrapped-final-stage--reveal
+	.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell:not(
+		[data-flip-active="true"]
+	)
+	.mymind-wrapped-final-stage__flip-control[data-card-face="back"]
+	.mymind-wrapped-printed-card-flip__plane--front {
+	display: none;
+}
+
+.mymind-wrapped-final-stage--reveal
+	.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell:not(
+		[data-flip-active="true"]
+	)
+	.mymind-wrapped-final-stage__flip-control[data-card-face="back"]
+	.mymind-wrapped-printed-card-flip__plane--back {
+	opacity: 1;
+	transform: none;
+	backface-visibility: hidden;
+	-webkit-backface-visibility: hidden;
 }
 
 .mymind-wrapped-final-stage__card-hit-shell {
@@ -7209,6 +7321,12 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	-webkit-appearance: none;
 }
 
+.mymind-wrapped-final-stage--reveal
+	.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+	--wrapped-card-base-rotate-x: 0deg;
+	--wrapped-card-base-rotate-y: 0deg;
+}
+
 .mymind-wrapped-final-stage--handoff-preparing
 	.mymind-wrapped-final-stage__card-visual-stage {
 	transform: translateY(clamp(-2.6rem, -4.2svh, -1.1rem)) scale(0.985);
@@ -7283,14 +7401,16 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	z-index: 4;
 	box-shadow:
 		inset 0 0 0 calc(var(--wrapped-card-render-scale, 1) * 1px)
-		rgb(255 255 255 / 0.22),
+		rgb(255 255 255 / var(--wrapped-team-card-edge-outline-opacity, 0.22)),
 		inset 0 calc(var(--wrapped-card-render-scale, 1) * 1px) 0
-		rgb(255 255 255 / 0.28),
+		rgb(255 255 255 / var(--wrapped-team-card-edge-top-opacity, 0.28)),
 		inset 0 calc(var(--wrapped-card-render-scale, 1) * -1px) 0
-		rgb(15 23 42 / 0.08);
+		rgb(15 23 42 / var(--wrapped-team-card-edge-bottom-opacity, 0.08));
 }
 
 .team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell[data-tilt-active="true"] {
+	--wrapped-card-base-rotate-x: 0deg;
+	--wrapped-card-base-rotate-y: 0deg;
 	box-shadow: none;
 	transform: rotateX(
 			calc(
@@ -7752,7 +7872,8 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	width: 100%;
 	max-width: none;
 	place-items: center;
-	perspective: none;
+	perspective: calc(var(--wrapped-share-preview-export-scale, 1) * 1320px);
+	perspective-origin: center 42%;
 }
 
 .mymind-wrapped-share-preview__spread {
@@ -7794,13 +7915,22 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	--wrapped-card-tilt-glare-opacity: var(
 		--wrapped-share-preview-card-glare-opacity
 	);
+	--wrapped-card-tilt-glare-x: 34%;
+	--wrapped-card-tilt-glare-y: 20%;
+	--wrapped-card-tilt-rotate-x: 2deg;
+	--wrapped-card-tilt-rotate-y: -8deg;
+	--wrapped-card-tilt-scale: 1;
 	box-shadow: 0 calc(var(--wrapped-card-render-scale, 1) * 18px)
 		calc(var(--wrapped-card-render-scale, 1) * 28px)
 		rgb(15 23 42 / var(--wrapped-share-preview-card-shadow-opacity));
 	filter: none;
 	pointer-events: none;
 	user-select: none;
-	transform: translateZ(0);
+	transform: rotateX(var(--wrapped-card-tilt-rotate-x))
+		rotateY(var(--wrapped-card-tilt-rotate-y))
+		scale(var(--wrapped-card-tilt-scale));
+	transform-style: preserve-3d;
+	-webkit-transform-style: preserve-3d;
 }
 
 .mymind-wrapped-share-preview__card-shell--spread {
@@ -7808,7 +7938,6 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	box-shadow: 0 calc(var(--wrapped-card-render-scale, 1) * 14px)
 		calc(var(--wrapped-card-render-scale, 1) * 22px)
 		rgb(15 23 42 / var(--wrapped-share-preview-spread-shadow-opacity));
-	transform: translateZ(0);
 }
 
 .mymind-wrapped-share-preview__meta {
@@ -7913,7 +8042,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 
 @media (min-width: 56rem) {
 	.mymind-wrapped-final-stage__reveal-stage {
-		--wrapped-reveal-card-copy-gap: 32px;
+		--wrapped-reveal-card-copy-gap: clamp(3rem, 5vw, 4.75rem);
 	}
 
 	.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
@@ -8391,23 +8520,23 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	--wrapped-card-stat-mask-alpha-mid: 0.34;
 	--wrapped-card-stat-mask-alpha-far: 0.08;
 	--wrapped-card-portrait-highlight-x: 0px;
-	--wrapped-card-portrait-highlight-y: calc(
-		var(--wrapped-card-render-scale, 1) *
-		4px
+	--wrapped-card-portrait-highlight-y: var(
+		--wrapped-share-preview-portrait-highlight-y,
+		calc(var(--wrapped-card-render-scale, 1) * 4px)
 	);
-	--wrapped-card-portrait-highlight-blur: calc(
-		var(--wrapped-card-render-scale, 1) *
-		4px
+	--wrapped-card-portrait-highlight-blur: var(
+		--wrapped-share-preview-portrait-highlight-blur,
+		calc(var(--wrapped-card-render-scale, 1) * 4px)
 	);
 	--wrapped-card-portrait-highlight-opacity: 0.52;
 	--wrapped-card-portrait-shadow-x: 0px;
-	--wrapped-card-portrait-shadow-y: calc(
-		var(--wrapped-card-render-scale, 1) *
-		-4px
+	--wrapped-card-portrait-shadow-y: var(
+		--wrapped-share-preview-portrait-shadow-y,
+		calc(var(--wrapped-card-render-scale, 1) * -4px)
 	);
-	--wrapped-card-portrait-shadow-blur: calc(
-		var(--wrapped-card-render-scale, 1) *
-		4px
+	--wrapped-card-portrait-shadow-blur: var(
+		--wrapped-share-preview-portrait-shadow-blur,
+		calc(var(--wrapped-card-render-scale, 1) * 4px)
 	);
 	--wrapped-card-portrait-shadow-opacity: 0.63;
 	transition:

--- a/apps/web/src/lib/screenshot.ts
+++ b/apps/web/src/lib/screenshot.ts
@@ -3,6 +3,7 @@ import { toBlob } from "html-to-image";
 const PADDING = 24;
 const DEFAULT_PIXEL_RATIO = 2;
 const ASSET_READY_TIMEOUT_MS = 3000;
+const PNG_MIME_TYPE = "image/png";
 const TRANSPARENT_IMAGE_PLACEHOLDER =
 	"data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=";
 
@@ -339,15 +340,19 @@ function wait(timeoutMs: number) {
 }
 
 export async function copyToClipboard(blob: Blob): Promise<boolean> {
+	const clipboardBlob = normalizePngBlob(blob);
+
 	try {
-		await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
+		await navigator.clipboard.write([
+			new ClipboardItem({ [clipboardBlob.type]: clipboardBlob }),
+		]);
 		return true;
 	} catch {
 		// Safari fallback: ClipboardItem may need a Promise
 		try {
 			await navigator.clipboard.write([
 				new ClipboardItem({
-					[blob.type]: Promise.resolve(blob),
+					[clipboardBlob.type]: Promise.resolve(clipboardBlob),
 				}),
 			]);
 			return true;
@@ -355,6 +360,33 @@ export async function copyToClipboard(blob: Blob): Promise<boolean> {
 			return false;
 		}
 	}
+}
+
+export async function copyPngToClipboardWhenReady(
+	blobPromise: Promise<Blob>,
+): Promise<boolean> {
+	const clipboardBlobPromise = blobPromise.then(normalizePngBlob);
+
+	try {
+		await navigator.clipboard.write([
+			new ClipboardItem({ [PNG_MIME_TYPE]: clipboardBlobPromise }),
+		]);
+		return true;
+	} catch {
+		try {
+			return await copyToClipboard(await clipboardBlobPromise);
+		} catch {
+			return false;
+		}
+	}
+}
+
+function normalizePngBlob(blob: Blob): Blob {
+	if (blob.type === PNG_MIME_TYPE) {
+		return blob;
+	}
+
+	return new Blob([blob], { type: PNG_MIME_TYPE });
 }
 
 export function downloadAsImage(blob: Blob, filename: string) {


### PR DESCRIPTION
## Summary
- make wrapped card sharing wait for the copied PNG before opening X
- add pending share UI and keep X opening in a new tab only after copy succeeds
- tune the wrapped card share capture, including 3000px clipboard export and tighter portrait inset shadows
- smooth the reveal/share card layout and preserve the selected card variant in copied images

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig

🤖 Generated with [Claude Code](https://claude.com/claude-code)