### PR TITLE
fix: skip model mom for single-source wrapped data

### DIFF
--- a/apps/web/src/features/wrapped/onboarding/models.ts
+++ b/apps/web/src/features/wrapped/onboarding/models.ts
@@ -12,6 +12,7 @@ import {
 import {
 	formatModelStageSourceLabel,
 	getModelStageTone,
+	hasModelStageSourceComparison,
 	resolveModelPreviewInput,
 	resolveModelStageModel,
 } from "./models/model-mix";
@@ -65,6 +66,7 @@ export {
 	getSkillsScrollableCardStyle,
 	getToolsEntryStyle,
 	getToolsStackHeightRem,
+	hasModelStageSourceComparison,
 	resolveLockInPreviewInput,
 	resolveLockInStageModel,
 	resolveModelPreviewInput,

--- a/apps/web/src/features/wrapped/onboarding/models/model-mix.test.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/model-mix.test.ts
@@ -1,7 +1,109 @@
+import type { WrappedSourceSplit } from "@rudel/api-routes";
 import { describe, expect, it } from "vitest";
-import { resolveModelStageModel } from "./model-mix";
+import {
+	hasModelStageSourceComparison,
+	resolveModelStageModel,
+} from "./model-mix";
+
+const claudeOnlySourceSplit = [
+	{
+		session_count: 7,
+		session_share_percent: 100,
+		source: "claude_code",
+	},
+	{
+		session_count: 0,
+		session_share_percent: 0,
+		source: "codex",
+	},
+] satisfies readonly WrappedSourceSplit[];
+
+const codexOnlySourceSplit = [
+	{
+		session_count: 0,
+		session_share_percent: 0,
+		source: "claude_code",
+	},
+	{
+		session_count: 9,
+		session_share_percent: 100,
+		source: "codex",
+	},
+] satisfies readonly WrappedSourceSplit[];
+
+const mixedSourceSplit = [
+	{
+		session_count: 7,
+		session_share_percent: 70,
+		source: "claude_code",
+	},
+	{
+		session_count: 3,
+		session_share_percent: 30,
+		source: "codex",
+	},
+] satisfies readonly WrappedSourceSplit[];
 
 describe("resolveModelStageModel", () => {
+	it("does not enable the MoM comparison when Codex has no uploaded sessions", () => {
+		const model = resolveModelStageModel({
+			modelByMonth: [
+				{
+					model: "claude-opus-4-6",
+					month: "2026-04",
+					session_count: 7,
+				},
+			],
+			sourceSplit: claudeOnlySourceSplit,
+		});
+
+		expect(model.hasSourceComparison).toBe(false);
+		expect(hasModelStageSourceComparison(claudeOnlySourceSplit)).toBe(false);
+		expect(model.subline).toBe(
+			"The full-run bar leaned Claude. The month-by-month comparison unlocks once both Claude and Codex have sessions.",
+		);
+	});
+
+	it("does not enable the MoM comparison when Claude has no uploaded sessions", () => {
+		const model = resolveModelStageModel({
+			modelByMonth: [
+				{
+					model: "gpt-5.4",
+					month: "2026-04",
+					session_count: 9,
+				},
+			],
+			sourceSplit: codexOnlySourceSplit,
+		});
+
+		expect(model.hasSourceComparison).toBe(false);
+		expect(hasModelStageSourceComparison(codexOnlySourceSplit)).toBe(false);
+		expect(model.subline).toBe(
+			"The full-run bar leaned Codex. The month-by-month comparison unlocks once both Claude and Codex have sessions.",
+		);
+	});
+
+	it("enables the MoM comparison when both sources have uploaded sessions", () => {
+		const model = resolveModelStageModel({
+			modelByMonth: [
+				{
+					model: "claude-opus-4-6",
+					month: "2026-04",
+					session_count: 7,
+				},
+				{
+					model: "gpt-5.4",
+					month: "2026-04",
+					session_count: 3,
+				},
+			],
+			sourceSplit: mixedSourceSplit,
+		});
+
+		expect(model.hasSourceComparison).toBe(true);
+		expect(hasModelStageSourceComparison(mixedSourceSplit)).toBe(true);
+	});
+
 	it("does not count synthetic model rows as Codex in the monthly chart", () => {
 		const model = resolveModelStageModel({
 			modelByMonth: [

--- a/apps/web/src/features/wrapped/onboarding/models/model-mix.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/model-mix.ts
@@ -25,6 +25,7 @@ interface WrappedModelShareMonth {
 }
 
 interface ModelStageModel {
+	hasSourceComparison: boolean;
 	headline: string;
 	months: readonly WrappedModelShareMonth[];
 	monthsLabel: string;
@@ -219,21 +220,24 @@ export function resolveModelStageModel(input: {
 	const subline =
 		summary.length === 0 && activeMonths.length === 0
 			? "We will chart Claude and Codex once enough history lands."
-			: activeMonths.length === 0
-				? "The full-run split is ready. The month-by-month view needs a little more history."
-				: sourceSplit.isBalanced
-					? "The all-time bar stayed close, and the monthly stacks kept both tools in rotation."
-					: earliestLeader && latestLeader && earliestLeader !== latestLeader
-						? `${earliestLeader} led early, then ${latestLeader} took the latest month.`
-						: overallLeader
-							? `The full-run bar and the monthly stacks both leaned ${overallLeader}.`
-							: "The top bar shows the full-run split. The six stacks show how it moved month to month.";
+			: !sourceSplit.hasSourceComparison && overallLeader
+				? `The full-run bar leaned ${overallLeader}. The month-by-month comparison unlocks once both Claude and Codex have sessions.`
+				: activeMonths.length === 0
+					? "The full-run split is ready. The month-by-month view needs a little more history."
+					: sourceSplit.isBalanced
+						? "The all-time bar stayed close, and the monthly stacks kept both tools in rotation."
+						: earliestLeader && latestLeader && earliestLeader !== latestLeader
+							? `${earliestLeader} led early, then ${latestLeader} took the latest month.`
+							: overallLeader
+								? `The full-run bar and the monthly stacks both leaned ${overallLeader}.`
+								: "The top bar shows the full-run split. The six stacks show how it moved month to month.";
 	const totalSessions = summary.reduce(
 		(sum, segment) => sum + segment.sessionCount,
 		0,
 	);
 
 	return {
+		hasSourceComparison: sourceSplit.hasSourceComparison,
 		headline,
 		months,
 		monthsLabel: `${activeMonths.length} active month${activeMonths.length === 1 ? "" : "s"}`,
@@ -254,6 +258,16 @@ export function formatModelStageSourceLabel(
 
 export function getModelStageTone(source: WrappedSourceSplit["source"]) {
 	return MODEL_STAGE_TONES[source];
+}
+
+export function hasModelStageSourceComparison(
+	sourceSplit: readonly WrappedSourceSplit[],
+) {
+	return MODEL_STAGE_SOURCE_ORDER.every(
+		(source) =>
+			(sourceSplit.find((sourceEntry) => sourceEntry.source === source)
+				?.session_count ?? 0) > 0,
+	);
 }
 
 function buildPreviewMonthlyModelUsage(
@@ -446,6 +460,11 @@ function summarizeModelSourceSplit(
 	return {
 		claudeShare,
 		codexShare,
+		hasSourceComparison: MODEL_STAGE_SOURCE_ORDER.every(
+			(source) =>
+				(summary.find((segment) => segment.source === source)?.sessionCount ??
+					0) > 0,
+		),
 		hasSignal: claudeShare > 0 || codexShare > 0,
 		isBalanced: Math.abs(claudeShare - codexShare) <= 8,
 		leadingLabel: rankedSegments[0]?.label ?? null,

--- a/apps/web/src/features/wrapped/onboarding/shell.test.tsx
+++ b/apps/web/src/features/wrapped/onboarding/shell.test.tsx
@@ -1,0 +1,180 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WrappedTeamCardOnboarding } from "@/features/wrapped/onboarding/shell";
+import type { WrappedOnboardingMetrics } from "@/features/wrapped/onboarding/types";
+
+Object.defineProperty(window, "matchMedia", {
+	writable: true,
+	value: vi.fn().mockImplementation((query: string) => ({
+		matches: query.includes("prefers-reduced-motion"),
+		media: query,
+		onchange: null,
+		addEventListener: vi.fn(),
+		addListener: vi.fn(),
+		dispatchEvent: vi.fn(),
+		removeEventListener: vi.fn(),
+		removeListener: vi.fn(),
+	})),
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("WrappedTeamCardOnboarding model step", () => {
+	it("skips the MoM sequence and advances to the next step when only one source has sessions", async () => {
+		const { container } = renderWrappedTeamCardOnboarding(
+			buildOnboardingMetrics({
+				modelByMonth: [
+					{
+						model: "claude-opus-4-6",
+						month: "2026-04",
+						session_count: 12,
+					},
+				],
+				sourceSplit: [
+					{
+						session_count: 12,
+						session_share_percent: 100,
+						source: "claude_code",
+					},
+					{
+						session_count: 0,
+						session_share_percent: 0,
+						source: "codex",
+					},
+				],
+			}),
+		);
+
+		expect(
+			await screen.findByRole("heading", { name: "Claude pilled." }),
+		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Continue" })).not.toBeDisabled();
+
+		act(() => {
+			fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		});
+
+		expect(
+			container.querySelector(".mymind-wrapped-route--step-pulse"),
+		).not.toBeNull();
+		expect(
+			screen.getByRole("button", {
+				name: "Go to onboarding step 9: Check repo pulse",
+			}),
+		).toHaveAttribute("aria-current", "step");
+		expect(screen.queryByText("Here's how it looked MoM")).toBeNull();
+	});
+
+	it("keeps the MoM sequence when both sources have sessions", async () => {
+		renderWrappedTeamCardOnboarding(
+			buildOnboardingMetrics({
+				modelByMonth: [
+					{
+						model: "claude-opus-4-6",
+						month: "2026-04",
+						session_count: 12,
+					},
+					{
+						model: "gpt-5.4",
+						month: "2026-04",
+						session_count: 8,
+					},
+				],
+				sourceSplit: [
+					{
+						session_count: 12,
+						session_share_percent: 60,
+						source: "claude_code",
+					},
+					{
+						session_count: 8,
+						session_share_percent: 40,
+						source: "codex",
+					},
+				],
+			}),
+		);
+
+		expect(
+			await screen.findByRole("heading", { name: "Claude pilled." }),
+		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Continue" })).not.toBeDisabled();
+
+		act(() => {
+			fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		});
+
+		expect(
+			screen.getByRole("heading", { name: "Here's how it looked MoM" }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("heading", {
+				name: "Your repo pulse is still landing",
+			}),
+		).toBeNull();
+	});
+});
+
+function renderWrappedTeamCardOnboarding(
+	onboardingMetrics: WrappedOnboardingMetrics,
+) {
+	return render(
+		<MemoryRouter initialEntries={["/wrapped?step=model"]}>
+			<WrappedTeamCardOnboarding
+				displayName="Ada"
+				finalStage={<div>Final card</div>}
+				onboardingMetrics={onboardingMetrics}
+				totalSessions={onboardingMetrics.totalSessions}
+			/>
+		</MemoryRouter>,
+	);
+}
+
+function buildOnboardingMetrics(input: {
+	modelByMonth: WrappedOnboardingMetrics["modelByMonth"];
+	sourceSplit: WrappedOnboardingMetrics["sourceSplit"];
+}): WrappedOnboardingMetrics {
+	const totalSessions = input.sourceSplit.reduce(
+		(sum, sourceEntry) => sum + sourceEntry.session_count,
+		0,
+	);
+
+	return {
+		activeDays: 4,
+		avgSessionMin: 24,
+		commitRate: null,
+		commitSessions: 0,
+		daysSinceFirst: 12,
+		estimatedCostTokenBasis: 0,
+		estimatedCostUsd: 0,
+		favoriteModel: null,
+		longestSessionMin: 72,
+		modelByMonth: input.modelByMonth,
+		repoPulse: {
+			entries: [],
+			leadRepoName: null,
+			totalRepos: 0,
+			totalSessions: 0,
+		},
+		skillsAdoptionRate: null,
+		slashCommandsAdoptionRate: null,
+		sourceSplit: input.sourceSplit,
+		subagentsAdoptionRate: null,
+		successRate: null,
+		topProjectName: null,
+		topProjectSessions: 0,
+		topProjectTokens: 0,
+		topSkills: [],
+		topSlashCommand: null,
+		topSlashCommandCount: null,
+		topSlashCommands: [],
+		topSubagent: null,
+		topSubagentCount: null,
+		topSubagents: [],
+		totalSessions,
+		totalTokens: 120_000,
+	};
+}

--- a/apps/web/src/features/wrapped/onboarding/shell.tsx
+++ b/apps/web/src/features/wrapped/onboarding/shell.tsx
@@ -6,7 +6,7 @@ import {
 	useReducedMotion,
 } from "motion/react";
 import type { ReactNode } from "react";
-import { startTransition, useRef, useState } from "react";
+import { startTransition, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useMountEffect } from "@/hooks/useMountEffect";
 import { cn } from "@/lib/utils";
@@ -27,7 +27,11 @@ import {
 	getStepPreviewStateParam,
 	resolveActiveStepIndex,
 } from "./helpers";
-import { resolveScalePreviewTokens } from "./models";
+import {
+	hasModelStageSourceComparison,
+	resolveModelPreviewInput,
+	resolveScalePreviewTokens,
+} from "./models";
 import {
 	WrappedOnboardingScaleRainBackdrop,
 	WrappedOnboardingStage,
@@ -169,6 +173,26 @@ export function WrappedTeamCardOnboarding(
 					activePreviewState,
 				)
 			: 0;
+	const shouldPlayModelHistorySequence = useMemo(() => {
+		if (!isModelStep) {
+			return false;
+		}
+
+		const modelPreviewInput = resolveModelPreviewInput(
+			{
+				modelByMonth: onboardingMetrics.modelByMonth,
+				sourceSplit: onboardingMetrics.sourceSplit,
+			},
+			activePreviewState,
+		);
+
+		return hasModelStageSourceComparison(modelPreviewInput.sourceSplit);
+	}, [
+		activePreviewState,
+		isModelStep,
+		onboardingMetrics.modelByMonth,
+		onboardingMetrics.sourceSplit,
+	]);
 	const effectiveScaleAdvanceState = isScaleStep ? scaleAdvanceState : "idle";
 	const isScaleAdvancePending =
 		effectiveScaleAdvanceState === "spend" ||
@@ -306,6 +330,11 @@ export function WrappedTeamCardOnboarding(
 			}
 
 			if (!isModelComparisonSequenceComplete) {
+				return;
+			}
+
+			if (!shouldPlayModelHistorySequence) {
+				goToStep(nextStepIndex);
 				return;
 			}
 

--- a/apps/web/src/features/wrapped/onboarding/stages/model.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/model.tsx
@@ -155,6 +155,7 @@ export function WrappedOnboardingModelStage(props: ModelStageProps) {
 	const shouldReduceMotion = useReducedMotion();
 	const reduceMotion = shouldReduceMotion ?? false;
 	const hasAnimatedData = model.summary.length > 0;
+	const shouldShowHistorySequence = model.hasSourceComparison;
 	const leadingSource = getLeadingModelStageSource(model.summary);
 	const resultHeadline = getModelStageResultHeadline(leadingSource);
 	const splitCards = [
@@ -229,7 +230,7 @@ export function WrappedOnboardingModelStage(props: ModelStageProps) {
 			return;
 		}
 
-		if (!hasAnimatedData) {
+		if (!hasAnimatedData || !shouldShowHistorySequence) {
 			onHistoryRevealComplete?.();
 			return;
 		}
@@ -256,7 +257,13 @@ export function WrappedOnboardingModelStage(props: ModelStageProps) {
 		return () => {
 			clearModelStageSequenceTimers(sequenceTimerRefs);
 		};
-	}, [advanceState, hasAnimatedData, onHistoryRevealComplete, reduceMotion]);
+	}, [
+		advanceState,
+		hasAnimatedData,
+		onHistoryRevealComplete,
+		reduceMotion,
+		shouldShowHistorySequence,
+	]);
 
 	if (!hasAnimatedData) {
 		return (


### PR DESCRIPTION
## Summary
- gate the wrapped model MoM/history sequence on both Claude and Codex having uploaded session counts
- skip the model history advance when one source is zero, so users continue to the next story step
- add regression coverage for Claude-only, Codex-only, and mixed-source source splits

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig

🤖 Generated with [Claude Code](https://claude.com/claude-code)