### PR TITLE
fix: add sessions sidebar shortcut

### DIFF
--- a/apps/web/src/features/shell/config/shell-routes.test.tsx
+++ b/apps/web/src/features/shell/config/shell-routes.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	getCurrentShellRoute,
 	shellRouteMap,
+	shellRoutes,
 } from "@/features/shell/config/shell-routes";
 
 describe("getCurrentShellRoute", () => {
@@ -19,5 +20,15 @@ describe("getCurrentShellRoute", () => {
 		expect(getCurrentShellRoute("/dashboard/sessions/session-123")).toBe(
 			shellRouteMap.sessions,
 		);
+	});
+
+	it("uses history as the sessions shortcut", () => {
+		expect(shellRouteMap.sessions.shortcut).toBe("H");
+	});
+
+	it("keeps primary shell shortcuts unique", () => {
+		const shortcuts = shellRoutes.map((route) => route.shortcut);
+
+		expect(new Set(shortcuts).size).toBe(shortcuts.length);
 	});
 });

--- a/apps/web/src/features/shell/config/shell-routes.tsx
+++ b/apps/web/src/features/shell/config/shell-routes.tsx
@@ -10,7 +10,7 @@ export type ShellRouteDefinition = {
 	path: string;
 	title: string;
 	navLabel: string;
-	shortcut?: string;
+	shortcut: string;
 	icon: ShellRouteIcon;
 };
 
@@ -28,6 +28,7 @@ export const shellRoutes = [
 		path: appRoutes.dashboardSessions(),
 		title: "Sessions",
 		navLabel: "Sessions",
+		shortcut: "H",
 		icon: <Clock3Icon />,
 	},
 	{


### PR DESCRIPTION
## Summary
- Add the missing `H` keyboard shortcut to the Sessions shell route so the collapsed sidebar tooltip shows a kbd indicator and keyboard navigation can reach Sessions.
- Make primary shell route shortcuts required in the route definition.
- Add tests for the Sessions shortcut and shortcut uniqueness.

## Test plan
- `bun --cwd apps/web test src/features/shell/config/shell-routes.test.tsx`
- `./node_modules/.bin/biome check apps/web/src/features/shell/config/shell-routes.tsx apps/web/src/features/shell/config/shell-routes.test.tsx`
- `bun run check-types` from `apps/web`
- `bun run verify`