### PR TITLE
fix: show unrevealed wrapped team cards

### DIFF
--- a/apps/web/src/features/team/TeamPage.tsx
+++ b/apps/web/src/features/team/TeamPage.tsx
@@ -9,7 +9,6 @@ import {
 } from "@/app/ui/card";
 import { Skeleton } from "@/app/ui/skeleton";
 import { TeamMembersCardGrid } from "@/features/team/components/TeamMembersCardGrid";
-import { TeamRosterGallery } from "@/features/team/components/TeamRosterGallery";
 import {
 	type TeamPageDiagnostics,
 	useTeamPageData,
@@ -233,11 +232,9 @@ export function TeamPage() {
 		isError,
 		isPending,
 		teamMemberRows,
-		teamPlayers,
 		refetch,
 		teamCards,
 	} = useTeamPageData();
-	const showUnreleasedLineupCards = false;
 
 	let content = <TeamMembersCardGrid rows={teamMemberRows} />;
 
@@ -255,33 +252,5 @@ export function TeamPage() {
 		content = <TeamPageEmpty />;
 	}
 
-	return (
-		<>
-			<div className="px-4 lg:px-6">{content}</div>
-
-			{/* Unreleased feature: keep the postponed lineup gallery in code only
-			until the team cards return to the roadmap. */}
-			{showUnreleasedLineupCards &&
-			!isPending &&
-			!isError &&
-			teamPlayers.length > 0 ? (
-				<div className="px-4 lg:px-6">
-					<details className="rounded-[1.25rem] border border-border/60 bg-muted/20 px-5 py-4">
-						<summary className="cursor-pointer text-sm font-semibold text-foreground">
-							Postponed lineup cards ({teamPlayers.length})
-						</summary>
-						<p className="pt-2 text-sm text-muted-foreground">
-							Kept below the member cards for reference while this feature stays
-							unreleased.
-						</p>
-						<div className="pt-5">
-							<div className="flex justify-center">
-								<TeamRosterGallery players={teamPlayers} />
-							</div>
-						</div>
-					</details>
-				</div>
-			) : null}
-		</>
-	);
+	return <div className="px-4 lg:px-6">{content}</div>;
 }

--- a/apps/web/src/features/team/components/TeamMembersCardGrid.tsx
+++ b/apps/web/src/features/team/components/TeamMembersCardGrid.tsx
@@ -1,13 +1,24 @@
-import { DashboardModelBadges } from "@/features/dashboard/components/DashboardModelBadges";
-import type { TeamCardTone } from "@/features/team/data/team-card-types";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
-import { cn } from "@/lib/utils";
+import {
+	WrappedTeamMemberCard,
+	type WrappedTeamMemberCardHeaderMetric,
+	type WrappedTeamMemberCardStatItem,
+} from "@/features/wrapped/team-card/card";
+import { UNKNOWN_GUEST_CARD_PRESET } from "@/features/wrapped/wrapped-guest-card-presets";
+import "@/features/wrapped/wrapped.css";
+
+const TEAM_CARD_PENDING_ARCHETYPE_LABEL = "To be revealed";
 
 const compactCurrencyFormatter = new Intl.NumberFormat("en-US", {
 	currency: "USD",
 	maximumFractionDigits: 1,
 	notation: "compact",
 	style: "currency",
+});
+
+const compactNumberFormatter = new Intl.NumberFormat("en-US", {
+	maximumFractionDigits: 1,
+	notation: "compact",
 });
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
@@ -21,65 +32,68 @@ const shortDateFormatter = new Intl.DateTimeFormat("en-US", {
 	month: "short",
 });
 
-const adaptedTeamCardShellClassName =
-	"team-lineup-featured-card relative isolate flex h-[358px] w-[233px] flex-col overflow-hidden rounded-[18px] border border-[#ECECEC] bg-[linear-gradient(180deg,#fbfcfe_0%,#f0f3f7_100%)] px-[14px] pt-[15px] pb-[10px] text-[#302d2b] shadow-[0_0_10.1px_rgba(0,0,0,0.08)]";
+const pendingArchetypeMetric = {
+	title: TEAM_CARD_PENDING_ARCHETYPE_LABEL,
+	value: TEAM_CARD_PENDING_ARCHETYPE_LABEL,
+} satisfies WrappedTeamMemberCardHeaderMetric;
 
