### PR TITLE
fix: restore chat overview green

### DIFF
--- a/apps/web/src/features/dashboard/dashboard-theme.css
+++ b/apps/web/src/features/dashboard/dashboard-theme.css
@@ -9,6 +9,7 @@
 	--dashboardy-muted: #667085;
 	--dashboardy-subtle: #98a2b3;
 	--dashboardy-accent: #2563eb;
+	--dashboardy-chat-user-segment: #25b6aa;
 	--dashboardy-card-shadow:
 		0 1px 2px rgba(15, 23, 42, 0.06), 0 22px 44px -34px rgba(15, 23, 42, 0.28);
 	--dashboardy-chip-surface: rgba(238, 242, 255, 0.95);
@@ -34,6 +35,7 @@
 	--dashboardy-muted: #cbd5e1;
 	--dashboardy-subtle: #94a3b8;
 	--dashboardy-accent: #93c5fd;
+	--dashboardy-chat-user-segment: #25b6aa;
 	--dashboardy-card-shadow:
 		0 1px 2px rgba(0, 0, 0, 0.14), 0 20px 44px -34px rgba(0, 0, 0, 0.48);
 	--dashboardy-chip-surface: rgba(30, 41, 59, 0.98);

--- a/apps/web/src/features/sessions/components/session-detail-view-parts.tsx
+++ b/apps/web/src/features/sessions/components/session-detail-view-parts.tsx
@@ -199,7 +199,7 @@ export function SessionTranscriptSummaryTab({
 		{
 			id: "user",
 			count: userMessages,
-			className: "bg-[color:var(--dashboardy-success-foreground)]",
+			className: "bg-[color:var(--dashboardy-chat-user-segment)]",
 		},
 		{
 			id: "assistant",


### PR DESCRIPTION
## Summary
- restore the previous lighter chat overview user segment green as a named dashboard token
- keep the transcript summary strip using the token instead of the darker success foreground color

## Test plan
- [x] bun run verify