### PR TITLE
fix: keep wrapped upload polling alive

### DIFF
--- a/apps/web/src/features/get-started/use-setup-progress.test.tsx
+++ b/apps/web/src/features/get-started/use-setup-progress.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useSetupProgress } from "@/features/get-started/use-setup-progress";
 
 const {
@@ -103,6 +103,7 @@ let capturedSummaryQueryOptions: SummaryQueryOptions | null = null;
 let capturedRawQueryOptions: RawQueryOptions | null = null;
 let summaryQueryResult: QueryResult<SummaryQueryData>;
 let rawCountQueryResult: QueryResult<RawSessionCountData>;
+const keepPollingAfterUploadForMs = 10 * 60 * 1000;
 
 function getCapturedSummaryQueryOptions() {
 	if (capturedSummaryQueryOptions === null) {
@@ -157,6 +158,10 @@ describe("useSetupProgress", () => {
 		});
 	});
 
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("uses raw uploaded session count as the fastest landing signal", () => {
 		rawCountQueryResult = {
 			data: {
@@ -209,5 +214,51 @@ describe("useSetupProgress", () => {
 				},
 			}),
 		).toBe(false);
+	});
+
+	it("keeps raw polling after sessions are detected when requested", () => {
+		renderHook(() =>
+			useSetupProgress({
+				keepPollingAfterUploadForMs,
+			}),
+		);
+
+		const rawOptions = getCapturedRawQueryOptions();
+
+		expect(
+			rawOptions.refetchInterval?.({
+				state: {
+					data: {
+						count: 1,
+					},
+				},
+			}),
+		).toBe(1_000);
+	});
+
+	it("stops raw polling after the requested post-upload polling window", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+
+		renderHook(() =>
+			useSetupProgress({
+				keepPollingAfterUploadForMs,
+			}),
+		);
+
+		const rawOptions = getCapturedRawQueryOptions();
+		const uploadedQuery = {
+			state: {
+				data: {
+					count: 1,
+				},
+			},
+		};
+
+		expect(rawOptions.refetchInterval?.(uploadedQuery)).toBe(1_000);
+
+		vi.setSystemTime(keepPollingAfterUploadForMs);
+
+		expect(rawOptions.refetchInterval?.(uploadedQuery)).toBe(false);
 	});
 });

--- a/apps/web/src/features/get-started/use-setup-progress.ts
+++ b/apps/web/src/features/get-started/use-setup-progress.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 import { useAnalyticsQuery } from "@/features/analytics/queries/useAnalyticsQuery";
 import { useOrganization } from "@/features/workspace/organization/useOrganization";
 import { client, orpc } from "@/lib/orpc";
@@ -7,13 +8,40 @@ const SETUP_PROGRESS_LOOKBACK_DAYS = 365;
 const SETUP_PROGRESS_REFETCH_INTERVAL_MS = 3_000;
 const SETUP_PROGRESS_LANDING_REFETCH_INTERVAL_MS = 1_000;
 
