### PR TITLE
fix: poll wrapped setup screens after reload

### DIFF
--- a/apps/web/src/features/get-started/use-setup-progress.test.tsx
+++ b/apps/web/src/features/get-started/use-setup-progress.test.tsx
@@ -1,15 +1,19 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useSetupProgress } from "@/features/get-started/use-setup-progress";
 
 const {
 	mockGetOrganizationSessionCount,
+	mockRemoveQueries,
+	mockResetQueries,
 	mockSummaryQueryOptions,
 	mockUseAnalyticsQuery,
 	mockUseOrganization,
 	mockUseQuery,
 } = vi.hoisted(() => ({
 	mockGetOrganizationSessionCount: vi.fn(),
+	mockRemoveQueries: vi.fn(),
+	mockResetQueries: vi.fn(),
 	mockSummaryQueryOptions: vi.fn(),
 	mockUseAnalyticsQuery: vi.fn(),
 	mockUseOrganization: vi.fn(),
@@ -18,6 +22,10 @@ const {
 
 vi.mock("@tanstack/react-query", () => ({
 	useQuery: mockUseQuery,
+	useQueryClient: () => ({
+		removeQueries: mockRemoveQueries,
+		resetQueries: mockResetQueries,
+	}),
 }));
 
 vi.mock("@/features/analytics/queries/useAnalyticsQuery", () => ({
@@ -103,7 +111,6 @@ let capturedSummaryQueryOptions: SummaryQueryOptions | null = null;
 let capturedRawQueryOptions: RawQueryOptions | null = null;
 let summaryQueryResult: QueryResult<SummaryQueryData>;
 let rawCountQueryResult: QueryResult<RawSessionCountData>;
-const keepPollingAfterUploadForMs = 10 * 60 * 1000;
 
 function getCapturedSummaryQueryOptions() {
 	if (capturedSummaryQueryOptions === null) {
@@ -129,6 +136,8 @@ describe("useSetupProgress", () => {
 		rawCountQueryResult = defaultRawCountQueryResult;
 
 		mockGetOrganizationSessionCount.mockReset();
+		mockRemoveQueries.mockReset();
+		mockResetQueries.mockReset();
 		mockSummaryQueryOptions.mockReset();
 		mockUseAnalyticsQuery.mockReset();
 		mockUseOrganization.mockReset();
@@ -156,6 +165,7 @@ describe("useSetupProgress", () => {
 			capturedRawQueryOptions = options;
 			return rawCountQueryResult;
 		});
+		mockResetQueries.mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
@@ -219,7 +229,7 @@ describe("useSetupProgress", () => {
 	it("keeps raw polling after sessions are detected when requested", () => {
 		renderHook(() =>
 			useSetupProgress({
-				keepPollingAfterUploadForMs,
+				keepPollingAfterUpload: true,
 			}),
 		);
 
@@ -236,13 +246,13 @@ describe("useSetupProgress", () => {
 		).toBe(1_000);
 	});
 
-	it("stops raw polling after the requested post-upload polling window", () => {
+	it("keeps raw polling after ten minutes when requested", () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(0);
 
 		renderHook(() =>
 			useSetupProgress({
-				keepPollingAfterUploadForMs,
+				keepPollingAfterUpload: true,
 			}),
 		);
 
@@ -257,8 +267,43 @@ describe("useSetupProgress", () => {
 
 		expect(rawOptions.refetchInterval?.(uploadedQuery)).toBe(1_000);
 
-		vi.setSystemTime(keepPollingAfterUploadForMs);
+		vi.setSystemTime(10 * 60 * 1000);
 
-		expect(rawOptions.refetchInterval?.(uploadedQuery)).toBe(false);
+		expect(rawOptions.refetchInterval?.(uploadedQuery)).toBe(1_000);
+	});
+
+	it("refreshes cached analytics when the uploaded session count increases", async () => {
+		rawCountQueryResult = {
+			data: {
+				count: 72,
+			},
+			isFetched: true,
+			isPending: false,
+		};
+
+		const { rerender } = renderHook(() => useSetupProgress());
+
+		expect(mockRemoveQueries).not.toHaveBeenCalled();
+		expect(mockResetQueries).not.toHaveBeenCalled();
+
+		rawCountQueryResult = {
+			data: {
+				count: 132,
+			},
+			isFetched: true,
+			isPending: false,
+		};
+		rerender();
+
+		await waitFor(() => {
+			expect(mockRemoveQueries).toHaveBeenCalledWith({
+				queryKey: ["org", "org-1", "analytics"],
+				type: "inactive",
+			});
+		});
+		expect(mockResetQueries).toHaveBeenCalledWith({
+			queryKey: ["org", "org-1", "analytics"],
+			type: "active",
+		});
 	});
 });

--- a/apps/web/src/features/get-started/use-setup-progress.ts
+++ b/apps/web/src/features/get-started/use-setup-progress.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { useAnalyticsQuery } from "@/features/analytics/queries/useAnalyticsQuery";
 import { useOrganization } from "@/features/workspace/organization/useOrganization";
@@ -10,37 +10,17 @@ const SETUP_PROGRESS_LANDING_REFETCH_INTERVAL_MS = 1_000;
 
 interface UseSetupProgressOptions {
 	enabled?: boolean;
-	keepPollingAfterUploadForMs?: number;
+	keepPollingAfterUpload?: boolean;
 }
 
 export function useSetupProgress({
 	enabled = true,
-	keepPollingAfterUploadForMs,
+	keepPollingAfterUpload = false,
 }: UseSetupProgressOptions = {}) {
 	const { state } = useOrganization();
 	const activeOrganizationId = state.activeOrg?.id;
-	const uploadPollingStartedAtRef = useRef<number | null>(null);
-
-	useEffect(() => {
-		if (!enabled || keepPollingAfterUploadForMs === undefined) {
-			uploadPollingStartedAtRef.current = null;
-		}
-	}, [enabled, keepPollingAfterUploadForMs]);
-
-	function shouldKeepPollingAfterUpload(totalSessions: number) {
-		if (keepPollingAfterUploadForMs === undefined || totalSessions <= 0) {
-			return false;
-		}
-
-		if (uploadPollingStartedAtRef.current === null) {
-			uploadPollingStartedAtRef.current = Date.now();
-		}
-
-		return (
-			Date.now() - uploadPollingStartedAtRef.current <
-			keepPollingAfterUploadForMs
-		);
-	}
+	const queryClient = useQueryClient();
+	const previousTotalSessionCountRef = useRef<number | null>(null);
 
 	const summaryQuery = useAnalyticsQuery({
 		...orpc.analytics.sessions.summary.queryOptions({
@@ -52,10 +32,7 @@ export function useSetupProgress({
 		enabled,
 		refetchInterval: (query) => {
 			const totalSessions = query.state.data?.total_sessions ?? 0;
-			if (
-				!enabled ||
-				(totalSessions > 0 && !shouldKeepPollingAfterUpload(totalSessions))
-			) {
+			if (!enabled || (totalSessions > 0 && !keepPollingAfterUpload)) {
 				return false;
 			}
 
@@ -76,10 +53,7 @@ export function useSetupProgress({
 		enabled: enabled && !!activeOrganizationId,
 		refetchInterval: (query) => {
 			const totalSessions = query.state.data?.count ?? 0;
-			if (
-				!enabled ||
-				(totalSessions > 0 && !shouldKeepPollingAfterUpload(totalSessions))
-			) {
+			if (!enabled || (totalSessions > 0 && !keepPollingAfterUpload)) {
 				return false;
 			}
 
@@ -101,6 +75,37 @@ export function useSetupProgress({
 		(state.isLoading ||
 			summaryQuery.isPending ||
 			rawSessionCountQuery.isPending);
+
+	useEffect(() => {
+		if (!enabled || !activeOrganizationId) {
+			previousTotalSessionCountRef.current = null;
+			return;
+		}
+
+		const previousTotalSessionCount = previousTotalSessionCountRef.current;
+		previousTotalSessionCountRef.current = totalSessionCount;
+
+		if (
+			previousTotalSessionCount === null ||
+			totalSessionCount <= previousTotalSessionCount
+		) {
+			return;
+		}
+
+		const analyticsQueryKey = [
+			"org",
+			activeOrganizationId,
+			"analytics",
+		] as const;
+		queryClient.removeQueries({
+			queryKey: analyticsQueryKey,
+			type: "inactive",
+		});
+		void queryClient.resetQueries({
+			queryKey: analyticsQueryKey,
+			type: "active",
+		});
+	}, [activeOrganizationId, enabled, queryClient, totalSessionCount]);
 
 	return {
 		hasUploadedSessions: totalSessionCount > 0,

--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -214,8 +214,6 @@ vi.mock("@/features/wrapped/team-card/page", () => ({
 }));
 
 const now = new Date("2026-04-22T10:00:00.000Z");
-const wrappedSetupKeepPollingAfterUploadMs = 10 * 60 * 1000;
-
 const session: NonNullable<AppSession> = {
 	session: {
 		id: "session-1",
@@ -834,7 +832,7 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByRole("button", { name: "Start story" })).toBeDisabled();
 		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
 			enabled: true,
-			keepPollingAfterUploadForMs: wrappedSetupKeepPollingAfterUploadMs,
+			keepPollingAfterUpload: true,
 		});
 		expect(mockUseAnalyticsQuery).not.toHaveBeenCalled();
 	});
@@ -900,6 +898,64 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByText("Readiness: missing")).toBeInTheDocument();
 		expect(screen.getByText("Total sessions: 38")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Start story" })).toBeDisabled();
+	});
+
+	it("waits when fresh uploads outrun cached wrapped gate data", async () => {
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 72,
+		});
+
+		const { rerender } = render(
+			<MemoryRouter initialEntries={["/wrapped?flow=sessions-landed"]}>
+				<WrappedRouteGate isPending={false} publicId={null} session={session} />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
+		expect(screen.getByText("Total sessions: 72")).toBeInTheDocument();
+
+		await waitFor(() => {
+			expect(screen.getByText("Can continue: no")).toBeInTheDocument();
+		});
+
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 132,
+		});
+		mockUseAnalyticsQuery.mockReturnValue({
+			data: {
+				archetype_gate: {
+					is_eligible: true,
+					reason: "eligible",
+					thresholds: {
+						max_distance_ratio_to_max: 0.25,
+						min_active_days: 14,
+						min_top_two_margin: 0.1,
+						min_total_sessions: 100,
+					},
+					values: {
+						active_days: 14,
+						archetype_distance_ratio_to_max: 0.1,
+						archetype_top_two_margin: 0.2,
+						total_sessions: 72,
+					},
+				},
+			},
+			isLoading: false,
+		});
+
+		rerender(
+			<MemoryRouter initialEntries={["/wrapped?flow=sessions-landed"]}>
+				<WrappedRouteGate isPending={false} publicId={null} session={session} />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Preparing your wrapped...")).toBeInTheDocument();
+		expect(screen.queryByText("Wrapped story")).toBeNull();
+		expect(screen.queryByText("Wrapped setup complete page")).toBeNull();
 	});
 
 	it("treats a legacy non-session gate reason as ready after 100 sessions", () => {
@@ -1103,7 +1159,7 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByText("Wrapped story")).toBeInTheDocument();
 		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
 			enabled: true,
-			keepPollingAfterUploadForMs: undefined,
+			keepPollingAfterUpload: false,
 		});
 	});
 
@@ -1128,6 +1184,10 @@ describe("WrappedRouteGate", () => {
 		);
 
 		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
+		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
+			enabled: true,
+			keepPollingAfterUpload: true,
+		});
 	});
 
 	it("returns from the first story page to the upload screen", async () => {
@@ -1163,6 +1223,10 @@ describe("WrappedRouteGate", () => {
 			),
 		).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
+		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
+			enabled: true,
+			keepPollingAfterUpload: true,
+		});
 	});
 
 	it("restarts the story from scale when continuing from sessions landed", async () => {
@@ -1190,7 +1254,7 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByText("Story step: none")).toBeInTheDocument();
 		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
 			enabled: true,
-			keepPollingAfterUploadForMs: undefined,
+			keepPollingAfterUpload: false,
 		});
 	});
 

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -76,7 +76,6 @@ const WRAPPED_SETUP_ALL_COMPLETED_STEP_IDS = [
 	WRAPPED_SETUP_AUTH_STEP_ID,
 	WRAPPED_SETUP_UPLOAD_STEP_ID,
 ] as const;
-const WRAPPED_SETUP_KEEP_POLLING_AFTER_UPLOAD_MS = 10 * 60 * 1000;
 
 export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const { isPending, publicId, session } = props;
@@ -129,11 +128,13 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 			? false
 			: completedSetupUserIds[sessionUserId] === true ||
 				hasCompletedWrappedSetup(sessionUserId);
+	const shouldKeepPollingAfterUpload =
+		!hasCompletedSetup ||
+		forcedFlowStage === WRAPPED_ROUTE_DESKTOP_READY_FLOW ||
+		forcedFlowStage === WRAPPED_ROUTE_SESSIONS_LANDED_FLOW;
 	const setupProgress = useSetupProgress({
 		enabled: !publicId && !!session,
-		keepPollingAfterUploadForMs: hasCompletedSetup
-			? undefined
-			: WRAPPED_SETUP_KEEP_POLLING_AFTER_UPLOAD_MS,
+		keepPollingAfterUpload: shouldKeepPollingAfterUpload,
 	});
 	const shouldQueryWrappedArchetypeGate =
 		!publicId &&
@@ -702,14 +703,22 @@ function getWrappedRouteSessionGateState(input: {
 	const minimumSessionCount =
 		input.archetypeGate?.thresholds.min_total_sessions ??
 		WRAPPED_ARCHETYPE_GATE_THRESHOLDS.min_total_sessions;
+	const archetypeGateSessionCount =
+		input.archetypeGate?.values.total_sessions ?? null;
+	const isWaitingForFreshWrappedData =
+		input.hasReachedMinimumAfterMissing &&
+		archetypeGateSessionCount !== null &&
+		archetypeGateSessionCount < input.setupProgressTotalSessionCount;
 	const totalSessionCount =
-		input.archetypeGate?.values.total_sessions ??
-		input.setupProgressTotalSessionCount;
+		isWaitingForFreshWrappedData || archetypeGateSessionCount === null
+			? input.setupProgressTotalSessionCount
+			: archetypeGateSessionCount;
 	const hasMinimumArchetypeSessionCount =
 		totalSessionCount >= minimumSessionCount;
 	const isWaitingForStoryData =
 		hasMinimumArchetypeSessionCount &&
 		(input.isArchetypeGateLoading ||
+			isWaitingForFreshWrappedData ||
 			input.archetypeGate === null ||
 			input.archetypeGate.reason === "processing_archetype");
 	const canContinueToStory =

--- a/apps/web/src/features/wrapped/WrappedUploadPollingSmoke.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedUploadPollingSmoke.test.tsx
@@ -9,6 +9,7 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppSession } from "@/features/auth/auth-route-utils";
 import { WrappedRouteGate } from "@/features/wrapped/WrappedRouteGate";
+import { getWrappedSetupCompletionStorageKey } from "@/features/wrapped/wrapped-setup-state";
 
 const {
 	mockGetOrganizationSessionCount,
@@ -132,11 +133,11 @@ const session: NonNullable<AppSession> = {
 	},
 };
 
-function createWrapper(queryClient: QueryClient) {
+function createWrapper(queryClient: QueryClient, initialEntry = "/wrapped") {
 	return function WrappedPollingSmokeWrapper(props: { children: ReactNode }) {
 		return (
 			<QueryClientProvider client={queryClient}>
-				<MemoryRouter initialEntries={["/wrapped"]}>
+				<MemoryRouter initialEntries={[initialEntry]}>
 					{props.children}
 				</MemoryRouter>
 			</QueryClientProvider>
@@ -186,6 +187,16 @@ describe("Wrapped upload polling smoke", () => {
 		vi.useRealTimers();
 	});
 
+	function markSetupCompleted() {
+		const storageKey = getWrappedSetupCompletionStorageKey(session.user.id);
+
+		if (storageKey === null) {
+			throw new Error("Expected wrapped setup completion storage key");
+		}
+
+		window.localStorage.setItem(storageKey, "true");
+	}
+
 	it("updates the missing session count on the next poll after a second upload", async () => {
 		const queryClient = new QueryClient(queryClientConfig);
 
@@ -193,6 +204,38 @@ describe("Wrapped upload polling smoke", () => {
 			<WrappedRouteGate isPending={false} publicId={null} session={session} />,
 			{
 				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		expect(
+			await screen.findByRole("heading", { name: "55 sessions missing" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("45 sessions across 1 repo")).toBeInTheDocument();
+
+		rawSessionCount = 63;
+
+		await waitFor(
+			() => {
+				expect(
+					screen.getByRole("heading", { name: "37 sessions missing" }),
+				).toBeInTheDocument();
+			},
+			{ timeout: 1_500 },
+		);
+		expect(screen.getByText("63 sessions across 1 repo")).toBeInTheDocument();
+		expect(mockGetOrganizationSessionCount).toHaveBeenCalledTimes(2);
+
+		queryClient.clear();
+	});
+
+	it("keeps polling after reloading the repos screen from a completed setup", async () => {
+		const queryClient = new QueryClient(queryClientConfig);
+		markSetupCompleted();
+
+		render(
+			<WrappedRouteGate isPending={false} publicId={null} session={session} />,
+			{
+				wrapper: createWrapper(queryClient, "/wrapped?flow=sessions-landed"),
 			},
 		);
 


### PR DESCRIPTION
## Summary
- keep private wrapped polling active for the whole wrapped route, not only the setup and repos screens
- extract upload freshness into `useUploadAnalyticsRefresh`, which polls the raw uploaded-session count every second and refreshes org analytics when that count increases
- reuse that same hook on the team page so team cards update when newly uploaded sessions land
- keep the route in the wrapped preparation state when the fast upload count is ahead of cached wrapped gate data
- keep the setup-progress hook dumb: it now combines summary analytics with the shared raw-count freshness hook instead of owning cache invalidation itself

## Test plan
- [x] `bun --cwd apps/web test src/features/get-started/use-setup-progress.test.tsx src/features/get-started/use-setup-progress.polling.test.tsx src/features/wrapped/WrappedRouteGate.test.tsx src/features/wrapped/WrappedUploadPollingSmoke.test.tsx src/features/team/TeamPage.test.tsx`
- [x] `bun --cwd apps/web check-types`
- [x] `bun run lint:wrapped:hig`
- [x] `bun run verify`
