### PR TITLE
fix: add wrapped archetype copy

### DIFF
--- a/apps/web/src/features/wrapped/WrappedPublicMockPage.tsx
+++ b/apps/web/src/features/wrapped/WrappedPublicMockPage.tsx
@@ -107,6 +107,7 @@ const MOCK_PUBLIC_SHARE_ONBOARDING_METRICS = {
 	commitRate: 71,
 	commitSessions: 118,
 	daysSinceFirst: 94,
+	distinctProjectCount: 14,
 	estimatedCostTokenBasis: 5_068_300,
 	estimatedCostUsd: 687,
 	favoriteModel: "claude-sonnet-4.5",

--- a/apps/web/src/features/wrapped/onboarding/shell.test.tsx
+++ b/apps/web/src/features/wrapped/onboarding/shell.test.tsx
@@ -148,6 +148,7 @@ function buildOnboardingMetrics(input: {
 		commitRate: null,
 		commitSessions: 0,
 		daysSinceFirst: 12,
+		distinctProjectCount: 0,
 		estimatedCostTokenBasis: 0,
 		estimatedCostUsd: 0,
 		favoriteModel: null,

--- a/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
@@ -23,6 +23,7 @@ const emptyToolsMetrics: WrappedOnboardingMetrics = {
 	commitRate: null,
 	commitSessions: 0,
 	daysSinceFirst: 0,
+	distinctProjectCount: 0,
 	estimatedCostTokenBasis: 0,
 	estimatedCostUsd: 0,
 	favoriteModel: null,

--- a/apps/web/src/features/wrapped/onboarding/types.ts
+++ b/apps/web/src/features/wrapped/onboarding/types.ts
@@ -26,6 +26,7 @@ export interface WrappedOnboardingMetrics {
 	commitRate: number | null;
 	commitSessions: number;
 	daysSinceFirst: number;
+	distinctProjectCount: number;
 	estimatedCostTokenBasis: number;
 	estimatedCostUsd: number;
 	favoriteModel: string | null;

--- a/apps/web/src/features/wrapped/team-card/archetype-gradient-text.tsx
+++ b/apps/web/src/features/wrapped/team-card/archetype-gradient-text.tsx
@@ -1,0 +1,164 @@
+import type { CSSProperties } from "react";
+import {
+	getWrappedArchetypeCardBackgroundValue,
+	type WrappedArchetypeCardTheme,
+} from "./archetypes";
+
+interface WrappedArchetypeGradientTextStyle extends CSSProperties {
+	"--wrapped-reveal-archetype-accent": string;
+	"--wrapped-reveal-archetype-gt-direction": string;
+	"--wrapped-reveal-archetype-gt-gradient": string;
+}
+
+export type WrappedArchetypeGradientTextState = "active" | "waiting";
+
+const WRAPPED_ARCHETYPE_GRADIENT_TEXT_DARK = "#17161c";
+const WRAPPED_ARCHETYPE_GRADIENT_COLOR_PATTERN = /#[\da-fA-F]{3,8}\b/g;
+const WRAPPED_ARCHETYPE_LINEAR_GRADIENT_PATTERN =
+	/^linear-gradient\(([^,]+),\s*(.+)\)$/;
+const WRAPPED_ARCHETYPE_GRADIENT_DARK_HOLD_STOP = 60;
+const WRAPPED_ARCHETYPE_GRADIENT_COLOR_RANGE_START = 68;
+const WRAPPED_ARCHETYPE_GRADIENT_COLOR_RANGE_END = 100;
+const WRAPPED_ARCHETYPE_GRADIENT_COLOR_INSET_STOP = 15;
+
+export interface WrappedArchetypeGradientTextValue {
+	accent: string;
+	direction: string;
+	stops: string;
+}
+
+export function WrappedArchetypeGradientText(props: {
+	activeArchetype: WrappedArchetypeCardTheme;
+	className: string;
+	isHoverReplayEnabled?: boolean;
+	state: WrappedArchetypeGradientTextState;
+	suffix?: string;
+}) {
+	const {
+		activeArchetype,
+		className,
+		isHoverReplayEnabled = false,
+		state,
+		suffix = "",
+	} = props;
+	const gradient = getWrappedArchetypeGradientTextValue(activeArchetype);
+	const style: WrappedArchetypeGradientTextStyle = {
+		"--wrapped-reveal-archetype-accent": gradient.accent,
+		"--wrapped-reveal-archetype-gt-direction": gradient.direction,
+		"--wrapped-reveal-archetype-gt-gradient": gradient.stops,
+	};
+	const classNames = `mymind-wrapped-final-stage__gradient-text ${className}`;
+
+	return (
+		<span
+			className={classNames}
+			data-accent-state={state}
+			data-hover-replay={
+				isHoverReplayEnabled && state === "active" ? "ready" : undefined
+			}
+			data-label={activeArchetype.displayLabel}
+			style={style}
+		>
+			{activeArchetype.displayLabel}
+			{suffix}
+		</span>
+	);
+}
+
+export function getWrappedArchetypeGradientTextValue(
+	theme: WrappedArchetypeCardTheme,
+): WrappedArchetypeGradientTextValue {
+	const cardBackgroundValue = getWrappedArchetypeCardBackgroundValue(theme);
+	const gradientMatch = cardBackgroundValue?.match(
+		WRAPPED_ARCHETYPE_LINEAR_GRADIENT_PATTERN,
+	);
+	const colors = cardBackgroundValue?.match(
+		WRAPPED_ARCHETYPE_GRADIENT_COLOR_PATTERN,
+	);
+	const direction = gradientMatch?.[1]?.trim() ?? "184deg";
+	const gradientColors = colors ?? [];
+
+	return {
+		accent: buildWrappedArchetypeTextAccentGradient({
+			colors: gradientColors,
+			direction,
+		}),
+		direction,
+		stops: buildWrappedArchetypeTextGradientStops(gradientColors),
+	};
+}
+
+function formatWrappedArchetypeGradientStopPosition(position: number) {
+	return position.toFixed(2).replace(/\.?0+$/, "");
+}
+
+function resolveWrappedArchetypeGradientColorStop(position: number) {
+	const colorRange =
+		WRAPPED_ARCHETYPE_GRADIENT_COLOR_RANGE_END -
+		WRAPPED_ARCHETYPE_GRADIENT_COLOR_RANGE_START;
+
+	return (
+		WRAPPED_ARCHETYPE_GRADIENT_COLOR_RANGE_START + (colorRange * position) / 100
+	);
+}
+
+function buildWrappedArchetypeTextGradientStops(colors: readonly string[]) {
+	if (colors.length === 0) {
+		return `${WRAPPED_ARCHETYPE_GRADIENT_TEXT_DARK} 0%, ${WRAPPED_ARCHETYPE_GRADIENT_TEXT_DARK} 100%`;
+	}
+
+	if (colors.length === 1) {
+		return `${WRAPPED_ARCHETYPE_GRADIENT_TEXT_DARK} 0%, ${WRAPPED_ARCHETYPE_GRADIENT_TEXT_DARK} ${WRAPPED_ARCHETYPE_GRADIENT_DARK_HOLD_STOP}%, ${colors[0]} ${WRAPPED_ARCHETYPE_GRADIENT_COLOR_RANGE_START}%, ${colors[0]} ${WRAPPED_ARCHETYPE_GRADIENT_COLOR_RANGE_END}%`;
+	}
+
+	const firstColor = colors[0];
+	const lastColor = colors[colors.length - 1];
+	const interiorColors = colors.slice(1, -1);
+	const interiorDenominator = Math.max(interiorColors.length + 1, 1);
+	const interiorStops = interiorColors
+		.map((color, index) => {
+			const stopPosition =
+				WRAPPED_ARCHETYPE_GRADIENT_COLOR_INSET_STOP +
+				((100 - WRAPPED_ARCHETYPE_GRADIENT_COLOR_INSET_STOP * 2) *
+					(index + 1)) /
+					interiorDenominator;
+
+			return `${color} ${formatWrappedArchetypeGradientStopPosition(resolveWrappedArchetypeGradientColorStop(stopPosition))}%`;
+		})
+		.join(", ");
+	const edgeStops = [
+		`${firstColor} ${formatWrappedArchetypeGradientStopPosition(resolveWrappedArchetypeGradientColorStop(0))}%`,
+		`${firstColor} ${formatWrappedArchetypeGradientStopPosition(resolveWrappedArchetypeGradientColorStop(WRAPPED_ARCHETYPE_GRADIENT_COLOR_INSET_STOP))}%`,
+		interiorStops,
+		`${lastColor} ${formatWrappedArchetypeGradientStopPosition(resolveWrappedArchetypeGradientColorStop(100 - WRAPPED_ARCHETYPE_GRADIENT_COLOR_INSET_STOP))}%`,
+		`${lastColor} ${formatWrappedArchetypeGradientStopPosition(resolveWrappedArchetypeGradientColorStop(100))}%`,
+	].filter(Boolean);
+
+	return `${WRAPPED_ARCHETYPE_GRADIENT_TEXT_DARK} 0%, ${WRAPPED_ARCHETYPE_GRADIENT_TEXT_DARK} ${WRAPPED_ARCHETYPE_GRADIENT_DARK_HOLD_STOP}%, ${edgeStops.join(", ")}`;
+}
+
+function buildWrappedArchetypeTextAccentGradient(input: {
+	colors: readonly string[];
+	direction: string;
+}) {
+	const { colors, direction } = input;
+
+	if (colors.length === 0) {
+		return WRAPPED_ARCHETYPE_GRADIENT_TEXT_DARK;
+	}
+
+	if (colors.length === 1) {
+		return colors[0];
+	}
+
+	const denominator = Math.max(colors.length - 1, 1);
+	const colorStops = colors
+		.map((color, index) => {
+			const stopPosition = (100 * index) / denominator;
+
+			return `${color} ${formatWrappedArchetypeGradientStopPosition(stopPosition)}%`;
+		})
+		.join(", ");
+
+	return `linear-gradient(${direction}, ${colorStops})`;
+}

--- a/apps/web/src/features/wrapped/team-card/card-back.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/card-back.test.tsx
@@ -68,6 +68,7 @@ const onboardingMetrics = {
 	commitRate: 50,
 	commitSessions: 4,
 	daysSinceFirst: 8,
+	distinctProjectCount: 1,
 	estimatedCostTokenBasis: 3000,
 	estimatedCostUsd: 4,
 	favoriteModel: "claude-sonnet-4.5",

--- a/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
@@ -92,6 +92,7 @@ const onboardingMetrics: WrappedOnboardingMetrics = {
 	commitRate: 41,
 	commitSessions: 15,
 	daysSinceFirst: 180,
+	distinctProjectCount: 6,
 	estimatedCostTokenBasis: 0,
 	estimatedCostUsd: 42,
 	favoriteModel: "claude-sonnet-4",
@@ -441,6 +442,480 @@ describe("WrappedTeamCardRevealStage", () => {
 		}
 	});
 
+	it("renders the Maniac reveal copy with activity, repo, and session density metrics", () => {
+		vi.useFakeTimers();
+
+		render(
+			<WrappedTeamCardRevealStage
+				activeArchetype={{
+					displayLabel: "Maniac",
+					id: "maniac",
+					kind: "taxonomy",
+					classifierKey: "maniac",
+					shellClassName: "bg-red-200",
+					theme: "light",
+				}}
+				headerLeftMetric={{
+					title: "$42 estimated spend",
+					value: "$42",
+				}}
+				headerRightMetric={{
+					title: "Maniac",
+					value: "Maniac",
+				}}
+				isPreviewPostVisible={false}
+				onboardingMetrics={onboardingMetrics}
+				onPreviewPost={vi.fn()}
+				onRevealComplete={vi.fn()}
+				row={row}
+				shellClassName="bg-red-200"
+				shellStyle={{}}
+				shareCardCreatedAtLabel="04/24/2026"
+				statItems={[]}
+				statLayerOpacities={{
+					rainbowShineOpacity: 0.3,
+					textureOpacity: 1,
+					tileBorderOpacity: 1,
+					tileFillOpacity: 0.08,
+					tileInsetShadowOpacity: 0.5,
+					tileTopStrokeOpacity: 0.08,
+				}}
+				theme="light"
+				tiltController={tiltController}
+			/>,
+		);
+
+		advanceRevealIntroToGate();
+
+		expect(
+			screen.getByText(
+				"12 out of 180 days. 6 repos. Most people are consistent. Some people are everywhere at once. You're both. Somehow. 3.1 sessions every time you're active. We're a little scared honestly. Pls don't hurt someone",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("renders the Company Card title and reveal copy with spend metrics", () => {
+		vi.useFakeTimers();
+
+		render(
+			<WrappedTeamCardRevealStage
+				activeArchetype={{
+					displayLabel: "Company Card",
+					id: "company_card",
+					kind: "taxonomy",
+					classifierKey: "company_card",
+					shellClassName: "bg-yellow-200",
+					theme: "light",
+				}}
+				headerLeftMetric={{
+					title: "$44 estimated spend",
+					value: "$44",
+				}}
+				headerRightMetric={{
+					title: "Company Card",
+					value: "Company Card",
+				}}
+				isPreviewPostVisible={false}
+				onboardingMetrics={{
+					...onboardingMetrics,
+					commitRate: 48,
+				}}
+				onPreviewPost={vi.fn()}
+				onRevealComplete={vi.fn()}
+				row={{
+					...row,
+					cost: 44,
+					totalSessions: 8,
+				}}
+				shellClassName="bg-yellow-200"
+				shellStyle={{}}
+				shareCardCreatedAtLabel="04/24/2026"
+				statItems={[]}
+				statLayerOpacities={{
+					rainbowShineOpacity: 0.3,
+					textureOpacity: 1,
+					tileBorderOpacity: 1,
+					tileFillOpacity: 0.08,
+					tileInsetShadowOpacity: 0.5,
+					tileTopStrokeOpacity: 0.08,
+				}}
+				theme="light"
+				tiltController={tiltController}
+			/>,
+		);
+
+		act(() => {
+			vi.advanceTimersByTime(850);
+		});
+
+		expect(
+			screen.getByRole("heading", {
+				name: "Avery Chen, you got the Company Card?",
+			}),
+		).toBeInTheDocument();
+
+		act(() => {
+			vi.advanceTimersByTime(REVEAL_INTRO_READY_MS - 850);
+		});
+
+		expect(
+			screen.getByText(
+				"8 sessions. 48% of them shipped something. $5.50 a session. $44 in total. Not saying it's a problem. We don't judge. Spend as much as you want. Dario & Sam are happy to have you.",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("renders the ADHD Brain title and reveal copy with repo and commit metrics", () => {
+		vi.useFakeTimers();
+
+		render(
+			<WrappedTeamCardRevealStage
+				activeArchetype={{
+					displayLabel: "ADHD Brain",
+					id: "adhd_brain",
+					kind: "taxonomy",
+					classifierKey: "adhd_brain",
+					shellClassName: "bg-fuchsia-200",
+					theme: "light",
+				}}
+				headerLeftMetric={{
+					title: "$42 estimated spend",
+					value: "$42",
+				}}
+				headerRightMetric={{
+					title: "ADHD Brain",
+					value: "ADHD Brain",
+				}}
+				isPreviewPostVisible={false}
+				onboardingMetrics={{
+					...onboardingMetrics,
+					commitRate: 48,
+					distinctProjectCount: 6,
+				}}
+				onPreviewPost={vi.fn()}
+				onRevealComplete={vi.fn()}
+				row={row}
+				shellClassName="bg-fuchsia-200"
+				shellStyle={{}}
+				shareCardCreatedAtLabel="04/24/2026"
+				statItems={[]}
+				statLayerOpacities={{
+					rainbowShineOpacity: 0.3,
+					textureOpacity: 1,
+					tileBorderOpacity: 1,
+					tileFillOpacity: 0.08,
+					tileInsetShadowOpacity: 0.5,
+					tileTopStrokeOpacity: 0.08,
+				}}
+				theme="light"
+				tiltController={tiltController}
+			/>,
+		);
+
+		act(() => {
+			vi.advanceTimersByTime(850);
+		});
+
+		expect(
+			screen.getByRole("heading", {
+				name: "Avery Chen, you're an ADHD Brain.",
+			}),
+		).toBeInTheDocument();
+
+		act(() => {
+			vi.advanceTimersByTime(REVEAL_INTRO_READY_MS - 850);
+		});
+
+		expect(
+			screen.getByText(
+				"12 out of 180 days. 6 repos. 48% of sessions shipped something. You'd call yourself a DaVinci. We're just worried about the 6 repos.",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("renders the Hit and Runner title and reveal copy with session, repo, and commit metrics", () => {
+		vi.useFakeTimers();
+
+		render(
+			<WrappedTeamCardRevealStage
+				activeArchetype={{
+					displayLabel: "Hit and Runner",
+					id: "hit_and_runner",
+					kind: "taxonomy",
+					classifierKey: "hit_and_runner",
+					shellClassName: "bg-orange-200",
+					theme: "light",
+				}}
+				headerLeftMetric={{
+					title: "$42 estimated spend",
+					value: "$42",
+				}}
+				headerRightMetric={{
+					title: "Hit and Runner",
+					value: "Hit and Runner",
+				}}
+				isPreviewPostVisible={false}
+				onboardingMetrics={{
+					...onboardingMetrics,
+					avgSessionMin: 24,
+					commitRate: 48,
+					distinctProjectCount: 6,
+				}}
+				onPreviewPost={vi.fn()}
+				onRevealComplete={vi.fn()}
+				row={row}
+				shellClassName="bg-orange-200"
+				shellStyle={{}}
+				shareCardCreatedAtLabel="04/24/2026"
+				statItems={[]}
+				statLayerOpacities={{
+					rainbowShineOpacity: 0.3,
+					textureOpacity: 1,
+					tileBorderOpacity: 1,
+					tileFillOpacity: 0.08,
+					tileInsetShadowOpacity: 0.5,
+					tileTopStrokeOpacity: 0.08,
+				}}
+				theme="light"
+				tiltController={tiltController}
+			/>,
+		);
+
+		act(() => {
+			vi.advanceTimersByTime(850);
+		});
+
+		expect(
+			screen.getByRole("heading", {
+				name: "Avery Chen, you're a Hit and Runner.",
+			}),
+		).toBeInTheDocument();
+
+		act(() => {
+			vi.advanceTimersByTime(REVEAL_INTRO_READY_MS - 850);
+		});
+
+		expect(
+			screen.getByText(
+				"24 minutes average. 6 repos. 48% of sessions shipped something. Veni, vidi, commit. In at 24 minutes. Out before anyone noticed. You could be a hitman.",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("renders the Cheapskate title and reveal copy with spend and commit metrics", () => {
+		vi.useFakeTimers();
+
+		render(
+			<WrappedTeamCardRevealStage
+				activeArchetype={{
+					displayLabel: "Cheapskate",
+					id: "cheapskate",
+					kind: "taxonomy",
+					classifierKey: "cheapskate",
+					shellClassName: "bg-lime-200",
+					theme: "light",
+				}}
+				headerLeftMetric={{
+					title: "$44 estimated spend",
+					value: "$44",
+				}}
+				headerRightMetric={{
+					title: "Cheapskate",
+					value: "Cheapskate",
+				}}
+				isPreviewPostVisible={false}
+				onboardingMetrics={{
+					...onboardingMetrics,
+					commitRate: 48,
+				}}
+				onPreviewPost={vi.fn()}
+				onRevealComplete={vi.fn()}
+				row={{
+					...row,
+					cost: 44,
+					totalSessions: 8,
+				}}
+				shellClassName="bg-lime-200"
+				shellStyle={{}}
+				shareCardCreatedAtLabel="04/24/2026"
+				statItems={[]}
+				statLayerOpacities={{
+					rainbowShineOpacity: 0.3,
+					textureOpacity: 1,
+					tileBorderOpacity: 1,
+					tileFillOpacity: 0.08,
+					tileInsetShadowOpacity: 0.5,
+					tileTopStrokeOpacity: 0.08,
+				}}
+				theme="light"
+				tiltController={tiltController}
+			/>,
+		);
+
+		act(() => {
+			vi.advanceTimersByTime(850);
+		});
+
+		expect(
+			screen.getByRole("heading", {
+				name: "Avery Chen, you're a Cheapskate.",
+			}),
+		).toBeInTheDocument();
+
+		act(() => {
+			vi.advanceTimersByTime(REVEAL_INTRO_READY_MS - 850);
+		});
+
+		expect(
+			screen.getByText(
+				"$5.50 a session. 48% of those shipped something. Mr. Krabs is very proud of you. But you've never once picked up the check.",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("renders the Tourist title and reveal copy with sessions, commit, and spend metrics", () => {
+		vi.useFakeTimers();
+
+		render(
+			<WrappedTeamCardRevealStage
+				activeArchetype={{
+					displayLabel: "Tourist",
+					id: "tourist",
+					kind: "taxonomy",
+					classifierKey: "tourist",
+					shellClassName: "bg-emerald-200",
+					theme: "light",
+				}}
+				headerLeftMetric={{
+					title: "$44 estimated spend",
+					value: "$44",
+				}}
+				headerRightMetric={{
+					title: "Tourist",
+					value: "Tourist",
+				}}
+				isPreviewPostVisible={false}
+				onboardingMetrics={{
+					...onboardingMetrics,
+					commitRate: 48,
+				}}
+				onPreviewPost={vi.fn()}
+				onRevealComplete={vi.fn()}
+				row={{
+					...row,
+					cost: 44,
+					totalSessions: 8,
+				}}
+				shellClassName="bg-emerald-200"
+				shellStyle={{}}
+				shareCardCreatedAtLabel="04/24/2026"
+				statItems={[]}
+				statLayerOpacities={{
+					rainbowShineOpacity: 0.3,
+					textureOpacity: 1,
+					tileBorderOpacity: 1,
+					tileFillOpacity: 0.08,
+					tileInsetShadowOpacity: 0.5,
+					tileTopStrokeOpacity: 0.08,
+				}}
+				theme="light"
+				tiltController={tiltController}
+			/>,
+		);
+
+		act(() => {
+			vi.advanceTimersByTime(850);
+		});
+
+		expect(
+			screen.getByRole("heading", {
+				name: "Avery Chen, you're a Tourist.",
+			}),
+		).toBeInTheDocument();
+
+		act(() => {
+			vi.advanceTimersByTime(REVEAL_INTRO_READY_MS - 850);
+		});
+
+		expect(
+			screen.getByText(
+				"8 sessions. 48% shipped something. $5.50 a session. At least you tried it out! There's no prize for participation though",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("renders the Obsessed title and reveal copy with repo, activity, commit, and cost metrics", () => {
+		vi.useFakeTimers();
+
+		render(
+			<WrappedTeamCardRevealStage
+				activeArchetype={{
+					displayLabel: "Obsessed",
+					id: "obsessed",
+					kind: "taxonomy",
+					classifierKey: "obsessed",
+					shellClassName: "bg-black",
+					theme: "dark",
+				}}
+				headerLeftMetric={{
+					title: "$44 estimated spend",
+					value: "$44",
+				}}
+				headerRightMetric={{
+					title: "Obsessed",
+					value: "Obsessed",
+				}}
+				isPreviewPostVisible={false}
+				onboardingMetrics={{
+					...onboardingMetrics,
+					commitRate: 48,
+					distinctProjectCount: 1,
+				}}
+				onPreviewPost={vi.fn()}
+				onRevealComplete={vi.fn()}
+				row={{
+					...row,
+					cost: 44,
+					totalSessions: 8,
+				}}
+				shellClassName="bg-black"
+				shellStyle={{}}
+				shareCardCreatedAtLabel="04/24/2026"
+				statItems={[]}
+				statLayerOpacities={{
+					rainbowShineOpacity: 0.3,
+					textureOpacity: 1,
+					tileBorderOpacity: 1,
+					tileFillOpacity: 0.08,
+					tileInsetShadowOpacity: 0.5,
+					tileTopStrokeOpacity: 0.08,
+				}}
+				theme="dark"
+				tiltController={tiltController}
+			/>,
+		);
+
+		act(() => {
+			vi.advanceTimersByTime(850);
+		});
+
+		expect(
+			screen.getByRole("heading", {
+				name: "Avery Chen, you're Obsessed.",
+			}),
+		).toBeInTheDocument();
+
+		act(() => {
+			vi.advanceTimersByTime(REVEAL_INTRO_READY_MS - 850);
+		});
+
+		expect(
+			screen.getByText(
+				"1 repo. That's it. 12 out of 180 days. All of it, same place. 48% of your sessions shipped something. At $5.50 a session. May god help anyone who tries to distract you.",
+			),
+		).toBeInTheDocument();
+	});
+
 	it("drops the back of the card first and flips to the front on click", () => {
 		vi.useFakeTimers();
 		const onRevealComplete = vi.fn();
@@ -490,7 +965,7 @@ describe("WrappedTeamCardRevealStage", () => {
 				name: "Avery Chen,",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Smooth Operator")).toHaveAttribute(
+		expect(screen.getByText("Smooth Operator.")).toHaveAttribute(
 			"data-accent-state",
 			"waiting",
 		);
@@ -504,10 +979,10 @@ describe("WrappedTeamCardRevealStage", () => {
 
 		expect(
 			screen.getByRole("heading", {
-				name: "Avery Chen, you're a Smooth Operator",
+				name: "Avery Chen, you're a Smooth Operator.",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Smooth Operator")).toHaveAttribute(
+		expect(screen.getByText("Smooth Operator.")).toHaveAttribute(
 			"data-accent-state",
 			"waiting",
 		);
@@ -516,7 +991,7 @@ describe("WrappedTeamCardRevealStage", () => {
 			vi.advanceTimersByTime(670);
 		});
 
-		expect(screen.getByText("Smooth Operator")).toHaveAttribute(
+		expect(screen.getByText("Smooth Operator.")).toHaveAttribute(
 			"data-accent-state",
 			"active",
 		);
@@ -530,7 +1005,7 @@ describe("WrappedTeamCardRevealStage", () => {
 
 		expect(
 			screen.getByText(
-				"For the steady hand who keeps the machine moving without asking for attention on every pass.",
+				"12 out of 180 days. 24 minutes average. 88 at your longest. You start. You build. You stop. 3.1 sessions a day, $1.14 a session, no chaos. A little to bit too smooth... bit suspicious.",
 			),
 		).toBeInTheDocument();
 		expect(
@@ -614,12 +1089,12 @@ describe("WrappedTeamCardRevealStage", () => {
 		).toBeEnabled();
 		expect(
 			screen.getByRole("heading", {
-				name: "Avery Chen, you're a Smooth Operator",
+				name: "Avery Chen, you're a Smooth Operator.",
 			}),
 		).toBeInTheDocument();
 		expect(
 			screen.getByText(
-				"For the steady hand who keeps the machine moving without asking for attention on every pass.",
+				"12 out of 180 days. 24 minutes average. 88 at your longest. You start. You build. You stop. 3.1 sessions a day, $1.14 a session, no chaos. A little to bit too smooth... bit suspicious.",
 			),
 		).toBeInTheDocument();
 
@@ -637,12 +1112,12 @@ describe("WrappedTeamCardRevealStage", () => {
 		).toHaveAttribute("data-card-face", "back");
 		expect(
 			screen.getByRole("heading", {
-				name: "Avery Chen, you're a Smooth Operator",
+				name: "Avery Chen, you're a Smooth Operator.",
 			}),
 		).toBeInTheDocument();
 		expect(
 			screen.getByText(
-				"For the steady hand who keeps the machine moving without asking for attention on every pass.",
+				"12 out of 180 days. 24 minutes average. 88 at your longest. You start. You build. You stop. 3.1 sessions a day, $1.14 a session, no chaos. A little to bit too smooth... bit suspicious.",
 			),
 		).toBeInTheDocument();
 	});
@@ -884,7 +1359,7 @@ describe("WrappedTeamCardPublicStage", () => {
 
 		expect(
 			screen.getByRole("heading", {
-				name: "Avery Chen is a Smooth Operator",
+				name: "Avery Chen is a Smooth Operator.",
 			}),
 		).toBeInTheDocument();
 

--- a/apps/web/src/features/wrapped/team-card/final-stages.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.tsx
@@ -22,10 +22,8 @@ import { WrappedPrimaryAction } from "@/features/wrapped/actions";
 import type { WrappedOnboardingMetrics } from "@/features/wrapped/onboarding/types";
 import { WrappedStageFrame } from "@/features/wrapped/stage-frame";
 import { formatCurrency } from "@/lib/format";
-import {
-	getWrappedArchetypeCardBackgroundValue,
-	type WrappedArchetypeCardTheme,
-} from "./archetypes";
+import { WrappedArchetypeGradientText } from "./archetype-gradient-text";
+import type { WrappedArchetypeCardTheme } from "./archetypes";
 import { buildWrappedTeamCardBackMetrics } from "./back-metrics";
 import {
 	WrappedTeamMemberCard,
@@ -125,170 +123,15 @@ interface WrappedTeamCardFlipSurfaceProps {
 	tiltShellClassName?: string;
 }
 
-interface WrappedRevealArchetypeTitleStyle extends CSSProperties {
-	"--wrapped-reveal-archetype-accent": string;
-	"--wrapped-reveal-archetype-gt-direction": string;
-	"--wrapped-reveal-archetype-gt-gradient": string;
-}
-
 interface WrappedRevealCopyInput {
 	activeArchetype: WrappedArchetypeCardTheme;
 	audience?: "owner" | "public";
 	onboardingMetrics?: WrappedOnboardingMetrics;
 	row: TeamPageMemberRow;
+	statItems?: readonly WrappedTeamMemberCardStatItem[];
 }
 
 type WrappedRevealIntroPhase = "name" | "line" | "accent" | "description";
-type WrappedRevealGradientTextState = "active" | "waiting";
-
-const WRAPPED_REVEAL_TEXT_DARK = "#17161c";
-const WRAPPED_REVEAL_GRADIENT_COLOR_PATTERN = /#[\da-fA-F]{3,8}\b/g;
-const WRAPPED_REVEAL_LINEAR_GRADIENT_PATTERN =
-	/^linear-gradient\(([^,]+),\s*(.+)\)$/;
-const WRAPPED_REVEAL_GRADIENT_DARK_HOLD_STOP = 60;
-const WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_START = 68;
-const WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_END = 100;
-const WRAPPED_REVEAL_GRADIENT_COLOR_INSET_STOP = 15;
-
-interface WrappedRevealTextGradient {
-	accent: string;
-	direction: string;
-	stops: string;
-}
-
-function formatWrappedRevealGradientStopPosition(position: number) {
-	return position.toFixed(2).replace(/\.?0+$/, "");
-}
-
-function resolveWrappedRevealGradientColorStop(position: number) {
-	const colorRange =
-		WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_END -
-		WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_START;
-
-	return (
-		WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_START + (colorRange * position) / 100
-	);
-}
-
-function buildWrappedRevealTextGradientStops(colors: readonly string[]) {
-	if (colors.length === 0) {
-		return `${WRAPPED_REVEAL_TEXT_DARK} 0%, ${WRAPPED_REVEAL_TEXT_DARK} 100%`;
-	}
-
-	if (colors.length === 1) {
-		return `${WRAPPED_REVEAL_TEXT_DARK} 0%, ${WRAPPED_REVEAL_TEXT_DARK} ${WRAPPED_REVEAL_GRADIENT_DARK_HOLD_STOP}%, ${colors[0]} ${WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_START}%, ${colors[0]} ${WRAPPED_REVEAL_GRADIENT_COLOR_RANGE_END}%`;
-	}
-
-	const firstColor = colors[0];
-	const lastColor = colors[colors.length - 1];
-	const interiorColors = colors.slice(1, -1);
-	const interiorDenominator = Math.max(interiorColors.length + 1, 1);
-	const interiorStops = interiorColors
-		.map((color, index) => {
-			const stopPosition =
-				WRAPPED_REVEAL_GRADIENT_COLOR_INSET_STOP +
-				((100 - WRAPPED_REVEAL_GRADIENT_COLOR_INSET_STOP * 2) * (index + 1)) /
-					interiorDenominator;
-
-			return `${color} ${formatWrappedRevealGradientStopPosition(resolveWrappedRevealGradientColorStop(stopPosition))}%`;
-		})
-		.join(", ");
-	const edgeStops = [
-		`${firstColor} ${formatWrappedRevealGradientStopPosition(resolveWrappedRevealGradientColorStop(0))}%`,
-		`${firstColor} ${formatWrappedRevealGradientStopPosition(resolveWrappedRevealGradientColorStop(WRAPPED_REVEAL_GRADIENT_COLOR_INSET_STOP))}%`,
-		interiorStops,
-		`${lastColor} ${formatWrappedRevealGradientStopPosition(resolveWrappedRevealGradientColorStop(100 - WRAPPED_REVEAL_GRADIENT_COLOR_INSET_STOP))}%`,
-		`${lastColor} ${formatWrappedRevealGradientStopPosition(resolveWrappedRevealGradientColorStop(100))}%`,
-	].filter(Boolean);
-
-	return `${WRAPPED_REVEAL_TEXT_DARK} 0%, ${WRAPPED_REVEAL_TEXT_DARK} ${WRAPPED_REVEAL_GRADIENT_DARK_HOLD_STOP}%, ${edgeStops.join(", ")}`;
-}
-
-function buildWrappedRevealTextAccentGradient(input: {
-	colors: readonly string[];
-	direction: string;
-}) {
-	const { colors, direction } = input;
-
-	if (colors.length === 0) {
-		return WRAPPED_REVEAL_TEXT_DARK;
-	}
-
-	if (colors.length === 1) {
-		return colors[0];
-	}
-
-	const denominator = Math.max(colors.length - 1, 1);
-	const colorStops = colors
-		.map((color, index) => {
-			const stopPosition = (100 * index) / denominator;
-
-			return `${color} ${formatWrappedRevealGradientStopPosition(stopPosition)}%`;
-		})
-		.join(", ");
-
-	return `linear-gradient(${direction}, ${colorStops})`;
-}
-
-function getWrappedRevealTextGradientValue(
-	theme: WrappedArchetypeCardTheme,
-): WrappedRevealTextGradient {
-	const cardBackgroundValue = getWrappedArchetypeCardBackgroundValue(theme);
-	const gradientMatch = cardBackgroundValue?.match(
-		WRAPPED_REVEAL_LINEAR_GRADIENT_PATTERN,
-	);
-	const colors = cardBackgroundValue?.match(
-		WRAPPED_REVEAL_GRADIENT_COLOR_PATTERN,
-	);
-	const direction = gradientMatch?.[1]?.trim() ?? "184deg";
-	const gradientColors = colors ?? [];
-
-	return {
-		accent: buildWrappedRevealTextAccentGradient({
-			colors: gradientColors,
-			direction,
-		}),
-		direction,
-		stops: buildWrappedRevealTextGradientStops(gradientColors),
-	};
-}
-
-function WrappedArchetypeGradientText(props: {
-	activeArchetype: WrappedArchetypeCardTheme;
-	className: string;
-	isHoverReplayEnabled?: boolean;
-	state: WrappedRevealGradientTextState;
-}) {
-	const {
-		activeArchetype,
-		className,
-		isHoverReplayEnabled = false,
-		state,
-	} = props;
-	const gradient = getWrappedRevealTextGradientValue(activeArchetype);
-	const style: WrappedRevealArchetypeTitleStyle = {
-		"--wrapped-reveal-archetype-accent": gradient.accent,
-		"--wrapped-reveal-archetype-gt-direction": gradient.direction,
-		"--wrapped-reveal-archetype-gt-gradient": gradient.stops,
-	};
-	const classNames = `mymind-wrapped-final-stage__gradient-text ${className}${
-		activeArchetype.id === "obsessed" ? " is-obsession" : ""
-	}`;
-
-	return (
-		<span
-			className={classNames}
-			data-accent-state={state}
-			data-hover-replay={
-				isHoverReplayEnabled && state === "active" ? "ready" : undefined
-			}
-			data-label={activeArchetype.displayLabel}
-			style={style}
-		>
-			{activeArchetype.displayLabel}
-		</span>
-	);
-}
 
 /* ─────────────────────────────────────────────────────────
  * REVEAL COMPANION STORYBOARD
@@ -869,6 +712,7 @@ export function WrappedTeamCardPublicStage(
 		activeArchetype,
 		audience: "public",
 		row,
+		statItems,
 	});
 	const printedCardCaptureKey = [
 		activeArchetype.id,
@@ -964,12 +808,18 @@ export function WrappedTeamCardPublicStage(
 										{row.displayName}
 									</span>
 									<span className="mymind-wrapped-final-stage__archetype-line">
-										is a{" "}
+										{getWrappedRevealArchetypeLinePrefix({
+											activeArchetype,
+											audience: "public",
+										})}
 										<WrappedArchetypeGradientText
 											activeArchetype={activeArchetype}
 											className="mymind-wrapped-final-stage__archetype-accent"
 											isHoverReplayEnabled
 											state="active"
+											suffix={getWrappedRevealArchetypeLineSuffix(
+												activeArchetype,
+											)}
 										/>
 									</span>
 								</h1>
@@ -1063,6 +913,7 @@ export function WrappedTeamCardRevealStage(
 		activeArchetype,
 		onboardingMetrics,
 		row,
+		statItems,
 	});
 	const revealBackMetrics = getWrappedRevealBackMetrics({
 		onboardingMetrics,
@@ -1312,13 +1163,19 @@ export function WrappedTeamCardRevealStage(
 											initial={false}
 											transition={REVEAL_INTRO_COPY.lineTransition}
 										>
-											you&apos;re a{" "}
+											{getWrappedRevealArchetypeLinePrefix({
+												activeArchetype,
+												audience: "owner",
+											})}
 											<WrappedArchetypeGradientText
 												activeArchetype={activeArchetype}
 												className="mymind-wrapped-final-stage__intro-accent"
 												state={
 													shouldShowRevealIntroAccent ? "active" : "waiting"
 												}
+												suffix={getWrappedRevealArchetypeLineSuffix(
+													activeArchetype,
+												)}
 											/>
 										</motion.span>
 									</h1>
@@ -1434,12 +1291,18 @@ export function WrappedTeamCardRevealStage(
 												{row.displayName},
 											</span>
 											<span className="mymind-wrapped-final-stage__archetype-line">
-												you&apos;re a{" "}
+												{getWrappedRevealArchetypeLinePrefix({
+													activeArchetype,
+													audience: "owner",
+												})}
 												<WrappedArchetypeGradientText
 													activeArchetype={activeArchetype}
 													className="mymind-wrapped-final-stage__archetype-accent"
 													isHoverReplayEnabled
 													state="active"
+													suffix={getWrappedRevealArchetypeLineSuffix(
+														activeArchetype,
+													)}
 												/>
 											</span>
 										</h2>
@@ -1552,26 +1415,22 @@ function getWrappedRevealCopy(input: WrappedRevealCopyInput): {
 			};
 		case "hit_and_runner":
 			return {
-				description:
-					"For the operator who gets in, lands the move, and disappears before the mess settles.",
+				description: buildHitAndRunnerRevealDescription(input),
 				title: "Hit. Run. Repeat.",
 			};
 		case "adhd_brain":
 			return {
-				description:
-					"For the mind that keeps five tabs alive, three ideas moving, and the pace somehow intact.",
+				description: buildAdhdBrainRevealDescription(input),
 				title: "Every tab had a job.",
 			};
 		case "cheapskate":
 			return {
-				description:
-					"For the selective one who keeps the spend light and still finds the exact tool worth using.",
+				description: buildCheapskateRevealDescription(input),
 				title: "Low spend, sharp eye.",
 			};
 		case "company_card":
 			return {
-				description:
-					"For the teammate who never thinks small when the work calls for a heavier swing.",
+				description: buildCompanyCardRevealDescription(input),
 				title: "Big-budget instincts.",
 			};
 		case "decimal":
@@ -1582,26 +1441,22 @@ function getWrappedRevealCopy(input: WrappedRevealCopyInput): {
 			};
 		case "tourist":
 			return {
-				description:
-					"For the wanderer who touched every corner of the work and kept moving between scenes.",
+				description: buildTouristRevealDescription(input),
 				title: "Every repo got a visit.",
 			};
 		case "smooth_operator":
 			return {
-				description:
-					"For the steady hand who keeps the machine moving without asking for attention on every pass.",
+				description: buildSmoothOperatorRevealDescription(input),
 				title: "Smooth by default.",
 			};
 		case "obsessed":
 			return {
-				description:
-					"For the one who locked in so hard the sessions started stacking on top of each other.",
+				description: buildObsessedRevealDescription(input),
 				title: "Fully, maybe too fully, locked in.",
 			};
 		case "maniac":
 			return {
-				description:
-					"For the all-gas operator who pushes the pace until the card feels barely contained.",
+				description: buildManiacRevealDescription(input),
 				title: "No chill. All velocity.",
 			};
 		default:
@@ -1630,8 +1485,340 @@ function buildRoadrunnerRevealDescription(input: WrappedRevealCopyInput) {
 	return `You're here. Meep meep. You're gone. Active ${activeDays} out of ${daysSinceFirst} days. When you showed up, we noticed. ${costPerSession} a session. Meep Meep. Gone again. Where? Nobody knows`;
 }
 
+function buildManiacRevealDescription(input: WrappedRevealCopyInput) {
+	const { onboardingMetrics, row, statItems } = input;
+	const activeDays = formatWrappedRevealInteger(row.activeDays);
+	const daysSinceFirst = formatWrappedRevealInteger(
+		onboardingMetrics?.daysSinceFirst ?? row.activeDays,
+	);
+	const distinctProjectCount = formatWrappedRevealInteger(
+		resolveWrappedRevealDistinctProjectCount({
+			onboardingMetrics,
+			statItems,
+		}),
+	);
+	const sessionsPerActiveDay = formatWrappedRevealSessionsPerActiveDay({
+		activeDays: row.activeDays,
+		totalSessions: row.totalSessions,
+	});
+
+	return [
+		`${activeDays} out of ${daysSinceFirst} days. ${distinctProjectCount} repos.`,
+		"Most people are consistent. Some people are everywhere at once.",
+		"You're both. Somehow.",
+		`${sessionsPerActiveDay} sessions every time you're active.`,
+		"We're a little scared honestly. Pls don't hurt someone",
+	].join(" ");
+}
+
+function buildCompanyCardRevealDescription(input: WrappedRevealCopyInput) {
+	const { onboardingMetrics, row } = input;
+	const totalSessions = formatWrappedRevealInteger(row.totalSessions);
+	const commitRate = formatWrappedRevealInteger(
+		onboardingMetrics?.commitRate ?? 0,
+	);
+	const costPerSession = formatCurrency(
+		row.totalSessions > 0 ? row.cost / row.totalSessions : 0,
+	);
+	const totalCost = formatWrappedRevealWholeCurrency(row.cost);
+	const happyLine = formatWrappedRevealCompanyCardHappyLine({
+		favoriteModel: row.favoriteModel,
+		onboardingMetrics,
+	});
+
+	return [
+		`${totalSessions} sessions. ${commitRate}% of them shipped something.`,
+		`${costPerSession} a session. ${totalCost} in total.`,
+		"Not saying it's a problem. We don't judge.",
+		"Spend as much as you want.",
+		happyLine,
+	].join(" ");
+}
+
+function buildAdhdBrainRevealDescription(input: WrappedRevealCopyInput) {
+	const { onboardingMetrics, row, statItems } = input;
+	const activeDays = formatWrappedRevealInteger(row.activeDays);
+	const daysSinceFirst = formatWrappedRevealInteger(
+		onboardingMetrics?.daysSinceFirst ?? row.activeDays,
+	);
+	const distinctProjectCount = formatWrappedRevealInteger(
+		resolveWrappedRevealDistinctProjectCount({
+			onboardingMetrics,
+			statItems,
+		}),
+	);
+	const commitRate = formatWrappedRevealInteger(
+		onboardingMetrics?.commitRate ?? 0,
+	);
+
+	return [
+		`${activeDays} out of ${daysSinceFirst} days. ${distinctProjectCount} repos. ${commitRate}% of sessions shipped something.`,
+		"You'd call yourself a DaVinci.",
+		`We're just worried about the ${distinctProjectCount} repos.`,
+	].join(" ");
+}
+
+function buildHitAndRunnerRevealDescription(input: WrappedRevealCopyInput) {
+	const { onboardingMetrics, statItems } = input;
+	const avgSessionMin = formatWrappedRevealInteger(
+		onboardingMetrics?.avgSessionMin ?? 0,
+	);
+	const distinctProjectCount = formatWrappedRevealInteger(
+		resolveWrappedRevealDistinctProjectCount({
+			onboardingMetrics,
+			statItems,
+		}),
+	);
+	const commitRate = formatWrappedRevealInteger(
+		onboardingMetrics?.commitRate ?? 0,
+	);
+
+	return [
+		`${avgSessionMin} minutes average. ${distinctProjectCount} repos. ${commitRate}% of sessions shipped something.`,
+		"Veni, vidi, commit.",
+		`In at ${avgSessionMin} minutes. Out before anyone noticed.`,
+		"You could be a hitman.",
+	].join(" ");
+}
+
+function buildCheapskateRevealDescription(input: WrappedRevealCopyInput) {
+	const { onboardingMetrics, row } = input;
+	const commitRate = formatWrappedRevealInteger(
+		onboardingMetrics?.commitRate ?? 0,
+	);
+	const costPerSession = formatCurrency(
+		row.totalSessions > 0 ? row.cost / row.totalSessions : 0,
+	);
+
+	return [
+		`${costPerSession} a session. ${commitRate}% of those shipped something.`,
+		"Mr. Krabs is very proud of you. But you've never once picked up the check.",
+	].join(" ");
+}
+
+function buildObsessedRevealDescription(input: WrappedRevealCopyInput) {
+	const { onboardingMetrics, row, statItems } = input;
+	const activeDays = formatWrappedRevealInteger(row.activeDays);
+	const daysSinceFirst = formatWrappedRevealInteger(
+		onboardingMetrics?.daysSinceFirst ?? row.activeDays,
+	);
+	const distinctProjectCount = formatWrappedRevealInteger(
+		resolveWrappedRevealDistinctProjectCount({
+			onboardingMetrics,
+			statItems,
+		}),
+	);
+	const commitRate = formatWrappedRevealInteger(
+		onboardingMetrics?.commitRate ?? 0,
+	);
+	const costPerSession = formatCurrency(
+		row.totalSessions > 0 ? row.cost / row.totalSessions : 0,
+	);
+
+	return [
+		`${distinctProjectCount} repo. That's it.`,
+		`${activeDays} out of ${daysSinceFirst} days. All of it, same place.`,
+		`${commitRate}% of your sessions shipped something. At ${costPerSession} a session.`,
+		"May god help anyone who tries to distract you.",
+	].join(" ");
+}
+
+function buildSmoothOperatorRevealDescription(input: WrappedRevealCopyInput) {
+	const { onboardingMetrics, row } = input;
+	const activeDays = formatWrappedRevealInteger(row.activeDays);
+	const daysSinceFirst = formatWrappedRevealInteger(
+		onboardingMetrics?.daysSinceFirst ?? row.activeDays,
+	);
+	const avgSessionMin = formatWrappedRevealInteger(
+		onboardingMetrics?.avgSessionMin ?? 0,
+	);
+	const longestSessionMin = formatWrappedRevealInteger(
+		onboardingMetrics?.longestSessionMin ?? 0,
+	);
+	const sessionsPerActiveDay = formatWrappedRevealSessionsPerActiveDay({
+		activeDays: row.activeDays,
+		totalSessions: row.totalSessions,
+	});
+	const costPerSession = formatCurrency(
+		row.totalSessions > 0 ? row.cost / row.totalSessions : 0,
+	);
+
+	return [
+		`${activeDays} out of ${daysSinceFirst} days.`,
+		`${avgSessionMin} minutes average. ${longestSessionMin} at your longest.`,
+		"You start. You build. You stop.",
+		`${sessionsPerActiveDay} sessions a day, ${costPerSession} a session, no chaos.`,
+		"A little to bit too smooth... bit suspicious.",
+	].join(" ");
+}
+
+function buildTouristRevealDescription(input: WrappedRevealCopyInput) {
+	const { onboardingMetrics, row } = input;
+	const totalSessions = formatWrappedRevealInteger(row.totalSessions);
+	const commitRate = formatWrappedRevealInteger(
+		onboardingMetrics?.commitRate ?? 0,
+	);
+	const costPerSession = formatCurrency(
+		row.totalSessions > 0 ? row.cost / row.totalSessions : 0,
+	);
+
+	return [
+		`${totalSessions} sessions. ${commitRate}% shipped something. ${costPerSession} a session.`,
+		"At least you tried it out! There's no prize for participation though",
+	].join(" ");
+}
+
 function formatWrappedRevealInteger(value: number) {
 	return Math.max(0, Math.round(value)).toLocaleString("en-US");
+}
+
+function formatWrappedRevealWholeCurrency(value: number) {
+	return `$${formatWrappedRevealInteger(value)}`;
+}
+
+function formatWrappedRevealSessionsPerActiveDay(input: {
+	activeDays: number;
+	totalSessions: number;
+}) {
+	const activeDays = Math.max(0, input.activeDays);
+	const totalSessions = Math.max(0, input.totalSessions);
+	const sessionsPerActiveDay = activeDays > 0 ? totalSessions / activeDays : 0;
+
+	return sessionsPerActiveDay.toLocaleString("en-US", {
+		maximumFractionDigits: 1,
+	});
+}
+
+function resolveWrappedRevealDistinctProjectCount(input: {
+	onboardingMetrics?: WrappedOnboardingMetrics;
+	statItems?: readonly WrappedTeamMemberCardStatItem[];
+}) {
+	const onboardingCount = input.onboardingMetrics?.distinctProjectCount;
+
+	if (onboardingCount !== undefined && onboardingCount > 0) {
+		return onboardingCount;
+	}
+
+	const statItemValue = input.statItems?.find(
+		(item) => item.key === "repos",
+	)?.value;
+	const parsedStatItemValue = statItemValue
+		? Number.parseInt(statItemValue.replaceAll(/\D/gu, ""), 10)
+		: Number.NaN;
+
+	if (Number.isFinite(parsedStatItemValue)) {
+		return parsedStatItemValue;
+	}
+
+	return input.onboardingMetrics?.repoPulse.totalRepos ?? 0;
+}
+
+function formatWrappedRevealCompanyCardHappyLine(input: {
+	favoriteModel: string | null;
+	onboardingMetrics?: WrappedOnboardingMetrics;
+}) {
+	const usageSource = getWrappedRevealCompanyCardUsageSource(input);
+
+	if (usageSource === "claude") {
+		return "Dario's happy to have you.";
+	}
+
+	if (usageSource === "codex") {
+		return "Sam's happy to have you.";
+	}
+
+	return "Dario & Sam are happy to have you.";
+}
+
+function getWrappedRevealCompanyCardUsageSource(input: {
+	favoriteModel: string | null;
+	onboardingMetrics?: WrappedOnboardingMetrics;
+}) {
+	const sourceSplit = input.onboardingMetrics?.sourceSplit ?? [];
+	const hasClaude = sourceSplit.some(
+		(entry) =>
+			entry.source === "claude_code" &&
+			(entry.session_count > 0 || entry.session_share_percent > 0),
+	);
+	const hasCodex = sourceSplit.some(
+		(entry) =>
+			entry.source === "codex" &&
+			(entry.session_count > 0 || entry.session_share_percent > 0),
+	);
+
+	if (hasClaude && !hasCodex) {
+		return "claude";
+	}
+
+	if (hasCodex && !hasClaude) {
+		return "codex";
+	}
+
+	if (hasClaude && hasCodex) {
+		return "both";
+	}
+
+	const normalizedFavoriteModel = input.favoriteModel?.toLowerCase() ?? "";
+
+	if (normalizedFavoriteModel.includes("claude")) {
+		return "claude";
+	}
+
+	if (
+		normalizedFavoriteModel.includes("codex") ||
+		normalizedFavoriteModel.includes("gpt") ||
+		normalizedFavoriteModel.includes("openai")
+	) {
+		return "codex";
+	}
+
+	return "both";
+}
+
+function getWrappedRevealArchetypeLinePrefix(input: {
+	activeArchetype: WrappedArchetypeCardTheme;
+	audience: "owner" | "public";
+}) {
+	const archetypeId = input.activeArchetype.id;
+
+	if (input.audience === "public") {
+		if (archetypeId === "company_card") {
+			return "got the ";
+		}
+
+		if (archetypeId === "adhd_brain") {
+			return "is an ";
+		}
+
+		return archetypeId === "obsessed" ? "is " : "is a ";
+	}
+
+	if (archetypeId === "company_card") {
+		return "you got the ";
+	}
+
+	if (archetypeId === "adhd_brain") {
+		return "you're an ";
+	}
+
+	return archetypeId === "obsessed" ? "you're " : "you're a ";
+}
+
+function getWrappedRevealArchetypeLineSuffix(
+	activeArchetype: WrappedArchetypeCardTheme,
+) {
+	if (activeArchetype.id === "company_card") {
+		return "?";
+	}
+
+	return activeArchetype.id === "obsessed" ||
+		activeArchetype.id === "adhd_brain" ||
+		activeArchetype.id === "cheapskate" ||
+		activeArchetype.id === "hit_and_runner" ||
+		activeArchetype.id === "smooth_operator" ||
+		activeArchetype.id === "tourist"
+		? "."
+		: "";
 }
 
 export function WrappedTeamCardRevealFooter(props: {

--- a/apps/web/src/features/wrapped/team-card/onboarding-metrics.ts
+++ b/apps/web/src/features/wrapped/team-card/onboarding-metrics.ts
@@ -55,6 +55,8 @@ export function buildWrappedOnboardingMetrics(
 			totalSessions > 0 ? (commitSessions / totalSessions) * 100 : null,
 		commitSessions,
 		daysSinceFirst: wrappedMetrics?.days_since_first_session ?? 0,
+		distinctProjectCount:
+			developerDetails?.distinct_projects ?? developerProjects?.length ?? 0,
 		estimatedCostTokenBasis,
 		estimatedCostUsd,
 		favoriteModel: formatWrappedLabel(

--- a/apps/web/src/features/wrapped/team-card/page.tsx
+++ b/apps/web/src/features/wrapped/team-card/page.tsx
@@ -371,7 +371,10 @@ function WrappedTeamCardPageContent(props: {
 	// download behavior inside the share module.
 	const shareActions = createWrappedTeamCardShareActions({
 		archetypeLabel: activeArchetype.displayLabel,
+		avgSessionMin: onboardingMetrics.avgSessionMin,
+		commitRate: onboardingMetrics.commitRate,
 		daysSinceFirst: onboardingMetrics.daysSinceFirst,
+		distinctProjectCount: onboardingMetrics.distinctProjectCount,
 		displayName: visibleTeamCardRow.displayName,
 		onShareActionTriggered: (action) => {
 			trackUtilityUsed({

--- a/apps/web/src/features/wrapped/team-card/share.test.ts
+++ b/apps/web/src/features/wrapped/team-card/share.test.ts
@@ -153,6 +153,8 @@ describe("createWrappedTeamCardShareActions", () => {
 
 		const actions = createWrappedTeamCardShareActions({
 			archetypeLabel: "Maniac",
+			daysSinceFirst: 180,
+			distinctProjectCount: 6,
 			displayName: "Jane Doe",
 			resolveShareUrl,
 			row: buildTeamPageMemberRow({
@@ -229,8 +231,7 @@ describe("createWrappedTeamCardShareActions", () => {
 		const intentUrl = new URL(open.mock.calls[0]?.[0] ?? "");
 		expect(intentUrl.searchParams.get("text")).toBe(
 			[
-				"My Codex usage says I'm a Maniac.",
-				"Traits: 1.9M tokens over 219 sessions; high session count, heavy token burn, no visible off switch.",
+				"My Codex usage says I'm a Maniac. Active 12 out of 180 days, 6 repos, 18.3 sessions per active day. Yeah, you should be a little scared.",
 				"Check my profile out here https://rudel.ai/wrapped/public-card",
 				"[Your image is in your clipboard, pls paste and dont forget]",
 			].join("\n\n"),

--- a/apps/web/src/features/wrapped/team-card/share.ts
+++ b/apps/web/src/features/wrapped/team-card/share.ts
@@ -25,7 +25,10 @@ type WrappedShareActionKind = "copy" | "download" | "share";
 
 interface CreateWrappedTeamCardShareActionsParams {
 	archetypeLabel: string;
+	avgSessionMin?: number | null;
+	commitRate?: number | null;
 	daysSinceFirst?: number;
+	distinctProjectCount?: number;
 	displayName: string;
 	onShareActionTriggered?: (action: WrappedShareActionKind) => void;
 	resolveShareUrl?: () => Promise<string | undefined>;
@@ -49,7 +52,10 @@ export function createWrappedTeamCardShareActions(
 ): WrappedTeamCardShareActions {
 	const {
 		archetypeLabel,
+		avgSessionMin,
+		commitRate,
 		daysSinceFirst,
+		distinctProjectCount,
 		displayName,
 		onShareActionTriggered,
 		resolveShareUrl,
@@ -63,8 +69,11 @@ export function createWrappedTeamCardShareActions(
 	const shareText = buildWrappedXShareText({
 		activeDays: row.activeDays,
 		archetypeLabel,
+		avgSessionMin,
+		commitRate,
 		cost: row.cost,
 		daysSinceFirst,
+		distinctProjectCount,
 		displayName,
 		favoriteModel: row.favoriteModel,
 		sourceSplit,

--- a/apps/web/src/features/wrapped/team-card/use-page-data.ts
+++ b/apps/web/src/features/wrapped/team-card/use-page-data.ts
@@ -164,11 +164,11 @@ export function useWrappedTeamCardPageData(): UseWrappedTeamCardPageDataResult {
 		() =>
 			buildWrappedStatItems(
 				visibleTeamCardRow,
-				developerDetailsQuery.data?.distinct_projects ?? 0,
+				onboardingMetrics.distinctProjectCount,
 				wrappedData?.metrics.source_split ?? [],
 			),
 		[
-			developerDetailsQuery.data?.distinct_projects,
+			onboardingMetrics.distinctProjectCount,
 			visibleTeamCardRow,
 			wrappedData?.metrics.source_split,
 		],

--- a/apps/web/src/features/wrapped/wrapped-guest-card-presets.ts
+++ b/apps/web/src/features/wrapped/wrapped-guest-card-presets.ts
@@ -59,6 +59,7 @@ const RICK_PLACEHOLDER_ONBOARDING_METRICS: WrappedOnboardingMetrics = {
 	commitRate: 48,
 	commitSessions: 105,
 	daysSinceFirst: 214,
+	distinctProjectCount: 12,
 	estimatedCostTokenBasis: 0,
 	estimatedCostUsd: 347,
 	favoriteModel: "claude-3-7-sonnet",

--- a/apps/web/src/features/wrapped/wrapped-x-share.test.ts
+++ b/apps/web/src/features/wrapped/wrapped-x-share.test.ts
@@ -5,10 +5,13 @@ import {
 } from "@/features/wrapped/wrapped-x-share";
 
 describe("wrapped X share copy", () => {
-	it("builds archetype-specific copy with compact metrics", () => {
+	it("builds Maniac copy with activity, repo, and session density metrics", () => {
 		expect(
 			buildWrappedXShareText({
+				activeDays: 12,
 				archetypeLabel: "Maniac",
+				daysSinceFirst: 180,
+				distinctProjectCount: 6,
 				displayName: "Evren",
 				totalSessions: 219,
 				totalTokens: 1_920_000,
@@ -16,8 +19,8 @@ describe("wrapped X share copy", () => {
 		).toBe(
 			[
 				"My Claude Code and Codex usage says I'm a Maniac.",
-				"Traits: 1.9M tokens over 219 sessions; high session count, heavy token burn, no visible off switch.",
-			].join("\n\n"),
+				"Active 12 out of 180 days, 6 repos, 18.3 sessions per active day. Yeah, you should be a little scared.",
+			].join(" "),
 		);
 	});
 
@@ -54,6 +57,227 @@ describe("wrapped X share copy", () => {
 				"Meep meep.",
 				"Gone.",
 			].join("\n\n"),
+		);
+	});
+
+	it("builds Obsessed copy with repo, activity, and commit metrics", () => {
+		expect(
+			buildWrappedXShareText({
+				activeDays: 58,
+				archetypeLabel: "Obsessed",
+				commitRate: 48,
+				daysSinceFirst: 214,
+				distinctProjectCount: 1,
+				displayName: "Evren",
+				sourceSplit: [
+					{
+						session_count: 125,
+						session_share_percent: 57,
+						source: "claude_code",
+					},
+					{
+						session_count: 94,
+						session_share_percent: 43,
+						source: "codex",
+					},
+				],
+			}),
+		).toBe(
+			"My Claude Code and Codex usage says I'm Obsessed. 1 repo, 58 out of 214 days, 48% of sessions shipped something. Apparently I have nothing else in my life. I dare you to distract me.",
+		);
+	});
+
+	it("builds Company Card copy with spend metrics and source-specific names", () => {
+		expect(
+			buildWrappedXShareText({
+				archetypeLabel: "Company Card",
+				commitRate: 48,
+				cost: 44,
+				displayName: "Evren",
+				sourceSplit: [
+					{
+						session_count: 7,
+						session_share_percent: 50,
+						source: "claude_code",
+					},
+					{
+						session_count: 7,
+						session_share_percent: 50,
+						source: "codex",
+					},
+				],
+				totalSessions: 8,
+			}),
+		).toBe(
+			"My Claude Code and Codex usage says I got the Company Card... 8 sessions, 48% shipped something, $44 in total. Dario & Sam are probably happy to have me.",
+		);
+
+		expect(
+			buildWrappedXShareText({
+				archetypeLabel: "Company Card",
+				commitRate: 48,
+				cost: 44,
+				displayName: "Evren",
+				sourceSplit: [
+					{
+						session_count: 8,
+						session_share_percent: 100,
+						source: "claude_code",
+					},
+				],
+				totalSessions: 8,
+			}),
+		).toBe(
+			"My Claude Code usage says I got the Company Card... 8 sessions, 48% shipped something, $44 in total. Dario's probably happy to have me.",
+		);
+
+		expect(
+			buildWrappedXShareText({
+				archetypeLabel: "Company Card",
+				commitRate: 48,
+				cost: 44,
+				displayName: "Evren",
+				sourceSplit: [
+					{
+						session_count: 8,
+						session_share_percent: 100,
+						source: "codex",
+					},
+				],
+				totalSessions: 8,
+			}),
+		).toBe(
+			"My Codex usage says I got the Company Card... 8 sessions, 48% shipped something, $44 in total. Sam's probably happy to have me.",
+		);
+	});
+
+	it("builds Smooth Operator copy with cadence metrics", () => {
+		expect(
+			buildWrappedXShareText({
+				activeDays: 12,
+				archetypeLabel: "Smooth Operator",
+				avgSessionMin: 24,
+				daysSinceFirst: 180,
+				displayName: "Evren",
+				favoriteModel: "gpt-5.3-codex",
+				totalSessions: 37,
+			}),
+		).toBe(
+			"My Codex usage says I'm a Smooooooth Operator. Active 12 out of 180 days, 24 minute average session, 3.1 a day. Haters gonna try to find something on me, but they can't because I'm a smooooth operator.",
+		);
+	});
+
+	it("builds ADHD Brain copy with activity, repo, and commit metrics", () => {
+		expect(
+			buildWrappedXShareText({
+				activeDays: 12,
+				archetypeLabel: "ADHD Brain",
+				commitRate: 48,
+				daysSinceFirst: 180,
+				distinctProjectCount: 6,
+				displayName: "Evren",
+				sourceSplit: [
+					{
+						session_count: 21,
+						session_share_percent: 57,
+						source: "claude_code",
+					},
+					{
+						session_count: 16,
+						session_share_percent: 43,
+						source: "codex",
+					},
+				],
+			}),
+		).toBe(
+			"My Claude Code and Codex usage says I'm an ADHD Brain. 12 out of 180 days, 6 repos, 48% shipped. DaVinci also had many projects! I'm his reincarnation.. i guess.",
+		);
+	});
+
+	it("builds Hit and Runner copy with session, repo, and commit metrics", () => {
+		expect(
+			buildWrappedXShareText({
+				archetypeLabel: "Hit and Runner",
+				avgSessionMin: 24,
+				commitRate: 48,
+				distinctProjectCount: 6,
+				displayName: "Evren",
+				sourceSplit: [
+					{
+						session_count: 42,
+						session_share_percent: 100,
+						source: "codex",
+					},
+				],
+			}),
+		).toBe(
+			"My Codex usage says I'm a Hit and Runner. 24 minute sessions, 6 repos, 48% shipped. Veni, vidi, commit. In, out, no witnesses.",
+		);
+	});
+
+	it("builds Cheapskate copy with cost per session and commit metrics", () => {
+		expect(
+			buildWrappedXShareText({
+				archetypeLabel: "Cheapskate",
+				commitRate: 48,
+				cost: 44,
+				displayName: "Evren",
+				sourceSplit: [
+					{
+						session_count: 42,
+						session_share_percent: 100,
+						source: "codex",
+					},
+				],
+				totalSessions: 8,
+			}),
+		).toBe(
+			"My Codex usage says I'm a Cheapskate. $5.50 a session, 48% shipped. Mr. Krabs is very proud of me. Spent less, shipped more. Very efficient. Pls don't ask me to pay for dinner though.",
+		);
+	});
+
+	it("builds Tourist copy with total spend and source-specific fallback product", () => {
+		expect(
+			buildWrappedXShareText({
+				archetypeLabel: "Tourist",
+				commitRate: 48,
+				cost: 44,
+				displayName: "Evren",
+				sourceSplit: [
+					{
+						session_count: 42,
+						session_share_percent: 100,
+						source: "codex",
+					},
+				],
+				totalSessions: 8,
+			}),
+		).toBe(
+			"My Codex usage says I'm a Tourist. 8 sessions, 48% shipped, $44 spent in total.. I'm definitely not the person who'll get prompt injected by this OpenClaw thing. I'll stick to ChatGPT",
+		);
+
+		expect(
+			buildWrappedXShareText({
+				archetypeLabel: "Tourist",
+				commitRate: 48,
+				cost: 44,
+				displayName: "Evren",
+				sourceSplit: [
+					{
+						session_count: 8,
+						session_share_percent: 50,
+						source: "claude_code",
+					},
+					{
+						session_count: 8,
+						session_share_percent: 50,
+						source: "codex",
+					},
+				],
+				totalSessions: 8,
+			}),
+		).toBe(
+			"My Claude Code and Codex usage says I'm a Tourist. 8 sessions, 48% shipped, $44 spent in total.. I'm definitely not the person who'll get prompt injected by this OpenClaw thing. I'll stick to Claude",
 		);
 	});
 

--- a/apps/web/src/features/wrapped/wrapped-x-share.ts
+++ b/apps/web/src/features/wrapped/wrapped-x-share.ts
@@ -4,8 +4,11 @@ import { formatCurrency } from "@/lib/format";
 interface BuildWrappedXShareTextInput {
 	activeDays?: number | null;
 	archetypeLabel: string;
+	avgSessionMin?: number | null;
+	commitRate?: number | null;
 	cost?: number | null;
 	daysSinceFirst?: number | null;
+	distinctProjectCount?: number | null;
 	displayName: string;
 	favoriteModel?: string | null;
 	sourceSplit?: readonly WrappedSourceSplit[];
@@ -25,44 +28,13 @@ interface WrappedXShareCopy {
 const WRAPPED_X_INTENT_URL = "https://twitter.com/intent/tweet";
 
 const WRAPPED_X_SHARE_COPY_BY_ARCHETYPE: Record<string, WrappedXShareCopy> = {
-	"adhd brain": {
-		traits:
-			"jumps between threads, keeps too many tabs warm, still turns chaos into progress",
-	},
-	cheapskate: {
-		traits:
-			"watches token spend, stretches each prompt, gets the answer without lighting money on fire",
-	},
-	"company card": {
-		traits:
-			"pushes usage hard, trusts the budget line, treats the meter like someone else's problem",
-	},
 	decimal: {
 		traits:
 			"cares about precision, trims the messy edges, does not tolerate fuzzy answers",
 	},
-	"hit and runner": {
-		traits:
-			"drops in fast, gets the thing shipped, disappears before the meeting gets scheduled",
-	},
-	maniac: {
-		traits: "high session count, heavy token burn, no visible off switch",
-	},
-	obsessed: {
-		traits:
-			"keeps coming back, keeps digging deeper, probably knows the repo's floor plan",
-	},
 	roadrunner: {
 		traits:
 			"moves quickly, keeps sessions short, ships before the dust settles",
-	},
-	"smooth operator": {
-		traits:
-			"stays consistent, keeps the output clean, makes noisy work look routine",
-	},
-	tourist: {
-		traits:
-			"wanders across repos, samples every corner, collects project stamps",
 	},
 };
 
@@ -74,8 +46,11 @@ export function buildWrappedXShareText(input: BuildWrappedXShareTextInput) {
 	const {
 		activeDays,
 		archetypeLabel,
+		avgSessionMin,
+		commitRate,
 		cost,
 		daysSinceFirst,
+		distinctProjectCount,
 		favoriteModel,
 		sourceSplit,
 		totalSessions,
@@ -107,6 +82,102 @@ export function buildWrappedXShareText(input: BuildWrappedXShareTextInput) {
 				totalSessions,
 			}),
 		].join("\n\n");
+	}
+
+	if (normalizedArchetypeLabel === "company card") {
+		return [
+			`My ${usageSourceLabel} usage says I got the Company Card...`,
+			buildWrappedXCompanyCardShareBody({
+				commitRate,
+				cost,
+				favoriteModel,
+				sourceSplit,
+				totalSessions,
+			}),
+		].join(" ");
+	}
+
+	if (normalizedArchetypeLabel === "adhd brain") {
+		return [
+			openingLine,
+			buildWrappedXAdhdBrainShareBody({
+				activeDays,
+				commitRate,
+				daysSinceFirst,
+				distinctProjectCount,
+			}),
+		].join(" ");
+	}
+
+	if (normalizedArchetypeLabel === "cheapskate") {
+		return [
+			openingLine,
+			buildWrappedXCheapskateShareBody({
+				commitRate,
+				cost,
+				totalSessions,
+			}),
+		].join(" ");
+	}
+
+	if (normalizedArchetypeLabel === "hit and runner") {
+		return [
+			openingLine,
+			buildWrappedXHitAndRunnerShareBody({
+				avgSessionMin,
+				commitRate,
+				distinctProjectCount,
+			}),
+		].join(" ");
+	}
+
+	if (normalizedArchetypeLabel === "maniac") {
+		return [
+			openingLine,
+			buildWrappedXManiacShareBody({
+				activeDays,
+				daysSinceFirst,
+				distinctProjectCount,
+				totalSessions,
+			}),
+		].join(" ");
+	}
+
+	if (normalizedArchetypeLabel === "obsessed") {
+		return [
+			openingLine,
+			buildWrappedXObsessedShareBody({
+				activeDays,
+				commitRate,
+				daysSinceFirst,
+				distinctProjectCount,
+			}),
+		].join(" ");
+	}
+
+	if (normalizedArchetypeLabel === "smooth operator") {
+		return [
+			`My ${usageSourceLabel} usage says I'm a Smooooooth Operator.`,
+			buildWrappedXSmoothOperatorShareBody({
+				activeDays,
+				avgSessionMin,
+				daysSinceFirst,
+				totalSessions,
+			}),
+		].join(" ");
+	}
+
+	if (normalizedArchetypeLabel === "tourist") {
+		return [
+			openingLine,
+			buildWrappedXTouristShareBody({
+				commitRate,
+				cost,
+				favoriteModel,
+				sourceSplit,
+				totalSessions,
+			}),
+		].join(" ");
 	}
 
 	return [openingLine, `Traits: ${metrics}; ${copy.traits}.`].join("\n\n");
@@ -154,6 +225,165 @@ function buildWrappedXRoadrunnerShareBody(input: {
 	].join("\n\n");
 }
 
+function buildWrappedXManiacShareBody(input: {
+	activeDays?: number | null;
+	daysSinceFirst?: number | null;
+	distinctProjectCount?: number | null;
+	totalSessions?: number | null;
+}) {
+	const activeDays = formatWrappedXWholeNumber(input.activeDays);
+	const daysSinceFirst = formatWrappedXWholeNumber(input.daysSinceFirst);
+	const distinctProjectCount = formatWrappedXWholeNumber(
+		input.distinctProjectCount,
+	);
+	const sessionsPerActiveDay = formatWrappedXSessionsPerActiveDay({
+		activeDays: input.activeDays,
+		totalSessions: input.totalSessions,
+	});
+
+	return `Active ${activeDays} out of ${daysSinceFirst} days, ${distinctProjectCount} repos, ${sessionsPerActiveDay} sessions per active day. Yeah, you should be a little scared.`;
+}
+
+function buildWrappedXCompanyCardShareBody(input: {
+	commitRate?: number | null;
+	cost?: number | null;
+	favoriteModel?: string | null;
+	sourceSplit?: readonly WrappedSourceSplit[];
+	totalSessions?: number | null;
+}) {
+	const totalSessions = formatWrappedXWholeNumber(input.totalSessions);
+	const commitRate = formatWrappedXWholeNumber(input.commitRate);
+	const totalCost = formatWrappedXWholeCurrency(input.cost);
+	const happyLine = formatWrappedXCompanyCardHappyLine({
+		favoriteModel: input.favoriteModel,
+		sourceSplit: input.sourceSplit,
+	});
+
+	return `${totalSessions} sessions, ${commitRate}% shipped something, ${totalCost} in total. ${happyLine}`;
+}
+
+function buildWrappedXAdhdBrainShareBody(input: {
+	activeDays?: number | null;
+	commitRate?: number | null;
+	daysSinceFirst?: number | null;
+	distinctProjectCount?: number | null;
+}) {
+	const activeDays = formatWrappedXWholeNumber(input.activeDays);
+	const daysSinceFirst = formatWrappedXWholeNumber(input.daysSinceFirst);
+	const distinctProjectCount = formatWrappedXWholeNumber(
+		input.distinctProjectCount,
+	);
+	const commitRate = formatWrappedXWholeNumber(input.commitRate);
+
+	return `${activeDays} out of ${daysSinceFirst} days, ${distinctProjectCount} repos, ${commitRate}% shipped. DaVinci also had many projects! I'm his reincarnation.. i guess.`;
+}
+
+function buildWrappedXHitAndRunnerShareBody(input: {
+	avgSessionMin?: number | null;
+	commitRate?: number | null;
+	distinctProjectCount?: number | null;
+}) {
+	const avgSessionMin = formatWrappedXWholeNumber(input.avgSessionMin);
+	const distinctProjectCount = formatWrappedXWholeNumber(
+		input.distinctProjectCount,
+	);
+	const commitRate = formatWrappedXWholeNumber(input.commitRate);
+
+	return `${avgSessionMin} minute sessions, ${distinctProjectCount} repos, ${commitRate}% shipped. Veni, vidi, commit. In, out, no witnesses.`;
+}
+
+function buildWrappedXCheapskateShareBody(input: {
+	commitRate?: number | null;
+	cost?: number | null;
+	totalSessions?: number | null;
+}) {
+	const commitRate = formatWrappedXWholeNumber(input.commitRate);
+	const costPerSession = formatCurrency(
+		input.cost && input.totalSessions && input.totalSessions > 0
+			? input.cost / input.totalSessions
+			: 0,
+	);
+
+	return `${costPerSession} a session, ${commitRate}% shipped. Mr. Krabs is very proud of me. Spent less, shipped more. Very efficient. Pls don't ask me to pay for dinner though.`;
+}
+
+function buildWrappedXObsessedShareBody(input: {
+	activeDays?: number | null;
+	commitRate?: number | null;
+	daysSinceFirst?: number | null;
+	distinctProjectCount?: number | null;
+}) {
+	const activeDays = formatWrappedXWholeNumber(input.activeDays);
+	const daysSinceFirst = formatWrappedXWholeNumber(input.daysSinceFirst);
+	const distinctProjectCount = formatWrappedXWholeNumber(
+		input.distinctProjectCount,
+	);
+	const commitRate = formatWrappedXWholeNumber(input.commitRate);
+
+	return `${distinctProjectCount} repo, ${activeDays} out of ${daysSinceFirst} days, ${commitRate}% of sessions shipped something. Apparently I have nothing else in my life. I dare you to distract me.`;
+}
+
+function buildWrappedXSmoothOperatorShareBody(input: {
+	activeDays?: number | null;
+	avgSessionMin?: number | null;
+	daysSinceFirst?: number | null;
+	totalSessions?: number | null;
+}) {
+	const activeDays = formatWrappedXWholeNumber(input.activeDays);
+	const daysSinceFirst = formatWrappedXWholeNumber(input.daysSinceFirst);
+	const avgSessionMin = formatWrappedXWholeNumber(input.avgSessionMin);
+	const sessionsPerActiveDay = formatWrappedXSessionsPerActiveDay({
+		activeDays: input.activeDays,
+		totalSessions: input.totalSessions,
+	});
+
+	return `Active ${activeDays} out of ${daysSinceFirst} days, ${avgSessionMin} minute average session, ${sessionsPerActiveDay} a day. Haters gonna try to find something on me, but they can't because I'm a smooooth operator.`;
+}
+
+function buildWrappedXTouristShareBody(input: {
+	commitRate?: number | null;
+	cost?: number | null;
+	favoriteModel?: string | null;
+	sourceSplit?: readonly WrappedSourceSplit[];
+	totalSessions?: number | null;
+}) {
+	const totalSessions = formatWrappedXWholeNumber(input.totalSessions);
+	const commitRate = formatWrappedXWholeNumber(input.commitRate);
+	const totalCost = formatWrappedXWholeCurrency(input.cost);
+	const fallbackProduct = formatWrappedXTouristFallbackProduct({
+		favoriteModel: input.favoriteModel,
+		sourceSplit: input.sourceSplit,
+	});
+
+	return `${totalSessions} sessions, ${commitRate}% shipped, ${totalCost} spent in total.. I'm definitely not the person who'll get prompt injected by this OpenClaw thing. I'll stick to ${fallbackProduct}`;
+}
+
+function formatWrappedXCompanyCardHappyLine(input: {
+	favoriteModel?: string | null;
+	sourceSplit?: readonly WrappedSourceSplit[];
+}) {
+	const usageSourceLabel = formatWrappedXUsageSourceLabel(input);
+
+	if (usageSourceLabel === "Claude Code") {
+		return "Dario's probably happy to have me.";
+	}
+
+	if (usageSourceLabel === "Codex") {
+		return "Sam's probably happy to have me.";
+	}
+
+	return "Dario & Sam are probably happy to have me.";
+}
+
+function formatWrappedXTouristFallbackProduct(input: {
+	favoriteModel?: string | null;
+	sourceSplit?: readonly WrappedSourceSplit[];
+}) {
+	const usageSourceLabel = formatWrappedXUsageSourceLabel(input);
+
+	return usageSourceLabel === "Codex" ? "ChatGPT" : "Claude";
+}
+
 function formatWrappedXShareMetrics(input: {
 	totalSessions?: number | null;
 	totalTokens?: number | null;
@@ -191,6 +421,23 @@ function formatWrappedXCompactNumber(value: number) {
 
 function formatWrappedXWholeNumber(value: number | null | undefined) {
 	return Math.round(Math.max(0, value ?? 0)).toLocaleString("en-US");
+}
+
+function formatWrappedXWholeCurrency(value: number | null | undefined) {
+	return `$${formatWrappedXWholeNumber(value)}`;
+}
+
+function formatWrappedXSessionsPerActiveDay(input: {
+	activeDays?: number | null;
+	totalSessions?: number | null;
+}) {
+	const activeDays = Math.max(0, input.activeDays ?? 0);
+	const totalSessions = Math.max(0, input.totalSessions ?? 0);
+	const sessionsPerActiveDay = activeDays > 0 ? totalSessions / activeDays : 0;
+
+	return sessionsPerActiveDay.toLocaleString("en-US", {
+		maximumFractionDigits: 1,
+	});
 }
 
 function formatWrappedXScaledNumber(value: number, scale: number) {


### PR DESCRIPTION
## Summary
- add metric-driven reveal and X share copy for wrapped archetypes
- pass distinct repo, commit rate, average session, and cadence metrics into card sharing
- support archetype title punctuation through the shared gradient text helper

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig
- [x] bun run --cwd apps/web test src/features/wrapped/wrapped-x-share.test.ts src/features/wrapped/team-card/final-stages.test.tsx src/features/wrapped/team-card/share.test.ts src/features/wrapped/team-card/card-back.test.tsx src/features/wrapped/onboarding/shell.test.tsx