### PR TITLE
fix: enforce wrapped mobile handoff

### DIFF
--- a/apps/api/src/__tests__/email.test.ts
+++ b/apps/api/src/__tests__/email.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	buildInvitationEmailContent,
 	buildInvitationLink,
+	buildWrappedDesktopResumeLink,
 	getResendConfigWarnings,
 	sendOrganizationInvitationEmail,
 	syncSignupContact,
@@ -20,6 +21,15 @@ describe("email helpers", () => {
 		expect(buildInvitationLink("https://app.rudel.ai/", "invite_123")).toBe(
 			"https://app.rudel.ai/invitation/invite_123",
 		);
+	});
+
+	test("buildWrappedDesktopResumeLink trims trailing slashes", () => {
+		expect(
+			buildWrappedDesktopResumeLink(
+				"https://app.rudel.ai/",
+				"123e4567-e89b-12d3-a456-426614174000",
+			),
+		).toBe("https://app.rudel.ai/resume/123e4567-e89b-12d3-a456-426614174000");
 	});
 
 	test("buildInvitationEmailContent escapes user-controlled HTML", () => {

--- a/apps/api/src/__tests__/wrapped-resume.service.test.ts
+++ b/apps/api/src/__tests__/wrapped-resume.service.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface SqlQuery {
+	sql: string;
+	values: unknown[];
+}
+
+const sqlQueries: SqlQuery[] = [];
+let selectRows: unknown[] = [];
+let updateRows: unknown[] = [];
+
+function sqlClient(strings: TemplateStringsArray, ...values: unknown[]) {
+	const sql = strings.join("?").replace(/\s+/gu, " ").trim();
+	sqlQueries.push({ sql, values });
+
+	if (sql.startsWith("SELECT")) {
+		return selectRows;
+	}
+
+	if (sql.startsWith("UPDATE")) {
+		return updateRows;
+	}
+
+	if (sql.startsWith("INSERT")) {
+		return [];
+	}
+
+	throw new Error(`Unexpected SQL query: ${sql}`);
+}
+
+mock.module("../db.js", () => ({
+	sqlClient,
+}));
+
+const { consumeWrappedResume, createWrappedResume } = await import(
+	"../services/wrapped-resume.service.js"
+);
+
+describe("wrapped resume service", () => {
+	beforeEach(() => {
+		sqlQueries.length = 0;
+		selectRows = [];
+		updateRows = [];
+	});
+
+	test("creates a one-day resume token record for the normalized account email", async () => {
+		const createdBefore = Date.now();
+
+		const record = await createWrappedResume({
+			email: " Ada@Example.COM ",
+			shareId: "share-123",
+			userId: "user-1",
+		});
+
+		expect(record.email).toBe("ada@example.com");
+		expect(record.shareId).toBe("share-123");
+		expect(record.token).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u,
+		);
+		expect(new Date(record.expiresAt).getTime()).toBeGreaterThan(
+			createdBefore + 23 * 60 * 60 * 1000,
+		);
+
+		const insertQuery = getSqlQuery(0);
+		expect(insertQuery.sql.startsWith("INSERT INTO wrapped_resume")).toBe(true);
+		expect(insertQuery.values[1]).toBe("ada@example.com");
+		expect(insertQuery.values[2]).toBe("share-123");
+		expect(insertQuery.values[3]).toBe("user-1");
+	});
+
+	test("consumes a valid token and redirects to wrapped", async () => {
+		selectRows = [
+			{
+				email: "ada@example.com",
+				expiresAt: new Date(Date.now() + 60_000).toISOString(),
+				shareId: null,
+				token: "token-1",
+				usedAt: null,
+			},
+		];
+		updateRows = [{ token: "token-1" }];
+
+		const result = await consumeWrappedResume({
+			email: " ADA@Example.COM ",
+			token: "token-1",
+		});
+
+		expect(result).toEqual({
+			redirectTo: "/wrapped",
+			shareId: null,
+			status: "consumed",
+		});
+		expect(getSqlQuery(1).sql.startsWith("UPDATE wrapped_resume")).toBe(true);
+	});
+
+	test("preserves share attribution when consuming a valid token", async () => {
+		selectRows = [
+			{
+				email: "ada@example.com",
+				expiresAt: new Date(Date.now() + 60_000).toISOString(),
+				shareId: "share-123",
+				token: "token-1",
+				usedAt: null,
+			},
+		];
+		updateRows = [{ token: "token-1" }];
+
+		const result = await consumeWrappedResume({
+			email: "ada@example.com",
+			token: "token-1",
+		});
+
+		expect(result).toEqual({
+			redirectTo: "/wrapped?share_id=share-123",
+			shareId: "share-123",
+			status: "consumed",
+		});
+	});
+
+	test("rejects a token that belongs to another email without marking it used", async () => {
+		selectRows = [
+			{
+				email: "ada@example.com",
+				expiresAt: new Date(Date.now() + 60_000).toISOString(),
+				shareId: null,
+				token: "token-1",
+				usedAt: null,
+			},
+		];
+
+		const result = await consumeWrappedResume({
+			email: "grace@example.com",
+			token: "token-1",
+		});
+
+		expect(result).toEqual({ status: "email_mismatch" });
+		expect(sqlQueries).toHaveLength(1);
+	});
+
+	test("rejects expired and already-used tokens without marking them used", async () => {
+		selectRows = [
+			{
+				email: "ada@example.com",
+				expiresAt: new Date(Date.now() - 60_000).toISOString(),
+				shareId: null,
+				token: "expired-token",
+				usedAt: null,
+			},
+		];
+
+		expect(
+			await consumeWrappedResume({
+				email: "ada@example.com",
+				token: "expired-token",
+			}),
+		).toEqual({ status: "expired" });
+		expect(sqlQueries).toHaveLength(1);
+
+		sqlQueries.length = 0;
+		selectRows = [
+			{
+				email: "ada@example.com",
+				expiresAt: new Date(Date.now() + 60_000).toISOString(),
+				shareId: null,
+				token: "used-token",
+				usedAt: new Date().toISOString(),
+			},
+		];
+
+		expect(
+			await consumeWrappedResume({
+				email: "ada@example.com",
+				token: "used-token",
+			}),
+		).toEqual({ status: "used" });
+		expect(sqlQueries).toHaveLength(1);
+	});
+
+	test("treats a token as used when another request claims it first", async () => {
+		selectRows = [
+			{
+				email: "ada@example.com",
+				expiresAt: new Date(Date.now() + 60_000).toISOString(),
+				shareId: null,
+				token: "token-1",
+				usedAt: null,
+			},
+		];
+		updateRows = [];
+
+		const result = await consumeWrappedResume({
+			email: "ada@example.com",
+			token: "token-1",
+		});
+
+		expect(result).toEqual({ status: "used" });
+		expect(getSqlQuery(1).sql.startsWith("UPDATE wrapped_resume")).toBe(true);
+	});
+});
+
+function getSqlQuery(index: number) {
+	const query = sqlQueries[index];
+
+	if (!query) {
+		throw new Error(`Expected SQL query at index ${index}`);
+	}
+
+	return query;
+}

--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -249,6 +249,30 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByText("Public page: share-123")).toBeInTheDocument();
 	});
 
