### PR TITLE
fix: close wrapped support chat from top tray

### DIFF
--- a/apps/web/src/features/wrapped/WrappedCardProfileStep.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedCardProfileStep.test.tsx
@@ -5,14 +5,15 @@ import { describe, expect, it, vi } from "vitest";
 import { WrappedCardProfileStep } from "@/features/wrapped/WrappedCardProfileStep";
 import type { WrappedGuestPreviewProfile } from "@/features/wrapped/wrapped-guest-preview";
 
-const { mockOpenChatwoot, mockSetChatwootBubbleVisibility } = vi.hoisted(
-	() => ({
+const { mockCloseChatwoot, mockOpenChatwoot, mockSetChatwootBubbleVisibility } =
+	vi.hoisted(() => ({
+		mockCloseChatwoot: vi.fn(),
 		mockOpenChatwoot: vi.fn(),
 		mockSetChatwootBubbleVisibility: vi.fn(),
-	}),
-);
+	}));
 
 vi.mock("@/lib/chatwoot", () => ({
+	closeChatwoot: mockCloseChatwoot,
 	openChatwoot: mockOpenChatwoot,
 	setChatwootBubbleVisibility: mockSetChatwootBubbleVisibility,
 }));

--- a/apps/web/src/features/wrapped/WrappedSetupPage.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedSetupPage.test.tsx
@@ -4,14 +4,15 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WrappedSetupPage } from "@/features/wrapped/WrappedSetupPage";
 
-const { mockOpenChatwoot, mockSetChatwootBubbleVisibility } = vi.hoisted(
-	() => ({
+const { mockCloseChatwoot, mockOpenChatwoot, mockSetChatwootBubbleVisibility } =
+	vi.hoisted(() => ({
+		mockCloseChatwoot: vi.fn(),
 		mockOpenChatwoot: vi.fn(),
 		mockSetChatwootBubbleVisibility: vi.fn(),
-	}),
-);
+	}));
 
 vi.mock("@/lib/chatwoot", () => ({
+	closeChatwoot: mockCloseChatwoot,
 	openChatwoot: mockOpenChatwoot,
 	setChatwootBubbleVisibility: mockSetChatwootBubbleVisibility,
 }));
