### PR TITLE
feat: polish wrapped public sharing

### DIFF
--- a/apps/api/src/__tests__/wrapped-share-slug.test.ts
+++ b/apps/api/src/__tests__/wrapped-share-slug.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildWrappedShareIdBase,
+	getNextWrappedShareIdCandidate,
+} from "../services/wrapped-share-slug.js";
+
+describe("wrapped share slugs", () => {
+	test("uses the provided username as the public id base", () => {
+		expect(
+			buildWrappedShareIdBase({
+				fallbackLabel: "Evren Dombak",
+				username: "Evren_Dev",
+			}),
+		).toBe("Evren_Dev");
+	});
+
+	test("falls back to a route-safe label slug when username is missing", () => {
+		expect(
+			buildWrappedShareIdBase({
+				fallbackLabel: "Evren Dombak",
+			}),
+		).toBe("evren-dombak");
+	});
+
+	test("appends the lowest available dash suffix when the base is taken", () => {
+		expect(
+			getNextWrappedShareIdCandidate({
+				baseId: "evren",
+				existingIds: ["evren", "evren-1", "evren-3"],
+			}),
+		).toBe("evren-2");
+	});
+});

--- a/apps/api/src/handlers/wrapped-share.ts
+++ b/apps/api/src/handlers/wrapped-share.ts
@@ -19,11 +19,14 @@ const create = os.wrappedShare.create
 		// system before launch.
 		checkWrappedShareCreateRateLimit(context.user.id);
 
-		return createWrappedShare({
+		const shareOptions = {
 			organizationId: context.organizationId,
 			snapshot: input.snapshot,
 			userId: context.user.id,
-		});
+			...(input.username ? { username: input.username } : {}),
+		};
+
+		return createWrappedShare(shareOptions);
 	});
 
 // Public replay is intentionally anonymous. The only contract is the share id

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -122,10 +122,15 @@ const STATIC_DIR = join(
 	"..",
 	process.env.STATIC_DIR ?? "public",
 );
-const WRAPPED_PUBLIC_PATH_PATTERN =
-	/^\/wrapped\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/iu;
-const WRAPPED_SHARE_CARD_IMAGE_PATH_PATTERN =
-	/^\/wrapped\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/x-card\.png$/iu;
+const WRAPPED_PUBLIC_SHARE_ID_SEGMENT = "([A-Za-z0-9_-]+)";
+const WRAPPED_PUBLIC_PATH_PATTERN = new RegExp(
+	`^/wrapped/${WRAPPED_PUBLIC_SHARE_ID_SEGMENT}/?$`,
+	"u",
+);
+const WRAPPED_SHARE_CARD_IMAGE_PATH_PATTERN = new RegExp(
+	`^/wrapped/${WRAPPED_PUBLIC_SHARE_ID_SEGMENT}/x-card\\.png$`,
+	"u",
+);
 
 function corsHeaders(origin: string | null): Record<string, string> {
 	if (!origin || !trustedOrigins.includes(origin)) return {};

--- a/apps/api/src/services/wrapped-share-slug.ts
+++ b/apps/api/src/services/wrapped-share-slug.ts
@@ -1,0 +1,56 @@
+interface BuildWrappedShareIdBaseInput {
+	fallbackLabel: string;
+	username?: string;
+}
+
+const WRAPPED_SHARE_FALLBACK_ID_BASE = "wrapped";
+const WRAPPED_SHARE_FALLBACK_ID_BASE_MAX_LENGTH = 64;
+const WRAPPED_SHARE_ROUTE_SEGMENT_PATTERN = /^[A-Za-z0-9_-]+$/u;
+
+export function buildWrappedShareIdBase(input: BuildWrappedShareIdBaseInput) {
+	const username = input.username?.trim().replace(/^@+/u, "");
+
+	if (username && WRAPPED_SHARE_ROUTE_SEGMENT_PATTERN.test(username)) {
+		return username;
+	}
+
+	return (
+		slugifyWrappedShareFallbackLabel(input.fallbackLabel) ??
+		WRAPPED_SHARE_FALLBACK_ID_BASE
+	);
+}
+
+export function getNextWrappedShareIdCandidate(input: {
+	baseId: string;
+	existingIds: readonly string[];
+}) {
+	const { baseId, existingIds } = input;
+	const existingIdSet = new Set(existingIds);
+
+	if (!existingIdSet.has(baseId)) {
+		return baseId;
+	}
+
+	let suffix = 1;
+	let candidateId = `${baseId}-${suffix}`;
+
+	while (existingIdSet.has(candidateId)) {
+		suffix += 1;
+		candidateId = `${baseId}-${suffix}`;
+	}
+
+	return candidateId;
+}
+
+function slugifyWrappedShareFallbackLabel(value: string) {
+	const slug = value
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9_-]+/gu, "-")
+		.replace(/-+/gu, "-")
+		.replace(/^-|-$/gu, "")
+		.slice(0, WRAPPED_SHARE_FALLBACK_ID_BASE_MAX_LENGTH)
+		.replace(/-$/u, "");
+
+	return slug.length > 0 ? slug : null;
+}

--- a/apps/api/src/services/wrapped-share.service.ts
+++ b/apps/api/src/services/wrapped-share.service.ts
@@ -8,15 +8,21 @@ import {
 	WrappedShareSnapshotSchema,
 } from "@rudel/api-routes";
 import { sqlClient } from "../db.js";
+import {
+	buildWrappedShareIdBase,
+	getNextWrappedShareIdCandidate,
+} from "./wrapped-share-slug.js";
 
 interface CreateWrappedShareOptions {
 	organizationId: string;
 	snapshot: WrappedShareSnapshot;
 	userId: string;
+	username?: string;
 }
 
 const WRAPPED_SHARE_TTL_DAYS = 30;
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+const WRAPPED_SHARE_ID_INSERT_ATTEMPTS = 20;
 
 // Persist a fully rendered public snapshot. We store the already-resolved card
 // data instead of rebuilding it later so the public share route stays simple and
@@ -24,39 +30,57 @@ const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
 export async function createWrappedShare(
 	options: CreateWrappedShareOptions,
 ): Promise<WrappedShareRecord> {
-	const { organizationId, snapshot, userId } = options;
-	const shareId = crypto.randomUUID();
+	const { organizationId, snapshot, userId, username } = options;
+	const shareIdBase = buildWrappedShareIdBase({
+		fallbackLabel: snapshot.row.displayName,
+		username,
+	});
 	const createdAt = new Date();
 	const expiresAt = createWrappedShareExpiry(createdAt);
 	const createdAtIso = createdAt.toISOString();
 	const expiresAtIso = expiresAt.toISOString();
 
-	await sqlClient`
-		INSERT INTO wrapped_share (
-			id,
-			organization_id,
-			payload_version,
-			snapshot_json,
-			user_id,
-			created_at,
-			expires_at
-		)
-		VALUES (
-			${shareId},
-			${organizationId},
-			${WRAPPED_SHARE_PAYLOAD_VERSION},
-			${JSON.stringify(snapshot)},
-			${userId},
-			${createdAtIso},
-			${expiresAtIso}
-		)
-	`;
+	for (
+		let attempt = 0;
+		attempt < WRAPPED_SHARE_ID_INSERT_ATTEMPTS;
+		attempt += 1
+	) {
+		const shareId = await buildAvailableWrappedShareId(shareIdBase);
+		const insertedRows = await sqlClient<Array<{ id: string }>>`
+			INSERT INTO wrapped_share (
+				id,
+				organization_id,
+				payload_version,
+				snapshot_json,
+				user_id,
+				created_at,
+				expires_at
+			)
+			VALUES (
+				${shareId},
+				${organizationId},
+				${WRAPPED_SHARE_PAYLOAD_VERSION},
+				${JSON.stringify(snapshot)},
+				${userId},
+				${createdAtIso},
+				${expiresAtIso}
+			)
+			ON CONFLICT (id) DO NOTHING
+			RETURNING id
+		`;
 
-	return {
-		created_at: createdAtIso,
-		expires_at: expiresAtIso,
-		id: shareId,
-	};
+		const insertedShareId = insertedRows[0]?.id;
+
+		if (insertedShareId) {
+			return {
+				created_at: createdAtIso,
+				expires_at: expiresAtIso,
+				id: insertedShareId,
+			};
+		}
+	}
+
+	throw new Error("Could not allocate a wrapped share id");
 }
 
 // Public share lookup deliberately returns only the persisted snapshot payload.
@@ -112,6 +136,27 @@ export async function getPublicWrappedShare(
 function parseWrappedShareSnapshot(snapshotJson: string): WrappedShareSnapshot {
 	const parsedSnapshot = JSON.parse(snapshotJson) as unknown;
 	return WrappedShareSnapshotSchema.parse(parsedSnapshot);
+}
+
+async function buildAvailableWrappedShareId(baseId: string) {
+	const existingIds = await getExistingWrappedShareIdsForBase(baseId);
+
+	return getNextWrappedShareIdCandidate({
+		baseId,
+		existingIds,
+	});
+}
+
+async function getExistingWrappedShareIdsForBase(baseId: string) {
+	const suffixPrefix = `${baseId}-`;
+	const rows = await sqlClient<Array<{ id: string }>>`
+		SELECT id
+		FROM wrapped_share
+		WHERE id = ${baseId}
+			OR left(id, ${suffixPrefix.length}) = ${suffixPrefix}
+	`;
+
+	return rows.map((row) => row.id);
 }
 
 // Shares are intentionally short-lived so stale public links do not become a

--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -69,8 +69,8 @@ function getWrappedFlowPath(flow: string, search?: string) {
 	return `${WRAPPED_TEAM_CARD_PATH}?${searchParams.toString()}`;
 }
 
-// Public wrapped pages live at /wrapped/:id in this pass. The id is still the
-// existing UUID-backed share id even though the route shape is changing.
+// Public wrapped pages live at /wrapped/:id. New links use username-style ids,
+// while older UUID ids still resolve because the backend key is plain text.
 export function getWrappedPublicIdFromPath(pathname: string) {
 	const routeMatch = pathname.match(/^\/wrapped\/([^/]+)\/?$/u);
 	const encodedPublicId = routeMatch?.[1];

--- a/apps/web/src/features/get-started/use-setup-progress.test.tsx
+++ b/apps/web/src/features/get-started/use-setup-progress.test.tsx
@@ -1,0 +1,213 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSetupProgress } from "@/features/get-started/use-setup-progress";
+
+const {
+	mockGetOrganizationSessionCount,
+	mockSummaryQueryOptions,
+	mockUseAnalyticsQuery,
+	mockUseOrganization,
+	mockUseQuery,
+} = vi.hoisted(() => ({
+	mockGetOrganizationSessionCount: vi.fn(),
+	mockSummaryQueryOptions: vi.fn(),
+	mockUseAnalyticsQuery: vi.fn(),
+	mockUseOrganization: vi.fn(),
+	mockUseQuery: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+	useQuery: mockUseQuery,
+}));
+
+vi.mock("@/features/analytics/queries/useAnalyticsQuery", () => ({
+	useAnalyticsQuery: mockUseAnalyticsQuery,
+}));
+
+vi.mock("@/features/workspace/organization/useOrganization", () => ({
+	useOrganization: mockUseOrganization,
+}));
+
+vi.mock("@/lib/orpc", () => ({
+	client: {
+		getOrganizationSessionCount: mockGetOrganizationSessionCount,
+	},
+	orpc: {
+		analytics: {
+			sessions: {
+				summary: {
+					queryOptions: mockSummaryQueryOptions,
+				},
+			},
+		},
+	},
+}));
+
+interface SummaryQueryData {
+	total_sessions: number;
+}
+
+interface RawSessionCountData {
+	count: number;
+}
+
+interface QueryResult<TData> {
+	data: TData | undefined;
+	isFetched: boolean;
+	isPending: boolean;
+}
+
+interface RefetchQuery<TData> {
+	state: {
+		data: TData | undefined;
+	};
+}
+
+interface SummaryQueryOptions {
+	enabled?: boolean;
+	refetchInterval?: (query: RefetchQuery<SummaryQueryData>) => false | number;
+	refetchIntervalInBackground?: boolean;
+	refetchOnReconnect?: boolean | "always";
+	refetchOnWindowFocus?: boolean | "always";
+}
+
+interface RawQueryOptions {
+	enabled?: boolean;
+	queryFn?: () => Promise<RawSessionCountData>;
+	queryKey?: readonly unknown[];
+	refetchInterval?: (
+		query: RefetchQuery<RawSessionCountData>,
+	) => false | number;
+	refetchIntervalInBackground?: boolean;
+	refetchOnReconnect?: boolean | "always";
+	refetchOnWindowFocus?: boolean | "always";
+}
+
+const defaultSummaryQueryResult: QueryResult<SummaryQueryData> = {
+	data: {
+		total_sessions: 0,
+	},
+	isFetched: true,
+	isPending: false,
+};
+
+const defaultRawCountQueryResult: QueryResult<RawSessionCountData> = {
+	data: {
+		count: 0,
+	},
+	isFetched: true,
+	isPending: false,
+};
+
+let capturedSummaryQueryOptions: SummaryQueryOptions | null = null;
+let capturedRawQueryOptions: RawQueryOptions | null = null;
+let summaryQueryResult: QueryResult<SummaryQueryData>;
+let rawCountQueryResult: QueryResult<RawSessionCountData>;
+
+function getCapturedSummaryQueryOptions() {
+	if (capturedSummaryQueryOptions === null) {
+		throw new Error("Expected summary query options to be captured");
+	}
+
+	return capturedSummaryQueryOptions;
+}
+
+function getCapturedRawQueryOptions() {
+	if (capturedRawQueryOptions === null) {
+		throw new Error("Expected raw session count query options to be captured");
+	}
+
+	return capturedRawQueryOptions;
+}
+
+describe("useSetupProgress", () => {
+	beforeEach(() => {
+		capturedSummaryQueryOptions = null;
+		capturedRawQueryOptions = null;
+		summaryQueryResult = defaultSummaryQueryResult;
+		rawCountQueryResult = defaultRawCountQueryResult;
+
+		mockGetOrganizationSessionCount.mockReset();
+		mockSummaryQueryOptions.mockReset();
+		mockUseAnalyticsQuery.mockReset();
+		mockUseOrganization.mockReset();
+		mockUseQuery.mockReset();
+
+		mockSummaryQueryOptions.mockReturnValue({
+			queryKey: ["analytics", "sessions", "summary"],
+		});
+		mockUseOrganization.mockReturnValue({
+			state: {
+				activeOrg: {
+					id: "org-1",
+					name: "Org",
+					slug: "org",
+				},
+				isLoading: false,
+				organizations: [],
+			},
+		});
+		mockUseAnalyticsQuery.mockImplementation((options: SummaryQueryOptions) => {
+			capturedSummaryQueryOptions = options;
+			return summaryQueryResult;
+		});
+		mockUseQuery.mockImplementation((options: RawQueryOptions) => {
+			capturedRawQueryOptions = options;
+			return rawCountQueryResult;
+		});
+	});
+
+	it("uses raw uploaded session count as the fastest landing signal", () => {
+		rawCountQueryResult = {
+			data: {
+				count: 2,
+			},
+			isFetched: true,
+			isPending: false,
+		};
+
+		const { result } = renderHook(() => useSetupProgress());
+
+		expect(result.current.hasUploadedSessions).toBe(true);
+		expect(result.current.totalSessionCount).toBe(2);
+	});
+
+	it("polls quickly and refetches when the setup page regains focus", () => {
+		renderHook(() => useSetupProgress());
+
+		const summaryOptions = getCapturedSummaryQueryOptions();
+		const rawOptions = getCapturedRawQueryOptions();
+
+		expect(summaryOptions.refetchOnWindowFocus).toBe("always");
+		expect(summaryOptions.refetchOnReconnect).toBe("always");
+		expect(summaryOptions.refetchIntervalInBackground).toBe(true);
+		expect(rawOptions.refetchOnWindowFocus).toBe("always");
+		expect(rawOptions.refetchOnReconnect).toBe("always");
+		expect(rawOptions.refetchIntervalInBackground).toBe(true);
+		expect(
+			rawOptions.refetchInterval?.({
+				state: {
+					data: {
+						count: 0,
+					},
+				},
+			}),
+		).toBe(1_000);
+	});
+
+	it("stops raw polling after sessions are detected", () => {
+		renderHook(() => useSetupProgress());
+
+		const rawOptions = getCapturedRawQueryOptions();
+
+		expect(
+			rawOptions.refetchInterval?.({
+				state: {
+					data: {
+						count: 1,
+					},
+				},
+			}),
+		).toBe(false);
+	});
+});

--- a/apps/web/src/features/wrapped/WrappedDevPage.tsx
+++ b/apps/web/src/features/wrapped/WrappedDevPage.tsx
@@ -277,10 +277,11 @@ export function WrappedDevPage() {
 
 function WrappedDevToolbar(props: {
 	activeStage: WrappedDevStage;
+	children?: ReactNode;
 	floating?: boolean;
 	onStageChange: (stage: WrappedDevStage) => void;
 }) {
-	const { activeStage, floating = false, onStageChange } = props;
+	const { activeStage, children, floating = false, onStageChange } = props;
 
 	return (
 		<div
@@ -304,6 +305,7 @@ function WrappedDevToolbar(props: {
 					</Button>
 				))}
 			</div>
+			{children}
 		</div>
 	);
 }

--- a/apps/web/src/features/wrapped/WrappedPublicMockPage.tsx
+++ b/apps/web/src/features/wrapped/WrappedPublicMockPage.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, ReactNode } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { appRoutes } from "@/app/routes";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
 import type { WrappedOnboardingMetrics } from "@/features/wrapped/onboarding/types";
