### PR TITLE
fix: speed up wrapped setup upload polling

### DIFF
--- a/apps/web/src/features/get-started/use-setup-progress.polling.test.tsx
+++ b/apps/web/src/features/get-started/use-setup-progress.polling.test.tsx
@@ -1,0 +1,133 @@
+import {
+	QueryClient,
+	type QueryClientConfig,
+	QueryClientProvider,
+} from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSetupProgress } from "@/features/get-started/use-setup-progress";
+
+const {
+	mockGetOrganizationSessionCount,
+	mockSummaryQueryOptions,
+	mockUseAnalyticsQuery,
+	mockUseOrganization,
+} = vi.hoisted(() => ({
+	mockGetOrganizationSessionCount: vi.fn(),
+	mockSummaryQueryOptions: vi.fn(),
+	mockUseAnalyticsQuery: vi.fn(),
+	mockUseOrganization: vi.fn(),
+}));
+
+vi.mock("@/features/analytics/queries/useAnalyticsQuery", () => ({
+	useAnalyticsQuery: mockUseAnalyticsQuery,
+}));
+
+vi.mock("@/features/workspace/organization/useOrganization", () => ({
+	useOrganization: mockUseOrganization,
+}));
+
+vi.mock("@/lib/orpc", () => ({
+	client: {
+		getOrganizationSessionCount: mockGetOrganizationSessionCount,
+	},
+	orpc: {
+		analytics: {
+			sessions: {
+				summary: {
+					queryOptions: mockSummaryQueryOptions,
+				},
+			},
+		},
+	},
+}));
+
+const queryClientConfig: QueryClientConfig = {
+	defaultOptions: {
+		queries: {
+			gcTime: Infinity,
+			retry: false,
+			staleTime: 0,
+		},
+	},
+};
+
+function createWrapper(queryClient: QueryClient) {
+	return function TestQueryClientProvider(props: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={queryClient}>
+				{props.children}
+			</QueryClientProvider>
+		);
+	};
+}
+
+describe("useSetupProgress polling", () => {
+	beforeEach(() => {
+		mockGetOrganizationSessionCount.mockReset();
+		mockSummaryQueryOptions.mockReset();
+		mockUseAnalyticsQuery.mockReset();
+		mockUseOrganization.mockReset();
+
+		mockSummaryQueryOptions.mockReturnValue({
+			queryKey: ["analytics", "sessions", "summary"],
+		});
+		mockUseOrganization.mockReturnValue({
+			state: {
+				activeOrg: {
+					id: "org-1",
+					name: "Org",
+					slug: "org",
+				},
+				isLoading: false,
+				organizations: [],
+			},
+		});
+		mockUseAnalyticsQuery.mockReturnValue({
+			data: {
+				total_sessions: 0,
+			},
+			isFetched: true,
+			isPending: false,
+		});
+	});
+
+	it("detects uploaded sessions on the next one-second raw-count poll", async () => {
+		const queryClient = new QueryClient(queryClientConfig);
+		mockGetOrganizationSessionCount
+			.mockResolvedValueOnce({ count: 0 })
+			.mockResolvedValueOnce({ count: 0 })
+			.mockResolvedValueOnce({ count: 1 });
+
+		const { result } = renderHook(() => useSetupProgress(), {
+			wrapper: createWrapper(queryClient),
+		});
+
+		await waitFor(() => {
+			expect(mockGetOrganizationSessionCount).toHaveBeenCalledTimes(1);
+		});
+		expect(result.current.hasUploadedSessions).toBe(false);
+		expect(result.current.totalSessionCount).toBe(0);
+
+		await waitFor(
+			() => {
+				expect(mockGetOrganizationSessionCount).toHaveBeenCalledTimes(2);
+			},
+			{ timeout: 1_500 },
+		);
+		expect(result.current.hasUploadedSessions).toBe(false);
+		expect(result.current.totalSessionCount).toBe(0);
+
+		await waitFor(
+			() => {
+				expect(result.current.hasUploadedSessions).toBe(true);
+			},
+			{ timeout: 1_500 },
+		);
+		expect(mockGetOrganizationSessionCount).toHaveBeenCalledTimes(3);
+		expect(result.current.totalSessionCount).toBe(1);
+
+		queryClient.clear();
+	});
+});

--- a/apps/web/src/features/get-started/use-setup-progress.ts
+++ b/apps/web/src/features/get-started/use-setup-progress.ts
@@ -1,9 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
 import { useAnalyticsQuery } from "@/features/analytics/queries/useAnalyticsQuery";
 import { useOrganization } from "@/features/workspace/organization/useOrganization";