-const adaptedTeamCardHeaderValueClassName =
-	"[font-family:var(--dashboard-01-font-roster-display)] text-[17.07px] font-extrabold leading-none tracking-[-0.01em] tabular-nums text-[#272423]";
+function buildHeaderLeftMetric(row: TeamPageMemberRow) {
+	const formattedSpend = formatSpendValue(row.cost);
 
-const adaptedTeamCardHeaderLabelClassName =
-	"ml-[5px] text-[10px] font-semibold leading-none tracking-[-0.03em] text-[#7b7671]";
-
-const adaptedTeamCardNameClassName =
-	"[font-family:var(--dashboard-01-font-roster-display)] text-[19px] font-extrabold leading-[0.9] tracking-[-0.02em] text-[#252220]";
-
-const adaptedTeamCardModelSlotClassName =
-	"flex flex-1 items-center justify-center";
-
-const adaptedTeamCardMediaPanelClassName =
-	"team-lineup-featured-media-panel mt-[12px] h-[158px] w-full rounded-[14px] border border-black/8 bg-white/86";
-
-const portraitPanelClassName =
-	"relative flex h-full w-full flex-col justify-between overflow-hidden rounded-[10px] px-[12px] py-[10px]";
-
-const portraitPlaceholderInitialsClassName =
-	"text-[54px] font-extrabold leading-none tracking-[-0.08em] text-black/66";
-
-const tonePortraitClassNames = {
-	blue: "bg-[linear-gradient(180deg,#d8e8ff_0%,#8fb7ec_100%)] text-[#24466d]",
-	teal: "bg-[linear-gradient(180deg,#d7f6ef_0%,#87d8c7_100%)] text-[#174f48]",
-	orange: "bg-[linear-gradient(180deg,#ffe8d5_0%,#f2b780_100%)] text-[#6f3c11]",
-	lime: "bg-[linear-gradient(180deg,#ecf7d0_0%,#b6db72_100%)] text-[#475d1d]",
-	violet: "bg-[linear-gradient(180deg,#ece8ff_0%,#c3b2f5_100%)] text-[#4c3977]",
-	rose: "bg-[linear-gradient(180deg,#ffe5ea_0%,#ec9eb0_100%)] text-[#71364d]",
-	slate: "bg-[linear-gradient(180deg,#e7edf2_0%,#bcc7d4_100%)] text-[#43515f]",
-} as const satisfies Record<TeamCardTone, string>;
-
-export interface TeamMemberCardHeaderMetric {
-	label?: string;
-	title?: string;
-	value: string;
+	return {
+		title: `${currencyFormatter.format(row.cost)} estimated spend`,
+		value: formattedSpend,
+	} satisfies WrappedTeamMemberCardHeaderMetric;
 }
 
-export interface TeamMemberCardStatItem {
-	key: string;
-	label: string;
-	title?: string;
-	value: string;
+function buildTeamCardStats(
+	row: TeamPageMemberRow,
+): readonly WrappedTeamMemberCardStatItem[] {
+	return [
+		{
+			key: "sessions",
+			label: "SESS",
+			title: `${row.totalSessions.toLocaleString()} sessions`,
+			value: row.totalSessions.toLocaleString(),
+		},
+		{
+			key: "days",
+			label: "DAYS",
+			title: `${row.activeDays.toLocaleString()} active days`,
+			value: row.activeDays.toLocaleString(),
+		},
+		{
+			key: "tokens",
+			label: "TOK",
+			title:
+				row.totalTokens > 0
+					? `${row.totalTokens.toLocaleString()} total tokens`
+					: "No traced tokens yet.",
+			value: formatCompactNumber(row.totalTokens),
+		},
+		{
+			key: "last",
+			label: "LAST",
+			title: row.lastActiveDate ?? "No recent activity",
+			value: formatShortDate(row.lastActiveDate),
+		},
+		{
+			key: "input",
+			label: "IN",
+			title: `${row.inputTokens.toLocaleString()} input tokens`,
+			value: formatCompactNumber(row.inputTokens),
+		},
+		{
+			key: "output",
+			label: "OUT",
+			title: `${row.outputTokens.toLocaleString()} output tokens`,
+			value: formatCompactNumber(row.outputTokens),
+		},
+	];
 }
 
-function getAvatarInitials(name: string) {
-	const parts = name.split(/\s+/).filter(Boolean);
-
-	if (parts.length === 0) {
-		return "TM";
-	}
-
-	if (parts.length === 1) {
-		return parts[0]?.slice(0, 2).toUpperCase() ?? "TM";
-	}
-
-	return `${parts[0]?.[0] ?? ""}${parts.at(-1)?.[0] ?? ""}`.toUpperCase();
+function formatCompactNumber(value: number) {
+	return compactNumberFormatter.format(Math.max(0, value));
 }
 
 function formatShortDate(lastActiveDate: string | null) {
@@ -94,22 +108,6 @@ function formatShortDate(lastActiveDate: string | null) {
 	}
 
 	return shortDateFormatter.format(parsedDate);
-}
-
-function formatTotalTokens(totalTokens: number) {
-	const normalizedTotal = Math.max(0, totalTokens);
-
-	if (normalizedTotal >= 1_000_000) {
-		const value = Math.ceil(normalizedTotal / 100_000) / 10;
-		return `${Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1)}M`;
-	}
-
-	if (normalizedTotal >= 1_000) {
-		const value = Math.ceil(normalizedTotal / 100) / 10;
-		return `${Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1)}K`;
-	}
-
-	return `${Math.ceil(normalizedTotal)}`;
 }
 
 function formatSpendValue(cost: number) {
@@ -128,221 +126,27 @@ function formatSpendValue(cost: number) {
 	return currencyFormatter.format(cost);
 }
 
-function formatInputOutputSplit(inputTokens: number, outputTokens: number) {
-	const totalTokens = inputTokens + outputTokens;
-
-	if (totalTokens <= 0) {
-		return "0/0";
-	}
-
-	const inputShare = Math.round((inputTokens / totalTokens) * 100);
-	const outputShare = 100 - inputShare;
-
-	return `${inputShare}/${outputShare}`;
-}
-
-function getCardTone(row: TeamPageMemberRow): TeamCardTone {
-	if (!row.hasActivity) {
-		return "slate";
-	}
-
-	const favoriteModel = row.favoriteModel?.toLowerCase() ?? "";
-
-	if (favoriteModel.includes("opus")) {
-		return "orange";
-	}
-
-	if (
-		favoriteModel.includes("claude") ||
-		favoriteModel.includes("sonnet") ||
-		favoriteModel.includes("haiku")
-	) {
-		return "teal";
-	}
-
-	if (favoriteModel.includes("gpt") || favoriteModel.includes("codex")) {
-		return "blue";
-	}
-
-	return "rose";
-}
-
-function buildCardStats(row: TeamPageMemberRow): TeamMemberCardStatItem[] {
-	return [
-		{
-			key: "sessions",
-			label: "SESS",
-			title: `${row.totalSessions.toLocaleString()} sessions`,
-			value: row.totalSessions.toLocaleString(),
-		},
-		{
-			key: "tokens",
-			label: "TOK",
-			title:
-				row.totalTokens > 0
-					? `${row.totalTokens.toLocaleString()} total tokens`
-					: "No traced tokens yet.",
-			value: formatTotalTokens(row.totalTokens),
-		},
-		{
-			key: "last",
-			label: "LAST",
-			title: row.lastActiveDate ?? "No recent activity",
-			value: formatShortDate(row.lastActiveDate),
-		},
-		{
-			key: "input-output",
-			label: "IN/OUT",
-			title: `${row.inputTokens.toLocaleString()} input tokens / ${row.outputTokens.toLocaleString()} output tokens`,
-			value: formatInputOutputSplit(row.inputTokens, row.outputTokens),
-		},
-	];
-}
-
-export function TeamMemberCard({
-	headerLeftMetric,
-	headerRightMetric,
-	row,
-	mediaPanelClassName,
-	statItems,
-	statValueClassName,
-	statTileClassName,
-}: {
-	headerLeftMetric?: TeamMemberCardHeaderMetric;
-	headerRightMetric?: TeamMemberCardHeaderMetric;
-	row: TeamPageMemberRow;
-	mediaPanelClassName?: string;
-	statItems?: readonly TeamMemberCardStatItem[];
-	statValueClassName?: string;
-	statTileClassName?: string;
-}) {
-	const tone = getCardTone(row);
-	const isMissingProfileImage = !row.imageUrl;
-	const effectiveTone = isMissingProfileImage ? "rose" : tone;
-	const stats = statItems ?? buildCardStats(row);
-	const initials = getAvatarInitials(row.displayName);
-	const resolvedHeaderLeftMetric = headerLeftMetric ?? {
-		label: "COST",
-		title: `${currencyFormatter.format(row.cost)} estimated spend`,
-		value: formatSpendValue(row.cost),
-	};
-
-	return (
-		<li className="list-none">
-			<article className={adaptedTeamCardShellClassName}>
-				<div className="flex items-start justify-between gap-[10px]">
-					<div
-						className="flex min-w-0 items-center"
-						title={resolvedHeaderLeftMetric.title}
-					>
-						<div className={adaptedTeamCardHeaderValueClassName}>
-							{resolvedHeaderLeftMetric.value}
-						</div>
-						<div className={adaptedTeamCardHeaderLabelClassName}>
-							{resolvedHeaderLeftMetric.label}
-						</div>
-					</div>
-
-					{headerRightMetric ? (
-						<div
-							className="min-w-0 max-w-[7rem] text-right"
-							title={headerRightMetric.title}
-						>
-							{headerRightMetric.label ? (
-								<div className="text-[10px] font-semibold leading-none tracking-[0.06em] text-[#7b7671]">
-									{headerRightMetric.label}
-								</div>
-							) : null}
-							<div
-								className={cn(
-									"text-[11px] font-semibold leading-[0.95] tracking-[-0.03em] text-[#272423]",
-									headerRightMetric.label ? "mt-[4px]" : null,
-								)}
-							>
-								{headerRightMetric.value}
-							</div>
-						</div>
-					) : null}
-				</div>
-
-				<div
-					className={cn(
-						adaptedTeamCardMediaPanelClassName,
-						mediaPanelClassName,
-					)}
-				>
-					<div
-						className={cn(
-							portraitPanelClassName,
-							tonePortraitClassNames[effectiveTone],
-						)}
-					>
-						{row.imageUrl ? (
-							<>
-								<img
-									src={row.imageUrl}
-									alt={row.displayName}
-									className="absolute inset-0 h-full w-full object-cover object-center"
-								/>
-								<div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.18)_0%,rgba(255,255,255,0)_34%,rgba(0,0,0,0.18)_100%)]" />
-								<div className="relative z-10 flex-1" />
-							</>
-						) : (
-							<div className="flex h-full w-full items-center justify-center">
-								<div className={portraitPlaceholderInitialsClassName}>
-									{initials}
-								</div>
-							</div>
-						)}
-					</div>
-				</div>
-
-				<div className="mt-[16px] flex flex-1 flex-col px-[3px] text-center">
-					<div className={adaptedTeamCardNameClassName}>{row.displayName}</div>
-					<div className={adaptedTeamCardModelSlotClassName}>
-						{row.favoriteModel ? (
-							<div className="flex max-w-full justify-center">
-								<DashboardModelBadges models={[row.favoriteModel]} />
-							</div>
-						) : null}
-					</div>
-				</div>
-
-				<div className="relative z-10 grid grid-cols-2 gap-[6px] [font-family:var(--dashboard-01-font-roster-mono)] text-[11px] font-normal text-[#4b4d49]">
-					{stats.map((stat) => (
-						<div
-							key={stat.key}
-							className={cn(
-								"relative z-10 grid min-h-[32px] min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center justify-center gap-[6px] rounded-[10px] border border-black/8 bg-white/74 px-[8px] py-[6px] shadow-[inset_0_1px_0_rgba(255,255,255,0.72)]",
-								statTileClassName,
-							)}
-							title={stat.title}
-						>
-							<div className="shrink-0 leading-none tracking-[0.08em] text-black/42">
-								{stat.label}
-							</div>
-							<div
-								className={cn(
-									"min-w-0 text-right leading-none tracking-[-0.04em] tabular-nums text-[#272423]",
-									statValueClassName,
-								)}
-							>
-								{stat.value}
-							</div>
-						</div>
-					))}
-				</div>
-			</article>
-		</li>
-	);
-}
-
 export function TeamMembersCardGrid({ rows }: { rows: TeamPageMemberRow[] }) {
 	return (
 		<div className="team-lineup-surface-scope">
 			<ul className="grid justify-center gap-[10px] [grid-template-columns:repeat(auto-fit,minmax(233px,233px))]">
 				{rows.map((row) => (
-					<TeamMemberCard key={row.userId} row={row} />
+					<li key={row.userId} className="list-none">
+						<WrappedTeamMemberCard
+							disableOuterShadow={false}
+							headerLeftMetric={buildHeaderLeftMetric(row)}
+							headerRightMetric={pendingArchetypeMetric}
+							hideHeaderLogo
+							layoutPreset="team-card-preview"
+							mediaPanelClassName="mx-auto"
+							row={row}
+							shellClassName={UNKNOWN_GUEST_CARD_PRESET.shellClassName}
+							shellStyle={UNKNOWN_GUEST_CARD_PRESET.shellStyle}
+							statItems={buildTeamCardStats(row)}
+							statTileClassName=""
+							theme={UNKNOWN_GUEST_CARD_PRESET.theme}
+						/>
+					</li>
 				))}
 			</ul>
 		</div>

--- a/apps/web/src/features/team/use-team-page-data.ts
+++ b/apps/web/src/features/team/use-team-page-data.ts
@@ -9,10 +9,7 @@ import {
 } from "@/dev/frontend-fixtures";
 import { useDateRange } from "@/features/analytics/date-range/useDateRange";
 import { useAnalyticsQuery } from "@/features/analytics/queries/useAnalyticsQuery";
-import {
-	buildTeamRosterPlayers,
-	type TeamRosterMemberSource,
-} from "@/features/team/data/team-roster-data";
+import type { TeamRosterMemberSource } from "@/features/team/data/team-roster-data";
 import { useOrganization } from "@/features/workspace/organization/useOrganization";
 import { MAX_ANALYTICS_DAYS } from "@/lib/analytics-date-range";
 import { authClient } from "@/lib/auth-client";
@@ -204,15 +201,11 @@ export function useTeamPageData() {
 	const teamCards = fixtureData?.teamCards ?? teamCardsQuery.data;
 	const developerSummaries =
 		fixtureData?.developerSummaries ?? developersQuery.data;
-	const teamPlayers = useMemo(
-		() => buildTeamRosterPlayers(teamCards, members),
-		[members, teamCards],
-	);
 	const teamMemberRows = useMemo(
 		() => buildTeamMemberRows(members, teamCards, developerSummaries),
 		[members, teamCards, developerSummaries],
 	);
-	const hasRosterData = teamMemberRows.length > 0 || teamPlayers.length > 0;
+	const hasRosterData = teamMemberRows.length > 0;
 	const diagnostics: TeamPageDiagnostics = {
 		endDate: dateRangeState.endDate,
 		endpoint: "analytics.developers.teamCards",
@@ -246,7 +239,6 @@ export function useTeamPageData() {
 				developersQuery.isPending ||
 				isOrganizationPending),
 		teamMemberRows,
-		teamPlayers,
 		requestedDays,
 		refetch: async () => {
 			await Promise.all([


### PR DESCRIPTION
## Summary
- replace the team page member cards with the current wrapped card component
- show every team archetype as `To be revealed`
- use the onboarding unrevealed card colorway and remove the postponed lineup card path from the page data flow

## Test plan
- `node_modules/.bin/biome check apps/web/src/features/team/TeamPage.tsx apps/web/src/features/team/components/TeamMembersCardGrid.tsx apps/web/src/features/team/use-team-page-data.ts`
- `bun run check-types` from `apps/web`
- `bun run verify`