@@ -173,12 +173,6 @@ const MOCK_PUBLIC_SHARE_ONBOARDING_METRICS = {
 	totalTokens: 5_068_300,
 } satisfies WrappedOnboardingMetrics;
 
-const MOCK_PUBLIC_SHARE_BACK_METRICS = buildWrappedTeamCardBackMetrics({
-	onboardingMetrics: MOCK_PUBLIC_SHARE_ONBOARDING_METRICS,
-	row: MOCK_PUBLIC_SHARE_ROW,
-	shareCardCreatedAtLabel: "Apr 28, 2026",
-});
-
 const MOCK_PUBLIC_SHARE_SHELL_STYLE: WrappedPublicMockCardShellStyle = {
 	"--team-lineup-card-grain-opacity": "0.18",
 	"--team-lineup-card-grain-size": "38px",
@@ -189,6 +183,24 @@ const MOCK_PUBLIC_SHARE_ARCHETYPE = getMockPublicShareArchetype();
 export function WrappedPublicMockPage(props: WrappedPublicMockPageProps) {
 	const { debugControls } = props;
 	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const onboardingMetrics = searchParams.has("longSkill")
+		? {
+				...MOCK_PUBLIC_SHARE_ONBOARDING_METRICS,
+				topSkills: [
+					{
+						count: 24,
+						name: "long-context-refactor-orchestration",
+					},
+					...MOCK_PUBLIC_SHARE_ONBOARDING_METRICS.topSkills.slice(1),
+				],
+			}
+		: MOCK_PUBLIC_SHARE_ONBOARDING_METRICS;
+	const backMetrics = buildWrappedTeamCardBackMetrics({
+		onboardingMetrics,
+		row: MOCK_PUBLIC_SHARE_ROW,
+		shareCardCreatedAtLabel: "Apr 28, 2026",
+	});
 
 	useMountEffect(() => {
 		document.body.classList.add("mymind-wrapped-body");
@@ -213,7 +225,7 @@ export function WrappedPublicMockPage(props: WrappedPublicMockPageProps) {
 				</WrappedPublicCardAction>
 			}
 			activeArchetype={MOCK_PUBLIC_SHARE_ARCHETYPE}
-			backMetrics={MOCK_PUBLIC_SHARE_BACK_METRICS}
+			backMetrics={backMetrics}
 			debugControls={debugControls}
 			headerLeftMetric={MOCK_PUBLIC_SHARE_HEADER_LEFT_METRIC}
 			headerRightMetric={MOCK_PUBLIC_SHARE_HEADER_RIGHT_METRIC}

--- a/apps/web/src/features/wrapped/WrappedSetupPage.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedSetupPage.test.tsx
@@ -1,11 +1,8 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { WrappedSetupPage } from "@/features/wrapped/WrappedSetupPage";
-
-const CHATWOOT_OPENED_EVENT = "chatwoot:opened";
-const CHATWOOT_CLOSED_EVENT = "chatwoot:closed";
 
 const { mockCloseChatwoot, mockOpenChatwoot, mockSetChatwootBubbleVisibility } =
 	vi.hoisted(() => ({
@@ -36,21 +33,12 @@ Object.defineProperty(window, "matchMedia", {
 	})),
 });
 
-beforeEach(() => {
-	mockOpenChatwoot.mockImplementation(async () => {
-		window.dispatchEvent(new Event(CHATWOOT_OPENED_EVENT));
-	});
-	mockCloseChatwoot.mockImplementation(async () => {
-		window.dispatchEvent(new Event(CHATWOOT_CLOSED_EVENT));
-	});
-});
-
 afterEach(() => {
 	vi.useRealTimers();
 	window.sessionStorage.clear();
-	mockCloseChatwoot.mockReset();
-	mockOpenChatwoot.mockReset();
-	mockSetChatwootBubbleVisibility.mockReset();
+	mockCloseChatwoot.mockClear();
+	mockOpenChatwoot.mockClear();
+	mockSetChatwootBubbleVisibility.mockClear();
 });
 
 function hasExactTextContent(expectedText: string) {

--- a/apps/web/src/features/wrapped/actions.tsx
+++ b/apps/web/src/features/wrapped/actions.tsx
@@ -38,18 +38,20 @@ export function WrappedPrimaryAction(props: WrappedPrimaryActionProps) {
 		);
 	}
 
+	const {
+		children,
+		className: _className,
+		icon,
+		kind: _kind,
+		type,
+		...buttonProps
+	} = props;
+
 	return (
-		<button
-			type={props.type ?? "button"}
-			disabled={props.disabled}
-			onClick={props.onClick}
-			className={className}
-		>
-			<span>{props.children}</span>
-			{props.icon ? (
-				<span className="mymind-wrapped-primary-action__icon">
-					{props.icon}
-				</span>
+		<button type={type ?? "button"} {...buttonProps} className={className}>
+			<span>{children}</span>
+			{icon ? (
+				<span className="mymind-wrapped-primary-action__icon">{icon}</span>
 			) : null}
 		</button>
 	);

--- a/apps/web/src/features/wrapped/data/handover-data.ts
+++ b/apps/web/src/features/wrapped/data/handover-data.ts
@@ -18,7 +18,7 @@ export const wrappedHandoverData = WrappedHandoverSchema.parse({
 			cornerRadiusPx: 20,
 		},
 		profile: {
-			avatarSrc: null,
+			avatarSrc: "/logo-light.png",
 			fallbackLabel: "User",
 		},
 		callToActions: [
@@ -26,11 +26,6 @@ export const wrappedHandoverData = WrappedHandoverSchema.parse({
 				id: "share-x",
 				label: "Share on X",
 				kind: "share-x",
-			},
-			{
-				id: "share-linkedin",
-				label: "Share on LinkedIn",
-				kind: "share-linkedin",
 			},
 			{
 				id: "follow-x",

--- a/apps/web/src/features/wrapped/lib/handover-schema.ts
+++ b/apps/web/src/features/wrapped/lib/handover-schema.ts
@@ -1,11 +1,7 @@
 import { WrappedV1Schema } from "@rudel/api-routes";
 import { z } from "zod";
 
-export const WrappedCallToActionKindSchema = z.enum([
-	"share-x",
-	"share-linkedin",
-	"follow-x",
-]);
+export const WrappedCallToActionKindSchema = z.enum(["share-x", "follow-x"]);
 
 export const WrappedCallToActionSchema = z.object({
 	id: z.string().min(1),
@@ -46,7 +42,7 @@ export const WrappedCanvasSchema = z.object({
 });
 
 export const WrappedProfileSchema = z.object({
-	avatarSrc: z.string().min(1).nullable(),
+	avatarSrc: z.string().min(1),
 	fallbackLabel: z.string().min(1),
 });
 

--- a/apps/web/src/features/wrapped/support-chatwoot-button.test.tsx
+++ b/apps/web/src/features/wrapped/support-chatwoot-button.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { WrappedSupportChatwootButton } from "./support-chatwoot-button";
 
 const CHATWOOT_OPENED_EVENT = "chatwoot:opened";
@@ -18,18 +18,9 @@ vi.mock("@/lib/chatwoot", () => ({
 	openChatwoot: mockOpenChatwoot,
 }));
 
-beforeEach(() => {
-	mockOpenChatwoot.mockImplementation(async () => {
-		window.dispatchEvent(new Event(CHATWOOT_OPENED_EVENT));
-	});
-	mockCloseChatwoot.mockImplementation(async () => {
-		window.dispatchEvent(new Event(CHATWOOT_CLOSED_EVENT));
-	});
-});
-
 afterEach(() => {
-	mockCloseChatwoot.mockReset();
-	mockOpenChatwoot.mockReset();
+	mockCloseChatwoot.mockClear();
+	mockOpenChatwoot.mockClear();
 });
 
 describe("WrappedSupportChatwootButton", () => {
@@ -51,23 +42,6 @@ describe("WrappedSupportChatwootButton", () => {
 			position: "fixed",
 			zIndex: "2147483647",
 		});
-	});
-
-	it("waits for an open signal before replacing the launcher with close", async () => {
-		const user = userEvent.setup();
-		mockOpenChatwoot.mockResolvedValueOnce(undefined);
-
-		render(<WrappedSupportChatwootButton />);
-
-		await user.click(screen.getByRole("button", { name: "Open support" }));
-
-		expect(mockOpenChatwoot).toHaveBeenCalledTimes(1);
-		expect(
-			screen.queryByRole("button", { name: "Close support" }),
-		).not.toBeInTheDocument();
-		expect(
-			screen.getByRole("button", { name: "Open support" }),
-		).toBeInTheDocument();
 	});
 
 	it("keeps an externally opened chat closable from the persistent control", async () => {

--- a/apps/web/src/features/wrapped/support-chatwoot-button.tsx
+++ b/apps/web/src/features/wrapped/support-chatwoot-button.tsx
@@ -1,4 +1,4 @@
-import { HelpCircle, XCircle } from "lucide-react";
+import { HelpCircle, X } from "lucide-react";
 import type { CSSProperties } from "react";
 import { useState } from "react";
 import { createPortal } from "react-dom";
@@ -41,10 +41,12 @@ export function WrappedSupportChatwootButton() {
 
 	async function handleClick() {
 		if (isChatwootOpen) {
+			setIsChatwootOpen(false);
 			await closeChatwoot();
 			return;
 		}
 
+		setIsChatwootOpen(true);
 		await openChatwoot();
 	}
 
@@ -56,7 +58,7 @@ export function WrappedSupportChatwootButton() {
 			onClick={() => void handleClick()}
 		>
 			{isChatwootOpen ? (
-				<XCircle className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
+				<X className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
 			) : (
 				<HelpCircle className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
 			)}
@@ -83,7 +85,7 @@ export function WrappedSupportChatwootButton() {
 							style={PERSISTENT_CLOSE_CONTROL_STYLE}
 							onClick={() => void handleClick()}
 						>
-							<XCircle className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
+							<X className="mymind-wrapped-top-tray__edge-icon mymind-wrapped-top-tray__edge-icon--help" />
 						</button>,
 						document.body,
 					)}

--- a/apps/web/src/features/wrapped/team-card/archetype-gradient-text.test.ts
+++ b/apps/web/src/features/wrapped/team-card/archetype-gradient-text.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getWrappedArchetypeGradientTextValue } from "./archetype-gradient-text";
+
+describe("getWrappedArchetypeGradientTextValue", () => {
+	it("uses a carbon charcoal gradient for the Obsessed archetype text", () => {
+		const gradient = getWrappedArchetypeGradientTextValue({
+			classifierKey: "obsessed",
+			displayLabel: "Obsessed",
+			id: "obsessed",
+			kind: "taxonomy",
+			shellClassName: "bg-black",
+			theme: "dark",
+		});
+
+		expect(gradient.direction).toBe("161.01deg");
+		expect(gradient.accent).toContain("#323238");
+		expect(gradient.accent).toContain("#3F3F45");
+		expect(gradient.stops).toContain("#323238");
+		expect(gradient.stops).toContain("#3F3F45");
+	});
+});

--- a/apps/web/src/features/wrapped/team-card/archetype-gradient-text.tsx
+++ b/apps/web/src/features/wrapped/team-card/archetype-gradient-text.tsx
@@ -1,4 +1,9 @@
-import type { CSSProperties } from "react";
+import {
+	type CSSProperties,
+	// biome-ignore lint/style/noRestrictedImports: this component needs a short client-side replay gate so the CSS sweep can restart when the archetype changes.
+	useEffect,
+	useState,
+} from "react";
 import {
 	getWrappedArchetypeCardBackgroundValue,
 	type WrappedArchetypeCardTheme,
@@ -14,12 +19,19 @@ export type WrappedArchetypeGradientTextState = "active" | "waiting";
 
 const WRAPPED_ARCHETYPE_GRADIENT_TEXT_DARK = "#17161c";
 const WRAPPED_ARCHETYPE_GRADIENT_COLOR_PATTERN = /#[\da-fA-F]{3,8}\b/g;
-const WRAPPED_ARCHETYPE_LINEAR_GRADIENT_PATTERN =
-	/^linear-gradient\(([^,]+),\s*(.+)\)$/;
+const WRAPPED_ARCHETYPE_GRADIENT_TEXT_DIRECTION = "161.01deg";
+const WRAPPED_OBSESSED_GRADIENT_TEXT_COLORS = [
+	"#141416",
+	"#323238",
+	"#0B0B0C",
+	"#3F3F45",
+	"#18181A",
+] as const;
 const WRAPPED_ARCHETYPE_GRADIENT_DARK_HOLD_STOP = 60;
 const WRAPPED_ARCHETYPE_GRADIENT_COLOR_RANGE_START = 68;
 const WRAPPED_ARCHETYPE_GRADIENT_COLOR_RANGE_END = 100;
 const WRAPPED_ARCHETYPE_GRADIENT_COLOR_INSET_STOP = 15;
+const WRAPPED_ARCHETYPE_HOVER_REPLAY_READY_DELAY_MS = 620;
 
 export interface WrappedArchetypeGradientTextValue {
 	accent: string;
@@ -42,6 +54,13 @@ export function WrappedArchetypeGradientText(props: {
 		suffix = "",
 	} = props;
 	const gradient = getWrappedArchetypeGradientTextValue(activeArchetype);
+	const shouldEnableHoverReplay = isHoverReplayEnabled && state === "active";
+	const hoverReplayKey = shouldEnableHoverReplay
+		? activeArchetype.id
+		: undefined;
+	const [hoverReplayState, setHoverReplayState] = useState<
+		"entering" | "ready" | undefined
+	>(() => (shouldEnableHoverReplay ? "entering" : undefined));
 	const style: WrappedArchetypeGradientTextStyle = {
 		"--wrapped-reveal-archetype-accent": gradient.accent,
 		"--wrapped-reveal-archetype-gt-direction": gradient.direction,
@@ -49,19 +68,36 @@ export function WrappedArchetypeGradientText(props: {
 	};
 	const classNames = `mymind-wrapped-final-stage__gradient-text ${className}`;
 
+	useEffect(() => {
+		if (!hoverReplayKey) {
+			setHoverReplayState(undefined);
+			return;
+		}
+
+		setHoverReplayState("entering");
+
+		const timeoutId = window.setTimeout(() => {
+			setHoverReplayState("ready");
+		}, WRAPPED_ARCHETYPE_HOVER_REPLAY_READY_DELAY_MS);
+
+		return () => {
+			window.clearTimeout(timeoutId);
+		};
+	}, [hoverReplayKey]);
+
 	return (
-		<span
-			className={classNames}
-			data-accent-state={state}
-			data-hover-replay={
-				isHoverReplayEnabled && state === "active" ? "ready" : undefined
-			}
-			data-label={activeArchetype.displayLabel}
-			style={style}
-		>
-			{activeArchetype.displayLabel}
-			{suffix}
-		</span>
+		<>
+			<span
+				className={classNames}
+				data-accent-state={state}
+				data-hover-replay={hoverReplayState}
+				data-label={activeArchetype.displayLabel}
+				style={style}
+			>
+				{activeArchetype.displayLabel}
+			</span>
+			{suffix ? <span aria-hidden="true">{suffix}</span> : null}
+		</>
 	);
 }
 
@@ -69,23 +105,33 @@ export function getWrappedArchetypeGradientTextValue(
 	theme: WrappedArchetypeCardTheme,
 ): WrappedArchetypeGradientTextValue {
 	const cardBackgroundValue = getWrappedArchetypeCardBackgroundValue(theme);
-	const gradientMatch = cardBackgroundValue?.match(
-		WRAPPED_ARCHETYPE_LINEAR_GRADIENT_PATTERN,
-	);
 	const colors = cardBackgroundValue?.match(
 		WRAPPED_ARCHETYPE_GRADIENT_COLOR_PATTERN,
 	);
-	const direction = gradientMatch?.[1]?.trim() ?? "184deg";
-	const gradientColors = colors ?? [];
+	const gradientColors = getWrappedArchetypeTextGradientColors({
+		colors: colors ?? [],
+		theme,
+	});
 
 	return {
 		accent: buildWrappedArchetypeTextAccentGradient({
 			colors: gradientColors,
-			direction,
+			direction: WRAPPED_ARCHETYPE_GRADIENT_TEXT_DIRECTION,
 		}),
-		direction,
+		direction: WRAPPED_ARCHETYPE_GRADIENT_TEXT_DIRECTION,
 		stops: buildWrappedArchetypeTextGradientStops(gradientColors),
 	};
+}
+
+function getWrappedArchetypeTextGradientColors(input: {
+	colors: readonly string[];
+	theme: WrappedArchetypeCardTheme;
+}) {
+	if (input.theme.id === "obsessed") {
+		return WRAPPED_OBSESSED_GRADIENT_TEXT_COLORS;
+	}
+
+	return input.colors;
 }
 
 function formatWrappedArchetypeGradientStopPosition(position: number) {

--- a/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
@@ -553,6 +553,14 @@ describe("WrappedTeamCardRevealStage", () => {
 				name: "Avery Chen, you got the Company Card?",
 			}),
 		).toBeInTheDocument();
+		expect(
+			document.querySelector(".mymind-wrapped-final-stage__intro-accent")
+				?.childNodes[0]?.textContent,
+		).toBe("Company Card");
+		expect(
+			document.querySelector(".mymind-wrapped-final-stage__intro-accent")
+				?.nextElementSibling?.textContent,
+		).toBe("?");
 
 		act(() => {
 			vi.advanceTimersByTime(REVEAL_INTRO_READY_MS - 850);
@@ -965,7 +973,7 @@ describe("WrappedTeamCardRevealStage", () => {
 				name: "Avery Chen,",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Smooth Operator.")).toHaveAttribute(
+		expect(screen.getByText("Smooth Operator")).toHaveAttribute(
 			"data-accent-state",
 			"waiting",
 		);
@@ -982,7 +990,7 @@ describe("WrappedTeamCardRevealStage", () => {
 				name: "Avery Chen, you're a Smooth Operator.",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Smooth Operator.")).toHaveAttribute(
+		expect(screen.getByText("Smooth Operator")).toHaveAttribute(
 			"data-accent-state",
 			"waiting",
 		);
@@ -991,7 +999,7 @@ describe("WrappedTeamCardRevealStage", () => {
 			vi.advanceTimersByTime(670);
 		});
 
-		expect(screen.getByText("Smooth Operator.")).toHaveAttribute(
+		expect(screen.getByText("Smooth Operator")).toHaveAttribute(
 			"data-accent-state",
 			"active",
 		);
@@ -1202,7 +1210,7 @@ describe("WrappedTeamCardRevealStage", () => {
 		expect(onPreviewPost).toHaveBeenCalledTimes(1);
 	});
 
-	it("keeps the footer action as continue after the user has revealed the front", () => {
+	it("flips a user-turned back card to the front before sharing", () => {
 		vi.useFakeTimers();
 		const onPreviewPost = vi.fn();
 
@@ -1305,6 +1313,23 @@ describe("WrappedTeamCardRevealStage", () => {
 		);
 
 		expect(onPreviewPost).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole("button", {
+				name: "Show back of card",
+			}),
+		).toHaveAttribute("data-card-face", "front");
+
+		act(() => {
+			vi.advanceTimersByTime(REVEAL_CARD_FLIP_DURATION_MS - 1);
+		});
+
+		expect(onPreviewPost).not.toHaveBeenCalled();
+
+		act(() => {
+			vi.advanceTimersByTime(1);
+		});
+
+		expect(onPreviewPost).not.toHaveBeenCalled();
 
 		act(() => {
 			vi.advanceTimersByTime(REVEAL_EXIT_TO_SHARE_MS);
@@ -1315,7 +1340,7 @@ describe("WrappedTeamCardRevealStage", () => {
 });
 
 describe("WrappedTeamCardPublicStage", () => {
-	it("starts on the public front and lets the viewer flip to the back", () => {
+	it("asks the viewer to turn around before showing the make yours action", () => {
 		vi.useFakeTimers();
 		const activeArchetype = {
 			displayLabel: "Smooth Operator",
@@ -1368,7 +1393,22 @@ describe("WrappedTeamCardPublicStage", () => {
 		});
 		expect(showBackButton).toHaveAttribute("data-card-face", "front");
 
-		fireEvent.click(showBackButton);
+		expect(
+			screen.getByRole("button", {
+				name: "Turn around",
+			}),
+		).toBeEnabled();
+		expect(
+			screen.queryByRole("button", {
+				name: "Make yours",
+			}),
+		).not.toBeInTheDocument();
+
+		fireEvent.click(
+			screen.getByRole("button", {
+				name: "Turn around",
+			}),
+		);
 
 		expect(tiltController.handlePointerLeave).toHaveBeenCalledTimes(1);
 		expect(
@@ -1376,6 +1416,11 @@ describe("WrappedTeamCardPublicStage", () => {
 				name: "Show front of card",
 			}),
 		).toHaveAttribute("data-card-face", "back");
+		expect(
+			screen.getByRole("button", {
+				name: "Turn around",
+			}),
+		).toBeDisabled();
 
 		act(() => {
 			vi.advanceTimersByTime(REVEAL_CARD_FLIP_DURATION_MS);
@@ -1384,6 +1429,38 @@ describe("WrappedTeamCardPublicStage", () => {
 		expect(
 			screen.getByRole("button", {
 				name: "Show front of card",
+			}),
+		).toBeEnabled();
+		expect(
+			screen.getByRole("button", {
+				name: "Make yours",
+			}),
+		).toBeEnabled();
+
+		fireEvent.click(
+			screen.getByRole("button", {
+				name: "Show front of card",
+			}),
+		);
+
+		expect(
+			screen.queryByRole("button", {
+				name: "Turn around",
+			}),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("button", {
+				name: "Make yours",
+			}),
+		).toBeEnabled();
+
+		act(() => {
+			vi.advanceTimersByTime(REVEAL_CARD_FLIP_DURATION_MS);
+		});
+
+		expect(
+			screen.getByRole("button", {
+				name: "Make yours",
 			}),
 		).toBeEnabled();
 	});

--- a/apps/web/src/features/wrapped/team-card/final-stages.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.tsx
@@ -1,11 +1,6 @@
 import type { WrappedShareAppearance } from "@rudel/api-routes";
-import {
-	ChevronRight,
-	Clipboard,
-	Download,
-	Loader2,
-	Share2,
-} from "lucide-react";
+import { IconBrandX } from "@tabler/icons-react";
+import { ChevronRight, Clipboard, Download, Loader2 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
 	type CSSProperties,
@@ -257,7 +252,6 @@ export function WrappedTeamCardShareStage(
 		isDownloadPending = false,
 		isFrontCardHandoffHidden = false,
 		isSharePending = false,
-		onBack,
 		onCopy,
 		onContinueToDashboard,
 		onDownload,
@@ -293,7 +287,7 @@ export function WrappedTeamCardShareStage(
 					className="mymind-wrapped-final-stage__share-copy-shell"
 				>
 					<h1 className="mymind-wrapped-stage-copy__headline mymind-wrapped-final-stage__headline">
-						Show this to world
+						Share it with the world
 					</h1>
 				</motion.div>
 			}
@@ -399,62 +393,39 @@ export function WrappedTeamCardShareStage(
 				</div>
 			}
 			support={
-				<>
-					<motion.div
-						{...getWrappedShareChromeMotion({
-							delay: 0.42,
-							reduceMotion,
-							y: 12,
-						})}
+				<motion.div
+					{...getWrappedShareChromeMotion({
+						delay: 0.42,
+						reduceMotion,
+						y: 12,
+					})}
+					className="mymind-wrapped-action-stack mymind-wrapped-share-action-stack"
+				>
+					<WrappedPrimaryAction
+						kind="button"
+						aria-busy={isSharePending ? "true" : undefined}
+						className="mymind-wrapped-share-primary-action mymind-wrapped-share-primary-action--x"
+						disabled={isSharePending}
+						onClick={onShare}
 					>
-						<nav className="mymind-wrapped-share-actions">
-							<Button
-								type="button"
-								size="lg"
-								aria-busy={isSharePending ? "true" : undefined}
-								className="mymind-wrapped-share-actions__primary"
-								disabled={isSharePending}
-								onClick={onShare}
-							>
-								{isSharePending ? (
-									<Loader2 className="size-4 animate-spin" />
-								) : (
-									<Share2 className="size-4" />
-								)}
-								{isSharePending ? "Copying image..." : "Share to X"}
-							</Button>
-						</nav>
-					</motion.div>
-
-					<motion.div
-						{...getWrappedShareChromeMotion({
-							delay: 0.48,
-							reduceMotion,
-							y: 12,
-						})}
-						className="mymind-wrapped-share-actions__meta-grid"
+						<span className="mymind-wrapped-share-primary-action__label">
+							{isSharePending ? (
+								<Loader2 className="size-4 animate-spin" />
+							) : (
+								<IconBrandX className="size-4" />
+							)}
+							<span>{isSharePending ? "Copying image..." : "Share on X"}</span>
+						</span>
+					</WrappedPrimaryAction>
+					<WrappedPrimaryAction
+						kind="button"
+						aria-label="Continue to dashboard"
+						className="mymind-wrapped-share-primary-action mymind-wrapped-share-primary-action--text"
+						onClick={onContinueToDashboard}
 					>
-						<Button
-							type="button"
-							size="lg"
-							variant="outline"
-							className="mymind-wrapped-share-actions__secondary"
-							onClick={onBack}
-						>
-							Back to card
-						</Button>
-						<Button
-							type="button"
-							size="lg"
-							variant="outline"
-							aria-label="Continue to dashboard"
-							className="mymind-wrapped-share-actions__secondary"
-							onClick={onContinueToDashboard}
-						>
-							Continue
-						</Button>
-					</motion.div>
-				</>
+						Continue to dashboard
+					</WrappedPrimaryAction>
+				</motion.div>
 			}
 		/>
 	);
@@ -708,12 +679,25 @@ export function WrappedTeamCardPublicStage(
 	const reduceMotion = shouldReduceMotion ?? false;
 	const [isCardFrontVisible, setIsCardFrontVisible] = useState(true);
 	const [isCardFlipAnimating, setIsCardFlipAnimating] = useState(false);
+	const [hasPublicTurnAroundCompleted, setHasPublicTurnAroundCompleted] =
+		useState(false);
 	const revealCopy = getWrappedRevealCopy({
 		activeArchetype,
 		audience: "public",
 		row,
 		statItems,
 	});
+	const revealArchetypeHeadingLabel = getWrappedRevealArchetypeHeadingLabel({
+		activeArchetype,
+		audience: "public",
+		row,
+	});
+	const revealArchetypeLinePrefix = getWrappedRevealArchetypeLinePrefix({
+		activeArchetype,
+		audience: "public",
+	});
+	const revealArchetypeLineSuffix =
+		getWrappedRevealArchetypeLineSuffix(activeArchetype);
 	const printedCardCaptureKey = [
 		activeArchetype.id,
 		row.userId,
@@ -734,12 +718,15 @@ export function WrappedTeamCardPublicStage(
 
 		const timeoutId = window.setTimeout(() => {
 			setIsCardFlipAnimating(false);
+			if (!isCardFrontVisible) {
+				setHasPublicTurnAroundCompleted(true);
+			}
 		}, REVEAL_STAGE_CARD_FLIP_DURATION_MS);
 
 		return () => {
 			window.clearTimeout(timeoutId);
 		};
-	}, [isCardFlipAnimating, reduceMotion]);
+	}, [isCardFlipAnimating, isCardFrontVisible, reduceMotion]);
 
 	function handlePublicCardFlipToggle() {
 		if (isCardFlipAnimating) {
@@ -749,6 +736,9 @@ export function WrappedTeamCardPublicStage(
 		tiltController.handlePointerLeave();
 
 		if (reduceMotion) {
+			if (isCardFrontVisible) {
+				setHasPublicTurnAroundCompleted(true);
+			}
 			setIsCardFrontVisible((currentValue) => !currentValue);
 			return;
 		}
@@ -756,6 +746,20 @@ export function WrappedTeamCardPublicStage(
 		setIsCardFlipAnimating(true);
 		setIsCardFrontVisible((currentValue) => !currentValue);
 	}
+
+	const publicPrimaryAction = hasPublicTurnAroundCompleted ? (
+		action
+	) : (
+		<WrappedPrimaryAction
+			kind="button"
+			className="text-[1.0625rem] font-semibold"
+			disabled={isCardFlipAnimating}
+			icon={<ChevronRight className="size-4" />}
+			onClick={handlePublicCardFlipToggle}
+		>
+			Turn around
+		</WrappedPrimaryAction>
+	);
 
 	return (
 		<WrappedStageFrame
@@ -803,23 +807,21 @@ export function WrappedTeamCardPublicStage(
 							</div>
 
 							<aside className="mymind-wrapped-final-stage__archetype-copy mymind-wrapped-public-card-stage__copy">
-								<h1 className="mymind-wrapped-final-stage__archetype-title">
+								<h1
+									aria-label={revealArchetypeHeadingLabel}
+									className="mymind-wrapped-final-stage__archetype-title"
+								>
 									<span className="mymind-wrapped-final-stage__archetype-name">
 										{row.displayName}
 									</span>
 									<span className="mymind-wrapped-final-stage__archetype-line">
-										{getWrappedRevealArchetypeLinePrefix({
-											activeArchetype,
-											audience: "public",
-										})}
+										{revealArchetypeLinePrefix}
 										<WrappedArchetypeGradientText
 											activeArchetype={activeArchetype}
 											className="mymind-wrapped-final-stage__archetype-accent"
 											isHoverReplayEnabled
 											state="active"
-											suffix={getWrappedRevealArchetypeLineSuffix(
-												activeArchetype,
-											)}
+											suffix={revealArchetypeLineSuffix}
 										/>
 									</span>
 								</h1>
@@ -833,7 +835,7 @@ export function WrappedTeamCardPublicStage(
 			}
 			support={
 				<div className="mymind-wrapped-action-stack mymind-wrapped-action-stack--single-action mymind-wrapped-public-card-stage__action">
-					{action}
+					{publicPrimaryAction}
 				</div>
 			}
 		/>
@@ -906,6 +908,8 @@ export function WrappedTeamCardRevealStage(
 	const [hasInitialCardFlipSettled, setHasInitialCardFlipSettled] =
 		useState(false);
 	const [isCardFlipAnimating, setIsCardFlipAnimating] = useState(false);
+	const [isRevealExitQueuedAfterFlip, setIsRevealExitQueuedAfterFlip] =
+		useState(false);
 	const [isRevealExitPending, setIsRevealExitPending] = useState(false);
 	const revealTimerRefs = useRef<number[]>([]);
 	const onRevealCompleteRef = useRef(onRevealComplete);
@@ -934,6 +938,20 @@ export function WrappedTeamCardRevealStage(
 		hasCardFrontBeenRevealed &&
 		(hasInitialCardFlipSettled || !isCardFlipAnimating) &&
 		!isRevealExitPending;
+	const revealArchetypeHeadingLabel = getWrappedRevealArchetypeHeadingLabel({
+		activeArchetype,
+		audience: "owner",
+		row,
+	});
+	const revealIntroHeadingLabel = shouldShowRevealIntroLine
+		? revealArchetypeHeadingLabel
+		: undefined;
+	const revealArchetypeLinePrefix = getWrappedRevealArchetypeLinePrefix({
+		activeArchetype,
+		audience: "owner",
+	});
+	const revealArchetypeLineSuffix =
+		getWrappedRevealArchetypeLineSuffix(activeArchetype);
 	const revealCompanionState = shouldShowArchetypeCompanion
 		? "visible"
 		: isRevealExitPending
@@ -989,6 +1007,7 @@ export function WrappedTeamCardRevealStage(
 			setHasCardFrontBeenRevealed(false);
 			setHasInitialCardFlipSettled(false);
 			setIsCardFlipAnimating(false);
+			setIsRevealExitQueuedAfterFlip(false);
 			setIsRevealExitPending(false);
 			return;
 		}
@@ -999,6 +1018,7 @@ export function WrappedTeamCardRevealStage(
 		setHasCardFrontBeenRevealed(false);
 		setHasInitialCardFlipSettled(false);
 		setIsCardFlipAnimating(false);
+		setIsRevealExitQueuedAfterFlip(false);
 		setIsRevealExitPending(false);
 		const timeoutIds = [
 			window.setTimeout(() => {
@@ -1045,12 +1065,17 @@ export function WrappedTeamCardRevealStage(
 		const timeoutId = window.setTimeout(() => {
 			setIsCardFlipAnimating(false);
 			setHasInitialCardFlipSettled(true);
+
+			if (isRevealExitQueuedAfterFlip) {
+				setIsRevealExitQueuedAfterFlip(false);
+				setIsRevealExitPending(true);
+			}
 		}, REVEAL_STAGE_CARD_FLIP_DURATION_MS);
 
 		return () => {
 			window.clearTimeout(timeoutId);
 		};
-	}, [isCardFlipAnimating, reduceMotion]);
+	}, [isCardFlipAnimating, isRevealExitQueuedAfterFlip, reduceMotion]);
 
 	function startRevealCardDrop() {
 		clearRevealTimers();
@@ -1079,6 +1104,7 @@ export function WrappedTeamCardRevealStage(
 		}
 
 		tiltController.handlePointerLeave();
+		setIsRevealExitQueuedAfterFlip(false);
 		setHasCardFrontBeenRevealed(true);
 
 		if (reduceMotion) {
@@ -1091,7 +1117,26 @@ export function WrappedTeamCardRevealStage(
 		setIsCardFrontVisible((currentValue) => !currentValue);
 	}
 
+	function revealFrontBeforeShareHandoff() {
+		tiltController.handlePointerLeave();
+
+		if (reduceMotion) {
+			setIsCardFrontVisible(true);
+			setIsRevealExitQueuedAfterFlip(false);
+			setIsRevealExitPending(true);
+			return;
+		}
+
+		setIsRevealExitQueuedAfterFlip(true);
+		setIsCardFlipAnimating(true);
+		setIsCardFrontVisible(true);
+	}
+
 	function handleRevealFooterAction() {
+		if (isCardFlipAnimating || isRevealExitPending || isPostHandoffPreparing) {
+			return;
+		}
+
 		if (!isCardDropped) {
 			if (!shouldShowRevealIntroContinue) {
 				return;
@@ -1103,6 +1148,11 @@ export function WrappedTeamCardRevealStage(
 
 		if (!hasCardFrontBeenRevealed) {
 			handleCardFlipToggle();
+			return;
+		}
+
+		if (!isCardFrontVisible) {
+			revealFrontBeforeShareHandoff();
 			return;
 		}
 
@@ -1147,7 +1197,10 @@ export function WrappedTeamCardRevealStage(
 									className="mymind-wrapped-final-stage__canvas-copy-shell"
 									transition={REVEAL_INTRO_COPY.transition}
 								>
-									<h1 className="mymind-wrapped-final-stage__canvas-copy">
+									<h1
+										aria-label={revealIntroHeadingLabel}
+										className="mymind-wrapped-final-stage__canvas-copy"
+									>
 										<span className="mymind-wrapped-final-stage__canvas-copy-name">
 											{row.displayName},
 										</span>
@@ -1163,19 +1216,14 @@ export function WrappedTeamCardRevealStage(
 											initial={false}
 											transition={REVEAL_INTRO_COPY.lineTransition}
 										>
-											{getWrappedRevealArchetypeLinePrefix({
-												activeArchetype,
-												audience: "owner",
-											})}
+											{revealArchetypeLinePrefix}
 											<WrappedArchetypeGradientText
 												activeArchetype={activeArchetype}
 												className="mymind-wrapped-final-stage__intro-accent"
 												state={
 													shouldShowRevealIntroAccent ? "active" : "waiting"
 												}
-												suffix={getWrappedRevealArchetypeLineSuffix(
-													activeArchetype,
-												)}
+												suffix={revealArchetypeLineSuffix}
 											/>
 										</motion.span>
 									</h1>
@@ -1286,23 +1334,21 @@ export function WrappedTeamCardRevealStage(
 													}
 										}
 									>
-										<h2 className="mymind-wrapped-final-stage__archetype-title">
+										<h2
+											aria-label={revealArchetypeHeadingLabel}
+											className="mymind-wrapped-final-stage__archetype-title"
+										>
 											<span className="mymind-wrapped-final-stage__archetype-name">
 												{row.displayName},
 											</span>
 											<span className="mymind-wrapped-final-stage__archetype-line">
-												{getWrappedRevealArchetypeLinePrefix({
-													activeArchetype,
-													audience: "owner",
-												})}
+												{revealArchetypeLinePrefix}
 												<WrappedArchetypeGradientText
 													activeArchetype={activeArchetype}
 													className="mymind-wrapped-final-stage__archetype-accent"
 													isHoverReplayEnabled
 													state="active"
-													suffix={getWrappedRevealArchetypeLineSuffix(
-														activeArchetype,
-													)}
+													suffix={revealArchetypeLineSuffix}
 												/>
 											</span>
 										</h2>
@@ -1319,7 +1365,10 @@ export function WrappedTeamCardRevealStage(
 			support={
 				<WrappedTeamCardRevealFooter
 					isDisabled={
-						isCardFlipAnimating || isPostHandoffPreparing || isRevealExitPending
+						isCardFlipAnimating ||
+						isPostHandoffPreparing ||
+						isRevealExitPending ||
+						isRevealExitQueuedAfterFlip
 					}
 					isVisible={shouldShowRevealFooter}
 					label={revealFooterLabel}
@@ -1802,6 +1851,24 @@ function getWrappedRevealArchetypeLinePrefix(input: {
 	}
 
 	return archetypeId === "obsessed" ? "you're " : "you're a ";
+}
+
+function getWrappedRevealArchetypeLineText(input: {
+	activeArchetype: WrappedArchetypeCardTheme;
+	audience: "owner" | "public";
+}) {
+	return `${getWrappedRevealArchetypeLinePrefix(input)}${input.activeArchetype.displayLabel}${getWrappedRevealArchetypeLineSuffix(input.activeArchetype)}`;
+}
+
+function getWrappedRevealArchetypeHeadingLabel(input: {
+	activeArchetype: WrappedArchetypeCardTheme;
+	audience: "owner" | "public";
+	row: TeamPageMemberRow;
+}) {
+	const lineText = getWrappedRevealArchetypeLineText(input);
+	const nameSeparator = input.audience === "public" ? " " : ", ";
+
+	return `${input.row.displayName}${nameSeparator}${lineText}`;
 }
 
 function getWrappedRevealArchetypeLineSuffix(

--- a/apps/web/src/features/wrapped/team-card/page.tsx
+++ b/apps/web/src/features/wrapped/team-card/page.tsx
@@ -106,6 +106,7 @@ export function WrappedTeamCardPage(props: {
 		completionUserId,
 		liveArchetype,
 		onboardingMetrics,
+		publicUsername,
 		statItems,
 		visibleTeamCardRow,
 	} = useWrappedTeamCardPageData();
@@ -223,6 +224,7 @@ export function WrappedTeamCardPage(props: {
 			onboardingMetrics={onboardingMetrics}
 			onBackFromFirstStep={onBackFromFirstStep}
 			onContinueToDashboard={handleContinueToDashboard}
+			publicUsername={publicUsername}
 			shareAppearance={resolveWrappedShareAppearance(shareAppearance)}
 			shareCardCreatedAtLabel={shareCardCreatedAtLabel}
 			shellStyle={TEAM_CARD_SHELL_STYLE}
@@ -244,6 +246,7 @@ function WrappedTeamCardPageContent(props: {
 	onboardingMetrics: WrappedOnboardingMetrics;
 	onBackFromFirstStep?: () => void;
 	onContinueToDashboard: () => void;
+	publicUsername: string | undefined;
 	setDevOverrideIndex: (
 		nextValue: number | null | ((currentValue: number | null) => number | null),
 	) => void;
@@ -268,6 +271,7 @@ function WrappedTeamCardPageContent(props: {
 		onboardingMetrics,
 		onBackFromFirstStep,
 		onContinueToDashboard,
+		publicUsername,
 		setDevOverrideIndex,
 		setShareAppearance,
 		shareAppearance,
@@ -364,6 +368,7 @@ function WrappedTeamCardPageContent(props: {
 					utilityName: "shareCreated",
 				});
 			},
+			username: publicUsername,
 		},
 	);
 	// The share action helpers stay presentational from the page's perspective.

--- a/apps/web/src/features/wrapped/team-card/row.test.ts
+++ b/apps/web/src/features/wrapped/team-card/row.test.ts
@@ -5,9 +5,9 @@ describe("buildResolvedTeamCardRow", () => {
 	it("uses the guest preview name and image for card personalization", () => {
 		const row = buildResolvedTeamCardRow({
 			accountLabel: "Session User",
+			debugProfileImageSrc: "data:image/png;base64,abc",
 			developerDetails: undefined,
 			guestPreviewDisplayName: "Ada Lovelace",
-			profileImageSrc: "data:image/png;base64,abc",
 			sessionUserEmail: "session@example.com",
 			sessionUserId: "user_1",
 			sessionUserName: "Session User",
@@ -17,54 +17,5 @@ describe("buildResolvedTeamCardRow", () => {
 
 		expect(row.displayName).toBe("Ada Lovelace");
 		expect(row.imageUrl).toBe("data:image/png;base64,abc");
-	});
-
-	it("leaves the card image empty when the profile has no picture", () => {
-		const row = buildResolvedTeamCardRow({
-			accountLabel: "Session User",
-			developerDetails: undefined,
-			guestPreviewDisplayName: "Ada Lovelace",
-			profileImageSrc: null,
-			sessionUserEmail: "session@example.com",
-			sessionUserId: "user_1",
-			sessionUserName: "Session User",
-			teamMemberRows: [],
-			wrappedMetrics: undefined,
-		});
-
-		expect(row.imageUrl).toBeNull();
-	});
-
-	it("preserves the team member image when no profile override exists", () => {
-		const row = buildResolvedTeamCardRow({
-			accountLabel: "Session User",
-			developerDetails: undefined,
-			guestPreviewDisplayName: undefined,
-			profileImageSrc: undefined,
-			sessionUserEmail: "session@example.com",
-			sessionUserId: "user_1",
-			sessionUserName: "Session User",
-			teamMemberRows: [
-				{
-					activeDays: 4,
-					cost: 12,
-					displayName: "Session User",
-					email: "session@example.com",
-					favoriteModel: null,
-					hasActivity: true,
-					imageUrl: "https://example.com/avatar.png",
-					inputTokens: 10,
-					lastActiveDate: null,
-					outputTokens: 20,
-					role: "Member",
-					totalSessions: 3,
-					totalTokens: 30,
-					userId: "user_1",
-				},
-			],
-			wrappedMetrics: undefined,
-		});
-
-		expect(row.imageUrl).toBe("https://example.com/avatar.png");
 	});
 });

--- a/apps/web/src/features/wrapped/team-card/row.ts
+++ b/apps/web/src/features/wrapped/team-card/row.ts
@@ -3,9 +3,9 @@ import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
 
 interface BuildResolvedTeamCardRowParams {
 	accountLabel: string;
+	debugProfileImageSrc: string;
 	developerDetails: DeveloperDetails | undefined;
 	guestPreviewDisplayName: string | undefined;
-	profileImageSrc: string | null | undefined;
 	sessionUserEmail: string | undefined;
 	sessionUserId: string | undefined;
 	sessionUserName: string | undefined;
@@ -18,9 +18,9 @@ export function buildResolvedTeamCardRow(
 ): TeamPageMemberRow {
 	const {
 		accountLabel,
+		debugProfileImageSrc,
 		developerDetails,
 		guestPreviewDisplayName,
-		profileImageSrc,
 		sessionUserEmail,
 		sessionUserId,
 		sessionUserName,
@@ -31,10 +31,6 @@ export function buildResolvedTeamCardRow(
 		sessionUserEmail,
 		sessionUserId,
 		teamMemberRows,
-	});
-	const imageUrl = resolveTeamCardImageUrl({
-		currentUserRow,
-		profileImageSrc,
 	});
 	const { displayName } = resolveTeamCardDisplayName({
 		accountLabel,
@@ -56,7 +52,7 @@ export function buildResolvedTeamCardRow(
 				developerDetails.total_sessions > 0 ||
 				developerDetails.active_days > 0 ||
 				developerDetails.total_tokens > 0,
-			imageUrl,
+			imageUrl: debugProfileImageSrc,
 			inputTokens: developerDetails.input_tokens,
 			lastActiveDate: developerDetails.last_active_date,
 			outputTokens: developerDetails.output_tokens,
@@ -71,7 +67,7 @@ export function buildResolvedTeamCardRow(
 		return {
 			...currentUserRow,
 			...getWrappedMetricFallbackFields(wrappedMetrics, currentUserRow),
-			imageUrl,
+			imageUrl: debugProfileImageSrc,
 		};
 	}
 
@@ -84,7 +80,7 @@ export function buildResolvedTeamCardRow(
 		email,
 		favoriteModel: wrappedFallbackFields.favoriteModel,
 		hasActivity: wrappedFallbackFields.hasActivity,
-		imageUrl,
+		imageUrl: debugProfileImageSrc,
 		inputTokens: 0,
 		lastActiveDate: wrappedMetrics?.last_session_at ?? null,
 		outputTokens: 0,
@@ -93,17 +89,6 @@ export function buildResolvedTeamCardRow(
 		totalTokens: wrappedFallbackFields.totalTokens,
 		userId: sessionUserId ?? "wrapped-preview",
 	};
-}
-
-function resolveTeamCardImageUrl(input: {
-	currentUserRow: TeamPageMemberRow | undefined;
-	profileImageSrc: string | null | undefined;
-}) {
-	if (input.profileImageSrc !== undefined) {
-		return input.profileImageSrc;
-	}
-
-	return input.currentUserRow?.imageUrl ?? null;
 }
 
 function getWrappedMetricFallbackFields(

--- a/apps/web/src/features/wrapped/team-card/share.test.ts
+++ b/apps/web/src/features/wrapped/team-card/share.test.ts
@@ -232,6 +232,7 @@ describe("createWrappedTeamCardShareActions", () => {
 		expect(intentUrl.searchParams.get("text")).toBe(
 			[
 				"My Codex usage says I'm a Maniac. Active 12 out of 180 days, 6 repos, 18.3 sessions per active day. Yeah, you should be a little scared.",
+				"#RudelWrapped",
 				"Check my profile out here https://rudel.ai/wrapped/public-card",
 				"[Your image is in your clipboard, pls paste and dont forget]",
 			].join("\n\n"),

--- a/apps/web/src/features/wrapped/team-card/use-page-data.ts
+++ b/apps/web/src/features/wrapped/team-card/use-page-data.ts
@@ -27,6 +27,7 @@ interface UseWrappedTeamCardPageDataResult {
 	completionUserId: string | null;
 	liveArchetype: WrappedArchetypeCardTheme;
 	onboardingMetrics: WrappedOnboardingMetrics;
+	publicUsername: string | undefined;
 	statItems: readonly WrappedTeamMemberCardStatItem[];
 	visibleTeamCardRow: TeamPageMemberRow;
 }
@@ -43,7 +44,7 @@ interface UseWrappedTeamCardPageDataResult {
 // still marked "needs_truth_cleanup" or "needs_codex_feature_parity" in
 // onboarding/config.ts.
 export function useWrappedTeamCardPageData(): UseWrappedTeamCardPageDataResult {
-	const { accountLabel, session, wrappedData } = useWrappedCardData();
+	const { accountLabel, handover, session, wrappedData } = useWrappedCardData();
 	const { teamMemberRows } = useTeamPageData();
 	const sessionUserId = getSessionUserId(session);
 	const sessionUserName = getSessionUserName(session);
@@ -52,10 +53,11 @@ export function useWrappedTeamCardPageData(): UseWrappedTeamCardPageDataResult {
 		() => readWrappedGuestPreviewSnapshot(),
 		[],
 	);
-	const profileImageSrc = guestPreviewSnapshot
-		? guestPreviewSnapshot.profile.imageUrl
-		: getSessionUserImage(session);
+	const debugProfileImageSrc =
+		guestPreviewSnapshot?.profile.imageUrl ??
+		handover.preview.profile.avatarSrc;
 	const guestPreviewDisplayName = guestPreviewSnapshot?.profile.displayName;
+	const guestPreviewUsername = guestPreviewSnapshot?.profile.username;
 	const { data: activeMember } = authClient.useActiveMember();
 	const activeMemberUserId = getActiveMemberUserId(activeMember);
 	const resolvedUserId = sessionUserId ?? activeMemberUserId;
@@ -120,9 +122,9 @@ export function useWrappedTeamCardPageData(): UseWrappedTeamCardPageDataResult {
 		() =>
 			buildResolvedTeamCardRow({
 				accountLabel,
+				debugProfileImageSrc,
 				developerDetails: developerDetailsQuery.data,
 				guestPreviewDisplayName,
-				profileImageSrc,
 				sessionUserEmail,
 				sessionUserId: resolvedUserId,
 				sessionUserName,
@@ -131,9 +133,9 @@ export function useWrappedTeamCardPageData(): UseWrappedTeamCardPageDataResult {
 			}),
 		[
 			accountLabel,
+			debugProfileImageSrc,
 			developerDetailsQuery.data,
 			guestPreviewDisplayName,
-			profileImageSrc,
 			sessionUserEmail,
 			resolvedUserId,
 			sessionUserName,
@@ -177,11 +179,27 @@ export function useWrappedTeamCardPageData(): UseWrappedTeamCardPageDataResult {
 		() => resolveLiveArchetype(wrappedData?.archetype?.key),
 		[wrappedData?.archetype?.key],
 	);
+	const publicUsername = useMemo(
+		() =>
+			resolveWrappedPublicUsername({
+				fallbackDisplayName: visibleTeamCardRow.displayName,
+				guestPreviewUsername,
+				sessionUserEmail,
+				sessionUserName,
+			}),
+		[
+			guestPreviewUsername,
+			sessionUserEmail,
+			sessionUserName,
+			visibleTeamCardRow.displayName,
+		],
+	);
 
 	return {
 		completionUserId,
 		liveArchetype,
 		onboardingMetrics,
+		publicUsername,
 		statItems,
 		visibleTeamCardRow,
 	};
@@ -238,13 +256,57 @@ function getSessionUserEmail(
 		: undefined;
 }
 
-function getSessionUserImage(
-	session: ReturnType<typeof useWrappedCardData>["session"],
-) {
-	return session?.user &&
-		"image" in session.user &&
-		typeof session.user.image === "string" &&
-		session.user.image.trim().length > 0
-		? session.user.image.trim()
-		: undefined;
+function getEmailHandle(email: string | undefined) {
+	if (!email) {
+		return undefined;
+	}
+
+	const [emailHandle] = email.split("@");
+	return emailHandle?.trim() || undefined;
+}
+
+function resolveWrappedPublicUsername(input: {
+	fallbackDisplayName: string;
+	guestPreviewUsername: string | undefined;
+	sessionUserEmail: string | undefined;
+	sessionUserName: string | undefined;
+}) {
+	const guestPreviewUsername = input.guestPreviewUsername?.trim();
+
+	if (guestPreviewUsername && isWrappedPublicUsername(guestPreviewUsername)) {
+		return guestPreviewUsername;
+	}
+
+	const candidates = [
+		getEmailHandle(input.sessionUserEmail),
+		input.sessionUserName,
+		input.fallbackDisplayName,
+	];
+
+	for (const candidate of candidates) {
+		const username = normalizeWrappedPublicUsernameCandidate(candidate);
+
+		if (username) {
+			return username;
+		}
+	}
+
+	return undefined;
+}
+
+function normalizeWrappedPublicUsernameCandidate(value: string | undefined) {
+	const username = value
+		?.trim()
+		.replace(/^@+/u, "")
+		.replace(/[^A-Za-z0-9_-]+/gu, "-")
+		.replace(/-+/gu, "-")
+		.replace(/^-|-$/gu, "")
+		.slice(0, 64)
+		.replace(/-$/u, "");
+
+	return username && isWrappedPublicUsername(username) ? username : undefined;
+}
+
+function isWrappedPublicUsername(value: string) {
+	return /^[A-Za-z0-9_-]{1,64}$/u.test(value);
 }

--- a/apps/web/src/features/wrapped/team-card/use-share.ts
+++ b/apps/web/src/features/wrapped/team-card/use-share.ts
@@ -13,6 +13,7 @@ interface UseWrappedTeamCardShareOptions {
 	// We keep that callback optional so the hook stays reusable and does not own
 	// analytics directly.
 	onShareCreated?: (shareRecord: WrappedShareRecord) => void;
+	username?: string;
 }
 
 // This hook owns the "create a real share only when needed" behavior for the
@@ -32,9 +33,9 @@ export function useWrappedTeamCardShare(
 		{},
 	);
 	const [pendingShareKey, setPendingShareKey] = useState<string | null>(null);
-	const { onShareCreated } = options ?? {};
-	const snapshotKey = JSON.stringify(snapshot);
-	const activeShareRecord = shareRecordsByKey[snapshotKey] ?? null;
+	const { onShareCreated, username } = options ?? {};
+	const shareKey = JSON.stringify({ snapshot, username: username ?? null });
+	const activeShareRecord = shareRecordsByKey[shareKey] ?? null;
 	const shareUrl = activeShareRecord
 		? buildWrappedShareUrl(activeShareRecord.id)
 		: undefined;
@@ -47,44 +48,40 @@ export function useWrappedTeamCardShare(
 			return activeShareRecord;
 		}
 
-		const pendingShareRequest = shareRequestByKeyRef.current.get(snapshotKey);
+		const pendingShareRequest = shareRequestByKeyRef.current.get(shareKey);
 		if (pendingShareRequest) {
 			return pendingShareRequest;
 		}
 
-		setPendingShareKey(snapshotKey);
+		setPendingShareKey(shareKey);
 
+		const createShareInput = username ? { snapshot, username } : { snapshot };
 		const shareRequest = client.wrappedShare
-			.create({ snapshot })
+			.create(createShareInput)
 			.then((createdShare) => {
 				setShareRecordsByKey((currentRecords) => ({
 					...currentRecords,
-					[snapshotKey]: createdShare,
+					[shareKey]: createdShare,
 				}));
 				onShareCreated?.(createdShare);
 				return createdShare;
 			})
 			.finally(() => {
-				shareRequestByKeyRef.current.delete(snapshotKey);
+				shareRequestByKeyRef.current.delete(shareKey);
 				setPendingShareKey((currentPendingShareKey) =>
-					currentPendingShareKey === snapshotKey
-						? null
-						: currentPendingShareKey,
+					currentPendingShareKey === shareKey ? null : currentPendingShareKey,
 				);
 			});
 
-		shareRequestByKeyRef.current.set(snapshotKey, shareRequest);
+		shareRequestByKeyRef.current.set(shareKey, shareRequest);
 		return shareRequest;
 	}
 
 	return {
 		ensureShare,
-		isCreatingShare: pendingShareKey === snapshotKey,
+		isCreatingShare: pendingShareKey === shareKey,
 		shareUrl,
-		shareUrlLabel: formatShareUrlLabel(
-			shareUrl,
-			pendingShareKey === snapshotKey,
-		),
+		shareUrlLabel: formatShareUrlLabel(shareUrl, pendingShareKey === shareKey),
 	};
 }
 

--- a/apps/web/src/features/wrapped/wrapped-x-share.test.ts
+++ b/apps/web/src/features/wrapped/wrapped-x-share.test.ts
@@ -4,6 +4,12 @@ import {
 	buildWrappedXShareText,
 } from "@/features/wrapped/wrapped-x-share";
 
+const WRAPPED_X_SHARE_HASHTAG = "#RudelWrapped";
+
+function withWrappedHashtag(text: string) {
+	return [text, WRAPPED_X_SHARE_HASHTAG].join("\n\n");
+}
+
 describe("wrapped X share copy", () => {
 	it("builds Maniac copy with activity, repo, and session density metrics", () => {
 		expect(
@@ -17,10 +23,12 @@ describe("wrapped X share copy", () => {
 				totalTokens: 1_920_000,
 			}),
 		).toBe(
-			[
-				"My Claude Code and Codex usage says I'm a Maniac.",
-				"Active 12 out of 180 days, 6 repos, 18.3 sessions per active day. Yeah, you should be a little scared.",
-			].join(" "),
+			withWrappedHashtag(
+				[
+					"My Claude Code and Codex usage says I'm a Maniac.",
+					"Active 12 out of 180 days, 6 repos, 18.3 sessions per active day. Yeah, you should be a little scared.",
+				].join(" "),
+			),
 		);
 	});
 
@@ -48,15 +56,17 @@ describe("wrapped X share copy", () => {
 				totalTokens: 92_000,
 			}),
 		).toBe(
-			[
-				"My Claude Code and Codex usage says I'm a Roadrunner.",
-				"Meep meep.",
-				"Active 4 out of 21 days.",
-				"Meep meep.",
-				"When back I'm spending $5.50 a session.",
-				"Meep meep.",
-				"Gone.",
-			].join("\n\n"),
+			withWrappedHashtag(
+				[
+					"My Claude Code and Codex usage says I'm a Roadrunner.",
+					"Meep meep.",
+					"Active 4 out of 21 days.",
+					"Meep meep.",
+					"When back I'm spending $5.50 a session.",
+					"Meep meep.",
+					"Gone.",
+				].join("\n\n"),
+			),
 		);
 	});
 
@@ -83,7 +93,9 @@ describe("wrapped X share copy", () => {
 				],
 			}),
 		).toBe(
-			"My Claude Code and Codex usage says I'm Obsessed. 1 repo, 58 out of 214 days, 48% of sessions shipped something. Apparently I have nothing else in my life. I dare you to distract me.",
+			withWrappedHashtag(
+				"My Claude Code and Codex usage says I'm Obsessed. 1 repo, 58 out of 214 days, 48% of sessions shipped something. Apparently I have nothing else in my life. I dare you to distract me.",
+			),
 		);
 	});
 
@@ -109,7 +121,9 @@ describe("wrapped X share copy", () => {
 				totalSessions: 8,
 			}),
 		).toBe(
-			"My Claude Code and Codex usage says I got the Company Card... 8 sessions, 48% shipped something, $44 in total. Dario & Sam are probably happy to have me.",
+			withWrappedHashtag(
+				"My Claude Code and Codex usage says I got the Company Card... 8 sessions, 48% shipped something, $44 in total. Dario & Sam are probably happy to have me.",
+			),
 		);
 
 		expect(
@@ -128,7 +142,9 @@ describe("wrapped X share copy", () => {
 				totalSessions: 8,
 			}),
 		).toBe(
-			"My Claude Code usage says I got the Company Card... 8 sessions, 48% shipped something, $44 in total. Dario's probably happy to have me.",
+			withWrappedHashtag(
+				"My Claude Code usage says I got the Company Card... 8 sessions, 48% shipped something, $44 in total. Dario's probably happy to have me.",
+			),
 		);
 
 		expect(
@@ -147,7 +163,9 @@ describe("wrapped X share copy", () => {
 				totalSessions: 8,
 			}),
 		).toBe(
-			"My Codex usage says I got the Company Card... 8 sessions, 48% shipped something, $44 in total. Sam's probably happy to have me.",
+			withWrappedHashtag(
+				"My Codex usage says I got the Company Card... 8 sessions, 48% shipped something, $44 in total. Sam's probably happy to have me.",
+			),
 		);
 	});
 
@@ -163,7 +181,9 @@ describe("wrapped X share copy", () => {
 				totalSessions: 37,
 			}),
 		).toBe(
-			"My Codex usage says I'm a Smooooooth Operator. Active 12 out of 180 days, 24 minute average session, 3.1 a day. Haters gonna try to find something on me, but they can't because I'm a smooooth operator.",
+			withWrappedHashtag(
+				"My Codex usage says I'm a Smooooooth Operator. Active 12 out of 180 days, 24 minute average session, 3.1 a day. Haters gonna try to find something on me, but they can't because I'm a smooooth operator.",
+			),
 		);
 	});
 
@@ -190,7 +210,9 @@ describe("wrapped X share copy", () => {
 				],
 			}),
 		).toBe(
-			"My Claude Code and Codex usage says I'm an ADHD Brain. 12 out of 180 days, 6 repos, 48% shipped. DaVinci also had many projects! I'm his reincarnation.. i guess.",
+			withWrappedHashtag(
+				"My Claude Code and Codex usage says I'm an ADHD Brain. 12 out of 180 days, 6 repos, 48% shipped. DaVinci also had many projects! I'm his reincarnation.. i guess.",
+			),
 		);
 	});
 
@@ -211,7 +233,9 @@ describe("wrapped X share copy", () => {
 				],
 			}),
 		).toBe(
-			"My Codex usage says I'm a Hit and Runner. 24 minute sessions, 6 repos, 48% shipped. Veni, vidi, commit. In, out, no witnesses.",
+			withWrappedHashtag(
+				"My Codex usage says I'm a Hit and Runner. 24 minute sessions, 6 repos, 48% shipped. Veni, vidi, commit. In, out, no witnesses.",
+			),
 		);
 	});
 
@@ -232,7 +256,9 @@ describe("wrapped X share copy", () => {
 				totalSessions: 8,
 			}),
 		).toBe(
-			"My Codex usage says I'm a Cheapskate. $5.50 a session, 48% shipped. Mr. Krabs is very proud of me. Spent less, shipped more. Very efficient. Pls don't ask me to pay for dinner though.",
+			withWrappedHashtag(
+				"My Codex usage says I'm a Cheapskate. $5.50 a session, 48% shipped. Mr. Krabs is very proud of me. Spent less, shipped more. Very efficient. Pls don't ask me to pay for dinner though.",
+			),
 		);
 	});
 
@@ -253,7 +279,9 @@ describe("wrapped X share copy", () => {
 				totalSessions: 8,
 			}),
 		).toBe(
-			"My Codex usage says I'm a Tourist. 8 sessions, 48% shipped, $44 spent in total.. I'm definitely not the person who'll get prompt injected by this OpenClaw thing. I'll stick to ChatGPT",
+			withWrappedHashtag(
+				"My Codex usage says I'm a Tourist. 8 sessions, 48% shipped, $44 spent in total.. I'm definitely not the person who'll get prompt injected by this OpenClaw thing. I'll stick to ChatGPT",
+			),
 		);
 
 		expect(
@@ -277,7 +305,9 @@ describe("wrapped X share copy", () => {
 				totalSessions: 8,
 			}),
 		).toBe(
-			"My Claude Code and Codex usage says I'm a Tourist. 8 sessions, 48% shipped, $44 spent in total.. I'm definitely not the person who'll get prompt injected by this OpenClaw thing. I'll stick to Claude",
+			withWrappedHashtag(
+				"My Claude Code and Codex usage says I'm a Tourist. 8 sessions, 48% shipped, $44 spent in total.. I'm definitely not the person who'll get prompt injected by this OpenClaw thing. I'll stick to Claude",
+			),
 		);
 	});
 

--- a/apps/web/src/features/wrapped/wrapped-x-share.ts
+++ b/apps/web/src/features/wrapped/wrapped-x-share.ts
@@ -26,6 +26,7 @@ interface WrappedXShareCopy {
 }
 
 const WRAPPED_X_INTENT_URL = "https://twitter.com/intent/tweet";
+const WRAPPED_X_SHARE_HASHTAG = "#RudelWrapped";
 
 const WRAPPED_X_SHARE_COPY_BY_ARCHETYPE: Record<string, WrappedXShareCopy> = {
 	decimal: {
@@ -73,114 +74,134 @@ export function buildWrappedXShareText(input: BuildWrappedXShareTextInput) {
 	const openingLine = `My ${usageSourceLabel} usage says I'm ${archetypeIdentity}.`;
 
 	if (normalizedArchetypeLabel === "roadrunner") {
-		return [
-			openingLine,
-			buildWrappedXRoadrunnerShareBody({
-				activeDays,
-				cost,
-				daysSinceFirst,
-				totalSessions,
-			}),
-		].join("\n\n");
+		return appendWrappedXShareHashtag(
+			[
+				openingLine,
+				buildWrappedXRoadrunnerShareBody({
+					activeDays,
+					cost,
+					daysSinceFirst,
+					totalSessions,
+				}),
+			].join("\n\n"),
+		);
 	}
 
 	if (normalizedArchetypeLabel === "company card") {
-		return [
-			`My ${usageSourceLabel} usage says I got the Company Card...`,
-			buildWrappedXCompanyCardShareBody({
-				commitRate,
-				cost,
-				favoriteModel,
-				sourceSplit,
-				totalSessions,
-			}),
-		].join(" ");
+		return appendWrappedXShareHashtag(
+			[
+				`My ${usageSourceLabel} usage says I got the Company Card...`,
+				buildWrappedXCompanyCardShareBody({
+					commitRate,
+					cost,
+					favoriteModel,
+					sourceSplit,
+					totalSessions,
+				}),
+			].join(" "),
+		);
 	}
 
 	if (normalizedArchetypeLabel === "adhd brain") {
-		return [
-			openingLine,
-			buildWrappedXAdhdBrainShareBody({
-				activeDays,
-				commitRate,
-				daysSinceFirst,
-				distinctProjectCount,
-			}),
-		].join(" ");
+		return appendWrappedXShareHashtag(
+			[
+				openingLine,
+				buildWrappedXAdhdBrainShareBody({
+					activeDays,
+					commitRate,
+					daysSinceFirst,
+					distinctProjectCount,
+				}),
+			].join(" "),
+		);
 	}
 
 	if (normalizedArchetypeLabel === "cheapskate") {
-		return [
-			openingLine,
-			buildWrappedXCheapskateShareBody({
-				commitRate,
-				cost,
-				totalSessions,
-			}),
-		].join(" ");
+		return appendWrappedXShareHashtag(
+			[
+				openingLine,
+				buildWrappedXCheapskateShareBody({
+					commitRate,
+					cost,
+					totalSessions,
+				}),
+			].join(" "),
+		);
 	}
 
 	if (normalizedArchetypeLabel === "hit and runner") {
-		return [
-			openingLine,
-			buildWrappedXHitAndRunnerShareBody({
-				avgSessionMin,
-				commitRate,
-				distinctProjectCount,
-			}),
-		].join(" ");
+		return appendWrappedXShareHashtag(
+			[
+				openingLine,
+				buildWrappedXHitAndRunnerShareBody({
+					avgSessionMin,
+					commitRate,
+					distinctProjectCount,
+				}),
+			].join(" "),
+		);
 	}
 
 	if (normalizedArchetypeLabel === "maniac") {
-		return [
-			openingLine,
-			buildWrappedXManiacShareBody({
-				activeDays,
-				daysSinceFirst,
-				distinctProjectCount,
-				totalSessions,
-			}),
-		].join(" ");
+		return appendWrappedXShareHashtag(
+			[
+				openingLine,
+				buildWrappedXManiacShareBody({
+					activeDays,
+					daysSinceFirst,
+					distinctProjectCount,
+					totalSessions,
+				}),
+			].join(" "),
+		);
 	}
 
 	if (normalizedArchetypeLabel === "obsessed") {
-		return [
-			openingLine,
-			buildWrappedXObsessedShareBody({
-				activeDays,
-				commitRate,
-				daysSinceFirst,
-				distinctProjectCount,
-			}),
-		].join(" ");
+		return appendWrappedXShareHashtag(
+			[
+				openingLine,
+				buildWrappedXObsessedShareBody({
+					activeDays,
+					commitRate,
+					daysSinceFirst,
+					distinctProjectCount,
+				}),
+			].join(" "),
+		);
 	}
 
 	if (normalizedArchetypeLabel === "smooth operator") {
-		return [
-			`My ${usageSourceLabel} usage says I'm a Smooooooth Operator.`,
-			buildWrappedXSmoothOperatorShareBody({
-				activeDays,
-				avgSessionMin,
-				daysSinceFirst,
-				totalSessions,
-			}),
-		].join(" ");
+		return appendWrappedXShareHashtag(
+			[
+				`My ${usageSourceLabel} usage says I'm a Smooooooth Operator.`,
+				buildWrappedXSmoothOperatorShareBody({
+					activeDays,
+					avgSessionMin,
+					daysSinceFirst,
+					totalSessions,
+				}),
+			].join(" "),
+		);
 	}
 
 	if (normalizedArchetypeLabel === "tourist") {
-		return [
-			openingLine,
-			buildWrappedXTouristShareBody({
-				commitRate,
-				cost,
-				favoriteModel,
-				sourceSplit,
-				totalSessions,
-			}),
-		].join(" ");
+		return appendWrappedXShareHashtag(
+			[
+				openingLine,
+				buildWrappedXTouristShareBody({
+					commitRate,
+					cost,
+					favoriteModel,
+					sourceSplit,
+					totalSessions,
+				}),
+			].join(" "),
+		);
 	}
 
-	return [openingLine, `Traits: ${metrics}; ${copy.traits}.`].join("\n\n");
+	return appendWrappedXShareHashtag(
+		[openingLine, `Traits: ${metrics}; ${copy.traits}.`].join("\n\n"),
+	);
 }
 
 export function buildWrappedXIntentUrl(input: BuildWrappedXIntentUrlInput) {
@@ -199,6 +220,10 @@ function appendWrappedXSharePublicLink(text: string, url: string) {
 		`Check my profile out here ${url}`,
 		"[Your image is in your clipboard, pls paste and dont forget]",
 	].join("\n\n");
+}
+
+function appendWrappedXShareHashtag(text: string) {
+	return [text, WRAPPED_X_SHARE_HASHTAG].join("\n\n");
 }
 
 function buildWrappedXRoadrunnerShareBody(input: {

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -6583,7 +6583,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 @supports ((background-clip: text) or (-webkit-background-clip: text)) {
-	.mymind-wrapped-final-stage__gradient-text:not(.is-obsession) {
+	.mymind-wrapped-final-stage__gradient-text {
 		background-clip: text;
 		-webkit-background-clip: text;
 		-webkit-text-fill-color: transparent;
@@ -6598,7 +6598,6 @@ body.mymind-wrapped-body #cw-bubble-holder {
 }
 
 .mymind-wrapped-final-stage__gradient-text[data-accent-state="active"]:not(
-		.is-obsession,
 		[data-hover-replay="ready"]
 	) {
 	animation: mymind-wrapped-gradient-text-fill-replay
@@ -6606,9 +6605,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		var(--wrapped-reveal-intro-gt-easing) both;
 }
 
-.mymind-wrapped-final-stage__gradient-text[data-accent-state="active"][data-hover-replay="ready"]:not(
-		.is-obsession
-	) {
+.mymind-wrapped-final-stage__gradient-text[data-accent-state="active"][data-hover-replay="ready"] {
 	background-color: transparent;
 	background-image: var(--wrapped-reveal-archetype-accent);
 	background-position: 0% 0%;
@@ -6616,60 +6613,8 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	background-size: auto;
 }
 
-.mymind-wrapped-final-stage__gradient-text.is-obsession {
-	isolation: isolate;
-	background: none;
-	transition: color 240ms cubic-bezier(0.22, 1, 0.36, 1);
-	-webkit-text-fill-color: currentcolor;
-}
-
-.mymind-wrapped-final-stage__gradient-text.is-obsession::before {
-	content: "";
-	position: absolute;
-	z-index: -1;
-	inset: -0.02em -0.12em -0.05em;
-	border-radius: 0.12em;
-	background:
-		linear-gradient(
-			110deg,
-			#141416 0%,
-			#323238 28%,
-			#0b0b0c 54%,
-			#3f3f45 76%,
-			#18181a 100%
-		)
-		no-repeat 120% 50% / 220% 100%;
-	opacity: 0;
-	box-decoration-break: clone;
-	-webkit-box-decoration-break: clone;
-	box-shadow:
-		inset 0 1px 0 rgb(255 255 255 / 0.13),
-		inset 0 -1px 0 rgb(0 0 0 / 0.32);
-	pointer-events: none;
-	transition:
-		opacity 320ms cubic-bezier(0.22, 1, 0.36, 1),
-		background-position 1.45s cubic-bezier(0.22, 1, 0.36, 1);
-	will-change: opacity, background-position;
-}
-
-.mymind-wrapped-final-stage__gradient-text.is-obsession::after {
-	content: none;
-}
-
-.mymind-wrapped-final-stage__gradient-text.is-obsession[data-accent-state="active"] {
-	color: #fff;
-	-webkit-text-fill-color: #fff;
-}
-
-.mymind-wrapped-final-stage__gradient-text.is-obsession[data-accent-state="active"]::before {
-	background-position: 0% 50%;
-	opacity: 1;
-}
-
 @media (hover: hover) and (pointer: fine) {
-	.mymind-wrapped-final-stage__gradient-text[data-accent-state="active"][data-hover-replay="ready"]:not(
-			.is-obsession
-		):hover {
+	.mymind-wrapped-final-stage__gradient-text[data-accent-state="active"][data-hover-replay="ready"]:hover {
 		background-color: var(--wrapped-reveal-intro-gt-color);
 		background-image: linear-gradient(
 			var(--wrapped-reveal-archetype-gt-direction, 184deg),
@@ -6682,11 +6627,6 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		animation: mymind-wrapped-gradient-text-fill-replay
 			var(--wrapped-reveal-intro-gt-duration)
 			var(--wrapped-reveal-intro-gt-easing) both;
-	}
-
-	.mymind-wrapped-final-stage__gradient-text.is-obsession[data-accent-state="active"][data-hover-replay="ready"]:hover::before {
-		animation: mymind-wrapped-carbon-marker-sheen 1.05s
-			cubic-bezier(0.22, 1, 0.36, 1) both;
 	}
 }
 
@@ -6713,16 +6653,6 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		background-repeat: no-repeat;
 		background-size: var(--wrapped-reveal-intro-gt-width)
 			var(--wrapped-reveal-intro-gt-height);
-	}
-}
-
-@keyframes mymind-wrapped-carbon-marker-sheen {
-	from {
-		background-position: 120% 50%;
-	}
-
-	to {
-		background-position: 0% 50%;
 	}
 }
 
@@ -6791,7 +6721,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 			"copy"
 			"card";
 		grid-template-rows: auto auto;
-		row-gap: clamp(1rem, 3svh, 1.5rem);
+		row-gap: clamp(1rem, 2.4svh, 1.5rem);
 	}
 
 	.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
@@ -6820,6 +6750,23 @@ body.mymind-wrapped-body #cw-bubble-holder {
 		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
 		--wrapped-card-base-rotate-x: 0deg;
 		--wrapped-card-base-rotate-y: 0deg;
+	}
+
+	.mymind-wrapped-final-stage--reveal
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-title {
+		max-width: 17ch;
+		font-size: clamp(2.05rem, 8.2vw, 3rem);
+		line-height: 1.02;
+	}
+
+	.mymind-wrapped-final-stage--reveal
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-description {
+		margin-top: 0.72rem;
+		max-width: 31ch;
+		font-size: clamp(1rem, 2.8vw, 1.04rem);
+		line-height: 1.38;
 	}
 }
 
@@ -6971,15 +6918,29 @@ body.mymind-wrapped-body #cw-bubble-holder {
 
 .mymind-wrapped-final-stage--public-card {
 	width: 100%;
+	min-height: 0;
+}
+
+.mymind-wrapped-final-stage--public-card
+	.mymind-wrapped-final-stage__object--canvas {
+	min-height: 0;
 }
 
 .mymind-wrapped-public-card-stage__canvas,
 .mymind-wrapped-public-card-stage__card-layer {
-	min-height: clamp(24rem, 58svh, 35rem);
+	height: 100%;
+	min-height: 0;
 }
 
 .mymind-wrapped-public-card-stage__card-layer {
-	padding-top: clamp(2.2rem, 6svh, 3.8rem);
+	padding-top: 0;
+}
+
+.mymind-wrapped-public-card-stage__composition[data-companion-state="visible"] {
+	align-content: center;
+	min-height: 0;
+	height: 100%;
+	row-gap: clamp(1rem, 2.6svh, 1.7rem);
 }
 
 .mymind-wrapped-public-card-stage__copy {
@@ -6988,6 +6949,280 @@ body.mymind-wrapped-body #cw-bubble-holder {
 
 .mymind-wrapped-public-card-stage__action {
 	max-width: min(100%, 30rem);
+}
+
+@media (max-height: 61.25rem) {
+	.mymind-wrapped-route--public-card
+		.mymind-wrapped-shell--reference-top-chrome {
+		--wrapped-shell-top-inset: 16px;
+		--wrapped-shell-bottom-inset: 14px;
+		--wrapped-shell-stage-gap: 0.55rem;
+	}
+
+	.mymind-wrapped-public-card-stage__composition[data-companion-state="visible"] {
+		row-gap: clamp(0.9rem, 2svh, 1.25rem);
+	}
+}
+
+@media (orientation: portrait) and (max-height: 48.75rem) {
+	.mymind-wrapped-final-stage--public-card {
+		--wrapped-short-card-scale: 0.92;
+		gap: 0.45rem;
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--public-card
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 0.92;
+	}
+
+	.mymind-wrapped-public-card-stage__composition[data-companion-state="visible"] {
+		row-gap: clamp(0.75rem, 1.8svh, 1rem);
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-title {
+		font-size: clamp(1.88rem, 7.4vw, 2.28rem);
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-description {
+		margin-top: 0.58rem;
+		line-height: 1.34;
+	}
+}
+
+@media (orientation: portrait) and (max-height: 46.25rem) {
+	.mymind-wrapped-final-stage--public-card {
+		--wrapped-short-card-scale: 0.88;
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--public-card
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 0.88;
+	}
+
+	.mymind-wrapped-public-card-stage__composition[data-companion-state="visible"] {
+		row-gap: clamp(1rem, 2.4svh, 1.18rem);
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-title {
+		font-size: clamp(1.68rem, 6.6vw, 2.04rem);
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-description {
+		margin-top: 0.46rem;
+		line-height: 1.24;
+	}
+}
+
+@media (orientation: portrait) and (max-height: 43.75rem) {
+	.mymind-wrapped-final-stage--public-card {
+		--wrapped-short-card-scale: 0.86;
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--public-card
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 0.86;
+	}
+
+	.mymind-wrapped-public-card-stage__composition[data-companion-state="visible"] {
+		row-gap: clamp(0.9rem, 2.2svh, 1.05rem);
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-title {
+		font-size: clamp(1.58rem, 6.2vw, 1.92rem);
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-description {
+		margin-top: 0.42rem;
+		line-height: 1.2;
+	}
+}
+
+@media (orientation: portrait) and (max-height: 40rem) {
+	.mymind-wrapped-final-stage--public-card {
+		--wrapped-short-card-scale: 0.74;
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--public-card
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 0.74;
+	}
+
+	.mymind-wrapped-public-card-stage__composition[data-companion-state="visible"] {
+		row-gap: clamp(0.68rem, 1.8svh, 0.88rem);
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-title {
+		font-size: clamp(1.42rem, 5.6vw, 1.72rem);
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-description {
+		margin-top: 0.32rem;
+		max-width: 34ch;
+		line-height: 1.16;
+	}
+}
+
+@media (max-width: 55.999rem) and (max-height: 56.25rem) {
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		) {
+		--wrapped-short-card-scale: 1;
+		gap: 0.55rem;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__card-drop-layer {
+		padding-top: 0;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 1;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"] {
+		row-gap: clamp(0.85rem, 2svh, 1.15rem);
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-title {
+		font-size: clamp(1.9rem, 5.9vw, 2.35rem);
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-description {
+		margin-top: 0.55rem;
+		max-width: 32ch;
+		line-height: 1.3;
+	}
+}
+
+@media (max-width: 55.999rem) and (max-height: 48.75rem) {
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		) {
+		--wrapped-short-card-scale: 0.88;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 0.88;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"] {
+		row-gap: clamp(0.72rem, 1.9svh, 0.95rem);
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-title {
+		font-size: clamp(1.7rem, 5.4vw, 2.08rem);
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-description {
+		margin-top: 0.44rem;
+		line-height: 1.22;
+	}
+}
+
+@media (max-width: 55.999rem) and (max-height: 40rem) {
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		) {
+		--wrapped-short-card-scale: 0.74;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 0.74;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"] {
+		row-gap: clamp(0.64rem, 1.7svh, 0.84rem);
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-title {
+		font-size: clamp(1.42rem, 5vw, 1.72rem);
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__archetype-description {
+		margin-top: 0.32rem;
+		max-width: 34ch;
+		line-height: 1.16;
+	}
 }
 
 @media (min-width: 360px) {
@@ -8035,8 +8270,17 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	margin: 0 auto;
 }
 
+.mymind-wrapped-share-actions__meta-grid--stacked {
+	grid-template-columns: minmax(0, 1fr);
+}
+
 .mymind-wrapped-share-actions__secondary {
+	display: inline-flex;
 	min-height: 44px;
+	width: 100%;
+	align-items: center;
+	justify-content: center;
+	gap: 0.5rem;
 	border-color: rgb(17 24 39 / 0.08);
 	border-radius: 999px;
 	background: rgb(255 255 255 / 0.88);
@@ -8048,6 +8292,66 @@ body.mymind-wrapped-body #cw-bubble-holder {
 
 .mymind-wrapped-share-actions__secondary:hover {
 	background: white;
+}
+
+.mymind-wrapped-share-actions__secondary--x {
+	border-color: #17161c;
+	background: #17161c;
+	box-shadow: 0 8px 18px rgb(23 22 28 / 0.1);
+	color: white;
+}
+
+.mymind-wrapped-share-actions__secondary--x:hover {
+	background: #22201f;
+}
+
+.mymind-wrapped-share-actions__secondary--x:disabled {
+	background: rgb(23 22 28 / 0.28);
+	border-color: transparent;
+	box-shadow: none;
+	color: rgb(255 255 255 / 0.94);
+}
+
+.mymind-wrapped-share-actions__secondary--text {
+	border-color: transparent;
+	background: transparent;
+	box-shadow: none;
+	color: #2a2725;
+}
+
+.mymind-wrapped-share-actions__secondary--text:hover {
+	background: transparent;
+	color: #17161c;
+}
+
+.mymind-wrapped-share-primary-action {
+	font-size: 1.0625rem;
+	font-weight: 600;
+}
+
+.mymind-wrapped-share-primary-action--x {
+	border-color: #17161c;
+	background: #17161c;
+}
+
+.mymind-wrapped-share-primary-action__label {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.5rem;
+}
+
+.mymind-wrapped-share-primary-action--text {
+	border-color: transparent;
+	background: transparent;
+	box-shadow: none;
+	color: #2a2725;
+}
+
+.mymind-wrapped-share-primary-action--text:hover {
+	background: transparent;
+	box-shadow: none;
+	color: #17161c;
 }
 
 @media (min-width: 48rem) {
@@ -8462,6 +8766,330 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	}
 }
 
+@media (orientation: landscape) and (max-height: 48.75rem) {
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		) {
+		--wrapped-short-card-scale: 1.08;
+		gap: 0.45rem;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__card-drop-layer {
+		padding-top: 0;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 1.08;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"] {
+		align-items: center;
+		justify-content: center;
+		grid-template-areas: "card copy";
+		grid-template-columns: max-content minmax(13.5rem, 21rem);
+		grid-template-rows: auto;
+		column-gap: clamp(1.2rem, 4vw, 3rem);
+		row-gap: 0;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__slide-card-slot {
+		grid-area: card;
+		justify-self: end;
+		transform: none;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__card-visual-stage {
+		transform: none;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__archetype-copy {
+		position: relative;
+		grid-area: copy;
+		justify-items: start;
+		top: auto;
+		right: auto;
+		bottom: auto;
+		left: auto;
+		width: min(36vw, 21rem);
+		margin-inline: 0;
+		text-align: left;
+		translate: 0;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__archetype-title,
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__archetype-description {
+		text-align: left;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__archetype-title {
+		max-width: 15ch;
+		font-size: clamp(1.55rem, 3.15vw, 2.4rem);
+		line-height: 1.02;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__archetype-description {
+		margin-top: 0.56rem;
+		max-width: 29ch;
+		font-size: 1rem;
+		line-height: 1.3;
+	}
+
+	.mymind-wrapped-route--public-card
+		.mymind-wrapped-shell--reference-top-chrome {
+		--wrapped-shell-top-inset: 12px;
+		--wrapped-shell-bottom-inset: 10px;
+		--wrapped-shell-stage-gap: 0.45rem;
+	}
+
+	.mymind-wrapped-final-stage--public-card {
+		--wrapped-short-card-scale: 1.14;
+		gap: 0.45rem;
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--public-card
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 1.14;
+	}
+
+	.mymind-wrapped-public-card-stage__composition[data-companion-state="visible"] {
+		align-items: center;
+		justify-content: center;
+		grid-template-areas: "card copy";
+		grid-template-columns: max-content minmax(14rem, 22rem);
+		grid-template-rows: auto;
+		column-gap: clamp(1.4rem, 4.2vw, 3.25rem);
+		row-gap: 0;
+	}
+
+	.mymind-wrapped-public-card-stage__composition[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__slide-card-slot {
+		grid-area: card;
+		justify-self: end;
+		transform: none;
+	}
+
+	.mymind-wrapped-public-card-stage__composition[data-companion-state="visible"]
+		.mymind-wrapped-final-stage__card-visual-stage {
+		transform: none;
+	}
+
+	.mymind-wrapped-public-card-stage__composition[data-companion-state="visible"]
+		.mymind-wrapped-public-card-stage__copy {
+		position: relative;
+		grid-area: copy;
+		justify-items: start;
+		top: auto;
+		right: auto;
+		bottom: auto;
+		left: auto;
+		width: min(36vw, 22rem);
+		margin-inline: 0;
+		text-align: left;
+		translate: 0;
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__archetype-title,
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__archetype-description {
+		text-align: left;
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__archetype-title {
+		max-width: 15ch;
+		font-size: clamp(1.6rem, 3.1vw, 2.55rem);
+		line-height: 1.02;
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__archetype-description {
+		margin-top: 0.62rem;
+		max-width: 29ch;
+		font-size: 1rem;
+		line-height: 1.3;
+	}
+}
+
+@media (orientation: landscape) and (max-height: 40rem) {
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		) {
+		--wrapped-short-card-scale: 0.9;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 0.9;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"] {
+		grid-template-columns: max-content minmax(13rem, 19rem);
+		column-gap: clamp(1rem, 3.5vw, 2.4rem);
+	}
+
+	.mymind-wrapped-final-stage--public-card {
+		--wrapped-short-card-scale: 0.9;
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--public-card
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 0.9;
+	}
+
+	.mymind-wrapped-public-card-stage__composition[data-companion-state="visible"] {
+		grid-template-columns: max-content minmax(13rem, 19rem);
+		column-gap: clamp(1rem, 3.5vw, 2.4rem);
+	}
+}
+
+@media (orientation: landscape) and (max-height: 31rem) {
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		) {
+		--wrapped-short-card-scale: 0.7;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 0.7;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__reveal-stage[data-companion-state="visible"] {
+		grid-template-columns: max-content minmax(12rem, 17rem);
+		column-gap: clamp(0.75rem, 3vw, 1.7rem);
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__archetype-title {
+		font-size: clamp(1.28rem, 3.6vw, 1.82rem);
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__archetype-description {
+		margin-top: 0.42rem;
+		max-width: 25ch;
+		line-height: 1.22;
+	}
+
+	.mymind-wrapped-final-stage--public-card {
+		--wrapped-short-card-scale: 0.7;
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--public-card
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 0.7;
+	}
+
+	.mymind-wrapped-public-card-stage__composition[data-companion-state="visible"] {
+		column-gap: clamp(0.9rem, 3vw, 1.7rem);
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__archetype-title {
+		font-size: clamp(1.36rem, 3.8vw, 1.95rem);
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__archetype-description {
+		margin-top: 0.42rem;
+		max-width: 25ch;
+		line-height: 1.24;
+	}
+}
+
+@media (orientation: landscape) and (max-height: 23rem) {
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		) {
+		--wrapped-short-card-scale: 0.64;
+	}
+
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--reveal:not(
+			.mymind-wrapped-final-stage--public-card
+		)
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 0.64;
+	}
+
+	.mymind-wrapped-final-stage--public-card {
+		--wrapped-short-card-scale: 0.64;
+	}
+
+	.mymind-wrapped-final-stage--public-card
+		.mymind-wrapped-final-stage__card-hit-shell,
+	.mymind-wrapped-final-stage--public-card
+		.team-lineup-card-tilt-shell.mymind-wrapped-final-stage__tilt-shell {
+		--wrapped-card-render-scale: 0.64;
+	}
+}
+
 @media (min-width: 48rem) and (max-width: 69.999rem) {
 	.mymind-wrapped-final-stage__share-object-shell {
 		--wrapped-share-object-max-size: 28rem;
@@ -8537,7 +9165,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 @media (min-width: 48rem) {
 	.mymind-wrapped-final-stage--share {
 		grid-template-columns: minmax(0, 1fr);
-		grid-template-rows: auto auto auto;
+		grid-template-rows: auto minmax(0, 1fr) auto;
 		grid-template-areas:
 			"copy"
 			"object"
@@ -8584,7 +9212,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 
 @media (min-width: 70rem) and (min-height: 52rem) {
 	.mymind-wrapped-final-stage--share {
-		align-content: center;
+		align-content: stretch;
 	}
 }
 

--- a/packages/api-routes/src/schemas/wrapped-resume.ts
+++ b/packages/api-routes/src/schemas/wrapped-resume.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
+import { WrappedShareIdSchema } from "./wrapped-share.js";
 
 export const CreateWrappedResumeInputSchema = z.object({
 	// shareId is optional because mobile users can also need a desktop handoff
 	// from plain /wrapped, not only from a public wrapped page.
-	shareId: z.string().uuid().nullable().optional(),
+	shareId: WrappedShareIdSchema.nullable().optional(),
 });
 
 export const WrappedResumeRecordSchema = z.object({
@@ -19,7 +20,7 @@ export const ConsumeWrappedResumeInputSchema = z.object({
 
 export const WrappedResumeConsumeResultSchema = z.object({
 	redirect_to: z.string().min(1),
-	share_id: z.string().uuid().nullable(),
+	share_id: WrappedShareIdSchema.nullable(),
 });
 
 export type CreateWrappedResumeInput = z.infer<

--- a/packages/api-routes/src/schemas/wrapped-share.ts
+++ b/packages/api-routes/src/schemas/wrapped-share.ts
@@ -9,6 +9,18 @@ export const WRAPPED_SHARE_PAYLOAD_VERSION = 1 as const;
 // fields we are comfortable showing outside the authenticated product.
 export const WrappedShareThemeSchema = z.enum(["dark", "light", "muted"]);
 export const WrappedShareLayoutModeSchema = z.enum(["front", "front_back"]);
+export const WrappedShareIdSchema = z
+	.string()
+	.trim()
+	.min(1)
+	.max(128)
+	.regex(/^[A-Za-z0-9_-]+$/u);
+export const WrappedShareUsernameSchema = z
+	.string()
+	.trim()
+	.min(1)
+	.max(64)
+	.regex(/^[A-Za-z0-9_-]+$/u);
 
 export const WrappedShareHeaderMetricSchema = z.object({
 	label: z.string().optional(),
@@ -71,17 +83,18 @@ export const WrappedShareSnapshotSchema = z.object({
 
 export const CreateWrappedShareInputSchema = z.object({
 	snapshot: WrappedShareSnapshotSchema,
+	username: WrappedShareUsernameSchema.optional(),
 });
 
 export const GetPublicWrappedShareInputSchema = z.object({
-	// UUID keeps the lookup opaque and non-sequential.
-	shareId: z.string().uuid(),
+	// This accepts both new username-style share ids and older UUID rows.
+	shareId: WrappedShareIdSchema,
 });
 
 export const WrappedShareRecordSchema = z.object({
 	created_at: z.string(),
 	expires_at: z.string(),
-	id: z.string().uuid(),
+	id: WrappedShareIdSchema,
 });
 
 export const PublicWrappedShareSchema = WrappedShareRecordSchema.extend({

--- a/scripts/qa/pr-223/run-api-smoke.sh
+++ b/scripts/qa/pr-223/run-api-smoke.sh
@@ -141,6 +141,7 @@ create_wrapped_share() {
 	jq -n '
 		{
 			json: {
+				username: "qa-smoke",
 				snapshot: {
 					archetypeLabel: "Smooth Operator",
 					headerLeftMetric: {


### PR DESCRIPTION
## Summary
- Add wrapped public share slug generation and route/schema plumbing for public card links.
- Polish wrapped share/X flows, card metric truncation, CTA prop forwarding, and public/mock/dev wrapped data.
- Improve wrapped card reveal and public-card responsive layout for short portrait and landscape viewports.
- Add coverage for setup progress polling, share slugs, gradient text, card back metrics, and wrapped share behavior.

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig
- [x] cd apps/web && bun run test src/features/wrapped/team-card/final-stages.test.tsx