@@ -33,6 +34,7 @@ Object.defineProperty(window, "matchMedia", {
 afterEach(() => {
 	vi.useRealTimers();
 	window.sessionStorage.clear();
+	mockCloseChatwoot.mockClear();
 	mockOpenChatwoot.mockClear();
 	mockSetChatwootBubbleVisibility.mockClear();
 });
@@ -262,6 +264,30 @@ describe("WrappedSetupPage", () => {
 		fireEvent.click(supportButton);
 
 		expect(mockOpenChatwoot).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses the top support control to open and close chat", async () => {
+		const user = userEvent.setup();
+
+		render(
+			<MemoryRouter>
+				<WrappedSetupPage />
+			</MemoryRouter>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Open support" }));
+
+		expect(mockOpenChatwoot).toHaveBeenCalledTimes(1);
+		expect(
+			screen.getByRole("button", { name: "Close support" }),
+		).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Close support" }));
+
+		expect(mockCloseChatwoot).toHaveBeenCalledTimes(1);
+		expect(
+			screen.getByRole("button", { name: "Open support" }),
+		).toBeInTheDocument();
 	});
 
 	it("keeps upload support visible after it has appeared once", () => {

--- a/apps/web/src/features/wrapped/onboarding/controls.tsx
+++ b/apps/web/src/features/wrapped/onboarding/controls.tsx
@@ -1,14 +1,14 @@
-import { ChevronLeft, HelpCircle } from "lucide-react";
+import { ChevronLeft } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import type { ReactNode } from "react";
 import { appRoutes } from "@/app/routes";
 import { WrappedPrimaryAction } from "@/features/wrapped/actions";
 import { WrappedProgress } from "@/features/wrapped/WrappedProgress";
 import { getWrappedOnboardingProgressView } from "@/features/wrapped/wrapped-onboarding-progress";
-import { openChatwoot } from "@/lib/chatwoot";
 import { cn } from "@/lib/utils";
 import { WrappedMobileChatwootBubbleController } from "../mobile-chatwoot-bubble-controller";
 import { WrappedDebugControlStack } from "../route-stage-shell";
+import { WrappedSupportChatwootButton } from "../support-chatwoot-button";
 import type {
 	PreviewableWrappedStepId,
 	WrappedPreviewOption,
@@ -123,14 +123,7 @@ export function WrappedOnboardingHeader(props: WrappedOnboardingHeaderProps) {
 					</div>
 
 					<div className="mymind-wrapped-top-tray__slot mymind-wrapped-top-tray__slot--end">
-						<button
-							type="button"
-							aria-label="Open support"
-							className="mymind-wrapped-top-tray__edge-control"
-							onClick={() => void openChatwoot()}
-						>
-							<HelpCircle className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
-						</button>
+						<WrappedSupportChatwootButton />
 					</div>
 				</div>
 			</header>

--- a/apps/web/src/features/wrapped/route-stage-shell.tsx
+++ b/apps/web/src/features/wrapped/route-stage-shell.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, HelpCircle, X } from "lucide-react";
+import { ChevronLeft, X } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import type { ReactNode } from "react";
 import { Children, isValidElement } from "react";
@@ -12,10 +12,10 @@ import {
 	getWrappedOnboardingProgressView,
 	type WrappedOnboardingProgressStepId,
 } from "@/features/wrapped/wrapped-onboarding-progress";
-import { openChatwoot } from "@/lib/chatwoot";
 import { cn } from "@/lib/utils";
 import "@/features/wrapped/wrapped.css";
 import { WrappedMobileChatwootBubbleController } from "./mobile-chatwoot-bubble-controller";
+import { WrappedSupportChatwootButton } from "./support-chatwoot-button";
 
 interface WrappedRouteStageShellProps {
 	backLabel?: string;
@@ -263,14 +263,7 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 										className="mymind-wrapped-top-tray__utility-placeholder"
 									/>
 								) : shouldUseReferenceTopChrome ? (
-									<button
-										type="button"
-										aria-label="Open support"
-										className="mymind-wrapped-top-tray__edge-control"
-										onClick={() => void openChatwoot()}
-									>
-										<HelpCircle className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
-									</button>
+									<WrappedSupportChatwootButton />
 								) : (
 									<span
 										aria-hidden="true"

--- a/apps/web/src/features/wrapped/support-chatwoot-button.tsx
+++ b/apps/web/src/features/wrapped/support-chatwoot-button.tsx
@@ -1,0 +1,55 @@
+import { HelpCircle, X } from "lucide-react";
+import { useState } from "react";
+import { useMountEffect } from "@/hooks/useMountEffect";
+import { closeChatwoot, openChatwoot } from "@/lib/chatwoot";
+
+const CHATWOOT_OPENED_EVENT = "chatwoot:opened";
+const CHATWOOT_CLOSED_EVENT = "chatwoot:closed";
+
+export function WrappedSupportChatwootButton() {
+	const [isChatwootOpen, setIsChatwootOpen] = useState(false);
+
+	useMountEffect(() => {
+		function handleChatwootOpened() {
+			setIsChatwootOpen(true);
+		}
+
+		function handleChatwootClosed() {
+			setIsChatwootOpen(false);
+		}
+
+		window.addEventListener(CHATWOOT_OPENED_EVENT, handleChatwootOpened);
+		window.addEventListener(CHATWOOT_CLOSED_EVENT, handleChatwootClosed);
+
+		return () => {
+			window.removeEventListener(CHATWOOT_OPENED_EVENT, handleChatwootOpened);
+			window.removeEventListener(CHATWOOT_CLOSED_EVENT, handleChatwootClosed);
+		};
+	});
+
+	async function handleClick() {
+		if (isChatwootOpen) {
+			setIsChatwootOpen(false);
+			await closeChatwoot();
+			return;
+		}
+
+		setIsChatwootOpen(true);
+		await openChatwoot();
+	}
+
+	return (
+		<button
+			type="button"
+			aria-label={isChatwootOpen ? "Close support" : "Open support"}
+			className="mymind-wrapped-top-tray__edge-control"
+			onClick={() => void handleClick()}
+		>
+			{isChatwootOpen ? (
+				<X className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
+			) : (
+				<HelpCircle className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
+			)}
+		</button>
+	);
+}

--- a/apps/web/src/lib/chatwoot.ts
+++ b/apps/web/src/lib/chatwoot.ts
@@ -177,6 +177,15 @@ export async function openChatwoot() {
 	}
 }
 
+export async function closeChatwoot() {
+	try {
+		await ensureChatwootLoaded();
+		window.$chatwoot?.toggle("close");
+	} catch {
+		// Ignore widget load failures so the dashboard remains functional.
+	}
+}
+
 export async function setChatwootBubbleVisibility(
 	visibility: ChatwootBubbleVisibility,
 ) {


### PR DESCRIPTION
## Summary
- replace wrapped top-tray support question mark with a shared button that becomes an X while Chatwoot is open
- add a Chatwoot close helper and wire the X state to close the widget
- cover the open/close support control behavior in wrapped setup tests

## Test plan
- [x] ./node_modules/.bin/biome check apps/web/src/lib/chatwoot.ts apps/web/src/features/wrapped/support-chatwoot-button.tsx apps/web/src/features/wrapped/route-stage-shell.tsx apps/web/src/features/wrapped/onboarding/controls.tsx apps/web/src/features/wrapped/WrappedSetupPage.test.tsx apps/web/src/features/wrapped/WrappedCardProfileStep.test.tsx
- [x] bun run --cwd apps/web test src/features/wrapped/WrappedSetupPage.test.tsx src/features/wrapped/WrappedCardProfileStep.test.tsx
- [x] bun run lint:wrapped:hig
- [x] bun run verify