+interface UseSetupProgressOptions {
+	enabled?: boolean;
+	keepPollingAfterUploadForMs?: number;
+}
+
 export function useSetupProgress({
 	enabled = true,
-}: {
-	enabled?: boolean;
-} = {}) {
+	keepPollingAfterUploadForMs,
+}: UseSetupProgressOptions = {}) {
 	const { state } = useOrganization();
 	const activeOrganizationId = state.activeOrg?.id;
+	const uploadPollingStartedAtRef = useRef<number | null>(null);
+
+	useEffect(() => {
+		if (!enabled || keepPollingAfterUploadForMs === undefined) {
+			uploadPollingStartedAtRef.current = null;
+		}
+	}, [enabled, keepPollingAfterUploadForMs]);
+
+	function shouldKeepPollingAfterUpload(totalSessions: number) {
+		if (keepPollingAfterUploadForMs === undefined || totalSessions <= 0) {
+			return false;
+		}
+
+		if (uploadPollingStartedAtRef.current === null) {
+			uploadPollingStartedAtRef.current = Date.now();
+		}
+
+		return (
+			Date.now() - uploadPollingStartedAtRef.current <
+			keepPollingAfterUploadForMs
+		);
+	}
+
 	const summaryQuery = useAnalyticsQuery({
 		...orpc.analytics.sessions.summary.queryOptions({
 			input: { days: SETUP_PROGRESS_LOOKBACK_DAYS },
@@ -24,7 +52,10 @@ export function useSetupProgress({
 		enabled,
 		refetchInterval: (query) => {
 			const totalSessions = query.state.data?.total_sessions ?? 0;
-			if (!enabled || totalSessions > 0) {
+			if (
+				!enabled ||
+				(totalSessions > 0 && !shouldKeepPollingAfterUpload(totalSessions))
+			) {
 				return false;
 			}
 
@@ -45,7 +76,10 @@ export function useSetupProgress({
 		enabled: enabled && !!activeOrganizationId,
 		refetchInterval: (query) => {
 			const totalSessions = query.state.data?.count ?? 0;
-			if (!enabled || totalSessions > 0) {
+			if (
+				!enabled ||
+				(totalSessions > 0 && !shouldKeepPollingAfterUpload(totalSessions))
+			) {
 				return false;
 			}
 

--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -214,6 +214,7 @@ vi.mock("@/features/wrapped/team-card/page", () => ({
 }));
 
 const now = new Date("2026-04-22T10:00:00.000Z");
+const wrappedSetupKeepPollingAfterUploadMs = 10 * 60 * 1000;
 
 const session: NonNullable<AppSession> = {
 	session: {
@@ -831,6 +832,10 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByText("Readiness: missing")).toBeInTheDocument();
 		expect(screen.getByText("Total sessions: 3")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Start story" })).toBeDisabled();
+		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
+			enabled: true,
+			keepPollingAfterUploadForMs: wrappedSetupKeepPollingAfterUploadMs,
+		});
 		expect(mockUseAnalyticsQuery).not.toHaveBeenCalled();
 	});
 
@@ -1096,6 +1101,10 @@ describe("WrappedRouteGate", () => {
 		);
 
 		expect(screen.getByText("Wrapped story")).toBeInTheDocument();
+		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
+			enabled: true,
+			keepPollingAfterUploadForMs: undefined,
+		});
 	});
 
 	it("honors the sessions-landed flow even after setup completion was acknowledged", () => {
@@ -1179,6 +1188,10 @@ describe("WrappedRouteGate", () => {
 		await user.click(screen.getByRole("button", { name: "Start story" }));
 		expect(screen.getByText("Wrapped story")).toBeInTheDocument();
 		expect(screen.getByText("Story step: none")).toBeInTheDocument();
+		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
+			enabled: true,
+			keepPollingAfterUploadForMs: undefined,
+		});
 	});
 
 	it("tracks setup activation completion with source share attribution", async () => {

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -76,6 +76,7 @@ const WRAPPED_SETUP_ALL_COMPLETED_STEP_IDS = [
 	WRAPPED_SETUP_AUTH_STEP_ID,
 	WRAPPED_SETUP_UPLOAD_STEP_ID,
 ] as const;
+const WRAPPED_SETUP_KEEP_POLLING_AFTER_UPLOAD_MS = 10 * 60 * 1000;
 
 export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const { isPending, publicId, session } = props;
@@ -96,15 +97,6 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const wrappedLoopEntrySource = shareId ? "share_redirect" : "direct";
 	const sessionUserId = getSessionUserId(session);
 	const sessionUserEmail = getSessionUserEmail(session);
-	const setupProgress = useSetupProgress({
-		enabled: !publicId && !!session,
-	});
-	const shouldQueryWrappedArchetypeGate =
-		!publicId &&
-		!!session &&
-		setupProgress.hasUploadedSessions &&
-		setupProgress.totalSessionCount >=
-			WRAPPED_ARCHETYPE_GATE_THRESHOLDS.min_total_sessions;
 	const cliSetupStatus = useCliSetupStatus({
 		enabled: !publicId && !!session,
 	});
@@ -137,6 +129,18 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 			? false
 			: completedSetupUserIds[sessionUserId] === true ||
 				hasCompletedWrappedSetup(sessionUserId);
+	const setupProgress = useSetupProgress({
+		enabled: !publicId && !!session,
+		keepPollingAfterUploadForMs: hasCompletedSetup
+			? undefined
+			: WRAPPED_SETUP_KEEP_POLLING_AFTER_UPLOAD_MS,
+	});
+	const shouldQueryWrappedArchetypeGate =
+		!publicId &&
+		!!session &&
+		setupProgress.hasUploadedSessions &&
+		setupProgress.totalSessionCount >=
+			WRAPPED_ARCHETYPE_GATE_THRESHOLDS.min_total_sessions;
 	const hasCompletedCardProfile =
 		sessionUserId !== null &&
 		(completedCardProfileUserIds[sessionUserId] === true ||

--- a/apps/web/src/features/wrapped/WrappedSetupCompletePage.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedSetupCompletePage.test.tsx
@@ -57,7 +57,7 @@ describe("WrappedSetupCompletePage", () => {
 			<MemoryRouter>
 				<WrappedSetupCompletePage
 					onContinue={onContinue}
-					totalSessionCount={99}
+					totalSessionCount={11}
 					userId="user-1"
 				/>
 			</MemoryRouter>,
@@ -115,6 +115,48 @@ describe("WrappedSetupCompletePage", () => {
 		await waitFor(() => expect(onContinue).toHaveBeenCalledTimes(1), {
 			timeout: 2000,
 		});
+	});
+
+	it("prefers the fresher raw session total over stale repo rows", () => {
+		const onContinue = vi.fn();
+
+		mockUseAnalyticsQuery.mockReturnValue({
+			data: [
+				{
+					first_session: "2026-04-22T10:00:00Z",
+					git_remote: "github.com/acme/geneva.git",
+					last_session: "2026-04-22T10:00:00Z",
+					package_name: "",
+					project_path: "/Users/ada/geneva",
+					sessions: 8,
+					total_duration_min: 90,
+					total_tokens: 1200,
+				},
+				{
+					first_session: "2026-04-22T10:00:00Z",
+					git_remote: "",
+					last_session: "2026-04-22T10:00:00Z",
+					package_name: "@acme/design-system",
+					project_path: "/Users/ada/design-system",
+					sessions: 3,
+					total_duration_min: 45,
+					total_tokens: 900,
+				},
+			],
+			isLoading: false,
+		});
+
+		render(
+			<MemoryRouter>
+				<WrappedSetupCompletePage
+					onContinue={onContinue}
+					totalSessionCount={99}
+					userId="user-1"
+				/>
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("99 sessions across 2 repos")).toBeInTheDocument();
 	});
 
 	it("renders debug override repos without relying on analytics data", async () => {

--- a/apps/web/src/features/wrapped/WrappedSetupCompletePage.tsx
+++ b/apps/web/src/features/wrapped/WrappedSetupCompletePage.tsx
@@ -79,7 +79,7 @@ export function WrappedSetupCompletePage(props: WrappedSetupCompletePageProps) {
 			(sum, repo) => sum + repo.sessions,
 			0,
 		);
-		return repoSessionCount > 0 ? repoSessionCount : props.totalSessionCount;
+		return Math.max(repoSessionCount, props.totalSessionCount);
 	}, [props.totalSessionCount, uploadedRepos]);
 	const sessionReadinessState = getWrappedSetupCompleteResolvedReadinessState({
 		minimumSessionCount: props.minimumSessionCount,

--- a/apps/web/src/features/wrapped/WrappedUploadPollingSmoke.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedUploadPollingSmoke.test.tsx
@@ -1,0 +1,219 @@
+import {
+	QueryClient,
+	type QueryClientConfig,
+	QueryClientProvider,
+} from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppSession } from "@/features/auth/auth-route-utils";
+import { WrappedRouteGate } from "@/features/wrapped/WrappedRouteGate";
+
+const {
+	mockGetOrganizationSessionCount,
+	mockUseAnalyticsTracking,
+	mockUseCliSetupStatus,
+	mockUseIsMobile,
+	mockUseOrganization,
+} = vi.hoisted(() => ({
+	mockGetOrganizationSessionCount: vi.fn(),
+	mockUseAnalyticsTracking: vi.fn(),
+	mockUseCliSetupStatus: vi.fn(),
+	mockUseIsMobile: vi.fn(),
+	mockUseOrganization: vi.fn(),
+}));
+
+vi.mock("@/app/hooks/use-mobile", () => ({
+	useIsMobile: mockUseIsMobile,
+}));
+
+vi.mock("@/features/analytics/tracking/useAnalyticsTracking", () => ({
+	useAnalyticsTracking: mockUseAnalyticsTracking,
+}));
+
+vi.mock("@/features/get-started/use-cli-setup-status", () => ({
+	useCliSetupStatus: mockUseCliSetupStatus,
+}));
+
+vi.mock("@/features/workspace/organization/useOrganization", () => ({
+	useOrganization: mockUseOrganization,
+}));
+
+let rawSessionCount = 45;
+
+vi.mock("@/lib/orpc", () => ({
+	client: {
+		getOrganizationSessionCount: mockGetOrganizationSessionCount,
+	},
+	orpc: {
+		analytics: {
+			developers: {
+				projects: {
+					queryOptions: () => ({
+						queryFn: async () => [
+							{
+								first_session: "2026-04-22T10:00:00Z",
+								git_remote: "github.com/acme/geneva.git",
+								last_session: "2026-04-22T10:00:00Z",
+								package_name: "",
+								project_path: "/Users/ada/geneva",
+								sessions: 45,
+								total_duration_min: 90,
+								total_tokens: 1200,
+							},
+						],
+						queryKey: ["analytics", "developers", "projects"],
+					}),
+				},
+			},
+			sessions: {
+				summary: {
+					queryOptions: () => ({
+						queryFn: async () => ({
+							total_sessions: rawSessionCount,
+						}),
+						queryKey: ["analytics", "sessions", "summary"],
+					}),
+				},
+			},
+			wrapped: {
+				v1: {
+					queryOptions: () => ({
+						queryFn: async () => ({
+							archetype_gate: {
+								is_eligible: false,
+								reason: "session_threshold",
+								thresholds: {
+									min_total_sessions: 100,
+								},
+								values: {
+									total_sessions: rawSessionCount,
+								},
+							},
+						}),
+						queryKey: ["analytics", "wrapped", "v1"],
+					}),
+				},
+			},
+		},
+	},
+}));
+
+const queryClientConfig: QueryClientConfig = {
+	defaultOptions: {
+		queries: {
+			gcTime: Infinity,
+			retry: false,
+			staleTime: 0,
+		},
+	},
+};
+
+const now = new Date("2026-04-22T10:00:00.000Z");
+
+const session: NonNullable<AppSession> = {
+	session: {
+		id: "session-1",
+		token: "token-1",
+		userId: "user-1",
+		createdAt: now,
+		updatedAt: now,
+		expiresAt: now,
+	},
+	user: {
+		id: "user-1",
+		email: "ada@example.com",
+		name: "Ada Lovelace",
+		emailVerified: true,
+		image: "https://rudel.ai/uploads/ada.png",
+		createdAt: now,
+		updatedAt: now,
+	},
+};
+
+function createWrapper(queryClient: QueryClient) {
+	return function WrappedPollingSmokeWrapper(props: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={queryClient}>
+				<MemoryRouter initialEntries={["/wrapped"]}>
+					{props.children}
+				</MemoryRouter>
+			</QueryClientProvider>
+		);
+	};
+}
+
+describe("Wrapped upload polling smoke", () => {
+	beforeEach(() => {
+		rawSessionCount = 45;
+		mockGetOrganizationSessionCount.mockReset();
+		mockUseAnalyticsTracking.mockReset();
+		mockUseCliSetupStatus.mockReset();
+		mockUseIsMobile.mockReset();
+		mockUseOrganization.mockReset();
+		window.localStorage.clear();
+		window.sessionStorage.clear();
+
+		mockGetOrganizationSessionCount.mockImplementation(async () => ({
+			count: rawSessionCount,
+		}));
+		mockUseAnalyticsTracking.mockReturnValue({
+			trackWrappedActivationCompleted: vi.fn(),
+			trackWrappedOnboardingStarted: vi.fn(),
+			trackWrappedProfileCompleted: vi.fn(),
+			trackWrappedReferredSignupCompleted: vi.fn(),
+		});
+		mockUseCliSetupStatus.mockReturnValue({
+			hasCliLogin: true,
+			isLoading: false,
+		});
+		mockUseIsMobile.mockReturnValue(false);
+		mockUseOrganization.mockReturnValue({
+			state: {
+				activeOrg: {
+					id: "org-1",
+					name: "Org",
+					slug: "org",
+				},
+				isLoading: false,
+				organizations: [],
+			},
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("updates the missing session count on the next poll after a second upload", async () => {
+		const queryClient = new QueryClient(queryClientConfig);
+
+		render(
+			<WrappedRouteGate isPending={false} publicId={null} session={session} />,
+			{
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		expect(
+			await screen.findByRole("heading", { name: "55 sessions missing" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("45 sessions across 1 repo")).toBeInTheDocument();
+
+		rawSessionCount = 63;
+
+		await waitFor(
+			() => {
+				expect(
+					screen.getByRole("heading", { name: "37 sessions missing" }),
+				).toBeInTheDocument();
+			},
+			{ timeout: 1_500 },
+		);
+		expect(screen.getByText("63 sessions across 1 repo")).toBeInTheDocument();
+		expect(mockGetOrganizationSessionCount).toHaveBeenCalledTimes(2);
+
+		queryClient.clear();
+	});
+});


### PR DESCRIPTION
## Summary
- keep setup progress polling after the first wrapped upload for up to 10 minutes while setup is not complete
- stop the extra polling once the user continues into the story
- prefer the fresher raw session count over stale repo rows on the upload gate
- add a route-level smoke test for repeated uploads updating the missing-session screen on the next 1s poll

## Test plan
- [x] bun --cwd apps/web test src/features/wrapped/WrappedUploadPollingSmoke.test.tsx
- [x] bun --cwd apps/web test src/features/get-started/use-setup-progress.test.tsx src/features/get-started/use-setup-progress.polling.test.tsx
- [x] bun --cwd apps/web test src/features/wrapped/WrappedSetupCompletePage.test.tsx src/features/wrapped/WrappedRouteGate.test.tsx
- [x] bun run verify
- [x] bun run lint:wrapped:hig