### PR TITLE
fix: route new social logins to wrapped profile

### DIFF
--- a/apps/web/src/features/auth/AuthStateRefresh.test.tsx
+++ b/apps/web/src/features/auth/AuthStateRefresh.test.tsx
@@ -9,6 +9,7 @@ import {
 	getEmailSignupSuccessDestination,
 	getEmailSignupVerificationCallbackURL,
 	getPendingSignupRedirect,
+	getSocialLoginRedirectOptions,
 	getSocialSignupRedirectOptions,
 	isGetStartedPath,
 	primePendingSignupRedirect,
@@ -191,6 +192,17 @@ describe("auth state refresh", () => {
 				"/wrapped?share_id=share-123&flow=sessions-landed",
 			)}`,
 		);
+	});
+
+	it("uses card profile as the new-user destination for social logins from wrapped", () => {
+		expect(
+			getSocialLoginRedirectOptions("/wrapped", "?share_id=share-123"),
+		).toEqual({
+			callbackURL: `/?redirect=${encodeURIComponent(
+				"/wrapped?share_id=share-123&flow=sessions-landed",
+			)}`,
+			newUserCallbackURL: "/wrapped?share_id=share-123&flow=card-profile",
+		});
 	});
 
 	it("uses card profile as the new-user destination for social signups from wrapped", () => {
@@ -428,6 +440,28 @@ describe("auth state refresh", () => {
 			);
 		});
 		expect(mockRefreshAuthClientState).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses a card profile destination for new users created from social login", async () => {
+		window.history.replaceState({}, "", "/wrapped?share_id=share-123");
+		mockSignInSocial.mockResolvedValue({ error: null });
+
+		const user = userEvent.setup();
+		render(<LoginForm onSwitchToSignup={vi.fn()} />);
+
+		await user.click(
+			screen.getByRole("button", { name: "Log in with Google" }),
+		);
+
+		await waitFor(() => {
+			expect(mockSignInSocial).toHaveBeenCalledWith({
+				provider: "google",
+				callbackURL: `/?redirect=${encodeURIComponent(
+					"/wrapped?share_id=share-123&flow=sessions-landed",
+				)}`,
+				newUserCallbackURL: "/wrapped?share_id=share-123&flow=card-profile",
+			});
+		});
 	});
 
 	it("shows verbose dev details for email sign in failures", async () => {

--- a/apps/web/src/features/auth/LoginForm.tsx
+++ b/apps/web/src/features/auth/LoginForm.tsx
@@ -11,8 +11,8 @@ import { cn } from "@/lib/utils";
 import { navigateToDestination } from "./auth-navigation";
 import {
 	clearPendingSignupRedirect,
-	getAuthCallbackURL,
 	getEmailLoginSuccessDestination,
+	getSocialLoginRedirectOptions,
 } from "./auth-route-utils";
 import {
 	recordOAuthRedirectResult,
@@ -191,15 +191,17 @@ export function LoginForm(props: LoginFormProps) {
 			sourceComponent: "login_form",
 			authMethod: provider,
 		});
-		const callbackURL = getAuthCallbackURL();
+		const { callbackURL, newUserCallbackURL } = getSocialLoginRedirectOptions();
 		recordOAuthRedirectStart({
 			callbackURL,
+			newUserCallbackURL,
 			provider,
 			source: "login_form",
 		});
 		const { error } = await authClient.signIn.social({
 			provider,
 			callbackURL,
+			newUserCallbackURL,
 		});
 		recordOAuthRedirectResult({
 			errorMessage: error?.message,

--- a/apps/web/src/features/auth/auth-route-utils.ts
+++ b/apps/web/src/features/auth/auth-route-utils.ts
@@ -164,6 +164,21 @@ export function getSocialSignupRedirectOptions(
 	};
 }
 
+export function getSocialLoginRedirectOptions(
+	pathname = window.location.pathname,
+	search = window.location.search,
+): {
+	callbackURL: string;
+	newUserCallbackURL?: string;
+} {
+	return {
+		callbackURL: getAuthCallbackURL(pathname, search),
+		newUserCallbackURL:
+			getDirectAuthDestination(pathname, search, "card-profile") ??
+			appRoutes.wrappedCardProfile(),
+	};
+}
+
 function getWrappedAuthRedirectRoute(
 	flow: WrappedAuthRedirectFlow,
 	search: string,


### PR DESCRIPTION
## Summary
- send newly-created social login users to the Wrapped card profile step
- keep existing social login users on the normal post-login callback
- cover the wrapped share redirect case in auth route and login form tests

## Test plan
- [x] bun run test -- src/features/auth/AuthStateRefresh.test.tsx
- [x] bun run verify