### PR TITLE
perf: adapt wrapped particle budgets

### DIFF
--- a/apps/web/src/features/wrapped/onboarding/models/scale.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/scale.ts
@@ -1,4 +1,8 @@
 import type { WrappedStepContentLine } from "../helpers";
+import {
+	resolveWrappedMotionParticleCount,
+	type WrappedMotionPerformanceProfile,
+} from "../performance";
 
 const SCALE_STAGE_TOKENS_PER_BALL = 1_000;
 const SCALE_STAGE_MIN_BALL_COUNT = 1;
@@ -78,16 +82,20 @@ export function resolveScaleEstimatedSpendUsd(input: {
 	return Math.max(0, Math.round(normalizedTotalTokens * usdPerToken));
 }
 
-export function buildScaleRainBalls(totalTokens: number): ScaleRainBall[] {
+export function buildScaleRainBalls(
+	totalTokens: number,
+	performanceProfile: WrappedMotionPerformanceProfile = "full",
+): ScaleRainBall[] {
 	const logicalBallCount = resolveScaleRainBallCount(totalTokens);
 	if (logicalBallCount <= 0) {
 		return [];
 	}
 
-	const visibleBallCount = Math.min(
-		logicalBallCount,
-		SCALE_STAGE_MAX_ACTIVE_BALL_COUNT,
-	);
+	const visibleBallCount = resolveWrappedMotionParticleCount({
+		count: logicalBallCount,
+		maximumCount: SCALE_STAGE_MAX_ACTIVE_BALL_COUNT,
+		performanceProfile,
+	});
 	const random = createScaleRainSeededRandom(
 		Math.max(1, Math.floor(totalTokens)),
 	);

--- a/apps/web/src/features/wrapped/onboarding/performance.test.ts
+++ b/apps/web/src/features/wrapped/onboarding/performance.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildScaleRainBalls } from "./models/scale";
+import {
+	resolveWrappedMotionParticleCount,
+	resolveWrappedMotionPerformanceProfile,
+} from "./performance";
+
+type NavigatorTestProperty =
+	| "connection"
+	| "deviceMemory"
+	| "hardwareConcurrency";
+
+interface NavigatorConnectionTestValue {
+	effectiveType?: string;
+	saveData?: boolean;
+}
+
+const navigatorDescriptors = new Map<
+	NavigatorTestProperty,
+	PropertyDescriptor | undefined
+>();
+const originalMatchMediaDescriptor = Object.getOwnPropertyDescriptor(
+	window,
+	"matchMedia",
+);
+
+afterEach(() => {
+	for (const [property, descriptor] of navigatorDescriptors) {
+		if (descriptor) {
+			Object.defineProperty(window.navigator, property, descriptor);
+		} else {
+			Reflect.deleteProperty(window.navigator, property);
+		}
+	}
+
+	navigatorDescriptors.clear();
+
+	if (originalMatchMediaDescriptor) {
+		Object.defineProperty(window, "matchMedia", originalMatchMediaDescriptor);
+	} else {
+		Reflect.deleteProperty(window, "matchMedia");
+	}
+});
+
+describe("wrapped motion performance", () => {
+	it("uses the full profile when device hints are unconstrained", () => {
+		stubMatchMedia([]);
+		stubNavigatorProperty("hardwareConcurrency", 8);
+		stubNavigatorProperty("deviceMemory", 8);
+		stubNavigatorConnection({ effectiveType: "4g", saveData: false });
+
+		expect(resolveWrappedMotionPerformanceProfile()).toBe("full");
+	});
+
+	it("uses the constrained profile when reduced data is requested", () => {
+		stubMatchMedia(["(prefers-reduced-data: reduce)"]);
+		stubNavigatorProperty("hardwareConcurrency", 8);
+		stubNavigatorProperty("deviceMemory", 8);
+		stubNavigatorConnection({ effectiveType: "4g", saveData: false });
+
+		expect(resolveWrappedMotionPerformanceProfile()).toBe("constrained");
+	});
+
+	it("uses the constrained profile when the device has a slow update cadence", () => {
+		stubMatchMedia(["(update: slow)"]);
+		stubNavigatorProperty("hardwareConcurrency", 8);
+		stubNavigatorProperty("deviceMemory", 8);
+		stubNavigatorConnection({ effectiveType: "4g", saveData: false });
+
+		expect(resolveWrappedMotionPerformanceProfile()).toBe("constrained");
+	});
+
+	it("uses the constrained profile when data saver is enabled", () => {
+		stubMatchMedia([]);
+		stubNavigatorProperty("hardwareConcurrency", 8);
+		stubNavigatorProperty("deviceMemory", 8);
+		stubNavigatorConnection({ effectiveType: "4g", saveData: true });
+
+		expect(resolveWrappedMotionPerformanceProfile()).toBe("constrained");
+	});
+
+	it("uses the constrained profile on slow effective connections", () => {
+		stubMatchMedia([]);
+		stubNavigatorProperty("hardwareConcurrency", 8);
+		stubNavigatorProperty("deviceMemory", 8);
+		stubNavigatorConnection({ effectiveType: "3g", saveData: false });
+
+		expect(resolveWrappedMotionPerformanceProfile()).toBe("constrained");
+	});
+
+	it("uses the constrained profile on low-memory devices", () => {
+		stubMatchMedia([]);
+		stubNavigatorProperty("hardwareConcurrency", 8);
+		stubNavigatorProperty("deviceMemory", 4);
+		stubNavigatorConnection({ effectiveType: "4g", saveData: false });
+
+		expect(resolveWrappedMotionPerformanceProfile()).toBe("constrained");
+	});
+
+	it("uses the constrained profile on low-core devices", () => {
+		stubMatchMedia([]);
+		stubNavigatorProperty("hardwareConcurrency", 4);
+		stubNavigatorProperty("deviceMemory", 8);
+		stubNavigatorConnection({ effectiveType: "4g", saveData: false });
+
+		expect(resolveWrappedMotionPerformanceProfile()).toBe("constrained");
+	});
+
+	it("caps visual particles for constrained profiles", () => {
+		expect(
+			resolveWrappedMotionParticleCount({
+				count: 900,
+				maximumCount: 240,
+				performanceProfile: "full",
+			}),
+		).toBe(240);
+		expect(
+			resolveWrappedMotionParticleCount({
+				count: 900,
+				maximumCount: 240,
+				performanceProfile: "constrained",
+			}),
+		).toBe(100);
+		expect(
+			resolveWrappedMotionParticleCount({
+				count: 900,
+				maximumCount: 180,
+				performanceProfile: "constrained",
+			}),
+		).toBe(100);
+		expect(
+			resolveWrappedMotionParticleCount({
+				count: 1,
+				maximumCount: 240,
+				performanceProfile: "constrained",
+			}),
+		).toBe(1);
+		expect(
+			resolveWrappedMotionParticleCount({
+				count: 0,
+				maximumCount: 240,
+				performanceProfile: "constrained",
+			}),
+		).toBe(0);
+	});
+
+	it("applies the constrained particle budget to scale rain balls", () => {
+		expect(buildScaleRainBalls(1_000_000, "full")).toHaveLength(240);
+		expect(buildScaleRainBalls(1_000_000, "constrained")).toHaveLength(100);
+	});
+});
+
+function stubNavigatorConnection(connection: NavigatorConnectionTestValue) {
+	stubNavigatorProperty("connection", connection);
+}
+
+function stubNavigatorProperty(
+	property: NavigatorTestProperty,
+	value: unknown,
+) {
+	if (!navigatorDescriptors.has(property)) {
+		navigatorDescriptors.set(
+			property,
+			Object.getOwnPropertyDescriptor(window.navigator, property),
+		);
+	}
+
+	Object.defineProperty(window.navigator, property, {
+		configurable: true,
+		value,
+	});
+}
+
+function stubMatchMedia(matchingQueries: readonly string[]) {
+	Object.defineProperty(window, "matchMedia", {
+		configurable: true,
+		value: (query: string) => ({
+			addEventListener: () => {},
+			addListener: () => {},
+			dispatchEvent: () => false,
+			matches: matchingQueries.includes(query),
+			media: query,
+			onchange: null,
+			removeEventListener: () => {},
+			removeListener: () => {},
+		}),
+	});
+}

--- a/apps/web/src/features/wrapped/onboarding/performance.ts
+++ b/apps/web/src/features/wrapped/onboarding/performance.ts
@@ -1,0 +1,116 @@
+export type WrappedMotionPerformanceProfile = "full" | "constrained";
+
+const WRAPPED_CONSTRAINED_HARDWARE_THREADS = 4;
+const WRAPPED_CONSTRAINED_DEVICE_MEMORY_GB = 4;
+const WRAPPED_CONSTRAINED_MAX_PARTICLE_COUNT = 100;
+const WRAPPED_SLOW_EFFECTIVE_CONNECTIONS = new Set(["slow-2g", "2g", "3g"]);
+
+export function resolveWrappedMotionPerformanceProfile(): WrappedMotionPerformanceProfile {
+	if (typeof window === "undefined") {
+		return "full";
+	}
+
+	if (
+		matchesWrappedMotionMediaQuery("(prefers-reduced-data: reduce)") ||
+		matchesWrappedMotionMediaQuery("(update: slow)") ||
+		isWrappedSaveDataEnabled() ||
+		isWrappedSlowEffectiveConnection() ||
+		hasWrappedConstrainedDeviceMemory() ||
+		hasWrappedConstrainedHardwareConcurrency()
+	) {
+		return "constrained";
+	}
+
+	return "full";
+}
+
+export function resolveWrappedMotionParticleCount(input: {
+	count: number;
+	maximumCount: number;
+	minimumCount?: number;
+	performanceProfile: WrappedMotionPerformanceProfile;
+}) {
+	const normalizedCount = Math.max(0, Math.round(input.count));
+	const maximumCount = Math.max(0, Math.round(input.maximumCount));
+	const profileMaximumCount =
+		input.performanceProfile === "constrained"
+			? Math.min(maximumCount, WRAPPED_CONSTRAINED_MAX_PARTICLE_COUNT)
+			: maximumCount;
+
+	if (normalizedCount <= 0 || profileMaximumCount <= 0) {
+		return 0;
+	}
+
+	const minimumCount = Math.max(0, Math.round(input.minimumCount ?? 1));
+	const cappedCount = Math.min(normalizedCount, profileMaximumCount);
+
+	return Math.min(profileMaximumCount, Math.max(minimumCount, cappedCount));
+}
+
+function hasWrappedConstrainedHardwareConcurrency() {
+	const hardwareConcurrency = window.navigator.hardwareConcurrency;
+
+	return (
+		typeof hardwareConcurrency === "number" &&
+		hardwareConcurrency > 0 &&
+		hardwareConcurrency <= WRAPPED_CONSTRAINED_HARDWARE_THREADS
+	);
+}
+
+function hasWrappedConstrainedDeviceMemory() {
+	if (!("deviceMemory" in window.navigator)) {
+		return false;
+	}
+
+	const deviceMemory = window.navigator.deviceMemory;
+
+	return (
+		typeof deviceMemory === "number" &&
+		deviceMemory > 0 &&
+		deviceMemory <= WRAPPED_CONSTRAINED_DEVICE_MEMORY_GB
+	);
+}
+
+function isWrappedSaveDataEnabled() {
+	const connection = resolveWrappedNavigatorConnection();
+	if (!connection || !("saveData" in connection)) {
+		return false;
+	}
+
+	return connection.saveData === true;
+}
+
+function isWrappedSlowEffectiveConnection() {
+	const connection = resolveWrappedNavigatorConnection();
+	if (!connection || !("effectiveType" in connection)) {
+		return false;
+	}
+
+	const effectiveType = connection.effectiveType;
+	if (typeof effectiveType !== "string") {
+		return false;
+	}
+
+	return WRAPPED_SLOW_EFFECTIVE_CONNECTIONS.has(effectiveType);
+}
+
+function resolveWrappedNavigatorConnection() {
+	if (!("connection" in window.navigator)) {
+		return null;
+	}
+
+	const connection = window.navigator.connection;
+	if (typeof connection !== "object" || connection === null) {
+		return null;
+	}
+
+	return connection;
+}
+
+function matchesWrappedMotionMediaQuery(query: string) {
+	if (typeof window.matchMedia !== "function") {
+		return false;
+	}
+
+	return window.matchMedia(query).matches;
+}

--- a/apps/web/src/features/wrapped/onboarding/stages.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useMountEffect } from "@/hooks/useMountEffect";
 import { cn } from "@/lib/utils";
 import { WrappedStageCopy, WrappedStageFrame } from "../stage-frame";
@@ -10,6 +10,7 @@ import {
 	resolveScaleRainDisplayedTokens,
 	type ScaleRainBall,
 } from "./models";
+import { resolveWrappedMotionPerformanceProfile } from "./performance";
 import { WrappedOnboardingIntroStage } from "./stages/intro";
 import {
 	WrappedOnboardingLockInStage,
@@ -78,6 +79,7 @@ const SCALE_RAIN_EXIT_FADE_STEP = 0.045;
 const SCALE_RAIN_SWAY_CYCLE_MS = 2_800;
 const SCALE_RAIN_SWAY_EDGE_INSET_PX = 18;
 const SCALE_RAIN_SWAY_VELOCITY_FACTOR = 0.56;
+const SCALE_RAIN_TOKEN_REPORT_INTERVAL_MS = 50;
 
 export function WrappedOnboardingStage(props: WrappedOnboardingStageProps) {
 	const {
@@ -246,12 +248,18 @@ export function WrappedOnboardingScaleRainBackdrop(
 	props: WrappedOnboardingScaleRainBackdropProps,
 ) {
 	const { onDisplayedTokensChange, reduceMotion, totalTokens } = props;
-	const balls = buildScaleRainBalls(totalTokens);
+	const [motionPerformanceProfile] = useState(
+		resolveWrappedMotionPerformanceProfile,
+	);
+	const balls = useMemo(
+		() => buildScaleRainBalls(totalTokens, motionPerformanceProfile),
+		[motionPerformanceProfile, totalTokens],
+	);
 	const animationBallCount = balls.length;
 
 	return (
 		<WrappedOnboardingScaleRainSimulation
-			key={`scale-rain:${totalTokens}:${reduceMotion ? "reduce" : "full"}`}
+			key={`scale-rain:${totalTokens}:${reduceMotion ? "reduce" : "full"}:${motionPerformanceProfile}`}
 			balls={balls}
 			onDisplayedTokensChange={onDisplayedTokensChange}
 			reduceMotion={reduceMotion}
@@ -306,6 +314,7 @@ function WrappedOnboardingScaleRainSimulation(props: {
 		let emittedBallCount = 0;
 		let completedBallCount = 0;
 		let reportedTokens = 0;
+		let lastTokenReportAtMs = 0;
 		const releaseIntervalMs = resolveScaleRainReleaseIntervalMs(totalBallCount);
 		let nextReleaseAtMs = window.performance.now();
 		let releaseCursor = 0;
@@ -367,8 +376,13 @@ function WrappedOnboardingScaleRainSimulation(props: {
 				),
 				totalBallCount,
 			);
-			if (nextReportedTokens !== reportedTokens) {
+			if (
+				nextReportedTokens !== reportedTokens &&
+				(now - lastTokenReportAtMs >= SCALE_RAIN_TOKEN_REPORT_INTERVAL_MS ||
+					nextReportedTokens >= totalTokens)
+			) {
 				reportedTokens = nextReportedTokens;
+				lastTokenReportAtMs = now;
 				onDisplayedTokensChange?.(nextReportedTokens);
 			}
 
@@ -402,9 +416,10 @@ function WrappedOnboardingScaleRainSimulation(props: {
 					}}
 					className="mymind-wrapped-scale-rain__ball"
 					style={{
+						borderWidth: `${resolveScaleRainBorderWidth(ball)}px`,
 						height: `${ball.sizePx}px`,
 						opacity: reduceMotion ? 1 : 0,
-						top: `${-ball.sizePx}px`,
+						transform: `translate3d(0, ${-ball.sizePx}px, 0)`,
 						width: `${ball.sizePx}px`,
 					}}
 				/>
@@ -450,16 +465,15 @@ function renderScaleRainSimulation(
 		}
 
 		const { scaleX, scaleY } = resolveScaleRainScale(ball, now);
-		const borderWidth = Math.max(1, Math.min(3, ball.radius * 0.34));
-
-		node.style.width = `${ball.radius * 2}px`;
-		node.style.height = `${ball.radius * 2}px`;
-		node.style.borderWidth = `${borderWidth}px`;
-		node.style.left = `${ball.x - ball.radius}px`;
-		node.style.top = `${ball.y - ball.radius}px`;
 		node.style.opacity = `${ball.opacity}`;
-		node.style.transform = `scaleX(${scaleX}) scaleY(${scaleY})`;
+		node.style.transform = `translate3d(${ball.x - ball.radius}px, ${
+			ball.y - ball.radius
+		}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`;
 	}
+}
+
+function resolveScaleRainBorderWidth(ball: ScaleRainBall) {
+	return Math.max(1, Math.min(3, (ball.sizePx / 2) * 0.34));
 }
 
 function resolveScaleRainWallCollision(

--- a/apps/web/src/features/wrapped/onboarding/stages/metrics.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/metrics.tsx
@@ -17,6 +17,10 @@ import {
 	resolveScalePreviewTokens,
 	resolveScaleStageModel,
 } from "../models";
+import {
+	resolveWrappedMotionParticleCount,
+	resolveWrappedMotionPerformanceProfile,
+} from "../performance";
 import type {
 	WrappedOnboardingMetrics,
 	WrappedScaleAdvanceState,
@@ -79,6 +83,7 @@ interface ScaleKebabSimulationDrop extends ScaleKebabDrop {
 const SCALE_STAGE_KEBAB_COST_USD = 8;
 const SCALE_STAGE_KEBAB_EMOJI = "🥙";
 const SCALE_STAGE_KEBAB_EXIT_VELOCITY_PX = 3.8;
+const SCALE_STAGE_MAX_KEBAB_DROP_COUNT = 180;
 const SCALE_STAGE_KEBAB_SQUASH_DURATION_MS = 120;
 const SCALE_STAGE_KEBAB_SOURCE_X_PERCENTS = [8, 24, 40, 56, 72, 88] as const;
 export const SCALE_STAGE_SPEND_LABEL_HOLD_MS = 500;
@@ -552,7 +557,14 @@ function WrappedScaleKebabRain(props: {
 	totalDrops: number;
 }) {
 	const { onComplete, totalDrops } = props;
-	const dropCount = Math.max(0, totalDrops);
+	const [motionPerformanceProfile] = useState(
+		resolveWrappedMotionPerformanceProfile,
+	);
+	const dropCount = resolveWrappedMotionParticleCount({
+		count: totalDrops,
+		maximumCount: SCALE_STAGE_MAX_KEBAB_DROP_COUNT,
+		performanceProfile: motionPerformanceProfile,
+	});
 	const kebabRainRef = useRef<HTMLDivElement | null>(null);
 	const dropRefs = useRef<Array<HTMLSpanElement | null>>([]);
 
@@ -586,6 +598,8 @@ function WrappedScaleKebabRain(props: {
 			totalDrops: dropCount,
 			viewportWidthPx: width,
 		}).map((drop) => createScaleKebabSimulationDrop(drop));
+
+		renderScaleKebabStaticStyles(nodes, simulationDrops);
 
 		for (const drop of simulationDrops) {
 			activateScaleKebabDrop(drop, width);
@@ -650,9 +664,8 @@ function WrappedScaleKebabRain(props: {
 					}}
 					className="mymind-wrapped-scale-stage__kebab-drop"
 					style={{
-						left: "50%",
 						opacity: 0,
-						top: "0px",
+						transform: "translate3d(0, 0, 0)",
 					}}
 				>
 					{SCALE_STAGE_KEBAB_EMOJI}
@@ -792,6 +805,24 @@ function deactivateScaleKebabDrop(drop: ScaleKebabSimulationDrop) {
 	drop.vy = 0;
 }
 
+function renderScaleKebabStaticStyles(
+	nodes: Array<HTMLSpanElement | null>,
+	drops: readonly ScaleKebabSimulationDrop[],
+) {
+	for (let index = 0; index < drops.length; index += 1) {
+		const node = nodes[index];
+		const drop = drops[index];
+
+		if (!node || !drop) {
+			continue;
+		}
+
+		node.style.fontSize = `${drop.sizePx}px`;
+		node.style.width = `${drop.radius * 2}px`;
+		node.style.height = `${drop.radius * 2}px`;
+	}
+}
+
 function renderScaleKebabSimulation(
 	nodes: Array<HTMLSpanElement | null>,
 	drops: readonly ScaleKebabSimulationDrop[],
@@ -807,13 +838,10 @@ function renderScaleKebabSimulation(
 
 		const { scaleX, scaleY } = resolveScaleKebabScale(drop, now);
 
-		node.style.fontSize = `${drop.sizePx}px`;
-		node.style.width = `${drop.radius * 2}px`;
-		node.style.height = `${drop.radius * 2}px`;
-		node.style.left = `${drop.x - drop.radius}px`;
-		node.style.top = `${drop.y - drop.radius}px`;
 		node.style.opacity = `${drop.opacity}`;
-		node.style.transform = `scaleX(${scaleX}) scaleY(${scaleY})`;
+		node.style.transform = `translate3d(${drop.x - drop.radius}px, ${
+			drop.y - drop.radius
+		}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`;
 	}
 }
 

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -3301,6 +3301,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	pointer-events: none;
 	position: fixed;
 	inset: 0;
+	contain: layout paint style;
 	height: 100svh;
 	width: 100vw;
 }
@@ -3310,10 +3311,11 @@ body.mymind-wrapped-body #cw-bubble-holder {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	left: 0;
 	top: 0;
 	line-height: 1;
 	transform-origin: center bottom;
-	will-change: left, top, opacity, transform;
+	will-change: opacity, transform;
 }
 
 :is(
@@ -3394,6 +3396,7 @@ body.mymind-wrapped-body #cw-bubble-holder {
 .mymind-wrapped-scale-rain {
 	position: absolute;
 	inset: 0;
+	contain: layout paint style;
 	overflow: clip;
 	pointer-events: none;
 }
@@ -3401,13 +3404,14 @@ body.mymind-wrapped-body #cw-bubble-holder {
 .mymind-wrapped-scale-rain__ball {
 	position: absolute;
 	box-sizing: border-box;
-	will-change: left, top, opacity, transform;
+	left: 0;
+	top: 0;
+	will-change: opacity, transform;
 	border-radius: 999px;
 	background: #1bb8ff;
 	border: 3px solid #fff;
 	box-shadow: none;
 	transform-origin: center bottom;
-	transition: transform 0.08s ease-out;
 }
 
 .mymind-wrapped-scale-rain.is-reduced-motion .mymind-wrapped-scale-rain__ball {


### PR DESCRIPTION
## Summary
- Adds a wrapped motion performance profile that classifies constrained devices using reduced-data, slow-update, save-data, slow connection, low-memory, and low-core browser hints.
- Applies the profile to both falling token balls and falling kebabs.
- Keeps the full ball rain budget at 240 while constrained devices are capped at 100 particles for both animations.
- Moves per-frame particle positioning from `left`/`top` writes to `translate3d(...)` transforms and throttles token-counter React updates.
- Adds focused tests for every constrained-device signal and the particle-count budget behavior.

## Visual Explanation

```text
Before
Full devices             Constrained devices
Balls: 240 max           Balls: no hard shared 100 cap
Kebabs: unbounded input  Kebabs: half after cap
Per frame: left/top      Per frame: left/top

After
Full devices             Constrained devices
Balls: 240 max           Balls: 100 max
Kebabs: 180 max          Kebabs: 100 max
Per frame: transform     Per frame: transform
```

```text
runtime hint check
      |
      v
+---------------+       full profile       +-----------------------+
| device hints  | -----------------------> | rich visual rain      |
| look healthy  |                          | 240 balls / 180 kebabs|
+---------------+                          +-----------------------+
      |
      | constrained signal
      v
+-------------------+
| constrained rain  |
| 100 balls max     |
| 100 kebabs max    |
+-------------------+
```

## Test Plan
- `bun run test src/features/wrapped/onboarding/performance.test.ts`
- `bun --filter @rudel/web check-types`
- `bun run lint:wrapped:hig`
- `bun run verify`

Notes: `bun run verify` passed in the isolated PR worktree before the cap-only amendment. After the amendment, the focused performance test, web typecheck, and HIG audit passed. Verify still prints existing `wrapped.css` `!important` lint warnings and existing Vite chunk/import-size warnings, but exits successfully.