+	it("renders the public page before mobile handoff when a signed-in mobile viewer opens a share", () => {
+		mockUseIsMobile.mockReturnValue(true);
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 3,
+		});
+
+		render(
+			<MemoryRouter initialEntries={["/wrapped/share-123"]}>
+				<WrappedRouteGate
+					isPending={false}
+					publicId="share-123"
+					session={session}
+				/>
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Public page: share-123")).toBeInTheDocument();
+		expect(
+			screen.queryByText("Wrapped mobile handoff: ada@example.com"),
+		).toBeNull();
+	});
+
 	it("renders a loading state while auth is pending", () => {
 		render(
 			<MemoryRouter initialEntries={["/wrapped"]}>
@@ -359,6 +383,81 @@ describe("WrappedRouteGate", () => {
 		expect(
 			screen.getByText("Wrapped mobile handoff: ada@example.com"),
 		).toBeInTheDocument();
+	});
+
+	it("renders mobile handoff for signed-in mobile viewers when uploaded sessions already exist", () => {
+		mockUseIsMobile.mockReturnValue(true);
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 3,
+		});
+
+		render(
+			<MemoryRouter initialEntries={["/wrapped"]}>
+				<WrappedRouteGate isPending={false} publicId={null} session={session} />
+			</MemoryRouter>,
+		);
+
+		expect(
+			screen.getByText("Wrapped mobile handoff: ada@example.com"),
+		).toBeInTheDocument();
+		expect(screen.queryByText("Wrapped setup page")).toBeNull();
+		expect(screen.queryByText("Wrapped story")).toBeNull();
+	});
+
+	it("keeps acknowledged signed-in mobile viewers on the mobile handoff", () => {
+		const storageKey = getWrappedSetupCompletionStorageKey(session.user.id);
+
+		if (storageKey === null) {
+			throw new Error("Expected wrapped setup completion storage key");
+		}
+
+		window.localStorage.setItem(storageKey, "true");
+		mockUseIsMobile.mockReturnValue(true);
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 3,
+		});
+
+		render(
+			<MemoryRouter initialEntries={["/wrapped"]}>
+				<WrappedRouteGate isPending={false} publicId={null} session={session} />
+			</MemoryRouter>,
+		);
+
+		expect(
+			screen.getByText("Wrapped mobile handoff: ada@example.com"),
+		).toBeInTheDocument();
+		expect(screen.queryByText("Wrapped story")).toBeNull();
+	});
+
+	it.each([
+		"card-profile",
+		"desktop-ready",
+		"sessions-landed",
+		"story",
+	] as const)("keeps signed-in mobile viewers on the handoff for forced %s flow", (flow) => {
+		mockUseIsMobile.mockReturnValue(true);
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 3,
+		});
+
+		render(
+			<MemoryRouter initialEntries={[`/wrapped?flow=${flow}`]}>
+				<WrappedRouteGate isPending={false} publicId={null} session={session} />
+			</MemoryRouter>,
+		);
+
+		expect(
+			screen.getByText("Wrapped mobile handoff: ada@example.com"),
+		).toBeInTheDocument();
+		expect(screen.queryByText("Wrapped setup page")).toBeNull();
+		expect(screen.queryByText("Wrapped setup complete page")).toBeNull();
+		expect(screen.queryByText("Wrapped story")).toBeNull();
 	});
 
 	it("renders setup for signed-in desktop viewers without uploads", () => {

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -133,6 +133,7 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		forcedFlowStage === WRAPPED_ROUTE_DESKTOP_READY_FLOW;
 	const shouldForceStory =
 		forcedFlowStage === "story" && setupProgress.hasUploadedSessions;
+	const signedInMobileHandoffEmail = isMobile ? sessionUserEmail : undefined;
 
 	function setWrappedRouteFlowStage(nextStage: WrappedRouteFlowStage) {
 		startTransition(() => {
@@ -260,6 +261,13 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		);
 	} else if (!session) {
 		content = <WrappedGuestPage />;
+	} else if (signedInMobileHandoffEmail) {
+		content = (
+			<WrappedDesktopResumePromptPage
+				email={signedInMobileHandoffEmail}
+				shareId={shareId}
+			/>
+		);
 	} else if (shouldShowCardProfileStep) {
 		content = (
 			<WrappedCardProfileStep
@@ -309,17 +317,6 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		content = (
 			<WrappedTeamCardPage
 				onBackFromFirstStep={() => setWrappedRouteFlowStage("sessions-landed")}
-			/>
-		);
-	} else if (
-		isMobile &&
-		sessionUserEmail &&
-		!setupProgress.hasUploadedSessions
-	) {
-		content = (
-			<WrappedDesktopResumePromptPage
-				email={sessionUserEmail}
-				shareId={shareId}
 			/>
 		);
 	} else {


### PR DESCRIPTION
## Summary
- Route signed-in mobile wrapped viewers with an account email to the desktop handoff before setup/story flow branches can run.
- Add route-gate regression coverage for existing sessions, acknowledged setup, forced flow query params, and public share precedence.
- Add API coverage proving wrapped resume links are generated as /resume/:token and that tokens consume only when valid, unused, unexpired, and tied to the same email.

## Flow visuals

### Before

```mermaid
flowchart TD
	A["Signed-in user opens /wrapped on mobile"] --> B{"Public share route?"}
	B -- "yes" --> C["Show public Wrapped page"]
	B -- "no" --> D{"Uploaded sessions exist?"}
	D -- "no" --> E["Show desktop handoff"]
	D -- "yes" --> F{"Setup already acknowledged or forced flow?"}
	F -- "yes" --> G["Show Wrapped story or sessions-landed screen on mobile"]
	F -- "no" --> H["Show desktop setup screen on mobile"]
	G --> I["Bypass: no desktop link prompt"]
	H --> I
```

### After

```mermaid
flowchart TD
	A["Signed-in user opens /wrapped on mobile"] --> B{"Public share route?"}
	B -- "yes" --> C["Show public Wrapped page"]
	B -- "no" --> D{"Signed in with account email?"}
	D -- "yes" --> E["Always show desktop handoff"]
	D -- "no" --> F["Keep existing non-email fallback routing"]
	E --> G["User sends or copies desktop link"]
	G --> H["Generated link: /resume/:token"]
	H --> J["Open on desktop"]
	J --> K{"Signed into same email?"}
	K -- "yes" --> L["Consume one-time token"]
	K -- "no" --> M["Show unavailable / account mismatch error"]
	L --> N{"Original share_id present?"}
	N -- "yes" --> O["Redirect to /wrapped?share_id=..."]
	N -- "no" --> P["Redirect to /wrapped"]
```

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig
- [x] bun test src/__tests__/wrapped-resume.service.test.ts src/__tests__/email.test.ts in apps/api
- [x] bun --cwd apps/web test src/features/wrapped/WrappedRouteGate.test.tsx
