### PR TITLE
fix(api): correct FINAL/alias order in session_analytics queries

### DIFF
--- a/apps/api/src/services/error.service.ts
+++ b/apps/api/src/services/error.service.ts
@@ -213,7 +213,7 @@ export async function getErrorTrends(
         ${dimensionExpr} as dimension_value,
         sa.error_count,
         ${ERROR_PATTERN_SQL} as error_pattern
-      FROM rudel.session_analytics FINAL sa
+      FROM rudel.session_analytics AS sa FINAL
       WHERE ${buildInclusiveDateRangeFilter("startDate", "endDate", "sa.session_date")}
         AND sa.organization_id = {orgId:String}
         AND sa.error_count > 0
@@ -246,7 +246,7 @@ export async function getErrorTrends(
         ${dimensionExpr} as dimension_value,
         sa.error_count,
         ${ERROR_PATTERN_SQL} as error_pattern
-      FROM rudel.session_analytics FINAL sa
+      FROM rudel.session_analytics AS sa FINAL
       WHERE ${buildInclusiveDateRangeFilter("startDate", "endDate", "sa.session_date")}
         AND sa.organization_id = {orgId:String}
         AND sa.error_count > 0

--- a/apps/api/src/services/overview.service.ts
+++ b/apps/api/src/services/overview.service.ts
@@ -221,7 +221,7 @@ export async function getUsersTokenUsage(
       round(avg(sa.success_score), 2) as success_rate,
       length(arrayDistinct(arrayFilter(x -> x != '', arrayFlatten(groupArray(sa.skills))))) as distinct_skills,
       length(arrayDistinct(arrayFilter(x -> x != '', arrayFlatten(groupArray(sa.slash_commands))))) as distinct_slash_commands
-    FROM rudel.session_analytics FINAL AS sa
+    FROM rudel.session_analytics AS sa FINAL
     WHERE ${dateFilter}
       AND sa.organization_id = {orgId:String}
       AND sa.user_id != ''

--- a/apps/api/src/services/project.service.ts
+++ b/apps/api/src/services/project.service.ts
@@ -293,7 +293,7 @@ export async function getProjectActivity(
       COUNT(*) as sessions,
       COUNT(DISTINCT s.user_id) as unique_users
     FROM project_key pk
-    INNER JOIN rudel.session_analytics FINAL s ON if(s.git_remote != '', s.git_remote, if(s.package_name != '', s.package_name, s.project_path)) = pk.pk
+    INNER JOIN rudel.session_analytics AS s FINAL ON if(s.git_remote != '', s.git_remote, if(s.package_name != '', s.package_name, s.project_path)) = pk.pk
     WHERE ${buildDateFilter("days", "s.session_date")}
       AND s.organization_id = {orgId:String}
     GROUP BY ${dateGrouping}, pk.project_path

--- a/apps/api/src/services/session-analytics.service.ts
+++ b/apps/api/src/services/session-analytics.service.ts
@@ -159,7 +159,7 @@ export async function getSessionAnalytics(
       error_count,
       model_used,
       used_plan_mode
-    FROM rudel.session_analytics FINAL sa
+    FROM rudel.session_analytics AS sa FINAL
     WHERE ${buildDateFilter("days", "sa.session_date")}
       AND organization_id = {orgId:String}
       ${filters.length > 0 ? `AND ${filters.join("\n      AND ")}` : ""}
@@ -699,7 +699,7 @@ export async function getSessionDetail(
       total_interactions,
       session_archetype,
       model_used
-    FROM rudel.session_analytics FINAL sa
+    FROM rudel.session_analytics AS sa FINAL
     WHERE session_id = {sessionId:String}
       AND organization_id = {orgId:String}
     ORDER BY ingested_at DESC


### PR DESCRIPTION
ClickHouse parses `FROM table FINAL [AS] alias` as a syntax error — the alias must precede the FINAL modifier. Commit 4cdc015 added FINAL to all session_analytics queries but placed it before the alias in 6 sites, causing 500s on the affected RPC endpoints (overview/usersTokenUsage, errors/trends, sessions/list, sessions/detail, and the project activity join). Swapped each to `FROM table AS alias FINAL`.