### PR TITLE
fix: use circled wrapped chatwoot close icon

### DIFF
--- a/apps/web/src/features/wrapped/support-chatwoot-button.tsx
+++ b/apps/web/src/features/wrapped/support-chatwoot-button.tsx
@@ -1,4 +1,4 @@
-import { HelpCircle, X } from "lucide-react";
+import { HelpCircle, XCircle } from "lucide-react";
 import type { CSSProperties } from "react";
 import { useState } from "react";
 import { createPortal } from "react-dom";
@@ -56,7 +56,7 @@ export function WrappedSupportChatwootButton() {
 			onClick={() => void handleClick()}
 		>
 			{isChatwootOpen ? (
-				<X className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
+				<XCircle className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
 			) : (
 				<HelpCircle className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
 			)}
@@ -83,7 +83,7 @@ export function WrappedSupportChatwootButton() {
 							style={PERSISTENT_CLOSE_CONTROL_STYLE}
 							onClick={() => void handleClick()}
 						>
-							<X className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
+							<XCircle className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
 						</button>,
 						document.body,
 					)}


### PR DESCRIPTION
## Summary
- Replace the standalone wrapped Chatwoot close X with the matching circled-X lucide icon.
- Keep the close icon on the same sizing class as the existing help-circle launcher.

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig
- [x] bun --cwd apps/web test src/features/wrapped/support-chatwoot-button.test.tsx
- [x] bun x biome check apps/web/src/features/wrapped/support-chatwoot-button.tsx