### PR TITLE
fix: hide low-signal wrapped feature recaps

### DIFF
--- a/apps/web/src/features/wrapped/onboarding/models/feature-signal.test.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/feature-signal.test.ts
@@ -24,6 +24,9 @@ describe("wrapped feature signal thresholds", () => {
 		expect(model.emptyState).toBe("low-signal");
 		expect(model.hasRankedSkills).toBe(false);
 		expect(model.headline).toBe("You didn't use skills enough.");
+		expect(model.subline).toBe(
+			"Use skills in at least 20% of sessions to create a skills recap.",
+		);
 		expect(model.cards.some((card) => card.item.name === "Refactor")).toBe(
 			false,
 		);
@@ -53,6 +56,9 @@ describe("wrapped feature signal thresholds", () => {
 		expect(model.mode).toBe("thin-slash-command");
 		expect(model.topSlashCommand).toBeNull();
 		expect(model.headline).toBe("You didn't use slash commands enough.");
+		expect(model.subline).toBe(
+			"Use slash commands in at least 20% of sessions to create a slash-command recap.",
+		);
 		expect(model.entries.some((entry) => entry.name === "/fix")).toBe(false);
 	});
 

--- a/apps/web/src/features/wrapped/onboarding/models/feature-signal.test.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/feature-signal.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { resolveSkillsStageModel } from "./skills";
+import { resolveToolsStageModel } from "./tools";
+
+const emptyToolsInput = {
+	slashCommandsAdoptionRate: null,
+	subagentsAdoptionRate: null,
+	topSlashCommand: null,
+	topSlashCommandCount: null,
+	topSlashCommands: [],
+	topSubagent: null,
+	topSubagentCount: null,
+	topSubagents: [],
+	totalSessions: 0,
+} as const;
+
+describe("wrapped feature signal thresholds", () => {
+	it("hides skill names below 20 percent adoption", () => {
+		const model = resolveSkillsStageModel({
+			skillsAdoptionRate: 19,
+			topSkills: [{ count: 38, name: "Refactor" }],
+		});
+
+		expect(model.emptyState).toBe("low-signal");
+		expect(model.hasRankedSkills).toBe(false);
+		expect(model.headline).toBe("You didn't use skills enough.");
+		expect(model.cards.some((card) => card.item.name === "Refactor")).toBe(
+			false,
+		);
+	});
+
+	it("shows skill names at 20 percent adoption with enough top-skill count", () => {
+		const model = resolveSkillsStageModel({
+			skillsAdoptionRate: 20,
+			topSkills: [{ count: 3, name: "Refactor" }],
+		});
+
+		expect(model.emptyState).toBeNull();
+		expect(model.hasRankedSkills).toBe(true);
+		expect(model.cards[0]?.item.name).toBe("Refactor");
+	});
+
+	it("hides slash command names below 20 percent adoption", () => {
+		const model = resolveToolsStageModel({
+			...emptyToolsInput,
+			slashCommandsAdoptionRate: 19,
+			topSlashCommand: "/fix",
+			topSlashCommandCount: 38,
+			topSlashCommands: [{ count: 38, name: "/fix" }],
+			totalSessions: 100,
+		});
+
+		expect(model.mode).toBe("thin-slash-command");
+		expect(model.topSlashCommand).toBeNull();
+		expect(model.headline).toBe("You didn't use slash commands enough.");
+		expect(model.entries.some((entry) => entry.name === "/fix")).toBe(false);
+	});
+
+	it("shows slash command names at 20 percent adoption with enough top-command count", () => {
+		const model = resolveToolsStageModel({
+			...emptyToolsInput,
+			slashCommandsAdoptionRate: 20,
+			topSlashCommand: "/fix",
+			topSlashCommandCount: 3,
+			topSlashCommands: [{ count: 3, name: "/fix" }],
+			totalSessions: 15,
+		});
+
+		expect(model.mode).toBe("regular");
+		expect(model.topSlashCommand).toBe("/fix");
+		expect(model.entries[0]?.name).toBe("/fix");
+	});
+});

--- a/apps/web/src/features/wrapped/onboarding/models/feature-signal.test.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/feature-signal.test.ts
@@ -24,9 +24,7 @@ describe("wrapped feature signal thresholds", () => {
 		expect(model.emptyState).toBe("low-signal");
 		expect(model.hasRankedSkills).toBe(false);
 		expect(model.headline).toBe("You didn't use skills enough.");
-		expect(model.subline).toBe(
-			"Use skills in at least 20% of sessions to create a skills recap.",
-		);
+		expect(model.subline).toBe("Use skills in 20%+ of sessions for a recap.");
 		expect(model.cards.some((card) => card.item.name === "Refactor")).toBe(
 			false,
 		);
@@ -57,7 +55,7 @@ describe("wrapped feature signal thresholds", () => {
 		expect(model.topSlashCommand).toBeNull();
 		expect(model.headline).toBe("You didn't use slash commands enough.");
 		expect(model.subline).toBe(
-			"Use slash commands in at least 20% of sessions to create a slash-command recap.",
+			"Use slash commands in 20%+ of sessions for a recap.",
 		);
 		expect(model.entries.some((entry) => entry.name === "/fix")).toBe(false);
 	});

--- a/apps/web/src/features/wrapped/onboarding/models/feature-signal.test.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/feature-signal.test.ts
@@ -24,7 +24,7 @@ describe("wrapped feature signal thresholds", () => {
 		expect(model.emptyState).toBe("low-signal");
 		expect(model.hasRankedSkills).toBe(false);
 		expect(model.headline).toBe("You didn't use skills enough.");
-		expect(model.subline).toBe("Use skills in 20%+ of sessions for a recap.");
+		expect(model.subline).toBe("Use skills in +20% of sessions for a recap.");
 		expect(model.cards.some((card) => card.item.name === "Refactor")).toBe(
 			false,
 		);
@@ -55,7 +55,7 @@ describe("wrapped feature signal thresholds", () => {
 		expect(model.topSlashCommand).toBeNull();
 		expect(model.headline).toBe("You didn't use slash commands enough.");
 		expect(model.subline).toBe(
-			"Use slash commands in 20%+ of sessions for a recap.",
+			"Use slash commands in +20% of sessions for a recap.",
 		);
 		expect(model.entries.some((entry) => entry.name === "/fix")).toBe(false);
 	});

--- a/apps/web/src/features/wrapped/onboarding/models/feature-signal.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/feature-signal.ts
@@ -1,0 +1,45 @@
+export const MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE = 20;
+export const MIN_WRAPPED_RECAP_FEATURE_TOP_COUNT = 3;
+
+interface WrappedFeatureSignalInput {
+	adoptionRate: number | null;
+	topItemCount: number | null;
+}
+
+export function hasWrappedRecapFeatureSignal(input: WrappedFeatureSignalInput) {
+	return (
+		normalizeWrappedFeatureCount(input.topItemCount) >=
+			MIN_WRAPPED_RECAP_FEATURE_TOP_COUNT &&
+		hasWrappedRecapFeatureAdoptionSignal(input.adoptionRate)
+	);
+}
+
+export function hasWrappedLowFeatureUsageSignal(
+	input: WrappedFeatureSignalInput,
+) {
+	const adoptionRate = input.adoptionRate;
+
+	return (
+		normalizeWrappedFeatureCount(input.topItemCount) > 0 ||
+		(adoptionRate !== null && Number.isFinite(adoptionRate) && adoptionRate > 0)
+	);
+}
+
+function hasWrappedRecapFeatureAdoptionSignal(adoptionRate: number | null) {
+	if (adoptionRate === null) {
+		return true;
+	}
+
+	return (
+		Number.isFinite(adoptionRate) &&
+		adoptionRate >= MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE
+	);
+}
+
+function normalizeWrappedFeatureCount(count: number | null) {
+	if (count === null || !Number.isFinite(count)) {
+		return 0;
+	}
+
+	return Math.max(0, count);
+}

--- a/apps/web/src/features/wrapped/onboarding/models/skills.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/skills.ts
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { formatPercent } from "../format";
 import type { WrappedSkillUsageItem } from "../types";
+import { hasWrappedRecapFeatureSignal } from "./feature-signal";
 
 export const SKILLS_STACK = {
 	cardHeightRem: 5.5,
@@ -129,9 +130,14 @@ export function resolveSkillsStageModel(input: {
 	skillsAdoptionRate: number | null;
 	topSkills: readonly WrappedSkillUsageItem[];
 }) {
-	const rankedSkills = input.topSkills.filter(
+	const signalSkills = input.topSkills.filter(
 		(skill) => skill.name.trim().length > 0 && skill.count > 0,
 	);
+	const hasSkillsSignal = hasWrappedRecapFeatureSignal({
+		adoptionRate: input.skillsAdoptionRate,
+		topItemCount: signalSkills[0]?.count ?? null,
+	});
+	const rankedSkills = hasSkillsSignal ? signalSkills : [];
 	const displayItems = rankedSkills.length > 0 ? [...rankedSkills] : [];
 
 	const minimumVisibleItems = 3;
@@ -166,13 +172,20 @@ export function resolveSkillsStageModel(input: {
 	const isScrollable = visibleSkillsCount > SKILLS_STACK.visibleCards;
 
 	if (rankedSkills.length === 0) {
+		const hasLowSkillUsage = signalSkills.length > 0;
+
 		return {
 			cards,
+			emptyState: hasLowSkillUsage ? "low-signal" : "no-signal",
 			footnote: "",
 			hasRankedSkills: false,
-			headline: "You've got a skill issue.",
+			headline: hasLowSkillUsage
+				? "You didn't use skills enough."
+				: "You've got a skill issue.",
 			isScrollable,
-			subline: "",
+			subline: hasLowSkillUsage
+				? "Not enough sessions pulled in skills to build a recap yet."
+				: "",
 			trackHeightRem,
 		};
 	}
@@ -180,6 +193,7 @@ export function resolveSkillsStageModel(input: {
 	if (rankedSkills.length === 1) {
 		return {
 			cards,
+			emptyState: null,
 			footnote:
 				input.skillsAdoptionRate === null
 					? "Only one skill has enough signal to make the board so far."
@@ -202,6 +216,7 @@ export function resolveSkillsStageModel(input: {
 
 	return {
 		cards,
+		emptyState: null,
 		footnote,
 		hasRankedSkills: true,
 		headline: `${leaderName} leads the board`,

--- a/apps/web/src/features/wrapped/onboarding/models/skills.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/skills.ts
@@ -187,7 +187,7 @@ export function resolveSkillsStageModel(input: {
 				: "You've got a skill issue.",
 			isScrollable,
 			subline: hasLowSkillUsage
-				? `Use skills in ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}%+ of sessions for a recap.`
+				? `Use skills in +${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}% of sessions for a recap.`
 				: "",
 			trackHeightRem,
 		};

--- a/apps/web/src/features/wrapped/onboarding/models/skills.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/skills.ts
@@ -187,7 +187,7 @@ export function resolveSkillsStageModel(input: {
 				: "You've got a skill issue.",
 			isScrollable,
 			subline: hasLowSkillUsage
-				? `Use skills in at least ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}% of sessions to create a skills recap.`
+				? `Use skills in ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}%+ of sessions for a recap.`
 				: "",
 			trackHeightRem,
 		};

--- a/apps/web/src/features/wrapped/onboarding/models/skills.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/skills.ts
@@ -1,7 +1,10 @@
 import type { CSSProperties } from "react";
 import { formatPercent } from "../format";
 import type { WrappedSkillUsageItem } from "../types";
-import { hasWrappedRecapFeatureSignal } from "./feature-signal";
+import {
+	hasWrappedRecapFeatureSignal,
+	MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE,
+} from "./feature-signal";
 
 export const SKILLS_STACK = {
 	cardHeightRem: 5.5,
@@ -184,7 +187,7 @@ export function resolveSkillsStageModel(input: {
 				: "You've got a skill issue.",
 			isScrollable,
 			subline: hasLowSkillUsage
-				? "Not enough sessions pulled in skills to build a recap yet."
+				? `Use skills in at least ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}% of sessions to create a skills recap.`
 				: "",
 			trackHeightRem,
 		};

--- a/apps/web/src/features/wrapped/onboarding/models/tools.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/tools.ts
@@ -49,7 +49,7 @@ export function resolveToolsStageModel(input: {
 	}
 
 	if (mode === "thin-slash-command") {
-		const thinSlashCommandSubline = `Use slash commands in ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}%+ of sessions for a recap.`;
+		const thinSlashCommandSubline = `Use slash commands in +${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}% of sessions for a recap.`;
 
 		return {
 			entries: buildToolsPlaceholderEntries(),
@@ -312,13 +312,13 @@ export function getToolsSubline(input: {
 
 	if (topSlashCommand === null && !hasSubagent) {
 		return hasLowSlashCommandSignal
-			? `Use slash commands in ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}%+ of sessions for a recap.`
+			? `Use slash commands in +${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}% of sessions for a recap.`
 			: "You should try them out tho: slash commands and subagents.";
 	}
 
 	if (topSlashCommand === null) {
 		const slashCommandLine = hasLowSlashCommandSignal
-			? `Use slash commands in ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}%+ of sessions for a recap.`
+			? `Use slash commands in +${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}% of sessions for a recap.`
 			: "No slash command ranked yet.";
 
 		return `${formatPercent(subagentsAdoptionRate)} of sessions used a subagent. ${slashCommandLine}`;

--- a/apps/web/src/features/wrapped/onboarding/models/tools.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/tools.ts
@@ -1,6 +1,10 @@
 import type { CSSProperties } from "react";
 import { formatPercent } from "../format";
 import type { WrappedSkillUsageItem } from "../types";
+import {
+	hasWrappedLowFeatureUsageSignal,
+	hasWrappedRecapFeatureSignal,
+} from "./feature-signal";
 
 interface ToolsStageEntry {
 	id: string;
@@ -15,8 +19,6 @@ type ToolsStageMode =
 	| "regular"
 	| "thin-slash-command"
 	| "zero-slash-command";
-
-const MIN_RECAP_SLASH_COMMAND_COUNT = 3;
 
 export function resolveToolsStageModel(input: {
 	slashCommandsAdoptionRate: number | null;
@@ -48,10 +50,10 @@ export function resolveToolsStageModel(input: {
 	if (mode === "thin-slash-command") {
 		return {
 			entries: buildToolsPlaceholderEntries(),
-			footnote: "Almost no slash commands made the recap.",
-			headline: "Almost no slash commands.",
+			footnote: "Not enough sessions used slash commands to build a recap yet.",
+			headline: "You didn't use slash commands enough.",
 			mode,
-			subline: "Almost no slash commands made the recap.",
+			subline: "Not enough sessions used slash commands to build a recap yet.",
 			topSlashCommand,
 			topSubagent: input.topSubagent,
 		};
@@ -268,6 +270,7 @@ export function getToolsEntryStyle(
 }
 
 export function getToolsHeadline(input: {
+	slashCommandsAdoptionRate: number | null;
 	topSlashCommand: string | null;
 	topSlashCommandCount: number | null;
 	topSlashCommands: readonly WrappedSkillUsageItem[];
@@ -306,13 +309,13 @@ export function getToolsSubline(input: {
 
 	if (topSlashCommand === null && !hasSubagent) {
 		return hasLowSlashCommandSignal
-			? "Almost no slash commands made the recap."
+			? "You didn't use slash commands enough for a recap yet."
 			: "You should try them out tho: slash commands and subagents.";
 	}
 
 	if (topSlashCommand === null) {
 		const slashCommandLine = hasLowSlashCommandSignal
-			? "Almost no slash commands landed."
+			? "You didn't use slash commands enough for a recap yet."
 			: "No slash command ranked yet.";
 
 		return `${formatPercent(subagentsAdoptionRate)} of sessions used a subagent. ${slashCommandLine}`;
@@ -330,6 +333,7 @@ function getToolsUsageLabel(rate: number) {
 }
 
 function buildToolsStageEntries(input: {
+	slashCommandsAdoptionRate: number | null;
 	topSlashCommand: string | null;
 	topSlashCommandCount: number | null;
 	topSlashCommands: readonly WrappedSkillUsageItem[];
@@ -412,6 +416,7 @@ function resolveToolsStageMode(
 }
 
 function resolveRecapSlashCommand(input: {
+	slashCommandsAdoptionRate: number | null;
 	topSlashCommand: string | null;
 	topSlashCommandCount: number | null;
 	topSlashCommands: readonly WrappedSkillUsageItem[];
@@ -420,11 +425,11 @@ function resolveRecapSlashCommand(input: {
 		return null;
 	}
 
-	const slashCommandCount = resolveSlashCommandSignalCount(input);
-
 	if (
-		slashCommandCount !== null &&
-		slashCommandCount < MIN_RECAP_SLASH_COMMAND_COUNT
+		!hasWrappedRecapFeatureSignal({
+			adoptionRate: input.slashCommandsAdoptionRate,
+			topItemCount: resolveSlashCommandTopItemCount(input),
+		})
 	) {
 		return null;
 	}
@@ -433,17 +438,21 @@ function resolveRecapSlashCommand(input: {
 }
 
 function isThinSlashCommandSignal(input: {
+	slashCommandsAdoptionRate: number | null;
 	topSlashCommand: string | null;
 	topSlashCommandCount: number | null;
 	topSlashCommands: readonly WrappedSkillUsageItem[];
 }) {
-	const slashCommandCount = resolveSlashCommandSignalCount(input);
-
 	return (
 		input.topSlashCommand !== null &&
-		slashCommandCount !== null &&
-		slashCommandCount > 0 &&
-		slashCommandCount < MIN_RECAP_SLASH_COMMAND_COUNT
+		hasWrappedLowFeatureUsageSignal({
+			adoptionRate: input.slashCommandsAdoptionRate,
+			topItemCount: resolveSlashCommandTopItemCount(input),
+		}) &&
+		!hasWrappedRecapFeatureSignal({
+			adoptionRate: input.slashCommandsAdoptionRate,
+			topItemCount: resolveSlashCommandTopItemCount(input),
+		})
 	);
 }
 
@@ -456,22 +465,30 @@ function isZeroSlashCommandSignal(input: {
 	);
 }
 
-function resolveSlashCommandSignalCount(input: {
+function resolveSlashCommandTopItemCount(input: {
 	topSlashCommand: string | null;
 	topSlashCommandCount: number | null;
 	topSlashCommands: readonly WrappedSkillUsageItem[];
 }) {
-	const rankedCommandCount = input.topSlashCommands.reduce(
-		(totalCount, item) => totalCount + Math.max(0, item.count),
-		0,
-	);
+	const matchedTopCommand =
+		input.topSlashCommand === null
+			? null
+			: input.topSlashCommands.find(
+					(item) => item.name === input.topSlashCommand,
+				);
 
-	if (rankedCommandCount > 0) {
-		return rankedCommandCount;
+	if (matchedTopCommand !== null && matchedTopCommand !== undefined) {
+		return Math.max(0, matchedTopCommand.count);
 	}
 
 	if (input.topSlashCommandCount !== null) {
 		return Math.max(0, input.topSlashCommandCount);
+	}
+
+	const firstRankedCommand = input.topSlashCommands[0];
+
+	if (firstRankedCommand !== undefined) {
+		return Math.max(0, firstRankedCommand.count);
 	}
 
 	return input.topSlashCommand === null ? 0 : null;

--- a/apps/web/src/features/wrapped/onboarding/models/tools.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/tools.ts
@@ -4,6 +4,7 @@ import type { WrappedSkillUsageItem } from "../types";
 import {
 	hasWrappedLowFeatureUsageSignal,
 	hasWrappedRecapFeatureSignal,
+	MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE,
 } from "./feature-signal";
 
 interface ToolsStageEntry {
@@ -48,12 +49,14 @@ export function resolveToolsStageModel(input: {
 	}
 
 	if (mode === "thin-slash-command") {
+		const thinSlashCommandSubline = `Use slash commands in at least ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}% of sessions to create a slash-command recap.`;
+
 		return {
 			entries: buildToolsPlaceholderEntries(),
-			footnote: "Not enough sessions used slash commands to build a recap yet.",
+			footnote: thinSlashCommandSubline,
 			headline: "You didn't use slash commands enough.",
 			mode,
-			subline: "Not enough sessions used slash commands to build a recap yet.",
+			subline: thinSlashCommandSubline,
 			topSlashCommand,
 			topSubagent: input.topSubagent,
 		};
@@ -309,13 +312,13 @@ export function getToolsSubline(input: {
 
 	if (topSlashCommand === null && !hasSubagent) {
 		return hasLowSlashCommandSignal
-			? "You didn't use slash commands enough for a recap yet."
+			? `Use slash commands in at least ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}% of sessions to create a slash-command recap.`
 			: "You should try them out tho: slash commands and subagents.";
 	}
 
 	if (topSlashCommand === null) {
 		const slashCommandLine = hasLowSlashCommandSignal
-			? "You didn't use slash commands enough for a recap yet."
+			? `Use slash commands in at least ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}% of sessions to create a slash-command recap.`
 			: "No slash command ranked yet.";
 
 		return `${formatPercent(subagentsAdoptionRate)} of sessions used a subagent. ${slashCommandLine}`;

--- a/apps/web/src/features/wrapped/onboarding/models/tools.ts
+++ b/apps/web/src/features/wrapped/onboarding/models/tools.ts
@@ -49,7 +49,7 @@ export function resolveToolsStageModel(input: {
 	}
 
 	if (mode === "thin-slash-command") {
-		const thinSlashCommandSubline = `Use slash commands in at least ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}% of sessions to create a slash-command recap.`;
+		const thinSlashCommandSubline = `Use slash commands in ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}%+ of sessions for a recap.`;
 
 		return {
 			entries: buildToolsPlaceholderEntries(),
@@ -312,13 +312,13 @@ export function getToolsSubline(input: {
 
 	if (topSlashCommand === null && !hasSubagent) {
 		return hasLowSlashCommandSignal
-			? `Use slash commands in at least ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}% of sessions to create a slash-command recap.`
+			? `Use slash commands in ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}%+ of sessions for a recap.`
 			: "You should try them out tho: slash commands and subagents.";
 	}
 
 	if (topSlashCommand === null) {
 		const slashCommandLine = hasLowSlashCommandSignal
-			? `Use slash commands in at least ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}% of sessions to create a slash-command recap.`
+			? `Use slash commands in ${MIN_WRAPPED_RECAP_FEATURE_ADOPTION_RATE}%+ of sessions for a recap.`
 			: "No slash command ranked yet.";
 
 		return `${formatPercent(subagentsAdoptionRate)} of sessions used a subagent. ${slashCommandLine}`;

--- a/apps/web/src/features/wrapped/onboarding/stages/skills.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/skills.tsx
@@ -401,15 +401,21 @@ export function WrappedOnboardingSkillsStage(props: SkillsStageProps) {
 							</span>
 						</div>
 						<p className="mymind-wrapped-skills-stage__empty-caption">
-							you should try skills out,{" "}
-							<a
-								className="mymind-wrapped-skills-stage__footnote-link"
-								href={ANTHROPIC_SKILLS_DOCS_URL}
-								rel="noreferrer"
-								target="_blank"
-							>
-								see here
-							</a>
+							{model.emptyState === "low-signal" ? (
+								"you didn't use skills enough for a recap yet"
+							) : (
+								<>
+									you should try skills out,{" "}
+									<a
+										className="mymind-wrapped-skills-stage__footnote-link"
+										href={ANTHROPIC_SKILLS_DOCS_URL}
+										rel="noreferrer"
+										target="_blank"
+									>
+										see here
+									</a>
+								</>
+							)}
 						</p>
 					</div>
 				) : isIntroCopyVisible ? undefined : (

--- a/apps/web/src/features/wrapped/onboarding/stages/skills.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/skills.tsx
@@ -400,23 +400,19 @@ export function WrappedOnboardingSkillsStage(props: SkillsStageProps) {
 								/>
 							</span>
 						</div>
-						<p className="mymind-wrapped-skills-stage__empty-caption">
-							{model.emptyState === "low-signal" ? (
-								"you didn't use skills enough for a recap yet"
-							) : (
-								<>
-									you should try skills out,{" "}
-									<a
-										className="mymind-wrapped-skills-stage__footnote-link"
-										href={ANTHROPIC_SKILLS_DOCS_URL}
-										rel="noreferrer"
-										target="_blank"
-									>
-										see here
-									</a>
-								</>
-							)}
-						</p>
+						{model.emptyState === "no-signal" ? (
+							<p className="mymind-wrapped-skills-stage__empty-caption">
+								you should try skills out,{" "}
+								<a
+									className="mymind-wrapped-skills-stage__footnote-link"
+									href={ANTHROPIC_SKILLS_DOCS_URL}
+									rel="noreferrer"
+									target="_blank"
+								>
+									see here
+								</a>
+							</p>
+						) : null}
 					</div>
 				) : isIntroCopyVisible ? undefined : (
 					<motion.div

--- a/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
@@ -105,8 +105,7 @@ describe("WrappedOnboardingToolsStage", () => {
 		expect(onBaseModelSequenceComplete).toHaveBeenCalledTimes(1);
 	});
 
-	it("keeps tiny slash-command usage in the text-only recap", () => {
-		vi.useFakeTimers();
+	it("renders tiny slash-command usage as the empty recap", () => {
 		const onBaseModelSequenceComplete = vi.fn();
 
 		render(
@@ -129,19 +128,17 @@ describe("WrappedOnboardingToolsStage", () => {
 				name: /you didn't use slash commands enough/i,
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("No subagents.")).toBeInTheDocument();
 		expect(
-			screen.getByText("you didn't use slash commands enough for a recap yet"),
+			screen.getByText(
+				"Not enough sessions used slash commands to build a recap yet.",
+			),
 		).toBeInTheDocument();
+		expect(screen.getByText("404")).toBeInTheDocument();
+		expect(screen.queryByText("No subagents.")).toBeNull();
 		expect(
 			screen.queryByRole("button", { name: "/fix. 5% of sessions" }),
 		).toBeNull();
 		expect(screen.queryByRole("link", { name: "slash commands" })).toBeNull();
-
-		act(() => {
-			vi.runAllTimers();
-		});
-
 		expect(onBaseModelSequenceComplete).toHaveBeenCalledTimes(1);
 	});
 

--- a/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
@@ -129,9 +129,7 @@ describe("WrappedOnboardingToolsStage", () => {
 			}),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(
-				"Use slash commands in at least 20% of sessions to create a slash-command recap.",
-			),
+			screen.getByText("Use slash commands in 20%+ of sessions for a recap."),
 		).toBeInTheDocument();
 		expect(screen.getByText("404")).toBeInTheDocument();
 		expect(screen.queryByText("No subagents.")).toBeNull();

--- a/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
@@ -130,7 +130,7 @@ describe("WrappedOnboardingToolsStage", () => {
 		).toBeInTheDocument();
 		expect(
 			screen.getByText(
-				"Not enough sessions used slash commands to build a recap yet.",
+				"Use slash commands in at least 20% of sessions to create a slash-command recap.",
 			),
 		).toBeInTheDocument();
 		expect(screen.getByText("404")).toBeInTheDocument();

--- a/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
@@ -125,12 +125,18 @@ describe("WrappedOnboardingToolsStage", () => {
 		);
 
 		expect(
-			screen.getByRole("heading", { name: /almost no slash commands/i }),
+			screen.getByRole("heading", {
+				name: /you didn't use slash commands enough/i,
+			}),
 		).toBeInTheDocument();
 		expect(screen.getByText("No subagents.")).toBeInTheDocument();
 		expect(
+			screen.getByText("you didn't use slash commands enough for a recap yet"),
+		).toBeInTheDocument();
+		expect(
 			screen.queryByRole("button", { name: "/fix. 5% of sessions" }),
 		).toBeNull();
+		expect(screen.queryByRole("link", { name: "slash commands" })).toBeNull();
 
 		act(() => {
 			vi.runAllTimers();

--- a/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/tools.test.tsx
@@ -129,7 +129,7 @@ describe("WrappedOnboardingToolsStage", () => {
 			}),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText("Use slash commands in 20%+ of sessions for a recap."),
+			screen.getByText("Use slash commands in +20% of sessions for a recap."),
 		).toBeInTheDocument();
 		expect(screen.getByText("404")).toBeInTheDocument();
 		expect(screen.queryByText("No subagents.")).toBeNull();

--- a/apps/web/src/features/wrapped/onboarding/stages/tools.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/tools.tsx
@@ -44,7 +44,7 @@ const TOOLS_BASE_MODEL_LINES = [
 	"Just vibes.",
 ] as const;
 const TOOLS_THIN_SLASH_COMMAND_LINES = [
-	"Almost no slash commands.",
+	"You didn't use slash commands enough.",
 	"No subagents.",
 	"Just vibes.",
 ] as const;
@@ -502,25 +502,31 @@ function WrappedOnboardingToolsBaseModelStage(props: {
 							initial={false}
 							transition={TOOLS_STAGE_SEQUENCE_TRANSITION}
 						>
-							You should try them out tho:{" "}
-							<a
-								className="mymind-wrapped-tools-stage__footnote-link"
-								href={ANTHROPIC_COMMANDS_DOCS_URL}
-								rel="noreferrer"
-								target="_blank"
-							>
-								slash commands
-							</a>{" "}
-							and{" "}
-							<a
-								className="mymind-wrapped-tools-stage__footnote-link"
-								href={ANTHROPIC_SUBAGENTS_DOCS_URL}
-								rel="noreferrer"
-								target="_blank"
-							>
-								subagents
-							</a>
-							.
+							{mode === "thin-slash-command" ? (
+								"you didn't use slash commands enough for a recap yet"
+							) : (
+								<>
+									You should try them out tho:{" "}
+									<a
+										className="mymind-wrapped-tools-stage__footnote-link"
+										href={ANTHROPIC_COMMANDS_DOCS_URL}
+										rel="noreferrer"
+										target="_blank"
+									>
+										slash commands
+									</a>{" "}
+									and{" "}
+									<a
+										className="mymind-wrapped-tools-stage__footnote-link"
+										href={ANTHROPIC_SUBAGENTS_DOCS_URL}
+										rel="noreferrer"
+										target="_blank"
+									>
+										subagents
+									</a>
+									.
+								</>
+							)}
 						</motion.span>
 					}
 					descriptionClassName="mymind-wrapped-tools-stage__description-shell"
@@ -566,7 +572,11 @@ function resolveToolsTextOnlyLines(
 
 	if (mode === "thin-slash-command") {
 		return hasSubagentSignal
-			? ["Almost no slash commands.", "Subagents did show up.", "Just vibes."]
+			? [
+					"You didn't use slash commands enough.",
+					"Subagents did show up.",
+					"Just vibes.",
+				]
 			: TOOLS_THIN_SLASH_COMMAND_LINES;
 	}
 

--- a/apps/web/src/features/wrapped/onboarding/stages/tools.tsx
+++ b/apps/web/src/features/wrapped/onboarding/stages/tools.tsx
@@ -1,3 +1,4 @@
+import { Frown } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import type { CSSProperties } from "react";
 import { useRef, useState } from "react";
@@ -36,15 +37,13 @@ type ToolsStageSequenceFrame = {
 
 type ToolsStageScenePhase = "sequence" | "handoff" | "final";
 type ToolsStageModel = ReturnType<typeof resolveToolsStageModel>;
-type ToolsTextOnlyMode = Exclude<ToolsStageModel["mode"], "regular">;
+type ToolsTextOnlyMode = Extract<
+	ToolsStageModel["mode"],
+	"base-model" | "zero-slash-command"
+>;
 
 const TOOLS_BASE_MODEL_LINES = [
 	"You used no slash commands.",
-	"No subagents.",
-	"Just vibes.",
-] as const;
-const TOOLS_THIN_SLASH_COMMAND_LINES = [
-	"You didn't use slash commands enough.",
 	"No subagents.",
 	"Just vibes.",
 ] as const;
@@ -90,6 +89,16 @@ export function WrappedOnboardingToolsStage(props: ToolsStageProps) {
 		previewState,
 	);
 	const model = resolveToolsStageModel(previewInput);
+
+	if (model.mode === "thin-slash-command") {
+		return (
+			<WrappedOnboardingToolsLowSignalStage
+				model={model}
+				onSequenceComplete={onBaseModelSequenceComplete}
+			/>
+		);
+	}
+
 	const textOnlyMode = resolveToolsTextOnlyMode(model.mode);
 
 	if (textOnlyMode !== null) {
@@ -108,6 +117,53 @@ export function WrappedOnboardingToolsStage(props: ToolsStageProps) {
 			model={model}
 			onSequenceComplete={onBaseModelSequenceComplete}
 			reduceMotion={reduceMotion}
+		/>
+	);
+}
+
+function WrappedOnboardingToolsLowSignalStage(props: {
+	model: ToolsStageModel;
+	onSequenceComplete?: () => void;
+}) {
+	const { model, onSequenceComplete } = props;
+
+	useMountEffect(() => {
+		onSequenceComplete?.();
+		return undefined;
+	});
+
+	return (
+		<WrappedOnboardingStageFrame
+			className={cn(
+				"mymind-wrapped-tools-stage",
+				"mymind-wrapped-skills-stage",
+			)}
+			copy={
+				<WrappedOnboardingStageCopy
+					title={model.headline}
+					description={model.subline}
+				/>
+			}
+			object={
+				<div
+					className="mymind-wrapped-skills-stage__empty-state"
+					data-debug-label="empty state"
+				>
+					<div
+						aria-hidden="true"
+						className="mymind-wrapped-skills-stage__empty-icon-shell"
+						data-debug-label="empty icon shell"
+					>
+						<span className="mymind-wrapped-skills-stage__empty-code">404</span>
+						<span className="mymind-wrapped-skills-stage__empty-icon-badge">
+							<Frown
+								className="mymind-wrapped-skills-stage__empty-icon"
+								strokeWidth={1.9}
+							/>
+						</span>
+					</div>
+				</div>
+			}
 		/>
 	);
 }
@@ -502,31 +558,25 @@ function WrappedOnboardingToolsBaseModelStage(props: {
 							initial={false}
 							transition={TOOLS_STAGE_SEQUENCE_TRANSITION}
 						>
-							{mode === "thin-slash-command" ? (
-								"you didn't use slash commands enough for a recap yet"
-							) : (
-								<>
-									You should try them out tho:{" "}
-									<a
-										className="mymind-wrapped-tools-stage__footnote-link"
-										href={ANTHROPIC_COMMANDS_DOCS_URL}
-										rel="noreferrer"
-										target="_blank"
-									>
-										slash commands
-									</a>{" "}
-									and{" "}
-									<a
-										className="mymind-wrapped-tools-stage__footnote-link"
-										href={ANTHROPIC_SUBAGENTS_DOCS_URL}
-										rel="noreferrer"
-										target="_blank"
-									>
-										subagents
-									</a>
-									.
-								</>
-							)}
+							You should try them out tho:{" "}
+							<a
+								className="mymind-wrapped-tools-stage__footnote-link"
+								href={ANTHROPIC_COMMANDS_DOCS_URL}
+								rel="noreferrer"
+								target="_blank"
+							>
+								slash commands
+							</a>{" "}
+							and{" "}
+							<a
+								className="mymind-wrapped-tools-stage__footnote-link"
+								href={ANTHROPIC_SUBAGENTS_DOCS_URL}
+								rel="noreferrer"
+								target="_blank"
+							>
+								subagents
+							</a>
+							.
 						</motion.span>
 					}
 					descriptionClassName="mymind-wrapped-tools-stage__description-shell"
@@ -570,27 +620,17 @@ function resolveToolsTextOnlyLines(
 			: TOOLS_BASE_MODEL_LINES;
 	}
 
-	if (mode === "thin-slash-command") {
-		return hasSubagentSignal
-			? [
-					"You didn't use slash commands enough.",
-					"Subagents did show up.",
-					"Just vibes.",
-				]
-			: TOOLS_THIN_SLASH_COMMAND_LINES;
-	}
-
 	return TOOLS_BASE_MODEL_LINES;
 }
 
 function resolveToolsTextOnlyMode(
 	mode: ToolsStageModel["mode"],
 ): ToolsTextOnlyMode | null {
-	if (mode === "regular") {
-		return null;
+	if (mode === "base-model" || mode === "zero-slash-command") {
+		return mode;
 	}
 
-	return mode;
+	return null;
 }
 
 function resolveToolsStageSequenceFrames(

--- a/apps/web/src/features/wrapped/team-card/back-metrics.ts
+++ b/apps/web/src/features/wrapped/team-card/back-metrics.ts
@@ -1,4 +1,5 @@
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
+import { hasWrappedRecapFeatureSignal } from "@/features/wrapped/onboarding/models/feature-signal";
 import type { WrappedOnboardingMetrics } from "@/features/wrapped/onboarding/types";
 import type { WrappedTeamMemberCardBackMetric } from "./card-back";
 
@@ -44,14 +45,26 @@ export function buildWrappedTeamCardBackMetrics(input: {
 		Math.round(Math.max(row.cost, onboardingMetrics.estimatedCostUsd)),
 	);
 	const reposTouched = Math.max(0, onboardingMetrics.repoPulse.totalRepos);
-	const skillSessionsUsed = getWrappedBackFeatureSessionCount(
-		totalSessions,
-		onboardingMetrics.skillsAdoptionRate,
-	);
-	const commandSessionsUsed = getWrappedBackFeatureSessionCount(
-		totalSessions,
-		onboardingMetrics.slashCommandsAdoptionRate,
-	);
+	const hasSkillRecapSignal = hasWrappedRecapFeatureSignal({
+		adoptionRate: onboardingMetrics.skillsAdoptionRate,
+		topItemCount: onboardingMetrics.topSkills[0]?.count ?? null,
+	});
+	const hasSlashCommandRecapSignal = hasWrappedRecapFeatureSignal({
+		adoptionRate: onboardingMetrics.slashCommandsAdoptionRate,
+		topItemCount: getWrappedBackTopSlashCommandCount(onboardingMetrics),
+	});
+	const skillSessionsUsed = hasSkillRecapSignal
+		? getWrappedBackFeatureSessionCount(
+				totalSessions,
+				onboardingMetrics.skillsAdoptionRate,
+			)
+		: 0;
+	const commandSessionsUsed = hasSlashCommandRecapSignal
+		? getWrappedBackFeatureSessionCount(
+				totalSessions,
+				onboardingMetrics.slashCommandsAdoptionRate,
+			)
+		: 0;
 	const subagentSessionsUsed = getWrappedBackFeatureSessionCount(
 		totalSessions,
 		onboardingMetrics.subagentsAdoptionRate,
@@ -114,7 +127,9 @@ export function buildWrappedTeamCardBackMetrics(input: {
 		},
 		{
 			label: "FAV SKILL",
-			value: onboardingMetrics.topSkills[0]?.name ?? "Skill issue",
+			value: hasSkillRecapSignal
+				? (onboardingMetrics.topSkills[0]?.name ?? "Skill issue")
+				: "Skill issue",
 			valueTruncation: "start",
 		},
 		{
@@ -143,6 +158,32 @@ export function buildWrappedTeamCardBackMetrics(input: {
 			value: issuedDateLabel,
 		},
 	];
+}
+
+function getWrappedBackTopSlashCommandCount(
+	onboardingMetrics: WrappedOnboardingMetrics,
+) {
+	if (onboardingMetrics.topSlashCommand !== null) {
+		const matchedTopCommand = onboardingMetrics.topSlashCommands.find(
+			(command) => command.name === onboardingMetrics.topSlashCommand,
+		);
+
+		if (matchedTopCommand !== undefined) {
+			return Math.max(0, matchedTopCommand.count);
+		}
+	}
+
+	if (onboardingMetrics.topSlashCommandCount !== null) {
+		return Math.max(0, onboardingMetrics.topSlashCommandCount);
+	}
+
+	const firstRankedCommand = onboardingMetrics.topSlashCommands[0];
+
+	if (firstRankedCommand !== undefined) {
+		return Math.max(0, firstRankedCommand.count);
+	}
+
+	return onboardingMetrics.topSlashCommand === null ? 0 : null;
 }
 
 function formatWrappedBackInteger(value: number | null) {

--- a/apps/web/src/features/wrapped/team-card/card-back.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/card-back.test.tsx
@@ -43,6 +43,39 @@ describe("WrappedTeamMemberCardBack", () => {
 			valueTruncation: "start",
 		});
 	});
+
+	it("hides low-signal skills and slash commands from the card back", () => {
+		const metrics = buildWrappedTeamCardBackMetrics({
+			onboardingMetrics: {
+				...onboardingMetrics,
+				skillsAdoptionRate: 19,
+				slashCommandsAdoptionRate: 19,
+				topSkills: [{ count: 38, name: "low-signal-skill" }],
+				topSlashCommand: "/low-signal",
+				topSlashCommandCount: 38,
+				topSlashCommands: [{ count: 38, name: "/low-signal" }],
+				totalSessions: 100,
+			},
+			row: {
+				...row,
+				totalSessions: 100,
+			},
+			shareCardCreatedAtLabel: "Apr 28, 2026",
+		});
+
+		expect(
+			metrics.find((metric) => metric.label === "Skills used")?.value,
+		).toBe("0");
+		expect(
+			metrics.find((metric) => metric.label === "FAV SKILL"),
+		).toMatchObject({
+			value: "Skill issue",
+			valueTruncation: "start",
+		});
+		expect(
+			metrics.find((metric) => metric.label === "Commands used")?.value,
+		).toBe("0");
+	});
 });
 
 const row = {


### PR DESCRIPTION
## Summary

- Adds one shared wrapped recap signal gate: top item count must be at least `3`, and adoption must be at least `20%` when the adoption rate is available.
- Applies that gate to skills and slash commands so low-signal usage gets fallback copy instead of naming a skill or command.
- Keeps low-signal skills on the 404 empty state without the extra caption under the object, and makes low-signal slash commands use the same 404 empty-state treatment.
- Applies the same gate to the share-card back so low-signal skill and command metrics do not leak through `FAV SKILL`, `Skills used`, or `Commands used`.
- Adds model/stage/card-back tests for the 20% boundary and the share-card leakage case.

## Screenshots

Skills low-signal preview uses the existing `single-skill` preview state, which has `18%` skill adoption.

| Before | After |
| --- | --- |
| ![Before skills low signal](https://gist.githubusercontent.com/evrendom/a5dac24a8c3b4d8e07536ded74132368/raw/b517980605c7f187c352c5cb64d251fda55fd9ff/before-skills-low-signal.svg) | ![After skills low signal](https://gist.githubusercontent.com/evrendom/a5dac24a8c3b4d8e07536ded74132368/raw/1a91d2c0579847f0b73f964b9c4821f3cdbf627c/after-skills-low-signal.svg) |

Slash-command screenshots use a temporary screenshot-only fixture at `5%` slash-command adoption. The fixture was not committed; it exercises the same resolver path changed in this PR.

| Before | After |
| --- | --- |
| ![Before slash command low signal](https://gist.githubusercontent.com/evrendom/a5dac24a8c3b4d8e07536ded74132368/raw/4991803fe780d004e5bfa349b56306338c361074/before-tools-low-signal.svg) | ![After slash command low signal](https://gist.githubusercontent.com/evrendom/a5dac24a8c3b4d8e07536ded74132368/raw/97fe5a67db39921a5d9475a067bbbfc7b2c14c1c/after-tools-low-signal.svg) |

## Test plan

- [x] `bun run verify`
- [x] `bun run lint:wrapped:hig`
- [x] Captured before/after screenshots from isolated `.context` before/after dev-server copies.



