### PR TITLE
fix: keep upload analytics and React dev graph fresh

### DIFF
--- a/apps/web/src/features/analytics/queries/use-upload-analytics-refresh.ts
+++ b/apps/web/src/features/analytics/queries/use-upload-analytics-refresh.ts
@@ -1,0 +1,86 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+import { useOrganization } from "@/features/workspace/organization/useOrganization";
+import { client } from "@/lib/orpc";
+
+const UPLOAD_ANALYTICS_REFRESH_INTERVAL_MS = 1_000;
+
+interface UseUploadAnalyticsRefreshOptions {
+	enabled?: boolean;
+	keepPollingAfterUpload?: boolean;
+}
+
+export function useUploadAnalyticsRefresh({
+	enabled = true,
+	keepPollingAfterUpload = false,
+}: UseUploadAnalyticsRefreshOptions = {}) {
+	const { state } = useOrganization();
+	const activeOrganizationId = state.activeOrg?.id;
+	const queryClient = useQueryClient();
+	const previousRawSessionCountRef = useRef<number | null>(null);
+	const rawSessionCountQuery = useQuery({
+		queryKey: [
+			"upload-analytics-refresh",
+			"raw-session-count",
+			activeOrganizationId,
+		],
+		queryFn: async () => {
+			if (!activeOrganizationId) {
+				return { count: 0 };
+			}
+
+			return client.getOrganizationSessionCount({
+				organizationId: activeOrganizationId,
+			});
+		},
+		enabled: enabled && !!activeOrganizationId,
+		refetchInterval: (query) => {
+			const rawSessionCount = query.state.data?.count ?? 0;
+			if (!enabled || (rawSessionCount > 0 && !keepPollingAfterUpload)) {
+				return false;
+			}
+
+			return UPLOAD_ANALYTICS_REFRESH_INTERVAL_MS;
+		},
+		refetchIntervalInBackground: true,
+		refetchOnReconnect: "always",
+		refetchOnWindowFocus: "always",
+	});
+	const rawSessionCount = rawSessionCountQuery.data?.count ?? 0;
+
+	useEffect(() => {
+		if (!enabled || !activeOrganizationId) {
+			previousRawSessionCountRef.current = null;
+			return;
+		}
+
+		const previousRawSessionCount = previousRawSessionCountRef.current;
+		previousRawSessionCountRef.current = rawSessionCount;
+
+		if (
+			previousRawSessionCount === null ||
+			rawSessionCount <= previousRawSessionCount
+		) {
+			return;
+		}
+
+		const analyticsQueryKey = [
+			"org",
+			activeOrganizationId,
+			"analytics",
+		] as const;
+		queryClient.removeQueries({
+			queryKey: analyticsQueryKey,
+			type: "inactive",
+		});
+		void queryClient.resetQueries({
+			queryKey: analyticsQueryKey,
+			type: "active",
+		});
+	}, [activeOrganizationId, enabled, queryClient, rawSessionCount]);
+
+	return {
+		rawSessionCount,
+		rawSessionCountQuery,
+	};
+}

--- a/apps/web/src/features/get-started/use-setup-progress.ts
+++ b/apps/web/src/features/get-started/use-setup-progress.ts
@@ -1,12 +1,10 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef } from "react";
+import { useUploadAnalyticsRefresh } from "@/features/analytics/queries/use-upload-analytics-refresh";
 import { useAnalyticsQuery } from "@/features/analytics/queries/useAnalyticsQuery";
 import { useOrganization } from "@/features/workspace/organization/useOrganization";
-import { client, orpc } from "@/lib/orpc";
+import { orpc } from "@/lib/orpc";
 
 const SETUP_PROGRESS_LOOKBACK_DAYS = 365;
 const SETUP_PROGRESS_REFETCH_INTERVAL_MS = 3_000;
