### PR TITLE
fix: add wrapped share copy feedback

### DIFF
--- a/apps/web/src/components/ui/copy-feedback-icon.tsx
+++ b/apps/web/src/components/ui/copy-feedback-icon.tsx
@@ -1,0 +1,120 @@
+import { motion } from "motion/react";
+import { useId } from "react";
+
+export type CopyFeedbackStage = "copied" | "idle" | "resetting";
+
+interface CopyFeedbackIconProps {
+	className?: string;
+	reduceMotion: boolean;
+	stage: CopyFeedbackStage;
+}
+
+export function CopyFeedbackIcon(props: CopyFeedbackIconProps) {
+	const { className, reduceMotion, stage } = props;
+	const isCopied = stage === "copied";
+	const rectDelay = stage === "resetting" ? 0.045 : 0;
+	const rectDuration = stage === "copied" ? 0.18 : 0.1;
+	const pathDelay = stage === "copied" ? 0.04 : 0;
+	const pathDuration = stage === "copied" ? 0.1 : 0.05;
+	const frontRectAnimation = isCopied
+		? { y: -4, width: 14.5, height: 14.5, rx: 7.25 }
+		: { y: 0, width: 10.5, height: 10.5, rx: 2 };
+	const backRectAnimation = isCopied
+		? { x: -4, width: 14.5, height: 14.5, rx: 7.25 }
+		: { x: 0, width: 10.5, height: 10.5, rx: 2 };
+	const checkAnimation = isCopied
+		? {
+				opacity: 1,
+				strokeDasharray: "0.9px 1px",
+				strokeDashoffset: "0px",
+			}
+		: {
+				opacity: 0,
+				strokeDasharray: "0px 1px",
+				strokeDashoffset: "-1px",
+			};
+	const maskId = useId();
+
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			xmlns="http://www.w3.org/2000/svg"
+			fill="none"
+			aria-hidden="true"
+			className={className}
+		>
+			<motion.rect
+				x="4.75"
+				y="8.75"
+				width="10.5"
+				height="10.5"
+				rx="2"
+				stroke="currentColor"
+				strokeWidth="1.5"
+				style={{ transformOrigin: "10px 14px" }}
+				initial={false}
+				animate={frontRectAnimation}
+				transition={{
+					duration: reduceMotion ? 0.12 : rectDuration,
+					delay: reduceMotion ? 0 : rectDelay,
+					ease: [0.22, 1, 0.36, 1],
+				}}
+			/>
+			<g mask={`url(#${maskId})`}>
+				<motion.rect
+					x="8.75"
+					y="4.75"
+					width="10.5"
+					height="10.5"
+					rx="2"
+					stroke="currentColor"
+					strokeWidth="1.5"
+					style={{ transformOrigin: "14px 10px" }}
+					initial={false}
+					animate={backRectAnimation}
+					transition={{
+						duration: reduceMotion ? 0.12 : rectDuration,
+						delay: reduceMotion ? 0 : rectDelay,
+						ease: [0.22, 1, 0.36, 1],
+					}}
+				/>
+			</g>
+			<motion.path
+				d="M9.25 12.25L11 14.25L15 10"
+				stroke="currentColor"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				pathLength="1"
+				initial={false}
+				animate={checkAnimation}
+				transition={{
+					duration: reduceMotion ? 0.08 : pathDuration,
+					delay: reduceMotion ? 0 : pathDelay,
+					ease: [0.22, 1, 0.36, 1],
+				}}
+			/>
+			<mask id={maskId} maskUnits="userSpaceOnUse">
+				<rect width="24" height="24" fill="#fff" />
+				<motion.rect
+					x="4.75"
+					y="8.75"
+					width="10.5"
+					height="10.5"
+					rx="2"
+					fill="#000"
+					stroke="#000"
+					strokeWidth="1.5"
+					style={{ transformOrigin: "10px 14px" }}
+					initial={false}
+					animate={frontRectAnimation}
+					transition={{
+						duration: reduceMotion ? 0.12 : rectDuration,
+						delay: reduceMotion ? 0 : rectDelay,
+						ease: [0.22, 1, 0.36, 1],
+					}}
+				/>
+			</mask>
+		</svg>
+	);
+}