-import { orpc } from "@/lib/orpc";
+import { client, orpc } from "@/lib/orpc";
 
 const SETUP_PROGRESS_LOOKBACK_DAYS = 365;
 const SETUP_PROGRESS_REFETCH_INTERVAL_MS = 3_000;
+const SETUP_PROGRESS_LANDING_REFETCH_INTERVAL_MS = 1_000;
 
 export function useSetupProgress({
 	enabled = true,
@@ -11,10 +13,14 @@ export function useSetupProgress({
 	enabled?: boolean;
 } = {}) {
 	const { state } = useOrganization();
+	const activeOrganizationId = state.activeOrg?.id;
 	const summaryQuery = useAnalyticsQuery({
 		...orpc.analytics.sessions.summary.queryOptions({
 			input: { days: SETUP_PROGRESS_LOOKBACK_DAYS },
 		}),
+		refetchIntervalInBackground: true,
+		refetchOnReconnect: "always",
+		refetchOnWindowFocus: "always",
 		enabled,
 		refetchInterval: (query) => {
 			const totalSessions = query.state.data?.total_sessions ?? 0;
@@ -25,12 +31,42 @@ export function useSetupProgress({
 			return SETUP_PROGRESS_REFETCH_INTERVAL_MS;
 		},
 	});
+	const rawSessionCountQuery = useQuery({
+		queryKey: ["setup-progress", "raw-session-count", activeOrganizationId],
+		queryFn: async () => {
+			if (!activeOrganizationId) {
+				return { count: 0 };
+			}
 
-	const totalSessionCount = summaryQuery.data?.total_sessions ?? 0;
+			return client.getOrganizationSessionCount({
+				organizationId: activeOrganizationId,
+			});
+		},
+		enabled: enabled && !!activeOrganizationId,
+		refetchInterval: (query) => {
+			const totalSessions = query.state.data?.count ?? 0;
+			if (!enabled || totalSessions > 0) {
+				return false;
+			}
+
+			return SETUP_PROGRESS_LANDING_REFETCH_INTERVAL_MS;
+		},
+		refetchIntervalInBackground: true,
+		refetchOnReconnect: "always",
+		refetchOnWindowFocus: "always",
+	});
+
+	const totalSessionCount = Math.max(
+		summaryQuery.data?.total_sessions ?? 0,
+		rawSessionCountQuery.data?.count ?? 0,
+	);
 	const isInitialLoading =
 		enabled &&
 		!summaryQuery.isFetched &&
-		(state.isLoading || summaryQuery.isPending);
+		!rawSessionCountQuery.isFetched &&
+		(state.isLoading ||
+			summaryQuery.isPending ||
+			rawSessionCountQuery.isPending);
 
 	return {
 		hasUploadedSessions: totalSessionCount > 0,

--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, useSearchParams } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -87,13 +87,19 @@ vi.mock("@/features/wrapped/WrappedSetupPage", () => ({
 		currentStepIdOverride,
 		initialStepId,
 		onBack,
+		onContinue,
 	}: {
 		completedStepIdsOverride?: readonly CliSetupStepId[];
 		currentStepIdOverride?: CliSetupStepId | null;
 		initialStepId?: CliSetupStepId;
 		onBack?: () => void;
+		onContinue?: () => void;
 	}) => {
 		const [searchParams] = useSearchParams();
+		const completedStepIds = new Set(completedStepIdsOverride ?? []);
+		const isSetupComplete =
+			completedStepIds.has("install-and-login") &&
+			completedStepIds.has("enable-auto-upload");
 
 		return (
 			<div>
@@ -112,6 +118,15 @@ vi.mock("@/features/wrapped/WrappedSetupPage", () => ({
 						? completedStepIdsOverride.join(",")
 						: "none"}
 				</div>
+				{onContinue ? (
+					<button
+						type="button"
+						disabled={!isSetupComplete}
+						onClick={onContinue}
+					>
+						Continue
+					</button>
+				) : null}
 			</div>
 		);
 	},
@@ -358,6 +373,7 @@ describe("WrappedRouteGate", () => {
 			screen.getByText("Setup current step: install-and-login"),
 		).toBeInTheDocument();
 		expect(screen.getByText("Setup completed steps: none")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
 	});
 
 	it("renders upload setup when CLI login is complete but no sessions were uploaded", () => {
@@ -379,6 +395,7 @@ describe("WrappedRouteGate", () => {
 		expect(
 			screen.getByText("Setup completed steps: install-and-login"),
 		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
 	});
 
 	it("keeps showing setup while uploaded sessions are still being checked", () => {
@@ -401,7 +418,9 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByText("Setup completed steps: none")).toBeInTheDocument();
 	});
 
-	it("renders setup completion when sessions already exist but setup is not finished yet", () => {
+	it("marks both setup steps complete when sessions already exist", async () => {
+		const user = userEvent.setup();
+
 		mockUseSetupProgress.mockReturnValue({
 			hasUploadedSessions: true,
 			isLoading: false,
@@ -414,11 +433,24 @@ describe("WrappedRouteGate", () => {
 			</MemoryRouter>,
 		);
 
+		expect(screen.getByText("Wrapped setup page")).toBeInTheDocument();
+		expect(screen.getByText("Setup current step: none")).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"Setup completed steps: install-and-login,enable-auto-upload",
+			),
+		).toBeInTheDocument();
+		const continueButton = screen.getByRole("button", { name: "Continue" });
+		expect(continueButton).toBeEnabled();
+
+		await user.click(continueButton);
+
 		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
 	});
 
-	it("briefly marks upload complete before showing uploaded sessions when sessions land during setup", async () => {
-		vi.useFakeTimers();
+	it("enables setup continue when sessions land during setup", async () => {
+		const user = userEvent.setup();
+
 		mockUseSetupProgress.mockReturnValue({
 			hasUploadedSessions: false,
 			isLoading: false,
@@ -426,7 +458,7 @@ describe("WrappedRouteGate", () => {
 		});
 
 		const { rerender } = render(
-			<MemoryRouter initialEntries={["/wrapped?flow=sessions-landed"]}>
+			<MemoryRouter initialEntries={["/wrapped"]}>
 				<WrappedRouteGate isPending={false} publicId={null} session={session} />
 			</MemoryRouter>,
 		);
@@ -436,6 +468,7 @@ describe("WrappedRouteGate", () => {
 			screen.getByText("Setup current step: install-and-login"),
 		).toBeInTheDocument();
 		expect(screen.getByText("Setup completed steps: none")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
 
 		mockUseSetupProgress.mockReturnValue({
 			hasUploadedSessions: true,
@@ -444,7 +477,7 @@ describe("WrappedRouteGate", () => {
 		});
 
 		rerender(
-			<MemoryRouter initialEntries={["/wrapped?flow=sessions-landed"]}>
+			<MemoryRouter initialEntries={["/wrapped"]}>
 				<WrappedRouteGate isPending={false} publicId={null} session={session} />
 			</MemoryRouter>,
 		);
@@ -456,10 +489,10 @@ describe("WrappedRouteGate", () => {
 				"Setup completed steps: install-and-login,enable-auto-upload",
 			),
 		).toBeInTheDocument();
+		const continueButton = screen.getByRole("button", { name: "Continue" });
+		expect(continueButton).toBeEnabled();
 
-		await act(async () => {
-			vi.advanceTimersByTime(900);
-		});
+		await user.click(continueButton);
 
 		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
 	});
@@ -536,12 +569,13 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
 		await user.click(screen.getByRole("button", { name: "Back to setup" }));
 		expect(screen.getByText("Wrapped setup page")).toBeInTheDocument();
+		expect(screen.getByText("Setup current step: none")).toBeInTheDocument();
 		expect(
-			screen.getByText("Setup current step: enable-auto-upload"),
+			screen.getByText(
+				"Setup completed steps: install-and-login,enable-auto-upload",
+			),
 		).toBeInTheDocument();
-		expect(
-			screen.getByText("Setup completed steps: install-and-login"),
-		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
 	});
 
 	it("restarts the story from scale when continuing from sessions landed", async () => {

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, startTransition, useRef, useState } from "react";
+import { type ReactNode, startTransition, useState } from "react";
 import { useLocation, useSearchParams } from "react-router-dom";
 import { useIsMobile } from "@/app/hooks/use-mobile";
 import {
@@ -67,7 +67,6 @@ const WRAPPED_SETUP_ALL_COMPLETED_STEP_IDS = [
 	WRAPPED_SETUP_AUTH_STEP_ID,
 	WRAPPED_SETUP_UPLOAD_STEP_ID,
 ] as const;
-const WRAPPED_SETUP_UPLOAD_COMPLETE_HOLD_MS = 900;
 
 export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const { isPending, publicId, session } = props;
@@ -100,25 +99,9 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		useState<WrappedGuestPreviewProfile | null>(
 			() => guestPreviewSnapshot?.profile ?? null,
 		);
-	const [uploadCompletionShownUserIds, setUploadCompletionShownUserIds] =
-		useState<Record<string, true>>({});
-	const uploadSetupSeenUserIdsRef = useRef<Record<string, true>>({});
-	const uploadCompletionTimeoutRef = useRef<number | null>(null);
 	const forcedFlowStage = getWrappedRouteFlowStage(
 		searchParams.get(WRAPPED_ROUTE_FLOW_QUERY_PARAM),
 	);
-	const shouldRememberUploadSetupSeen =
-		!publicId &&
-		!isPending &&
-		sessionUserId !== null &&
-		!!session &&
-		!setupProgress.hasUploadedSessions &&
-		forcedFlowStage !== WRAPPED_ROUTE_CARD_PROFILE_FLOW &&
-		!(isMobile && sessionUserEmail);
-
-	if (shouldRememberUploadSetupSeen) {
-		uploadSetupSeenUserIdsRef.current[sessionUserId] = true;
-	}
 
 	const hasCompletedSetup =
 		sessionUserId === null
@@ -144,27 +127,10 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const shouldBacktrackToCardProfile =
 		forcedFlowStage === WRAPPED_ROUTE_DESKTOP_READY_FLOW &&
 		hasCompletedCardProfile;
-	const hasSeenUploadSetup =
-		sessionUserId === null
-			? false
-			: uploadSetupSeenUserIdsRef.current[sessionUserId] === true;
-	const hasShownUploadCompletion =
-		sessionUserId === null
-			? false
-			: uploadCompletionShownUserIds[sessionUserId] === true;
-	const shouldShowUploadCompletionStep =
-		sessionUserId !== null &&
-		setupProgress.hasUploadedSessions &&
-		!hasCompletedSetup &&
-		(hasSeenUploadSetup ||
-			forcedFlowStage === WRAPPED_ROUTE_DESKTOP_READY_FLOW) &&
-		!hasShownUploadCompletion &&
-		forcedFlowStage !== "story";
 	const shouldForceSessionsLanded =
 		forcedFlowStage === "sessions-landed" && setupProgress.hasUploadedSessions;
 	const shouldForceDesktopReady =
-		forcedFlowStage === WRAPPED_ROUTE_DESKTOP_READY_FLOW &&
-		setupProgress.hasUploadedSessions;
+		forcedFlowStage === WRAPPED_ROUTE_DESKTOP_READY_FLOW;
 	const shouldForceStory =
 		forcedFlowStage === "story" && setupProgress.hasUploadedSessions;
 
@@ -215,6 +181,14 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		startWrappedStoryFromBeginning();
 	}
 
+	function handleSetupContinue() {
+		if (!setupProgress.hasUploadedSessions) {
+			return;
+		}
+
+		setWrappedRouteFlowStage("sessions-landed");
+	}
+
 	function updateEditableCardProfile(
 		updates: WrappedGuestPreviewProfileUpdates,
 	) {
@@ -249,33 +223,8 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		document.body.classList.add("mymind-wrapped-body");
 
 		return () => {
-			if (uploadCompletionTimeoutRef.current !== null) {
-				window.clearTimeout(uploadCompletionTimeoutRef.current);
-			}
 			document.body.classList.remove("mymind-wrapped-body");
 		};
-	});
-
-	useEffectOnceWhen({
-		effect: () => {
-			if (!sessionUserId) {
-				return;
-			}
-
-			uploadCompletionTimeoutRef.current = window.setTimeout(() => {
-				uploadCompletionTimeoutRef.current = null;
-				setUploadCompletionShownUserIds((currentState) => ({
-					...currentState,
-					[sessionUserId]: true,
-				}));
-				setWrappedRouteFlowStage("sessions-landed");
-			}, WRAPPED_SETUP_UPLOAD_COMPLETE_HOLD_MS);
-		},
-		isReady: shouldShowUploadCompletionStep,
-		key:
-			sessionUserId === null
-				? null
-				: `${sessionUserId}:wrapped-upload-complete`,
 	});
 
 	useEffectOnceWhen({
@@ -299,24 +248,6 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 			!!shareId &&
 			!setupProgress.isLoading,
 		key: shareId,
-	});
-
-	useEffectOnceWhen({
-		effect: () => {
-			if (forcedFlowStage !== null) {
-				return;
-			}
-
-			setWrappedRouteFlowStage("sessions-landed");
-		},
-		isReady:
-			!publicId &&
-			!isPending &&
-			!!sessionUserId &&
-			setupProgress.hasUploadedSessions &&
-			!hasCompletedSetup &&
-			!shouldShowUploadCompletionStep,
-		key: sessionUserId,
 	});
 
 	let content: ReactNode;
@@ -353,31 +284,16 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 				hasCompletedCliLogin={
 					cliSetupStatus.hasCliLogin || setupProgress.hasUploadedSessions
 				}
+				isUploadComplete={setupProgress.hasUploadedSessions}
 				onBackToCardProfile={
 					shouldBacktrackToCardProfile
 						? () => setWrappedRouteFlowStage(WRAPPED_ROUTE_CARD_PROFILE_FLOW)
 						: undefined
 				}
+				onContinue={handleSetupContinue}
 			/>
 		);
-	} else if (shouldShowUploadCompletionStep) {
-		content = (
-			<WrappedUploadSetupPage
-				isUploadComplete
-				onBackToCardProfile={
-					shouldBacktrackToCardProfile
-						? () => setWrappedRouteFlowStage(WRAPPED_ROUTE_CARD_PROFILE_FLOW)
-						: undefined
-				}
-			/>
-		);
-	} else if (
-		sessionUserId &&
-		(shouldForceSessionsLanded ||
-			(setupProgress.hasUploadedSessions &&
-				sessionUserId &&
-				!hasCompletedSetup))
-	) {
+	} else if (sessionUserId && shouldForceSessionsLanded) {
 		content = (
 			<WrappedSetupCompletePage
 				onBack={() => setWrappedRouteFlowStage("desktop-ready")}
@@ -386,13 +302,20 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 				userId={sessionUserId}
 			/>
 		);
-	} else if (shouldForceStory || setupProgress.hasUploadedSessions) {
+	} else if (
+		shouldForceStory ||
+		(setupProgress.hasUploadedSessions && hasCompletedSetup)
+	) {
 		content = (
 			<WrappedTeamCardPage
 				onBackFromFirstStep={() => setWrappedRouteFlowStage("sessions-landed")}
 			/>
 		);
-	} else if (isMobile && sessionUserEmail) {
+	} else if (
+		isMobile &&
+		sessionUserEmail &&
+		!setupProgress.hasUploadedSessions
+	) {
 		content = (
 			<WrappedDesktopResumePromptPage
 				email={sessionUserEmail}
@@ -402,12 +325,16 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	} else {
 		content = (
 			<WrappedUploadSetupPage
-				hasCompletedCliLogin={cliSetupStatus.hasCliLogin}
+				hasCompletedCliLogin={
+					cliSetupStatus.hasCliLogin || setupProgress.hasUploadedSessions
+				}
+				isUploadComplete={setupProgress.hasUploadedSessions}
 				onBackToCardProfile={
 					shouldBacktrackToCardProfile
 						? () => setWrappedRouteFlowStage(WRAPPED_ROUTE_CARD_PROFILE_FLOW)
 						: undefined
 				}
+				onContinue={handleSetupContinue}
 			/>
 		);
 	}
@@ -493,6 +420,7 @@ function WrappedUploadSetupPage(props: {
 	hasCompletedCliLogin?: boolean;
 	isUploadComplete?: boolean;
 	onBackToCardProfile?: () => void;
+	onContinue?: () => void;
 }) {
 	const completedStepIdsOverride = props.isUploadComplete
 		? WRAPPED_SETUP_ALL_COMPLETED_STEP_IDS
@@ -511,6 +439,7 @@ function WrappedUploadSetupPage(props: {
 			completedStepIdsOverride={completedStepIdsOverride}
 			currentStepIdOverride={currentStepIdOverride}
 			onBack={props.onBackToCardProfile}
+			onContinue={props.onContinue}
 		/>
 	);
 }

--- a/apps/web/src/features/wrapped/WrappedSetupPage.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedSetupPage.test.tsx
@@ -229,6 +229,46 @@ describe("WrappedSetupPage", () => {
 		).toHaveLength(2);
 	});
 
+	it("keeps continue disabled until both setup steps are complete", async () => {
+		const user = userEvent.setup();
+		const handleContinue = vi.fn();
+
+		render(
+			<MemoryRouter>
+				<WrappedSetupPage onContinue={handleContinue} />
+			</MemoryRouter>,
+		);
+
+		const continueButton = screen.getByRole("button", { name: "Continue" });
+		expect(continueButton).toBeDisabled();
+
+		await user.click(continueButton);
+
+		expect(handleContinue).not.toHaveBeenCalled();
+	});
+
+	it("enables continue once both setup steps are complete", async () => {
+		const user = userEvent.setup();
+		const handleContinue = vi.fn();
+
+		render(
+			<MemoryRouter>
+				<WrappedSetupPage
+					completedStepIdsOverride={["install-and-login", "enable-auto-upload"]}
+					currentStepIdOverride={null}
+					onContinue={handleContinue}
+				/>
+			</MemoryRouter>,
+		);
+
+		const continueButton = screen.getByRole("button", { name: "Continue" });
+		expect(continueButton).toBeEnabled();
+
+		await user.click(continueButton);
+
+		expect(handleContinue).toHaveBeenCalledTimes(1);
+	});
+
 	it("reveals upload support after one minute and opens support chat", () => {
 		vi.useFakeTimers();
 

--- a/apps/web/src/features/wrapped/WrappedSetupPage.tsx
+++ b/apps/web/src/features/wrapped/WrappedSetupPage.tsx
@@ -1,3 +1,4 @@
+import { ArrowRight } from "lucide-react";
 import { MotionConfig } from "motion/react";
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
@@ -8,6 +9,7 @@ import {
 } from "@/components/analytics/CliSetupHint";
 import { useMountEffect } from "@/hooks/useMountEffect";
 import { openChatwoot } from "@/lib/chatwoot";
+import { WrappedPrimaryAction } from "./actions";
 import {
 	WrappedDebugControlStack,
 	WrappedRouteStageShell,
@@ -24,6 +26,7 @@ interface WrappedSetupPageProps {
 	debugControls?: ReactNode;
 	initialStepId?: CliSetupStepId;
 	onBack?: () => void;
+	onContinue?: () => void;
 }
 
 export function WrappedSetupPage(props: WrappedSetupPageProps) {
@@ -34,6 +37,7 @@ export function WrappedSetupPage(props: WrappedSetupPageProps) {
 		debugControls,
 		initialStepId,
 		onBack,
+		onContinue,
 	} = props;
 	const lastStepIndex = cliSetupCommands.length - 1;
 	const initialStepIndex = getInitialStepIndex(initialStepId, lastStepIndex);
@@ -53,6 +57,9 @@ export function WrappedSetupPage(props: WrappedSetupPageProps) {
 			? derivedCurrentStepId
 			: currentStepIdOverride;
 	const completedStepIds = completedStepIdsOverride ?? derivedCompletedStepIds;
+	const isSetupComplete = cliSetupCommands.every((step) =>
+		completedStepIds.includes(step.id),
+	);
 	const shouldOfferUploadSupport = currentStepId === "enable-auto-upload";
 
 	return (
@@ -86,6 +93,18 @@ export function WrappedSetupPage(props: WrappedSetupPageProps) {
 					</div>
 				}
 				title="Set up Rudel"
+				footer={
+					onContinue ? (
+						<WrappedPrimaryAction
+							kind="button"
+							disabled={!isSetupComplete}
+							icon={<ArrowRight className="size-4" />}
+							onClick={onContinue}
+						>
+							Continue
+						</WrappedPrimaryAction>
+					) : undefined
+				}
 			/>
 		</MotionConfig>
 	);


### PR DESCRIPTION
## Summary
- poll the raw organization session count every second while wrapped setup is waiting for uploads
- keep the setup page on-screen until both setup cards are green, then enable Continue into Sessions landed
- add focused hook and route tests covering existing sessions, session landing during setup, and the summary-lag case

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig
- [x] bun run test src/features/get-started/use-setup-progress.polling.test.tsx src/features/wrapped/WrappedRouteGate.test.tsx src/features/wrapped/WrappedSetupPage.test.tsx
- [x] bun ./node_modules/.bin/biome check apps/web/src/features/get-started/use-setup-progress.ts apps/web/src/features/get-started/use-setup-progress.polling.test.tsx apps/web/src/features/wrapped/WrappedSetupPage.tsx apps/web/src/features/wrapped/WrappedRouteGate.tsx apps/web/src/features/wrapped/WrappedSetupPage.test.tsx apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