-const SETUP_PROGRESS_LANDING_REFETCH_INTERVAL_MS = 1_000;
 
 interface UseSetupProgressOptions {
 	enabled?: boolean;
@@ -18,9 +16,10 @@ export function useSetupProgress({
 	keepPollingAfterUpload = false,
 }: UseSetupProgressOptions = {}) {
 	const { state } = useOrganization();
-	const activeOrganizationId = state.activeOrg?.id;
-	const queryClient = useQueryClient();
-	const previousTotalSessionCountRef = useRef<number | null>(null);
+	const { rawSessionCount, rawSessionCountQuery } = useUploadAnalyticsRefresh({
+		enabled,
+		keepPollingAfterUpload,
+	});
 
 	const summaryQuery = useAnalyticsQuery({
 		...orpc.analytics.sessions.summary.queryOptions({
@@ -39,34 +38,10 @@ export function useSetupProgress({
 			return SETUP_PROGRESS_REFETCH_INTERVAL_MS;
 		},
 	});
-	const rawSessionCountQuery = useQuery({
-		queryKey: ["setup-progress", "raw-session-count", activeOrganizationId],
-		queryFn: async () => {
-			if (!activeOrganizationId) {
-				return { count: 0 };
-			}
-
-			return client.getOrganizationSessionCount({
-				organizationId: activeOrganizationId,
-			});
-		},
-		enabled: enabled && !!activeOrganizationId,
-		refetchInterval: (query) => {
-			const totalSessions = query.state.data?.count ?? 0;
-			if (!enabled || (totalSessions > 0 && !keepPollingAfterUpload)) {
-				return false;
-			}
-
-			return SETUP_PROGRESS_LANDING_REFETCH_INTERVAL_MS;
-		},
-		refetchIntervalInBackground: true,
-		refetchOnReconnect: "always",
-		refetchOnWindowFocus: "always",
-	});
 
 	const totalSessionCount = Math.max(
 		summaryQuery.data?.total_sessions ?? 0,
-		rawSessionCountQuery.data?.count ?? 0,
+		rawSessionCount,
 	);
 	const isInitialLoading =
 		enabled &&
@@ -75,37 +50,6 @@ export function useSetupProgress({
 		(state.isLoading ||
 			summaryQuery.isPending ||
 			rawSessionCountQuery.isPending);
-
-	useEffect(() => {
-		if (!enabled || !activeOrganizationId) {
-			previousTotalSessionCountRef.current = null;
-			return;
-		}
-
-		const previousTotalSessionCount = previousTotalSessionCountRef.current;
-		previousTotalSessionCountRef.current = totalSessionCount;
-
-		if (
-			previousTotalSessionCount === null ||
-			totalSessionCount <= previousTotalSessionCount
-		) {
-			return;
-		}
-
-		const analyticsQueryKey = [
-			"org",
-			activeOrganizationId,
-			"analytics",
-		] as const;
-		queryClient.removeQueries({
-			queryKey: analyticsQueryKey,
-			type: "inactive",
-		});
-		void queryClient.resetQueries({
-			queryKey: analyticsQueryKey,
-			type: "active",
-		});
-	}, [activeOrganizationId, enabled, queryClient, totalSessionCount]);
 
 	return {
 		hasUploadedSessions: totalSessionCount > 0,

--- a/apps/web/src/features/team/TeamPage.test.tsx
+++ b/apps/web/src/features/team/TeamPage.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TeamPage } from "@/features/team/TeamPage";
+
+const { mockUseTeamPageData, mockUseUploadAnalyticsRefresh } = vi.hoisted(
+	() => ({
+		mockUseTeamPageData: vi.fn(),
+		mockUseUploadAnalyticsRefresh: vi.fn(),
+	}),
+);
+
+vi.mock("@/features/analytics/queries/use-upload-analytics-refresh", () => ({
+	useUploadAnalyticsRefresh: mockUseUploadAnalyticsRefresh,
+}));
+
+vi.mock("@/features/team/components/TeamMembersCardGrid", () => ({
+	TeamMembersCardGrid: ({ rows }: { rows: readonly unknown[] }) => (
+		<div>Team card grid: {rows.length}</div>
+	),
+}));
+
+vi.mock("@/features/team/use-team-page-data", () => ({
+	useTeamPageData: mockUseTeamPageData,
+}));
+
+describe("TeamPage", () => {
+	beforeEach(() => {
+		mockUseTeamPageData.mockReset();
+		mockUseUploadAnalyticsRefresh.mockReset();
+		mockUseTeamPageData.mockReturnValue({
+			diagnostics: {
+				days: 365,
+				endDate: "2026-04-22",
+				endpoint: "analytics.developers.teamCards",
+				maxDays: 365,
+				organizationId: "org-1",
+				organizationName: "Org",
+				requestedDays: 365,
+				startDate: "2025-04-22",
+			},
+			error: null,
+			isError: false,
+			isPending: false,
+			refetch: vi.fn(),
+			teamCards: [],
+			teamMemberRows: [
+				{
+					activeDays: 4,
+					cost: 12,
+					displayName: "Ada",
+					email: "ada@example.com",
+					favoriteModel: "o3",
+					hasActivity: true,
+					imageUrl: null,
+					inputTokens: 120,
+					lastActiveDate: "2026-04-22",
+					outputTokens: 240,
+					role: "Member",
+					totalSessions: 12,
+					totalTokens: 360,
+					userId: "user-1",
+				},
+			],
+		});
+	});
+
+	it("keeps team cards fresh when new uploads arrive", () => {
+		render(<TeamPage />);
+
+		expect(screen.getByText("Team card grid: 1")).toBeInTheDocument();
+		expect(mockUseUploadAnalyticsRefresh).toHaveBeenCalledWith({
+			keepPollingAfterUpload: true,
+		});
+	});
+});

--- a/apps/web/src/features/team/TeamPage.tsx
+++ b/apps/web/src/features/team/TeamPage.tsx
@@ -8,6 +8,7 @@ import {
 	CardTitle,
 } from "@/app/ui/card";
 import { Skeleton } from "@/app/ui/skeleton";
+import { useUploadAnalyticsRefresh } from "@/features/analytics/queries/use-upload-analytics-refresh";
 import { TeamMembersCardGrid } from "@/features/team/components/TeamMembersCardGrid";
 import {
 	type TeamPageDiagnostics,
@@ -226,6 +227,7 @@ function TeamPageEmpty() {
 }
 
 export function TeamPage() {
+	useUploadAnalyticsRefresh({ keepPollingAfterUpload: true });
 	const {
 		diagnostics,
 		error,

--- a/apps/web/src/features/team/TeamPageUploadFreshnessSmoke.test.tsx
+++ b/apps/web/src/features/team/TeamPageUploadFreshnessSmoke.test.tsx
@@ -1,0 +1,196 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TeamPage } from "@/features/team/TeamPage";
+
+const {
+	mockGetFullOrganization,
+	mockGetOrganizationSessionCount,
+	mockUseDateRange,
+	mockUseOrganization,
+} = vi.hoisted(() => ({
+	mockGetFullOrganization: vi.fn(),
+	mockGetOrganizationSessionCount: vi.fn(),
+	mockUseDateRange: vi.fn(),
+	mockUseOrganization: vi.fn(),
+}));
+
+vi.mock("@/features/analytics/date-range/useDateRange", () => ({
+	useDateRange: mockUseDateRange,
+}));
+
+vi.mock("@/features/workspace/organization/useOrganization", () => ({
+	useOrganization: mockUseOrganization,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+	authClient: {
+		organization: {
+			getFullOrganization: mockGetFullOrganization,
+		},
+	},
+}));
+
+let rawSessionCount = 12;
+
+function buildDeveloperSummary() {
+	return {
+		active_days: 4,
+		avg_session_duration_min: 12,
+		cost: 18,
+		favorite_model: "claude-sonnet-4-5",
+		input_tokens: rawSessionCount * 100,
+		last_active_date: "2026-04-22",
+		output_tokens: rawSessionCount * 200,
+		success_rate: 1,
+		success_rate_trend: 0,
+		total_duration_min: rawSessionCount * 12,
+		total_sessions: rawSessionCount,
+		total_tokens: rawSessionCount * 300,
+		user_id: "user-1",
+	};
+}
+
+function buildTeamCard() {
+	return {
+		active_days: 4,
+		cost: 18,
+		display_name: "Ada Lovelace",
+		favorite_model: "claude-sonnet-4-5",
+		input_tokens: rawSessionCount * 100,
+		last_active_date: "2026-04-22",
+		output_tokens: rawSessionCount * 200,
+		top_skills: [],
+		total_sessions: rawSessionCount,
+		total_tokens: rawSessionCount * 300,
+		user_id: "user-1",
+	};
+}
+
+vi.mock("@/lib/orpc", () => ({
+	client: {
+		getOrganizationSessionCount: mockGetOrganizationSessionCount,
+	},
+	orpc: {
+		analytics: {
+			developers: {
+				list: {
+					queryOptions: () => ({
+						queryFn: async () => [buildDeveloperSummary()],
+						queryKey: ["analytics", "developers", "list"],
+					}),
+				},
+				teamCards: {
+					queryOptions: () => ({
+						queryFn: async () => [buildTeamCard()],
+						queryKey: ["analytics", "developers", "teamCards"],
+					}),
+				},
+			},
+		},
+	},
+}));
+
+function createWrapper(queryClient: QueryClient) {
+	return function TeamPageUploadFreshnessSmokeWrapper(props: {
+		children: ReactNode;
+	}) {
+		return (
+			<QueryClientProvider client={queryClient}>
+				{props.children}
+			</QueryClientProvider>
+		);
+	};
+}
+
+describe("TeamPage upload freshness smoke", () => {
+	beforeEach(() => {
+		rawSessionCount = 12;
+		mockGetFullOrganization.mockReset();
+		mockGetOrganizationSessionCount.mockReset();
+		mockUseDateRange.mockReset();
+		mockUseOrganization.mockReset();
+
+		mockGetFullOrganization.mockResolvedValue({
+			data: {
+				members: [
+					{
+						role: "owner",
+						user: {
+							email: "ada@example.com",
+							image: null,
+							name: "Ada Lovelace",
+						},
+						userId: "user-1",
+					},
+				],
+			},
+		});
+		mockGetOrganizationSessionCount.mockImplementation(async () => ({
+			count: rawSessionCount,
+		}));
+		mockUseDateRange.mockReturnValue({
+			actions: {
+				setDateRange: vi.fn(),
+				setEndDate: vi.fn(),
+				setStartDate: vi.fn(),
+			},
+			meta: {
+				dayCount: 365,
+				source: "default",
+			},
+			state: {
+				endDate: "2026-04-22",
+				startDate: "2025-04-22",
+			},
+		});
+		mockUseOrganization.mockReturnValue({
+			state: {
+				activeOrg: {
+					id: "org-1",
+					name: "Org",
+					slug: "org",
+				},
+				isLoading: false,
+				organizations: [],
+			},
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("updates the visible team card stats on the next poll after new uploads land", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					gcTime: Infinity,
+					retry: false,
+					staleTime: 0,
+				},
+			},
+		});
+
+		render(<TeamPage />, {
+			wrapper: createWrapper(queryClient),
+		});
+
+		expect(await screen.findByText("Ada Lovelace")).toBeInTheDocument();
+		expect(screen.getByTitle("12 sessions")).toBeInTheDocument();
+
+		rawSessionCount = 63;
+
+		await waitFor(
+			() => {
+				expect(screen.getByTitle("63 sessions")).toBeInTheDocument();
+			},
+			{ timeout: 1_500 },
+		);
+		expect(screen.queryByTitle("12 sessions")).not.toBeInTheDocument();
+		expect(mockGetOrganizationSessionCount).toHaveBeenCalledTimes(2);
+
+		queryClient.clear();
+	});
+});

--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -1159,7 +1159,7 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByText("Wrapped story")).toBeInTheDocument();
 		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
 			enabled: true,
-			keepPollingAfterUpload: false,
+			keepPollingAfterUpload: true,
 		});
 	});
 
@@ -1254,7 +1254,7 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByText("Story step: none")).toBeInTheDocument();
 		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
 			enabled: true,
-			keepPollingAfterUpload: false,
+			keepPollingAfterUpload: true,
 		});
 	});
 

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -128,17 +128,13 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 			? false
 			: completedSetupUserIds[sessionUserId] === true ||
 				hasCompletedWrappedSetup(sessionUserId);
