### PR TITLE
fix: truncate wrapped favorite skill label

### DIFF
--- a/apps/web/src/features/wrapped/team-card/back-metrics.ts
+++ b/apps/web/src/features/wrapped/team-card/back-metrics.ts
@@ -113,8 +113,9 @@ export function buildWrappedTeamCardBackMetrics(input: {
 			value: formatWrappedBackInteger(skillSessionsUsed),
 		},
 		{
-			label: "Favorite skill",
+			label: "FAV SKILL",
 			value: onboardingMetrics.topSkills[0]?.name ?? "Skill issue",
+			valueTruncation: "start",
 		},
 		{
 			label: "Commands used",

--- a/apps/web/src/features/wrapped/team-card/card-back.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/card-back.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
+import type { WrappedOnboardingMetrics } from "@/features/wrapped/onboarding/types";
+import { buildWrappedTeamCardBackMetrics } from "@/features/wrapped/team-card/back-metrics";
+import {
+	WrappedTeamMemberCardBack,
+	type WrappedTeamMemberCardBackMetric,
+} from "@/features/wrapped/team-card/card-back";
+
+describe("WrappedTeamMemberCardBack", () => {
+	it("marks start-truncated metric values", () => {
+		const metrics = [
+			{
+				label: "FAV SKILL",
+				value: "extremely-long-favorite-skill-name",
+				valueTruncation: "start",
+			},
+		] satisfies readonly WrappedTeamMemberCardBackMetric[];
+
+		render(<WrappedTeamMemberCardBack metrics={metrics} />);
+
+		const metricRow = screen.getByText("FAV SKILL").closest("tr");
+		expect(metricRow).toHaveClass(
+			"mymind-wrapped-team-card-back__metric-row--value-truncate-start",
+		);
+		expect(
+			screen.getByText("extremely-long-favorite-skill-name"),
+		).toHaveAttribute("title", "extremely-long-favorite-skill-name");
+	});
+
+	it("marks the favorite skill metric for start truncation", () => {
+		const metrics = buildWrappedTeamCardBackMetrics({
+			onboardingMetrics,
+			row,
+			shareCardCreatedAtLabel: "Apr 28, 2026",
+		});
+
+		expect(
+			metrics.find((metric) => metric.label === "FAV SKILL"),
+		).toMatchObject({
+			value: "long-context-refactor-orchestration",
+			valueTruncation: "start",
+		});
+	});
+});
+
+const row = {
+	activeDays: 2,
+	cost: 4,
+	displayName: "Maya Chen",
+	email: null,
+	favoriteModel: "claude-sonnet-4.5",
+	hasActivity: true,
+	imageUrl: null,
+	inputTokens: 1000,
+	lastActiveDate: "2026-04-28",
+	outputTokens: 2000,
+	role: "Engineer",
+	totalSessions: 8,
+	totalTokens: 3000,
+	userId: "user-1",
+} satisfies TeamPageMemberRow;
+
+const onboardingMetrics = {
+	activeDays: 2,
+	avgSessionMin: 12,
+	commitRate: 50,
+	commitSessions: 4,
+	daysSinceFirst: 8,
+	estimatedCostTokenBasis: 3000,
+	estimatedCostUsd: 4,
+	favoriteModel: "claude-sonnet-4.5",
+	longestSessionMin: 32,
+	modelByMonth: [],
+	repoPulse: {
+		entries: [],
+		leadRepoName: null,
+		totalRepos: 1,
+		totalSessions: 8,
+	},
+	skillsAdoptionRate: 50,
+	slashCommandsAdoptionRate: 25,
+	sourceSplit: [],
+	subagentsAdoptionRate: 0,
+	successRate: 75,
+	topProjectName: "rudel",
+	topProjectSessions: 8,
+	topProjectTokens: 3000,
+	topSkills: [{ count: 4, name: "long-context-refactor-orchestration" }],
+	topSlashCommand: "/test",
+	topSlashCommandCount: 2,
+	topSlashCommands: [{ count: 2, name: "/test" }],
+	topSubagent: null,
+	topSubagentCount: 0,
+	topSubagents: [],
+	totalSessions: 8,
+	totalTokens: 3000,
+} satisfies WrappedOnboardingMetrics;

--- a/apps/web/src/features/wrapped/team-card/card-back.tsx
+++ b/apps/web/src/features/wrapped/team-card/card-back.tsx
@@ -7,6 +7,7 @@ export interface WrappedTeamMemberCardBackMetric {
 	label: string;
 	slot?: "body" | "footer";
 	value: string;
+	valueTruncation?: "start";
 }
 
 export type WrappedTeamMemberCardBackVariant = "default" | "gradient-only";
@@ -146,12 +147,22 @@ function WrappedTeamMemberCardBackMetricRow(props: {
 	const { metric } = props;
 
 	return (
-		<tr className="mymind-wrapped-team-card-back__metric-row">
+		<tr
+			className={cn(
+				"mymind-wrapped-team-card-back__metric-row",
+				metric.valueTruncation === "start"
+					? "mymind-wrapped-team-card-back__metric-row--value-truncate-start"
+					: null,
+			)}
+		>
 			<th scope="row" className="mymind-wrapped-team-card-back__metric-label">
 				{metric.label}
 			</th>
 			<td className="mymind-wrapped-team-card-back__metric-value">
-				<span className="mymind-wrapped-team-card-back__metric-value-text">
+				<span
+					className="mymind-wrapped-team-card-back__metric-value-text"
+					title={metric.valueTruncation === "start" ? metric.value : undefined}
+				>
 					{metric.value}
 				</span>
 			</td>

--- a/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
@@ -579,7 +579,7 @@ describe("WrappedTeamCardRevealStage", () => {
 		expect(screen.getByText("120K")).toBeInTheDocument();
 		expect(screen.getByText("Skills used")).toBeInTheDocument();
 		expect(screen.getByText("23")).toBeInTheDocument();
-		expect(screen.getByText("Favorite skill")).toBeInTheDocument();
+		expect(screen.getByText("FAV SKILL")).toBeInTheDocument();
 		expect(screen.getByText("Refactor")).toBeInTheDocument();
 		expect(screen.getByText("Commands used")).toBeInTheDocument();
 		expect(screen.getAllByText("11")[0]).toBeInTheDocument();

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -7605,21 +7605,41 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 .mymind-wrapped-team-card-back__metric-value {
+	width: 44%;
+	min-width: 0;
+	overflow: clip;
 	text-align: right;
 }
 
 .mymind-wrapped-team-card-back__metric-value-text {
 	display: block;
+	max-width: 100%;
 	font-size: calc(var(--wrapped-card-render-scale, 1) * 7.2px);
 	font-family: "Geist Mono", ui-monospace, monospace;
 	font-weight: 500;
 	letter-spacing: 0.08em;
 	line-height: 1.1;
+	overflow: clip;
 	overflow-wrap: anywhere;
 	text-align: right;
+	text-overflow: ellipsis;
 	text-transform: uppercase;
 	white-space: nowrap;
 	color: var(--wrapped-team-card-back-muted);
+}
+
+.mymind-wrapped-team-card-back__metric-row--value-truncate-start
+	.mymind-wrapped-team-card-back__metric-value {
+	overflow: visible;
+}
+
+.mymind-wrapped-team-card-back__metric-row--value-truncate-start
+	.mymind-wrapped-team-card-back__metric-value-text {
+	direction: rtl;
+	width: calc(100% + var(--wrapped-card-render-scale, 1) * 18px);
+	max-width: none;
+	margin-left: calc(var(--wrapped-card-render-scale, 1) * -18px);
+	text-align: right;
 }
 
 .mymind-wrapped-team-card-back__footer-lockup {


### PR DESCRIPTION
## Summary
- abbreviate the wrapped card back metric label to `FAV SKILL`
- add start-truncation support for long metric values while keeping the full value in the title
- constrain the card-back value column so long favorite skills clip without overlapping the label
- add card-back coverage for the truncation marker and generated metric

## Test plan
- [x] bun run lint:wrapped:hig
- [x] bun run test src/features/wrapped/team-card/card-back.test.tsx src/features/wrapped/team-card/final-stages.test.tsx
- [x] bun run verify