### PR TITLE
fix: keep wrapped chatwoot close control visible

### DIFF
--- a/apps/web/src/features/wrapped/WrappedCardProfileStep.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedCardProfileStep.test.tsx
@@ -13,6 +13,8 @@ const { mockCloseChatwoot, mockOpenChatwoot, mockSetChatwootBubbleVisibility } =
 	}));
 
 vi.mock("@/lib/chatwoot", () => ({
+	CHATWOOT_CLOSED_EVENT: "chatwoot:closed",
+	CHATWOOT_OPENED_EVENT: "chatwoot:opened",
 	closeChatwoot: mockCloseChatwoot,
 	openChatwoot: mockOpenChatwoot,
 	setChatwootBubbleVisibility: mockSetChatwootBubbleVisibility,

--- a/apps/web/src/features/wrapped/WrappedSetupPage.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedSetupPage.test.tsx
@@ -1,8 +1,11 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WrappedSetupPage } from "@/features/wrapped/WrappedSetupPage";
+
+const CHATWOOT_OPENED_EVENT = "chatwoot:opened";
+const CHATWOOT_CLOSED_EVENT = "chatwoot:closed";
 
 const { mockCloseChatwoot, mockOpenChatwoot, mockSetChatwootBubbleVisibility } =
 	vi.hoisted(() => ({
@@ -12,6 +15,8 @@ const { mockCloseChatwoot, mockOpenChatwoot, mockSetChatwootBubbleVisibility } =
 	}));
 
 vi.mock("@/lib/chatwoot", () => ({
+	CHATWOOT_CLOSED_EVENT: "chatwoot:closed",
+	CHATWOOT_OPENED_EVENT: "chatwoot:opened",
 	closeChatwoot: mockCloseChatwoot,
 	openChatwoot: mockOpenChatwoot,
 	setChatwootBubbleVisibility: mockSetChatwootBubbleVisibility,
@@ -31,12 +36,21 @@ Object.defineProperty(window, "matchMedia", {
 	})),
 });
 
+beforeEach(() => {
+	mockOpenChatwoot.mockImplementation(async () => {
+		window.dispatchEvent(new Event(CHATWOOT_OPENED_EVENT));
+	});
+	mockCloseChatwoot.mockImplementation(async () => {
+		window.dispatchEvent(new Event(CHATWOOT_CLOSED_EVENT));
+	});
+});
+
 afterEach(() => {
 	vi.useRealTimers();
 	window.sessionStorage.clear();
-	mockCloseChatwoot.mockClear();
-	mockOpenChatwoot.mockClear();
-	mockSetChatwootBubbleVisibility.mockClear();
+	mockCloseChatwoot.mockReset();
+	mockOpenChatwoot.mockReset();
+	mockSetChatwootBubbleVisibility.mockReset();
 });
 
 function hasExactTextContent(expectedText: string) {

--- a/apps/web/src/features/wrapped/support-chatwoot-button.test.tsx
+++ b/apps/web/src/features/wrapped/support-chatwoot-button.test.tsx
@@ -1,0 +1,112 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WrappedSupportChatwootButton } from "./support-chatwoot-button";
+
+const CHATWOOT_OPENED_EVENT = "chatwoot:opened";
+const CHATWOOT_CLOSED_EVENT = "chatwoot:closed";
+
+const { mockCloseChatwoot, mockOpenChatwoot } = vi.hoisted(() => ({
+	mockCloseChatwoot: vi.fn(),
+	mockOpenChatwoot: vi.fn(),
+}));
+
+vi.mock("@/lib/chatwoot", () => ({
+	CHATWOOT_CLOSED_EVENT: "chatwoot:closed",
+	CHATWOOT_OPENED_EVENT: "chatwoot:opened",
+	closeChatwoot: mockCloseChatwoot,
+	openChatwoot: mockOpenChatwoot,
+}));
+
+beforeEach(() => {
+	mockOpenChatwoot.mockImplementation(async () => {
+		window.dispatchEvent(new Event(CHATWOOT_OPENED_EVENT));
+	});
+	mockCloseChatwoot.mockImplementation(async () => {
+		window.dispatchEvent(new Event(CHATWOOT_CLOSED_EVENT));
+	});
+});
+
+afterEach(() => {
+	mockCloseChatwoot.mockReset();
+	mockOpenChatwoot.mockReset();
+});
+
+describe("WrappedSupportChatwootButton", () => {
+	it("renders the close control through the document body while support is open", async () => {
+		const user = userEvent.setup();
+
+		render(<WrappedSupportChatwootButton />);
+
+		await user.click(screen.getByRole("button", { name: "Open support" }));
+
+		expect(mockOpenChatwoot).toHaveBeenCalledTimes(1);
+
+		const closeButtons = screen.getAllByRole("button", {
+			name: "Close support",
+		});
+		expect(closeButtons).toHaveLength(1);
+		expect(closeButtons[0].parentElement).toBe(document.body);
+		expect(closeButtons[0]).toHaveStyle({
+			position: "fixed",
+			zIndex: "2147483647",
+		});
+	});
+
+	it("waits for an open signal before replacing the launcher with close", async () => {
+		const user = userEvent.setup();
+		mockOpenChatwoot.mockResolvedValueOnce(undefined);
+
+		render(<WrappedSupportChatwootButton />);
+
+		await user.click(screen.getByRole("button", { name: "Open support" }));
+
+		expect(mockOpenChatwoot).toHaveBeenCalledTimes(1);
+		expect(
+			screen.queryByRole("button", { name: "Close support" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Open support" }),
+		).toBeInTheDocument();
+	});
+
+	it("keeps an externally opened chat closable from the persistent control", async () => {
+		const user = userEvent.setup();
+
+		render(<WrappedSupportChatwootButton />);
+
+		act(() => {
+			window.dispatchEvent(new Event(CHATWOOT_OPENED_EVENT));
+		});
+
+		const closeButton = screen.getByRole("button", { name: "Close support" });
+		expect(closeButton.parentElement).toBe(document.body);
+
+		await user.click(closeButton);
+
+		expect(mockCloseChatwoot).toHaveBeenCalledTimes(1);
+		expect(
+			screen.getByRole("button", { name: "Open support" }),
+		).toBeInTheDocument();
+	});
+
+	it("returns to the launcher when Chatwoot reports that it closed", () => {
+		render(<WrappedSupportChatwootButton />);
+
+		act(() => {
+			window.dispatchEvent(new Event(CHATWOOT_OPENED_EVENT));
+		});
+
+		expect(
+			screen.getByRole("button", { name: "Close support" }),
+		).toBeInTheDocument();
+
+		act(() => {
+			window.dispatchEvent(new Event(CHATWOOT_CLOSED_EVENT));
+		});
+
+		expect(
+			screen.getByRole("button", { name: "Open support" }),
+		).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/wrapped/support-chatwoot-button.tsx
+++ b/apps/web/src/features/wrapped/support-chatwoot-button.tsx
@@ -1,10 +1,22 @@
 import { HelpCircle, X } from "lucide-react";
+import type { CSSProperties } from "react";
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { useMountEffect } from "@/hooks/useMountEffect";
-import { closeChatwoot, openChatwoot } from "@/lib/chatwoot";
+import {
+	CHATWOOT_CLOSED_EVENT,
+	CHATWOOT_OPENED_EVENT,
+	closeChatwoot,
+	openChatwoot,
+} from "@/lib/chatwoot";
 
-const CHATWOOT_OPENED_EVENT = "chatwoot:opened";
-const CHATWOOT_CLOSED_EVENT = "chatwoot:closed";
+const PERSISTENT_CLOSE_CONTROL_STYLE = {
+	position: "fixed",
+	top: "calc(env(safe-area-inset-top, 0px) + 24px)",
+	right:
+		"var(--wrapped-chatwoot-right-offset, calc(env(safe-area-inset-right, 0px) + 16px))",
+	zIndex: 2_147_483_647,
+} satisfies CSSProperties;
 
 export function WrappedSupportChatwootButton() {
 	const [isChatwootOpen, setIsChatwootOpen] = useState(false);
@@ -29,16 +41,14 @@ export function WrappedSupportChatwootButton() {
 
 	async function handleClick() {
 		if (isChatwootOpen) {
-			setIsChatwootOpen(false);
 			await closeChatwoot();
 			return;
 		}
 
-		setIsChatwootOpen(true);
 		await openChatwoot();
 	}
 
-	return (
+	const control = (
 		<button
 			type="button"
 			aria-label={isChatwootOpen ? "Close support" : "Open support"}
@@ -51,5 +61,32 @@ export function WrappedSupportChatwootButton() {
 				<HelpCircle className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
 			)}
 		</button>
+	);
+
+	if (!isChatwootOpen) {
+		return control;
+	}
+
+	return (
+		<>
+			<span
+				aria-hidden="true"
+				className="mymind-wrapped-top-tray__utility-placeholder"
+			/>
+			{typeof document === "undefined"
+				? null
+				: createPortal(
+						<button
+							type="button"
+							aria-label="Close support"
+							className="mymind-wrapped-top-tray__edge-control"
+							style={PERSISTENT_CLOSE_CONTROL_STYLE}
+							onClick={() => void handleClick()}
+						>
+							<X className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
+						</button>,
+						document.body,
+					)}
+		</>
 	);
 }

--- a/apps/web/src/lib/chatwoot.test.ts
+++ b/apps/web/src/lib/chatwoot.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	CHATWOOT_CLOSED_EVENT,
+	CHATWOOT_OPENED_EVENT,
+	closeChatwoot,
+	openChatwoot,
+} from "./chatwoot";
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	delete window.$chatwoot;
+});
+
+function stubLoadedChatwoot(toggle: (state?: "open" | "close") => void) {
+	window.$chatwoot = {
+		hasLoaded: true,
+		reset: vi.fn(),
+		setLabel: vi.fn(),
+		setUser: vi.fn(),
+		toggle,
+	};
+}
+
+function stubChatwootEnv() {
+	vi.stubEnv("VITE_CHATWOOT_BASE_URL", "https://app.chatwoot.com");
+	vi.stubEnv("VITE_CHATWOOT_WEBSITE_TOKEN", "website-token");
+}
+
+describe("chatwoot", () => {
+	it("dispatches a window event after opening the loaded widget", async () => {
+		const handleOpened = vi.fn();
+		const toggle = vi.fn();
+
+		stubChatwootEnv();
+		stubLoadedChatwoot(toggle);
+		window.addEventListener(CHATWOOT_OPENED_EVENT, handleOpened);
+
+		await openChatwoot();
+
+		window.removeEventListener(CHATWOOT_OPENED_EVENT, handleOpened);
+		expect(toggle).toHaveBeenCalledWith("open");
+		expect(handleOpened).toHaveBeenCalledTimes(1);
+	});
+
+	it("dispatches a window event after closing the loaded widget", async () => {
+		const handleClosed = vi.fn();
+		const toggle = vi.fn();
+
+		stubChatwootEnv();
+		stubLoadedChatwoot(toggle);
+		window.addEventListener(CHATWOOT_CLOSED_EVENT, handleClosed);
+
+		await closeChatwoot();
+
+		window.removeEventListener(CHATWOOT_CLOSED_EVENT, handleClosed);
+		expect(toggle).toHaveBeenCalledWith("close");
+		expect(handleClosed).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/lib/chatwoot.ts
+++ b/apps/web/src/lib/chatwoot.ts
@@ -38,6 +38,9 @@ declare global {
 const SCRIPT_ID = "rudel-chatwoot-sdk";
 const LOAD_TIMEOUT_MS = 5_000;
 
+export const CHATWOOT_OPENED_EVENT = "chatwoot:opened";
+export const CHATWOOT_CLOSED_EVENT = "chatwoot:closed";
+
 let loadPromise: Promise<void> | null = null;
 
 function getChatwootConfig(): ChatwootConfig | null {
@@ -87,6 +90,14 @@ function runChatwoot(config: ChatwootConfig) {
 		websiteToken: config.websiteToken,
 		baseUrl: config.baseUrl,
 	});
+}
+
+function dispatchChatwootStateEvent(eventName: string) {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	window.dispatchEvent(new Event(eventName));
 }
 
 export function isChatwootEnabled() {
@@ -171,7 +182,13 @@ export async function ensureChatwootLoaded(): Promise<void> {
 export async function openChatwoot() {
 	try {
 		await ensureChatwootLoaded();
-		window.$chatwoot?.toggle("open");
+		const api = window.$chatwoot;
+		if (!api) {
+			return;
+		}
+
+		api.toggle("open");
+		dispatchChatwootStateEvent(CHATWOOT_OPENED_EVENT);
 	} catch {
 		// Ignore widget load failures so the dashboard remains functional.
 	}
@@ -180,7 +197,13 @@ export async function openChatwoot() {
 export async function closeChatwoot() {
 	try {
 		await ensureChatwootLoaded();
-		window.$chatwoot?.toggle("close");
+		const api = window.$chatwoot;
+		if (!api) {
+			return;
+		}
+
+		api.toggle("close");
+		dispatchChatwootStateEvent(CHATWOOT_CLOSED_EVENT);
 	} catch {
 		// Ignore widget load failures so the dashboard remains functional.
 	}


### PR DESCRIPTION
## Summary
- Dispatch shared Chatwoot open/close events after successful SDK toggles.
- Keep the wrapped close control available above the Chatwoot iframe once the chat is actually open.
- Add focused tests for Chatwoot state events and the persistent wrapped support control.

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig
- [x] bun --cwd apps/web test src/lib/chatwoot.test.ts src/features/wrapped/support-chatwoot-button.test.tsx src/features/wrapped/WrappedSetupPage.test.tsx src/features/wrapped/WrappedAuthFlow.test.tsx src/features/wrapped/WrappedCardProfileStep.test.tsx
- [x] bun --cwd apps/web check-types