### PR TITLE
fix: keep wrapped model chart above footer

### DIFF
--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -1787,7 +1787,6 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	z-index: 1;
 	align-self: stretch;
 	margin-block-start: clamp(1.5rem, 4.5svh, 2.75rem);
-	margin-block-end: calc(-1 * (var(--wrapped-shell-stage-gap) + 2.75rem));
 }
 
 .mymind-wrapped-model-stage__subline {
@@ -8225,6 +8224,35 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	.mymind-wrapped-auth-form[data-email-auth-stage="choice"]
 		.mymind-wrapped-auth-form__choice-footer {
 		margin-bottom: 0;
+	}
+}
+
+@media (max-height: 900px) {
+	.mymind-wrapped-route--step-model .mymind-wrapped-shell {
+		--wrapped-shell-bottom-inset: clamp(12px, calc(15.56svh - 100px), 40px);
+	}
+
+	.mymind-wrapped-model-stage--immersive
+		.mymind-wrapped-model-stage__summary-card {
+		padding-top: clamp(6.25rem, calc(65svh - 405px), 11.6rem);
+	}
+
+	.mymind-wrapped-model-stage__chart-shell,
+	.mymind-wrapped-model-stage__race-row {
+		min-height: clamp(17.5rem, calc(100svh - 22.5rem), 29rem);
+	}
+
+	.mymind-wrapped-model-stage__race-track-shell {
+		min-height: clamp(15.5rem, calc(100svh - 25.2rem), 27rem);
+	}
+
+	.mymind-wrapped-model-stage__scene-shell--comparison
+		.mymind-wrapped-model-stage__chart-shell,
+	.mymind-wrapped-model-stage__scene-shell--details:not(
+			.mymind-wrapped-model-stage__scene-shell--history
+		)
+		.mymind-wrapped-model-stage__chart-shell {
+		padding-bottom: clamp(3.3rem, calc(14rem - 19svh), 4.25rem);
 	}
 }
 

--- a/scripts/lint-wrapped-apple-hig.ts
+++ b/scripts/lint-wrapped-apple-hig.ts
@@ -38,6 +38,8 @@ function main() {
 	runProgressTargetRule(auditFiles, findings);
 	runFooterButtonTargetRule(auditFiles, findings);
 	runKeyboardOnlyHintRule(auditFiles, findings);
+	runModelFooterClearanceRule(auditFiles, findings);
+	runModelShortViewportRule(auditFiles, findings);
 	runOverflowRule(auditFiles, findings);
 
 	if (findings.length === 0) {
@@ -285,6 +287,59 @@ function runOverflowRule(
 			"`overflow: hidden` on the wrapped body or route can block large-text fallback scrolling. For Apple-style mobile resilience, allow the page or individual slides to scroll when content outgrows the viewport.",
 		pattern: /overflow:\s*hidden/g,
 		rule: "dynamic-type",
+	});
+}
+
+function runModelFooterClearanceRule(
+	auditFiles: readonly AuditFile[],
+	findings: Finding[],
+) {
+	const wrappedCssFile = getAuditFile(auditFiles, WRAPPED_CSS_PATH);
+	const modelStageObjectHasNegativeBottomMargin =
+		/\.mymind-wrapped-model-stage\.mymind-wrapped-stage--without-support\.mymind-wrapped-model-stage--immersive\s*\n\s*\.mymind-wrapped-stage__object\s*\{[^}]*margin-block-end:\s*calc\(-1\s*\*/s.test(
+			wrappedCssFile.content,
+		);
+
+	if (!modelStageObjectHasNegativeBottomMargin) {
+		return;
+	}
+
+	findings.push({
+		excerpt: "margin-block-end uses a negative value in the immersive model stage.",
+		line: getLineNumber(wrappedCssFile, /margin-block-end:\s*calc\(-1\s*\*/),
+		message:
+			"The model comparison chart must preserve the shell footer gap so tall bars do not crowd or overlap the Continue button on shorter viewports.",
+		relativePath: WRAPPED_CSS_PATH,
+		rule: "footer-clearance",
+	});
+}
+
+function runModelShortViewportRule(
+	auditFiles: readonly AuditFile[],
+	findings: Finding[],
+) {
+	const wrappedCssFile = getAuditFile(auditFiles, WRAPPED_CSS_PATH);
+	const hasShortViewportModelChartOverrides =
+		/@media\s*\(max-height:\s*900px\)\s*\{[\s\S]*mymind-wrapped-model-stage__chart-shell[\s\S]*mymind-wrapped-model-stage__race-row[\s\S]*mymind-wrapped-model-stage__race-track-shell/.test(
+			wrappedCssFile.content,
+		);
+	const hasShortViewportModelShellOverrides =
+		/@media\s*\(max-height:\s*900px\)\s*\{[\s\S]*mymind-wrapped-route--step-model\s+\.mymind-wrapped-shell[\s\S]*--wrapped-shell-bottom-inset/.test(
+			wrappedCssFile.content,
+		);
+
+	if (hasShortViewportModelChartOverrides && hasShortViewportModelShellOverrides) {
+		return;
+	}
+
+	findings.push({
+		excerpt:
+			"Missing model chart and shell overrides inside `@media (max-height: 900px)`.",
+		line: getLineNumber(wrappedCssFile, /mymind-wrapped-model-stage__chart-shell/),
+		message:
+			"The model comparison chart needs short-height sizing and shell inset overrides so its bar labels keep clear of the Continue button before the browser gets below 820px.",
+		relativePath: WRAPPED_CSS_PATH,
+		rule: "footer-clearance",
 	});
 }
 


### PR DESCRIPTION
## Summary
- remove the negative bottom pull from the immersive wrapped model chart stage
- add model-specific short-height sizing from 900px down so chart labels stay clear of the Continue button
- add wrapped HIG audit coverage for the model footer clearance rules

## Test plan
- [x] bun run lint:wrapped:hig
- [x] bun run test src/features/wrapped/WrappedDevPage.test.tsx src/features/wrapped/onboarding/models/model-mix.test.ts
- [x] bun run verify
- [x] screenshot verification at 870px, 850px, and 820px viewport heights