### PR TITLE
fix: clarify CLI upload server errors

### DIFF
--- a/apps/cli/src/__tests__/uploader.test.ts
+++ b/apps/cli/src/__tests__/uploader.test.ts
@@ -37,4 +37,43 @@ describe("formatUploadError", () => {
 
 		expect(formatUploadError(error)).toBe("401 Unauthorized");
 	});
+
+	test("explains oversized upload requests", () => {
+		const error = new ORPCError("PAYLOAD_TOO_LARGE", {
+			status: 413,
+			data: {
+				body: {
+					error: "Request body too large. Maximum size is 500 MB.",
+				},
+			},
+		});
+
+		expect(formatUploadError(error)).toBe(
+			"Upload request is too large (413 Payload Too Large). Request body too large. Maximum size is 500 MB. This is a request-size limit, not an auth or proxy issue. This session will keep failing until its transcript/subagent payload is smaller; other failed sessions can still be retried with: rudel upload --retry",
+		);
+	});
+
+	test("explains transient gateway errors", () => {
+		const error = new ORPCError("BAD_GATEWAY");
+
+		expect(formatUploadError(error)).toBe(
+			"Temporary Rudel server/proxy error (502 Bad Gateway). The CLI retries these automatically; retry remaining failed uploads with: rudel upload --retry",
+		);
+	});
+
+	test("explains non-retryable server errors", () => {
+		const error = new ORPCError("INTERNAL_SERVER_ERROR");
+
+		expect(formatUploadError(error)).toBe(
+			"Rudel server error (500 Internal Server Error). This is not an auth problem. Retry later with: rudel upload --retry; if it repeats, share this status with the Rudel team.",
+		);
+	});
+
+	test("explains network errors", () => {
+		const error = new TypeError("fetch failed");
+
+		expect(formatUploadError(error)).toBe(
+			"Network error while contacting Rudel API: fetch failed. Check your connection and retry with: rudel upload --retry",
+		);
+	});
 });

--- a/apps/cli/src/lib/uploader.ts
+++ b/apps/cli/src/lib/uploader.ts
@@ -11,7 +11,7 @@ export interface UploadConfig {
 	onRetry?: (attempt: number, maxAttempts: number, error: string) => void;
 }
 
-const RETRYABLE_STATUS_CODES = new Set([502, 503]);
+const RETRYABLE_STATUS_CODES = new Set([502, 503, 504]);
 const MAX_ATTEMPTS = 3;
 const BASE_DELAY_MS = 1_000;
 
@@ -36,6 +36,18 @@ function isRetryable(error: unknown): boolean {
 
 function isRateLimited(error: unknown): error is ORPCError<string, unknown> {
 	return error instanceof ORPCError && error.status === 429;
+}
+
+function isPayloadTooLarge(
+	error: unknown,
+): error is ORPCError<string, unknown> {
+	return error instanceof ORPCError && error.status === 413;
+}
+
+function isServerError(error: unknown): error is ORPCError<string, unknown> {
+	return (
+		error instanceof ORPCError && error.status >= 500 && error.status <= 599
+	);
 }
 
 function isApiKeyRateLimited(
@@ -70,13 +82,47 @@ export function formatUploadError(error: unknown): string {
 		const limit = data?.limit ?? "unknown";
 		return `Rate limit reached (${limit} sessions per ${windowMin} min). Wait and retry with: rudel upload --retry`;
 	}
+	if (isPayloadTooLarge(error)) {
+		return formatPayloadTooLargeError(error);
+	}
+	if (isServerError(error)) {
+		return formatServerUploadError(error);
+	}
 	if (error instanceof ORPCError) {
 		return `${error.status} ${error.message}`;
+	}
+	if (error instanceof TypeError) {
+		return `Network error while contacting Rudel API: ${error.message}. Check your connection and retry with: rudel upload --retry`;
 	}
 	if (error instanceof Error) {
 		return error.message;
 	}
 	return String(error);
+}
+
+function formatPayloadTooLargeError(error: ORPCError<string, unknown>): string {
+	const status = `${error.status} ${error.message}`;
+	const detail = getPayloadTooLargeDetail(error);
+	const detailText = detail ? ` ${detail}` : "";
+	return `Upload request is too large (${status}).${detailText} This is a request-size limit, not an auth or proxy issue. This session will keep failing until its transcript/subagent payload is smaller; other failed sessions can still be retried with: rudel upload --retry`;
+}
+
+function formatServerUploadError(error: ORPCError<string, unknown>): string {
+	const status = `${error.status} ${error.message}`;
+	if (RETRYABLE_STATUS_CODES.has(error.status)) {
+		return `Temporary Rudel server/proxy error (${status}). The CLI retries these automatically; retry remaining failed uploads with: rudel upload --retry`;
+	}
+
+	return `Rudel server error (${status}). This is not an auth problem. Retry later with: rudel upload --retry; if it repeats, share this status with the Rudel team.`;
+}
+
+function getPayloadTooLargeDetail(
+	error: ORPCError<string, unknown>,
+): string | null {
+	const data = isRecord(error.data) ? error.data : null;
+	const bodyValue = data?.body;
+	const body = isRecord(bodyValue) ? bodyValue : null;
+	return getStringField(body, "error") ?? getStringField(data, "error");
 }
 
 function getErrorData(error: ORPCError<string, unknown>): ErrorData {
@@ -122,7 +168,7 @@ function formatWait(milliseconds: number) {
 
 /**
  * Upload a session transcript to the backend via oRPC.
- * Retries on transient errors (502, 503) with exponential backoff.
+ * Retries on transient errors (502, 503, 504) with exponential backoff.
  * Rate limit errors (429) are not retried — the window is too long.
  */
 export async function uploadSession(


### PR DESCRIPTION
## Summary
- Replace vague CLI upload 5xx messages with clearer server/proxy and retry guidance.
- Add an explicit oversized-upload message for 413 request-size failures.
- Treat 504 gateway timeouts as retryable alongside 502/503.
- Add formatter tests for oversized, gateway, server, and network errors.

## Test plan
- [x] bun test apps/cli/src/__tests__/uploader.test.ts
- [x] bun run --cwd apps/cli check-types
- [x] ./node_modules/.bin/biome check apps/cli/src/lib/uploader.ts apps/cli/src/__tests__/uploader.test.ts
- [x] bun run verify