-	const shouldKeepPollingAfterUpload =
-		!hasCompletedSetup ||
-		forcedFlowStage === WRAPPED_ROUTE_DESKTOP_READY_FLOW ||
-		forcedFlowStage === WRAPPED_ROUTE_SESSIONS_LANDED_FLOW;
+	const shouldReadPrivateWrappedData = !publicId && !!session;
 	const setupProgress = useSetupProgress({
-		enabled: !publicId && !!session,
-		keepPollingAfterUpload: shouldKeepPollingAfterUpload,
+		enabled: shouldReadPrivateWrappedData,
+		keepPollingAfterUpload: shouldReadPrivateWrappedData,
 	});
 	const shouldQueryWrappedArchetypeGate =
-		!publicId &&
-		!!session &&
+		shouldReadPrivateWrappedData &&
 		setupProgress.hasUploadedSessions &&
 		setupProgress.totalSessionCount >=
 			WRAPPED_ARCHETYPE_GATE_THRESHOLDS.min_total_sessions;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -82,6 +82,7 @@ export default defineConfig(async () => {
 			alias: {
 				"@": path.resolve(__dirname, "./src"),
 			},
+			dedupe: ["react", "react-dom"],
 		},
 		test: {
 			environment: "jsdom",


### PR DESCRIPTION
## Summary
- keep private wrapped polling active for the whole wrapped route, not only the setup and repos screens
- extract upload freshness into `useUploadAnalyticsRefresh`, which polls the raw uploaded-session count every second and refreshes org analytics when that count increases
- reuse that same hook on the team page so team cards update when newly uploaded sessions land
- keep the route in the wrapped preparation state when the fast upload count is ahead of cached wrapped gate data
- keep the setup-progress hook dumb: it now combines summary analytics with the shared raw-count freshness hook instead of owning cache invalidation itself
- dedupe React and React DOM in Vite so Base UI tabs/toggle primitives stay on one React module identity after dev-cache rebuilds
- add a real TeamPage smoke that renders the visible card and proves the session stat updates after the next upload poll

## Test plan
- [x] `bun --cwd apps/web test src/features/team/TeamPageUploadFreshnessSmoke.test.tsx`
- [x] `bun --cwd apps/web test src/features/get-started/use-setup-progress.test.tsx src/features/get-started/use-setup-progress.polling.test.tsx src/features/wrapped/WrappedRouteGate.test.tsx src/features/wrapped/WrappedUploadPollingSmoke.test.tsx src/features/team/TeamPage.test.tsx`
- [x] `bun --cwd apps/web check-types`
- [x] `bun run lint:wrapped:hig`
- [x] `bun run verify`