--- a/apps/web/src/features/wrapped/share-image.ts
+++ b/apps/web/src/features/wrapped/share-image.ts
@@ -40,7 +40,7 @@ interface CreateWrappedImageShareActionsParams {
 }
 
 interface WrappedImageShareActions {
-	handleCopyImage: () => Promise<void>;
+	handleCopyImage: () => Promise<boolean>;
 	handleDownloadImage: () => Promise<void>;
 	handleShareImage: () => Promise<void>;
 	shareUrl: string | undefined;
@@ -193,7 +193,7 @@ export function createWrappedImageShareActions(
 		);
 	}
 
-	async function handleCopyImage() {
+	async function handleCopyImage(): Promise<boolean> {
 		onShareActionTriggered?.("copy");
 		const imageBlob = await captureShareImage({
 			captureOptions,
@@ -202,17 +202,18 @@ export function createWrappedImageShareActions(
 		});
 
 		if (!imageBlob) {
-			return;
+			return false;
 		}
 
 		const copied = await copyToClipboard(imageBlob);
 
 		if (copied) {
 			toast.success(messages.copySuccess);
-			return;
+			return true;
 		}
 
 		toast.error("Could not copy the image. Try downloading it instead.");
+		return false;
 	}
 
 	async function handleDownloadImage() {

--- a/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
@@ -54,6 +54,8 @@ vi.mock("motion/react", async () => {
 			h1: createPrimitive("h1"),
 			h2: createPrimitive("h2"),
 			p: createPrimitive("p"),
+			path: createPrimitive("path"),
+			rect: createPrimitive("rect"),
 			span: createPrimitive("span"),
 		},
 		useReducedMotion: () => false,
@@ -351,6 +353,68 @@ describe("WrappedTeamCardShareStage", () => {
 			"true",
 		);
 		expect(screen.getByText("Input/output tokens")).toBeInTheDocument();
+	});
+
+	it("shows copied feedback on the copy image button after a successful copy", async () => {
+		vi.useFakeTimers();
+		const onCopy = vi.fn().mockResolvedValue(true);
+
+		render(
+			<WrappedTeamCardShareStage
+				appearance={{ layoutMode: "front_back", showArchetypeLabel: true }}
+				backMetrics={buildWrappedTeamCardBackMetrics({
+					onboardingMetrics,
+					row,
+					shareCardCreatedAtLabel: "04/24/2026",
+				})}
+				headerLeftMetric={{ title: "$42 estimated spend", value: "$42" }}
+				headerRightMetric={{
+					title: "Smooth Operator",
+					value: "Smooth Operator",
+				}}
+				onAppearanceChange={vi.fn()}
+				onBack={vi.fn()}
+				onContinueToDashboard={vi.fn()}
+				onCopy={onCopy}
+				onCopyProfileUrl={vi.fn()}
+				onDownload={vi.fn()}
+				onShare={vi.fn()}
+				profileUrlLabel="rudel.ai/wrapped/public-card"
+				row={row}
+				shareCardCreatedAtLabel="04/24/2026"
+				sharePostRef={{ current: null }}
+				shellClassName="bg-sky-200"
+				shellStyle={{}}
+				statItems={[]}
+				statLayerOpacities={{
+					rainbowShineOpacity: 0.3,
+					textureOpacity: 1,
+					tileBorderOpacity: 1,
+					tileFillOpacity: 0.08,
+					tileInsetShadowOpacity: 0.5,
+					tileTopStrokeOpacity: 0.08,
+				}}
+				theme="light"
+			/>,
+		);
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: "Copy image" }));
+			await Promise.resolve();
+		});
+
+		const copiedButton = screen.getByRole("button", { name: "Copied image" });
+		expect(onCopy).toHaveBeenCalledTimes(1);
+		expect(copiedButton).toHaveAttribute("data-copy-state", "copied");
+
+		act(() => {
+			vi.advanceTimersByTime(2_170);
+		});
+
+		expect(screen.getByRole("button", { name: "Copy image" })).toHaveAttribute(
+			"data-copy-state",
+			"idle",
+		);
 	});
 
 	it("shows a spinner in the download button while export is pending", () => {

--- a/apps/web/src/features/wrapped/team-card/final-stages.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.tsx
@@ -2,7 +2,6 @@ import type { WrappedShareAppearance } from "@rudel/api-routes";
 import { IconBrandX } from "@tabler/icons-react";
 import {
 	ChevronRight,
-	Clipboard,
 	Download,
 	Link as LinkIcon,
 	Loader2,
@@ -18,6 +17,10 @@ import {
 	useState,
 } from "react";
 import { Button } from "@/app/ui/button";
+import {
+	CopyFeedbackIcon,
+	type CopyFeedbackStage,
+} from "@/components/ui/copy-feedback-icon";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
 import { WrappedPrimaryAction } from "@/features/wrapped/actions";
 import type { WrappedOnboardingMetrics } from "@/features/wrapped/onboarding/types";
@@ -62,7 +65,7 @@ interface WrappedTeamCardShareStageProps extends WrappedTeamCardStageCardProps {
 	isProfileUrlCopyPending?: boolean;
 	isSharePending?: boolean;
 	onBack: () => void;
-	onCopy: () => void | Promise<void>;
+	onCopy: () => WrappedShareCopyResult | Promise<WrappedShareCopyResult>;
 	onCopyProfileUrl: () => void | Promise<void>;
 	onContinueToDashboard: () => void;
 	onDownload: () => void | Promise<void>;
@@ -136,6 +139,7 @@ interface WrappedRevealCopyInput {
 }
 
 type WrappedRevealIntroPhase = "name" | "line" | "accent" | "description";
+type WrappedShareCopyResult = boolean | undefined;
 
 /* ─────────────────────────────────────────────────────────
  * REVEAL COMPANION STORYBOARD
@@ -248,6 +252,8 @@ const REVEAL_STAGE_CARD_FLIP_DURATION_MS = Math.round(
 	REVEAL_STAGE_MOTION.duration.flip * 1_000,
 );
 const WRAPPED_FINAL_SHARE_CHROME_EASE = [0.22, 1, 0.36, 1] as const;
+const WRAPPED_SHARE_COPY_HOLD_MS = 2000;
+const WRAPPED_SHARE_COPY_RESET_MS = 170;
 
 export function WrappedTeamCardShareStage(
 	props: WrappedTeamCardShareStageProps,
@@ -282,6 +288,52 @@ export function WrappedTeamCardShareStage(
 	const reduceMotion = shouldReduceMotion ?? false;
 	const resolvedAppearance = resolveWrappedShareAppearance(appearance);
 	const shareObjectShellRef = useWrappedShareStageObjectSize();
+	const [copyStage, setCopyStage] = useState<CopyFeedbackStage>("idle");
+	const copyHoldTimeoutRef = useRef<number | null>(null);
+	const copyResetTimeoutRef = useRef<number | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (copyHoldTimeoutRef.current !== null) {
+				window.clearTimeout(copyHoldTimeoutRef.current);
+			}
+
+			if (copyResetTimeoutRef.current !== null) {
+				window.clearTimeout(copyResetTimeoutRef.current);
+			}
+		};
+	}, []);
+
+	function clearCopyFeedbackTimers() {
+		if (copyHoldTimeoutRef.current !== null) {
+			window.clearTimeout(copyHoldTimeoutRef.current);
+			copyHoldTimeoutRef.current = null;
+		}
+
+		if (copyResetTimeoutRef.current !== null) {
+			window.clearTimeout(copyResetTimeoutRef.current);
+			copyResetTimeoutRef.current = null;
+		}
+	}
+
+	async function handleCopyClick() {
+		const copyResult = await onCopy();
+
+		if (copyResult === false) {
+			return;
+		}
+
+		clearCopyFeedbackTimers();
+		setCopyStage("copied");
+		copyHoldTimeoutRef.current = window.setTimeout(() => {
+			setCopyStage("resetting");
+			copyHoldTimeoutRef.current = null;
+			copyResetTimeoutRef.current = window.setTimeout(() => {
+				setCopyStage("idle");
+				copyResetTimeoutRef.current = null;
+			}, WRAPPED_SHARE_COPY_RESET_MS);
+		}, WRAPPED_SHARE_COPY_HOLD_MS);
+	}
 
 	return (
 		<WrappedStageFrame
@@ -355,11 +407,18 @@ export function WrappedTeamCardShareStage(
 									type="button"
 									size="icon-sm"
 									variant="outline"
-									aria-label="Copy image"
+									aria-label={
+										copyStage === "copied" ? "Copied image" : "Copy image"
+									}
 									className="mymind-wrapped-share-toolbar__button"
-									onClick={onCopy}
+									data-copy-state={copyStage}
+									onClick={() => void handleCopyClick()}
 								>
-									<Clipboard className="size-4" />
+									<CopyFeedbackIcon
+										className="mymind-wrapped-share-toolbar__copy-icon"
+										stage={copyStage}
+										reduceMotion={reduceMotion}
+									/>
 								</Button>
 								<Button
 									type="button"

--- a/apps/web/src/features/wrapped/team-card/page.tsx
+++ b/apps/web/src/features/wrapped/team-card/page.tsx
@@ -576,7 +576,7 @@ function WrappedTeamCardPageContent(props: {
 						onAppearanceChange={(nextAppearance) => {
 							setShareAppearance(resolveWrappedShareAppearance(nextAppearance));
 						}}
-						onCopy={() => void shareActions.handleCopyPost()}
+						onCopy={() => shareActions.handleCopyPost()}
 						onCopyProfileUrl={() => void handleCopyProfileUrl()}
 						onContinueToDashboard={() =>
 							handleContinueToDashboard("wrapped_share_footer")

--- a/apps/web/src/features/wrapped/team-card/share.ts
+++ b/apps/web/src/features/wrapped/team-card/share.ts
@@ -47,7 +47,7 @@ interface CreateWrappedTeamCardShareActionsParams {
 
 interface WrappedTeamCardShareActions {
 	handleCopyProfileUrl: () => Promise<boolean>;
-	handleCopyPost: () => Promise<void>;
+	handleCopyPost: () => Promise<boolean>;
 	handleDownloadPost: () => Promise<void>;
 	handleSharePost: () => Promise<void>;
 	shareUrl: string | undefined;

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -7986,8 +7986,23 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	color: #2a2725;
 }
 
+.mymind-wrapped-share-toolbar__button[data-copy-state] {
+	color: #17161c;
+}
+
+.mymind-wrapped-share-toolbar__button[data-copy-state="copied"] {
+	background: rgb(255 255 255 / 0.96);
+	color: #000;
+}
+
 .mymind-wrapped-share-toolbar__button:hover {
 	background: white;
+}
+
+.mymind-wrapped-share-toolbar__copy-icon {
+	width: 1.5rem;
+	height: 1.5rem;
+	overflow: visible;
 }
 
 .mymind-wrapped-final-stage__back {


### PR DESCRIPTION
## Summary
- Rebased onto latest `main` and kept the new profile URL copy bar from main intact
- Scoped the PR to the wrapped share image copy button feedback only; the upload/setup copy surface is untouched
- Added the black copy-to-check icon treatment inside the circular share toolbar button after successful image copy
- Return copy success from the wrapped image share action so UI feedback only appears after a successful copy
- Add coverage for the share-stage copied feedback state

## Screenshot
![Wrapped share copy button before and after](https://github.com/obsessiondb/rudel/raw/e374ef2cd0fbee226ef091f59efcc6b7d06281ce/wrapped-copy-button-before-after-rebased.png)

## Test plan
- `bun run verify`
- `bun run lint:wrapped:hig`
- GitHub Actions `verify`
