### PR TITLE
fix: polish wrapped profile setup step

### DIFF
--- a/apps/web/src/features/wrapped/WrappedCardProfileStep.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedCardProfileStep.test.tsx
@@ -45,6 +45,7 @@ describe("WrappedCardProfileStep", () => {
 	it("renders the shared onboarding progress for the card profile step", async () => {
 		const user = userEvent.setup();
 		const handleContinue = vi.fn();
+		const handleDisplayNameChange = vi.fn();
 
 		render(
 			<MemoryRouter>
@@ -54,7 +55,7 @@ describe("WrappedCardProfileStep", () => {
 					isComplete={true}
 					onBack={vi.fn()}
 					onContinue={handleContinue}
-					onDisplayNameChange={vi.fn()}
+					onDisplayNameChange={handleDisplayNameChange}
 					onImageChange={vi.fn()}
 					previewProfile={previewProfile}
 				/>
@@ -69,6 +70,24 @@ describe("WrappedCardProfileStep", () => {
 				name: "Onboarding step 2: Personalize card",
 			}),
 		).toHaveAttribute("aria-current", "step");
+
+		await user.click(screen.getByRole("button", { name: "Save name" }));
+		expect(
+			screen.getByRole("button", { name: "Edit name" }),
+		).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Edit name" }));
+		expect(screen.getByRole("textbox", { name: "Name on card" })).toHaveValue(
+			"Ada Lovelace",
+		);
+
+		await user.clear(screen.getByRole("textbox", { name: "Name on card" }));
+		await user.type(
+			screen.getByRole("textbox", { name: "Name on card" }),
+			"Ada",
+		);
+
+		expect(handleDisplayNameChange).toHaveBeenCalled();
 
 		await user.click(screen.getByRole("button", { name: "Save name" }));
 		await user.click(screen.getByRole("button", { name: "Continue" }));

--- a/apps/web/src/features/wrapped/WrappedCardProfileStep.tsx
+++ b/apps/web/src/features/wrapped/WrappedCardProfileStep.tsx
@@ -67,6 +67,10 @@ export function WrappedCardProfileStep(props: WrappedCardProfileStepProps) {
 		setIsNameEditing(false);
 	}
 
+	function handleEditDisplayName() {
+		setIsNameEditing(true);
+	}
+
 	const imageEditLabel = imageUrl
 		? "Change profile picture"
 		: "Add profile picture";
@@ -130,19 +134,21 @@ export function WrappedCardProfileStep(props: WrappedCardProfileStepProps) {
 										ref={imageInputRef}
 										aria-label="Profile picture"
 										type="file"
+										name="wrapped-profile-picture"
 										accept="image/*"
 										className="sr-only"
 										onChange={handleImageUpload}
 									/>
 								</>
 							}
+							onDisplayNameEditStart={handleEditDisplayName}
 							profile={previewProfile}
 							size="profile"
 						/>
 					</div>
 				</div>
 			}
-			stageClassName="mymind-wrapped-entry-stage--auth"
+			stageClassName="mymind-wrapped-entry-stage--auth mymind-wrapped-entry-stage--auth-profile"
 			title={WRAPPED_CARD_PROFILE_TITLE}
 			titleClassName="mymind-wrapped-entry-stage__headline--auth-intro"
 			useReferenceTopChrome

--- a/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
+++ b/apps/web/src/features/wrapped/WrappedGuestPreviewCard.tsx
@@ -36,6 +36,7 @@ interface WrappedGuestPreviewCardProps {
 	cardStageRef?: Ref<HTMLDivElement>;
 	enableAppearanceOverlay?: boolean;
 	mediaOverlayContent?: ReactNode;
+	onDisplayNameEditStart?: () => void;
 	profile: WrappedGuestPreviewProfile | null;
 	size?: "hero" | "compact" | "profile";
 }
@@ -49,6 +50,7 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 		editableDisplayName,
 		enableAppearanceOverlay = false,
 		mediaOverlayContent,
+		onDisplayNameEditStart,
 		profile,
 		size = "hero",
 	} = props;
@@ -98,6 +100,7 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 				aria-label="Name on card"
 				autoComplete="name"
 				className="mymind-wrapped-card-profile-step__name-input"
+				name="wrapped-card-display-name"
 				placeholder={editableDisplayName.placeholder ?? "Your name"}
 				value={editableDisplayName.value}
 				onClick={(event) => event.stopPropagation()}
@@ -132,6 +135,19 @@ export function WrappedGuestPreviewCard(props: WrappedGuestPreviewCardProps) {
 				</button>
 			) : null}
 		</span>
+	) : onDisplayNameEditStart ? (
+		<button
+			type="button"
+			aria-label="Edit name"
+			className="mymind-wrapped-card-profile-step__name-display"
+			onClick={(event) => {
+				event.stopPropagation();
+				onDisplayNameEditStart();
+			}}
+			onPointerDown={(event) => event.stopPropagation()}
+		>
+			{row.displayName}
+		</button>
 	) : null;
 	const printedCardCaptureKey = [
 		row.userId,

--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -86,16 +86,23 @@ vi.mock("@/features/wrapped/WrappedSetupPage", () => ({
 		completedStepIdsOverride,
 		currentStepIdOverride,
 		initialStepId,
+		onBack,
 	}: {
 		completedStepIdsOverride?: readonly CliSetupStepId[];
 		currentStepIdOverride?: CliSetupStepId | null;
 		initialStepId?: CliSetupStepId;
+		onBack?: () => void;
 	}) => {
 		const [searchParams] = useSearchParams();
 
 		return (
 			<div>
 				<div>Wrapped setup page</div>
+				{onBack ? (
+					<button type="button" onClick={onBack}>
+						Back to card setup
+					</button>
+				) : null}
 				<div>Setup flow: {searchParams.get("flow") ?? "none"}</div>
 				<div>Setup initial step: {initialStepId ?? "none"}</div>
 				<div>Setup current step: {currentStepIdOverride ?? "none"}</div>
@@ -272,6 +279,14 @@ describe("WrappedRouteGate", () => {
 
 		expect(screen.getByText("Wrapped setup page")).toBeInTheDocument();
 		expect(screen.getByText("Setup flow: desktop-ready")).toBeInTheDocument();
+		await user.click(
+			screen.getByRole("button", { name: "Back to card setup" }),
+		);
+
+		expect(screen.getByText("Wrapped card profile step")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Continue profile" }));
+		expect(screen.getByText("Wrapped setup page")).toBeInTheDocument();
 		expect(readWrappedGuestPreviewSnapshot()).toMatchObject({
 			cardProfileCompletedUserId: "user-1",
 			profile: {

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -140,8 +140,10 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		!!session &&
 		sessionUserId !== null &&
 		forcedFlowStage === WRAPPED_ROUTE_CARD_PROFILE_FLOW &&
-		!hasCompletedCardProfile &&
 		activeCardProfile !== null;
+	const shouldBacktrackToCardProfile =
+		forcedFlowStage === WRAPPED_ROUTE_DESKTOP_READY_FLOW &&
+		hasCompletedCardProfile;
 	const hasSeenUploadSetup =
 		sessionUserId === null
 			? false
@@ -351,10 +353,24 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 				hasCompletedCliLogin={
 					cliSetupStatus.hasCliLogin || setupProgress.hasUploadedSessions
 				}
+				onBackToCardProfile={
+					shouldBacktrackToCardProfile
+						? () => setWrappedRouteFlowStage(WRAPPED_ROUTE_CARD_PROFILE_FLOW)
+						: undefined
+				}
 			/>
 		);
 	} else if (shouldShowUploadCompletionStep) {
-		content = <WrappedUploadSetupPage isUploadComplete />;
+		content = (
+			<WrappedUploadSetupPage
+				isUploadComplete
+				onBackToCardProfile={
+					shouldBacktrackToCardProfile
+						? () => setWrappedRouteFlowStage(WRAPPED_ROUTE_CARD_PROFILE_FLOW)
+						: undefined
+				}
+			/>
+		);
 	} else if (
 		sessionUserId &&
 		(shouldForceSessionsLanded ||
@@ -387,6 +403,11 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		content = (
 			<WrappedUploadSetupPage
 				hasCompletedCliLogin={cliSetupStatus.hasCliLogin}
+				onBackToCardProfile={
+					shouldBacktrackToCardProfile
+						? () => setWrappedRouteFlowStage(WRAPPED_ROUTE_CARD_PROFILE_FLOW)
+						: undefined
+				}
 			/>
 		);
 	}
@@ -471,6 +492,7 @@ function getWrappedSessionProfileUsername(input: {
 function WrappedUploadSetupPage(props: {
 	hasCompletedCliLogin?: boolean;
 	isUploadComplete?: boolean;
+	onBackToCardProfile?: () => void;
 }) {
 	const completedStepIdsOverride = props.isUploadComplete
 		? WRAPPED_SETUP_ALL_COMPLETED_STEP_IDS
@@ -485,8 +507,10 @@ function WrappedUploadSetupPage(props: {
 
 	return (
 		<WrappedSetupPage
+			backLabel="Back to card setup"
 			completedStepIdsOverride={completedStepIdsOverride}
 			currentStepIdOverride={currentStepIdOverride}
+			onBack={props.onBackToCardProfile}
 		/>
 	);
 }

--- a/apps/web/src/features/wrapped/WrappedSetupPage.tsx
+++ b/apps/web/src/features/wrapped/WrappedSetupPage.tsx
@@ -18,18 +18,22 @@ const WRAPPED_SETUP_SUPPORT_PROMPT_STORAGE_KEY =
 	"wrapped:setup-support-prompt-shown";
 
 interface WrappedSetupPageProps {
+	backLabel?: string;
 	completedStepIdsOverride?: readonly CliSetupStepId[];
 	currentStepIdOverride?: CliSetupStepId | null;
 	debugControls?: ReactNode;
 	initialStepId?: CliSetupStepId;
+	onBack?: () => void;
 }
 
 export function WrappedSetupPage(props: WrappedSetupPageProps) {
 	const {
+		backLabel = "Go back",
 		completedStepIdsOverride,
 		currentStepIdOverride,
 		debugControls,
 		initialStepId,
+		onBack,
 	} = props;
 	const lastStepIndex = cliSetupCommands.length - 1;
 	const initialStepIndex = getInitialStepIndex(initialStepId, lastStepIndex);
@@ -54,6 +58,7 @@ export function WrappedSetupPage(props: WrappedSetupPageProps) {
 	return (
 		<MotionConfig reducedMotion="user">
 			<WrappedRouteStageShell
+				backLabel={backLabel}
 				description={
 					<>
 						<p>Start sending sessions to Rudel.</p>
@@ -65,7 +70,8 @@ export function WrappedSetupPage(props: WrappedSetupPageProps) {
 					</>
 				}
 				entrancePreset="setup"
-				leadingControl={null}
+				leadingControl={onBack ? undefined : null}
+				onBack={onBack}
 				progressStepId="desktop-ready"
 				stageClassName="mymind-wrapped-entry-stage--setup"
 				stage={

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -4201,6 +4201,11 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	min-height: 0;
 }
 
+.mymind-wrapped-entry-stage--auth-profile
+	.mymind-wrapped-entry-stage__object--auth-profile {
+	--wrapped-card-profile-card-offset-y: 0;
+}
+
 .mymind-wrapped-entry-card {
 	display: grid;
 	gap: 1rem;
@@ -5459,6 +5464,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	display: grid;
 	justify-items: center;
 	width: 100%;
+	transform: translateY(var(--wrapped-card-profile-card-offset-y, 0));
 }
 
 .mymind-wrapped-card-profile-step__image-edit {
@@ -5519,6 +5525,28 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		rgb(15 23 42 / 0.1),
 		0 calc(var(--wrapped-card-render-scale, 1) * 5px)
 		calc(var(--wrapped-card-render-scale, 1) * 14px) rgb(15 23 42 / 0.08);
+}
+
+.mymind-wrapped-card-profile-step__name-display {
+	display: block;
+	width: 100%;
+	border: 0;
+	padding: 0;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	letter-spacing: inherit;
+	line-height: inherit;
+	text-align: inherit;
+	cursor: text;
+	appearance: none;
+}
+
+.mymind-wrapped-card-profile-step__name-display:focus-visible {
+	border-radius: calc(var(--wrapped-card-render-scale, 1) * 7px);
+	outline: calc(var(--wrapped-card-render-scale, 1) * 2px) solid
+		rgb(37 34 32 / 0.18);
+	outline-offset: 0;
 }
 
 .mymind-wrapped-card-profile-step__name-input {
@@ -8094,6 +8122,11 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 @media (min-height: 821px) and (max-height: 900px) {
+	.mymind-wrapped-entry-stage--auth-profile
+		.mymind-wrapped-entry-stage__object--auth-profile {
+		--wrapped-card-profile-card-offset-y: clamp(0.45rem, 2.4svh, 1.1rem);
+	}
+
 	.mymind-wrapped-auth-panel--form {
 		--wrapped-auth-form-overlap: clamp(1.15rem, 2.8svh, 1.55rem);
 	}
@@ -8114,6 +8147,11 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 @media (min-height: 761px) and (max-height: 820px) {
+	.mymind-wrapped-entry-stage--auth-profile
+		.mymind-wrapped-entry-stage__object--auth-profile {
+		--wrapped-card-profile-card-offset-y: clamp(0.55rem, 2.8svh, 1.2rem);
+	}
+
 	.mymind-wrapped-auth-panel--form {
 		--wrapped-auth-form-overlap: clamp(0.9rem, 2.4svh, 1.25rem);
 	}
@@ -8140,6 +8178,11 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 @media (min-height: 721px) and (max-height: 760px) {
+	.mymind-wrapped-entry-stage--auth-profile
+		.mymind-wrapped-entry-stage__object--auth-profile {
+		--wrapped-card-profile-card-offset-y: clamp(0.55rem, 2.6svh, 1rem);
+	}
+
 	.mymind-wrapped-auth-panel--form {
 		--wrapped-auth-form-overlap: clamp(0.75rem, 2.2svh, 1.2rem);
 	}
@@ -8166,6 +8209,11 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 @media (max-height: 720px) {
+	.mymind-wrapped-entry-stage--auth-profile
+		.mymind-wrapped-entry-stage__object--auth-profile {
+		--wrapped-card-profile-card-offset-y: clamp(0.25rem, 1.6svh, 0.65rem);
+	}
+
 	.mymind-wrapped-shell {
 		--wrapped-shell-top-inset: 20px;
 		--wrapped-shell-inline-inset: 20px;
@@ -8207,6 +8255,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	.mymind-wrapped-auth-card-preview--profile
 		.mymind-wrapped-auth-card-preview__tilt {
 		--wrapped-card-render-scale: 0.98;
+		--wrapped-short-card-scale: 0.94;
 	}
 
 	.mymind-wrapped-auth-form__scene--email {
@@ -8340,6 +8389,11 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 @media (max-height: 600px) {
+	.mymind-wrapped-auth-card-preview--profile
+		.mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-short-card-scale: 0.9;
+	}
+
 	.mymind-wrapped-entry-stage--auth {
 		gap: 0.45rem;
 	}
@@ -8350,6 +8404,13 @@ body.mymind-wrapped-body #cw-bubble-holder {
 
 	.mymind-wrapped-auth-panel--form .mymind-wrapped-auth-card-preview__tilt {
 		--wrapped-short-card-scale: 0.48;
+	}
+}
+
+@media (max-height: 520px) {
+	.mymind-wrapped-auth-card-preview--profile
+		.mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-short-card-scale: 0.84;
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep the wrapped profile card editable after saving the display name
- add profile-card back navigation from the setup step when arriving from card setup
- soften profile-card short-height scaling and spacing so small browser heights do not shrink the card too aggressively

## Test plan
- [x] bun run lint:wrapped:hig
- [x] bun run verify