### PR TITLE
feat: add team invite links

### DIFF
--- a/apps/api/src/handlers/team-invite-link.ts
+++ b/apps/api/src/handlers/team-invite-link.ts
@@ -24,7 +24,6 @@ const get = os.teamInviteLink.get
 			invite_url: buildTeamInviteUrl(link.token),
 			organization_id: link.organizationId,
 			organization_name: link.organizationName,
-			token: link.token,
 		};
 	});
 

--- a/apps/api/src/handlers/team-invite-link.ts
+++ b/apps/api/src/handlers/team-invite-link.ts
@@ -1,0 +1,59 @@
+import { ORPCError } from "@orpc/server";
+import { getFrontendOrigin } from "../frontend-origin.js";
+import { authMiddleware, os } from "../middleware.js";
+import {
+	acceptTeamInviteLink,
+	getTeamInviteLink,
+} from "../services/team-invite-link.service.js";
+
+const get = os.teamInviteLink.get
+	.use(authMiddleware)
+	.handler(async ({ context, input }) => {
+		const link = await getTeamInviteLink({
+			organizationId: input.organizationId,
+			userId: context.user.id,
+		});
+
+		if (!link) {
+			throw new ORPCError("FORBIDDEN", {
+				message: "Only organization owners and admins can create team links",
+			});
+		}
+
+		return {
+			invite_url: buildTeamInviteUrl(link.token),
+			organization_id: link.organizationId,
+			organization_name: link.organizationName,
+			token: link.token,
+		};
+	});
+
+const accept = os.teamInviteLink.accept
+	.use(authMiddleware)
+	.handler(async ({ context, input }) => {
+		const result = await acceptTeamInviteLink({
+			token: input.token,
+			userId: context.user.id,
+		});
+
+		if (result.status === "missing") {
+			throw new ORPCError("NOT_FOUND", {
+				message: "Team invite link is invalid",
+			});
+		}
+
+		return {
+			organization_id: result.organizationId,
+			organization_name: result.organizationName,
+			status: result.status,
+		};
+	});
+
+export const teamInviteLinkRouter = os.teamInviteLink.router({
+	accept,
+	get,
+});
+
+function buildTeamInviteUrl(token: string) {
+	return `${getFrontendOrigin()}/team/invite/${encodeURIComponent(token)}`;
+}

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -8,6 +8,7 @@ import { getClickhouse } from "./clickhouse.js";
 import { sqlClient } from "./db.js";
 import { adminRouter } from "./handlers/admin/index.js";
 import { analyticsRouter } from "./handlers/analytics/index.js";
+import { teamInviteLinkRouter } from "./handlers/team-invite-link.js";
 import { wrappedResumeRouter } from "./handlers/wrapped-resume.js";
 import { wrappedShareRouter } from "./handlers/wrapped-share.js";
 import {
@@ -372,6 +373,7 @@ export const router = os.router({
 	ingestSession: ingestSessionHandler,
 	getOrganizationSessionCount,
 	deleteOrganization,
+	teamInviteLink: teamInviteLinkRouter,
 	wrappedResume: wrappedResumeRouter,
 	wrappedShare: wrappedShareRouter,
 	admin: adminRouter,

--- a/apps/api/src/services/team-invite-link.service.ts
+++ b/apps/api/src/services/team-invite-link.service.ts
@@ -1,0 +1,224 @@
+import { Buffer } from "node:buffer";
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+import { sqlClient } from "../db.js";
+
+export type TeamInviteAcceptResult =
+	| {
+			organizationId: string;
+			organizationName: string;
+			status: "already_member" | "joined";
+	  }
+	| {
+			status: "missing";
+	  };
+
+export interface TeamInviteLink {
+	organizationId: string;
+	organizationName: string;
+	token: string;
+}
+
+const TEAM_INVITE_TOKEN_VERSION = "v1";
+const LOCAL_TEAM_INVITE_SECRET = "rudel-local-team-invite-secret";
+
+export async function getTeamInviteLink(input: {
+	organizationId: string;
+	userId: string;
+}): Promise<TeamInviteLink | null> {
+	const organization = await getManageableOrganization(input);
+
+	if (!organization) {
+		return null;
+	}
+
+	return {
+		organizationId: organization.id,
+		organizationName: organization.name,
+		token: createTeamInviteToken(organization.id),
+	};
+}
+
+export async function acceptTeamInviteLink(input: {
+	token: string;
+	userId: string;
+}): Promise<TeamInviteAcceptResult> {
+	const organizationId = getOrganizationIdFromTeamInviteToken(input.token);
+
+	if (!organizationId) {
+		return { status: "missing" };
+	}
+
+	const organization = await getOrganization(organizationId);
+
+	if (!organization) {
+		return { status: "missing" };
+	}
+
+	const existingMember = await getOrganizationMember({
+		organizationId,
+		userId: input.userId,
+	});
+
+	if (existingMember) {
+		return {
+			organizationId: organization.id,
+			organizationName: organization.name,
+			status: "already_member",
+		};
+	}
+
+	await addOrganizationMember({
+		organizationId,
+		userId: input.userId,
+	});
+
+	return {
+		organizationId: organization.id,
+		organizationName: organization.name,
+		status: "joined",
+	};
+}
+
+function createTeamInviteToken(organizationId: string) {
+	const payload = toBase64Url(organizationId);
+	const signature = signTeamInvitePayload(payload);
+
+	return `${TEAM_INVITE_TOKEN_VERSION}.${payload}.${signature}`;
+}
+
+function getOrganizationIdFromTeamInviteToken(token: string) {
+	const parts = token.split(".");
+
+	if (parts.length !== 3) {
+		return null;
+	}
+
+	const [version, payload, signature] = parts;
+
+	if (
+		version !== TEAM_INVITE_TOKEN_VERSION ||
+		!payload ||
+		!signature ||
+		!safeEqual(signature, signTeamInvitePayload(payload))
+	) {
+		return null;
+	}
+
+	return fromBase64Url(payload);
+}
+
+function signTeamInvitePayload(payload: string) {
+	return createHmac("sha256", getTeamInviteSecret())
+		.update(`${TEAM_INVITE_TOKEN_VERSION}.${payload}`)
+		.digest("base64url");
+}
+
+function getTeamInviteSecret() {
+	return process.env.BETTER_AUTH_SECRET ?? LOCAL_TEAM_INVITE_SECRET;
+}
+
+function safeEqual(left: string, right: string) {
+	const leftBuffer = Buffer.from(left);
+	const rightBuffer = Buffer.from(right);
+
+	if (leftBuffer.length !== rightBuffer.length) {
+		return false;
+	}
+
+	return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function toBase64Url(value: string) {
+	return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function fromBase64Url(value: string) {
+	try {
+		const decoded = Buffer.from(value, "base64url").toString("utf8");
+		return decoded.length > 0 ? decoded : null;
+	} catch {
+		return null;
+	}
+}
+
+async function getManageableOrganization(input: {
+	organizationId: string;
+	userId: string;
+}) {
+	const [organization] = await sqlClient<
+		Array<{ id: string; name: string; role: string }>
+	>`
+		SELECT
+			o.id,
+			o.name,
+			m.role
+		FROM organization o
+		INNER JOIN member m
+			ON m.organization_id = o.id
+		WHERE o.id = ${input.organizationId}
+			AND m.user_id = ${input.userId}
+		LIMIT 1
+	`;
+
+	if (
+		!organization ||
+		(organization.role !== "owner" && organization.role !== "admin")
+	) {
+		return null;
+	}
+
+	return organization;
+}
+
+async function getOrganization(organizationId: string) {
+	const [organization] = await sqlClient<Array<{ id: string; name: string }>>`
+		SELECT id, name
+		FROM organization
+		WHERE id = ${organizationId}
+		LIMIT 1
+	`;
+
+	return organization ?? null;
+}
+
+async function getOrganizationMember(input: {
+	organizationId: string;
+	userId: string;
+}) {
+	const [member] = await sqlClient<Array<{ id: string }>>`
+		SELECT id
+		FROM member
+		WHERE organization_id = ${input.organizationId}
+			AND user_id = ${input.userId}
+		LIMIT 1
+	`;
+
+	return member ?? null;
+}
+
+async function addOrganizationMember(input: {
+	organizationId: string;
+	userId: string;
+}) {
+	await sqlClient`
+		INSERT INTO member (
+			id,
+			organization_id,
+			user_id,
+			role,
+			created_at
+		)
+		SELECT
+			${randomUUID()},
+			${input.organizationId},
+			${input.userId},
+			'member',
+			${new Date().toISOString()}
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM member
+			WHERE organization_id = ${input.organizationId}
+				AND user_id = ${input.userId}
+		)
+	`;
+}

--- a/apps/web/src/app/AppRouter.tsx
+++ b/apps/web/src/app/AppRouter.tsx
@@ -51,6 +51,10 @@ const TeamPage = lazyNamed(
 	() => import("@/features/team/TeamPage"),
 	"TeamPage",
 );
+const TeamInviteAcceptPage = lazyNamed(
+	() => import("@/features/team/TeamInviteAcceptPage"),
+	"TeamInviteAcceptPage",
+);
 const PresetBaselinePage = lazyNamed(
 	() => import("@/app/system/PresetBaselinePage"),
 	"PresetBaselinePage",
@@ -105,6 +109,10 @@ export function AppRouter({
 			<Route
 				path="/invitation/:invitationId"
 				element={<AcceptInvitationPage />}
+			/>
+			<Route
+				path="/team/invite/:token"
+				element={<LazyRoute Component={TeamInviteAcceptPage} />}
 			/>
 			<Route
 				path="/__preset-baseline"

--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -5,6 +5,7 @@ const DASHBOARD_SESSIONS_PATH = `${DASHBOARD_PATH}/sessions`;
 const DASHBOARD_GET_STARTED_LEGACY_PATH = `${DASHBOARD_PATH}/get-started`;
 const GET_STARTED_PATH = "/get-started";
 const TEAM_PATH = "/team";
+const TEAM_INVITE_PATH = `${TEAM_PATH}/invite`;
 const SETTINGS_ROOT_PATH = "/settings";
 const SETTINGS_WORKSPACE_PATH = `${SETTINGS_ROOT_PATH}/workspace`;
 const SETTINGS_MEMBERS_PATH = `${SETTINGS_ROOT_PATH}/members`;
@@ -31,6 +32,8 @@ export const appRoutes = {
 	getStarted: () => GET_STARTED_PATH,
 	dashboardGetStartedLegacy: () => DASHBOARD_GET_STARTED_LEGACY_PATH,
 	team: () => TEAM_PATH,
+	teamInvite: (token: string) =>
+		`${TEAM_INVITE_PATH}/${encodeURIComponent(token)}`,
 	settings: () => SETTINGS_ROOT_PATH,
 	settingsRoot: () => SETTINGS_ROOT_PATH,
 	presetBaseline: () => PRESET_BASELINE_PATH,

--- a/apps/web/src/features/team/TeamInviteAcceptPage.tsx
+++ b/apps/web/src/features/team/TeamInviteAcceptPage.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { Navigate, useNavigate, useParams } from "react-router-dom";
+import { appRoutes } from "@/app/routes";
+import { useEffectOnceWhen } from "@/hooks/useEffectOnceWhen";
+import { authClient } from "@/lib/auth-client";
+import { client } from "@/lib/orpc";
+
+type TeamInviteState =
+	| { status: "idle" | "pending" }
+	| { message: string; status: "error" }
+	| { status: "ready" };
+
+export function TeamInviteAcceptPage() {
+	const { token } = useParams<{ token: string }>();
+	const navigate = useNavigate();
+	const { data: session, isPending: isSessionPending } =
+		authClient.useSession();
+	const [state, setState] = useState<TeamInviteState>({ status: "idle" });
+	const invitePath = token ? appRoutes.teamInvite(token) : appRoutes.team();
+
+	useEffectOnceWhen({
+		effect: () => {
+			if (!token) {
+				setState({
+					message: "Team invite link is missing.",
+					status: "error",
+				});
+				return;
+			}
+
+			void acceptTeamInvite({
+				navigateToTeam: () => navigate(appRoutes.team(), { replace: true }),
+				setState,
+				token,
+			});
+		},
+		isReady: !isSessionPending && !!session,
+		key: token ?? "missing-token",
+	});
+
+	if (isSessionPending) {
+		return <TeamInviteStateScreen body="Checking your account..." />;
+	}
+
+	if (!session) {
+		return (
+			<Navigate replace to={`/?redirect=${encodeURIComponent(invitePath)}`} />
+		);
+	}
+
+	if (state.status === "ready") {
+		return <Navigate replace to={appRoutes.team()} />;
+	}
+
+	if (state.status === "error") {
+		return (
+			<TeamInviteStateScreen
+				body={state.message}
+				title="Team link unavailable"
+			/>
+		);
+	}
+
+	return <TeamInviteStateScreen body="Joining the workspace..." />;
+}
+
+async function acceptTeamInvite(input: {
+	navigateToTeam: () => void;
+	setState: (state: TeamInviteState) => void;
+	token: string;
+}) {
+	const { navigateToTeam, setState, token } = input;
+
+	setState({ status: "pending" });
+
+	try {
+		const result = await client.teamInviteLink.accept({ token });
+		await authClient.organization.setActive({
+			organizationId: result.organization_id,
+		});
+		setState({ status: "ready" });
+		navigateToTeam();
+	} catch (error) {
+		setState({
+			message: getTeamInviteErrorMessage(error),
+			status: "error",
+		});
+	}
+}
+
+function TeamInviteStateScreen(props: { body: string; title?: string }) {
+	const { body, title = "Joining workspace" } = props;
+
+	return (
+		<section className="flex min-h-svh items-center justify-center bg-background px-4 py-6 sm:px-6 lg:px-8">
+			<div className="mx-auto w-full max-w-xl space-y-3 text-center">
+				<p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+					Rudel team
+				</p>
+				<h1 className="text-3xl font-semibold text-foreground">{title}</h1>
+				<p className="text-sm leading-6 text-muted-foreground sm:text-[0.9375rem]">
+					{body}
+				</p>
+			</div>
+		</section>
+	);
+}
+
+function getTeamInviteErrorMessage(error: unknown) {
+	if (error instanceof Error && error.message.trim().length > 0) {
+		return error.message;
+	}
+
+	return "This team invite link could not be used. Ask an admin or owner for a new link.";
+}

--- a/apps/web/src/features/team/TeamPage.tsx
+++ b/apps/web/src/features/team/TeamPage.tsx
@@ -229,16 +229,26 @@ function TeamPageEmpty() {
 export function TeamPage() {
 	useUploadAnalyticsRefresh({ keepPollingAfterUpload: true });
 	const {
+		canInviteTeamMembers,
 		diagnostics,
 		error,
+		isInviteLinkPending,
 		isError,
 		isPending,
 		teamMemberRows,
 		refetch,
+		teamInviteLink,
 		teamCards,
 	} = useTeamPageData();
 
-	let content = <TeamMembersCardGrid rows={teamMemberRows} />;
+	let content = (
+		<TeamMembersCardGrid
+			canInviteTeamMembers={canInviteTeamMembers}
+			isInviteLinkPending={isInviteLinkPending}
+			rows={teamMemberRows}
+			teamInviteLink={teamInviteLink}
+		/>
+	);
 
 	if (isPending) {
 		content = <TeamPageSkeleton />;
@@ -250,7 +260,11 @@ export function TeamPage() {
 				onRetry={refetch}
 			/>
 		);
-	} else if (teamMemberRows.length === 0 && (teamCards?.length ?? 0) === 0) {
+	} else if (
+		!canInviteTeamMembers &&
+		teamMemberRows.length === 0 &&
+		(teamCards?.length ?? 0) === 0
+	) {
 		content = <TeamPageEmpty />;
 	}
 

--- a/apps/web/src/features/team/components/TeamMembersCardGrid.tsx
+++ b/apps/web/src/features/team/components/TeamMembersCardGrid.tsx
@@ -1,13 +1,18 @@
+import { LinkIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
+import { WrappedTeamCardArtboardFrame } from "@/features/wrapped/team-card/artboard-frame";
 import {
 	WrappedTeamMemberCard,
 	type WrappedTeamMemberCardHeaderMetric,
 	type WrappedTeamMemberCardStatItem,
 } from "@/features/wrapped/team-card/card";
 import { UNKNOWN_GUEST_CARD_PRESET } from "@/features/wrapped/wrapped-guest-card-presets";
+import { copyTextToClipboardWithResult } from "@/lib/clipboard";
 import "@/features/wrapped/wrapped.css";
 
 const TEAM_CARD_PENDING_ARCHETYPE_LABEL = "To be revealed";
+const TEAM_LINK_COPY_RESET_MS = 1800;
 
 const compactCurrencyFormatter = new Intl.NumberFormat("en-US", {
 	currency: "USD",
@@ -126,10 +131,145 @@ function formatSpendValue(cost: number) {
 	return currencyFormatter.format(cost);
 }
 
-export function TeamMembersCardGrid({ rows }: { rows: TeamPageMemberRow[] }) {
+function TeamCardShapePlaceholder({
+	isInviteLinkPending,
+	teamInviteLink,
+}: {
+	isInviteLinkPending: boolean;
+	teamInviteLink: string | null;
+}) {
+	return (
+		<WrappedTeamCardArtboardFrame>
+			<article
+				aria-label="Add more members"
+				className="relative isolate grid h-[358px] w-[233px] place-items-center overflow-hidden rounded-[18px] bg-muted/45 p-6 text-card-foreground shadow-none"
+			>
+				<svg
+					aria-hidden="true"
+					className="absolute inset-0 size-full text-muted-foreground/35"
+					fill="none"
+					viewBox="0 0 233 358"
+				>
+					<rect
+						x="4"
+						y="4"
+						width="225"
+						height="350"
+						rx="15"
+						stroke="currentColor"
+						strokeDasharray="18 12"
+						strokeLinecap="round"
+						strokeWidth="6"
+					/>
+				</svg>
+				<div className="relative z-10 flex w-full flex-col items-center gap-3">
+					<p className="max-w-[19ch] text-center text-sm font-medium text-pretty text-muted-foreground">
+						Add more members to your team with this link
+					</p>
+					<TeamLinkCopySurface
+						isInviteLinkPending={isInviteLinkPending}
+						teamInviteLink={teamInviteLink}
+					/>
+				</div>
+			</article>
+		</WrappedTeamCardArtboardFrame>
+	);
+}
+
+function TeamLinkCopySurface({
+	isInviteLinkPending,
+	teamInviteLink,
+}: {
+	isInviteLinkPending: boolean;
+	teamInviteLink: string | null;
+}) {
+	const [copied, setCopied] = useState(false);
+	const resetTimeoutRef = useRef<number | null>(null);
+	const visibleTeamLink =
+		teamInviteLink ??
+		(isInviteLinkPending ? "Loading link..." : "Link unavailable");
+
+	useEffect(() => {
+		return () => {
+			if (resetTimeoutRef.current !== null) {
+				window.clearTimeout(resetTimeoutRef.current);
+			}
+		};
+	}, []);
+
+	async function handleCopyTeamLink() {
+		if (!teamInviteLink) {
+			return;
+		}
+
+		const result = await copyTextToClipboardWithResult(teamInviteLink, {
+			preferSelectionCopy: true,
+			allowPromptFallback: true,
+			promptMessage: "Copy team link: Cmd/Ctrl+C, Enter",
+		});
+
+		if (result !== "copied") {
+			return;
+		}
+
+		if (resetTimeoutRef.current !== null) {
+			window.clearTimeout(resetTimeoutRef.current);
+		}
+
+		setCopied(true);
+		resetTimeoutRef.current = window.setTimeout(() => {
+			setCopied(false);
+			resetTimeoutRef.current = null;
+		}, TEAM_LINK_COPY_RESET_MS);
+	}
+
+	return (
+		<div className="grid h-11 w-full min-w-0 grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-1 rounded-full border border-border/60 bg-background p-1">
+			<LinkIcon
+				aria-hidden="true"
+				className="mx-auto size-4 shrink-0 text-muted-foreground"
+			/>
+			<div
+				className="min-w-0 truncate [font-family:var(--font-mono)] text-[0.82rem] font-medium text-[#22201f]"
+				title={visibleTeamLink}
+			>
+				{visibleTeamLink}
+			</div>
+			<button
+				aria-label={copied ? "Copied team link" : "Copy team link"}
+				className="flex h-full min-w-18 items-center justify-center rounded-full bg-[#22201f] px-4 [font-family:var(--font-sans)] text-[0.86rem] font-bold text-[#fffaf5] transition-colors hover:bg-[#151312] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#22201f]/30 disabled:cursor-not-allowed disabled:bg-muted-foreground/40 disabled:text-background"
+				disabled={isInviteLinkPending || teamInviteLink === null}
+				onClick={() => void handleCopyTeamLink()}
+				type="button"
+			>
+				{copied ? "Copied" : "Copy"}
+			</button>
+		</div>
+	);
+}
+
+export function TeamMembersCardGrid({
+	canInviteTeamMembers,
+	isInviteLinkPending,
+	rows,
+	teamInviteLink,
+}: {
+	canInviteTeamMembers: boolean;
+	isInviteLinkPending: boolean;
+	rows: TeamPageMemberRow[];
+	teamInviteLink: string | null;
+}) {
 	return (
 		<div className="team-lineup-surface-scope">
 			<ul className="grid justify-center gap-[10px] [grid-template-columns:repeat(auto-fit,minmax(233px,233px))]">
+				{canInviteTeamMembers ? (
+					<li className="list-none">
+						<TeamCardShapePlaceholder
+							isInviteLinkPending={isInviteLinkPending}
+							teamInviteLink={teamInviteLink}
+						/>
+					</li>
+				) : null}
 				{rows.map((row) => (
 					<li key={row.userId} className="list-none">
 						<WrappedTeamMemberCard

--- a/apps/web/src/features/team/use-team-page-data.ts
+++ b/apps/web/src/features/team/use-team-page-data.ts
@@ -1,7 +1,6 @@
 import type { DeveloperSummary, DeveloperTeamCard } from "@rudel/api-routes";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { appRoutes } from "@/app/routes";
 import {
 	announceFrontendFixturesEnabled,
 	buildTeamAnalyticsFixtures,
@@ -132,16 +131,6 @@ function buildTeamMemberRows(
 		);
 }
 
-function buildTeamInviteUrl(token: string) {
-	const invitePath = appRoutes.teamInvite(token);
-
-	if (typeof window === "undefined") {
-		return invitePath;
-	}
-
-	return `${window.location.origin}${invitePath}`;
-}
-
 export function useTeamPageData() {
 	const { state: dateRangeState, meta: dateRangeMeta } = useDateRange();
 	const { meta: workspaceMeta, state: workspaceState } = useOrganization();
@@ -261,9 +250,7 @@ export function useTeamPageData() {
 		teamMemberRows,
 		canInviteTeamMembers,
 		isInviteLinkPending: teamInviteLinkQuery.isPending,
-		teamInviteLink: teamInviteLinkQuery.data
-			? buildTeamInviteUrl(teamInviteLinkQuery.data.token)
-			: null,
+		teamInviteLink: teamInviteLinkQuery.data?.invite_url ?? null,
 		requestedDays,
 		refetch: async () => {
 			await Promise.all([

--- a/apps/web/src/features/team/use-team-page-data.ts
+++ b/apps/web/src/features/team/use-team-page-data.ts
@@ -1,6 +1,7 @@
 import type { DeveloperSummary, DeveloperTeamCard } from "@rudel/api-routes";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
+import { appRoutes } from "@/app/routes";
 import {
 	announceFrontendFixturesEnabled,
 	buildTeamAnalyticsFixtures,
@@ -131,23 +132,36 @@ function buildTeamMemberRows(
 		);
 }
 
+function buildTeamInviteUrl(token: string) {
+	const invitePath = appRoutes.teamInvite(token);
+
+	if (typeof window === "undefined") {
+		return invitePath;
+	}
+
+	return `${window.location.origin}${invitePath}`;
+}
+
 export function useTeamPageData() {
 	const { state: dateRangeState, meta: dateRangeMeta } = useDateRange();
-	const { state: workspaceState } = useOrganization();
+	const { meta: workspaceMeta, state: workspaceState } = useOrganization();
 	const useFixtures = isFrontendFixturesEnabled();
 	announceFrontendFixturesEnabled("team");
 	const selectedDays = dateRangeMeta.dayCount;
 	const requestedDays = MAX_ANALYTICS_DAYS;
+	const activeOrganizationId = workspaceState.activeOrg?.id ?? null;
+	const canInviteTeamMembers =
+		activeOrganizationId !== null && workspaceMeta.isOrgAdmin;
 	const {
 		data: members = [],
 		isLoading: isOrganizationPending,
 		isError: isOrganizationError,
 		refetch: refetchMembers,
 	} = useQuery<readonly TeamRosterMemberSource[]>({
-		queryKey: ["team-page-members", workspaceState.activeOrg?.id],
+		queryKey: ["team-page-members", activeOrganizationId],
 		queryFn: async () => {
 			const response = await authClient.organization.getFullOrganization({
-				query: { organizationId: workspaceState.activeOrg?.id ?? "" },
+				query: { organizationId: activeOrganizationId ?? "" },
 			});
 			const fullOrganization =
 				(response.data as {
@@ -170,7 +184,13 @@ export function useTeamPageData() {
 				userId: member.userId,
 			}));
 		},
-		enabled: Boolean(workspaceState.activeOrg?.id),
+		enabled: activeOrganizationId !== null,
+	});
+	const teamInviteLinkQuery = useQuery({
+		...orpc.teamInviteLink.get.queryOptions({
+			input: { organizationId: activeOrganizationId ?? "" },
+		}),
+		enabled: canInviteTeamMembers,
 	});
 	const teamCardsQuery = useAnalyticsQuery({
 		...orpc.analytics.developers.teamCards.queryOptions({
@@ -211,7 +231,7 @@ export function useTeamPageData() {
 		endpoint: "analytics.developers.teamCards",
 		maxDays: MAX_ANALYTICS_DAYS,
 		startDate: dateRangeState.startDate,
-		organizationId: workspaceState.activeOrg?.id ?? null,
+		organizationId: activeOrganizationId,
 		organizationName: workspaceState.activeOrg?.name ?? null,
 		days: selectedDays,
 		requestedDays,
@@ -239,12 +259,18 @@ export function useTeamPageData() {
 				developersQuery.isPending ||
 				isOrganizationPending),
 		teamMemberRows,
+		canInviteTeamMembers,
+		isInviteLinkPending: teamInviteLinkQuery.isPending,
+		teamInviteLink: teamInviteLinkQuery.data
+			? buildTeamInviteUrl(teamInviteLinkQuery.data.token)
+			: null,
 		requestedDays,
 		refetch: async () => {
 			await Promise.all([
 				teamCardsQuery.refetch(),
 				developersQuery.refetch(),
 				refetchMembers(),
+				canInviteTeamMembers ? teamInviteLinkQuery.refetch() : null,
 			]);
 		},
 		teamCards,

--- a/apps/web/src/features/team/use-team-page-data.ts
+++ b/apps/web/src/features/team/use-team-page-data.ts
@@ -140,7 +140,7 @@ export function useTeamPageData() {
 	const requestedDays = MAX_ANALYTICS_DAYS;
 	const activeOrganizationId = workspaceState.activeOrg?.id ?? null;
 	const canInviteTeamMembers =
-		activeOrganizationId !== null && workspaceMeta.isOrgAdmin;
+		activeOrganizationId !== null && workspaceMeta?.isOrgAdmin === true;
 	const {
 		data: members = [],
 		isLoading: isOrganizationPending,
@@ -176,9 +176,14 @@ export function useTeamPageData() {
 		enabled: activeOrganizationId !== null,
 	});
 	const teamInviteLinkQuery = useQuery({
-		...orpc.teamInviteLink.get.queryOptions({
-			input: { organizationId: activeOrganizationId ?? "" },
-		}),
+		...(canInviteTeamMembers
+			? orpc.teamInviteLink.get.queryOptions({
+					input: { organizationId: activeOrganizationId ?? "" },
+				})
+			: {
+					queryFn: async () => null,
+					queryKey: ["team-invite-link", activeOrganizationId],
+				}),
 		enabled: canInviteTeamMembers,
 	});
 	const teamCardsQuery = useAnalyticsQuery({

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -82,7 +82,6 @@ export default defineConfig(async () => {
 			alias: {
 				"@": path.resolve(__dirname, "./src"),
 			},
-			dedupe: ["react", "react-dom"],
 		},
 		test: {
 			environment: "jsdom",

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -109,6 +109,19 @@ export const OrganizationSchema = z.object({
 	logo: z.string().nullable(),
 });
 
+export const TeamInviteLinkSchema = z.object({
+	invite_url: z.string().url(),
+	organization_id: z.string(),
+	organization_name: z.string(),
+	token: z.string(),
+});
+
+export const TeamInviteAcceptResultSchema = z.object({
+	organization_id: z.string(),
+	organization_name: z.string(),
+	status: z.enum(["already_member", "joined"]),
+});
+
 export const SessionTagSchema = z.enum([
 	"research",
 	"new_feature",
@@ -185,6 +198,14 @@ export const contract = {
 	deleteOrganization: oc
 		.input(z.object({ organizationId: z.string() }))
 		.output(z.object({ success: z.literal(true) })),
+	teamInviteLink: {
+		get: oc
+			.input(z.object({ organizationId: z.string() }))
+			.output(TeamInviteLinkSchema),
+		accept: oc
+			.input(z.object({ token: z.string().min(1) }))
+			.output(TeamInviteAcceptResultSchema),
+	},
 	wrappedShare: {
 		create: oc
 			.input(CreateWrappedShareInputSchema)

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -113,7 +113,6 @@ export const TeamInviteLinkSchema = z.object({
 	invite_url: z.string().url(),
 	organization_id: z.string(),
 	organization_name: z.string(),
-	token: z.string(),
 });
 
 export const TeamInviteAcceptResultSchema = z.object({


### PR DESCRIPTION
## Summary
- add signed team invite-link RPCs gated to organization owners/admins
- accept team invite links for authenticated users and add them as regular members
- show the admin/owner-only add-members card on `/team` with the real truncated invite URL and copy button
- add the `/team/invite/:token` accept route and dedupe React/ReactDOM in Vite resolution

## Test plan
- [x] `bun run verify`
- [x] Doppler prod-like web build and preview route smoke for `/team` and `/team/invite/smoke-token`
- [x] Doppler-backed API boot, `/health`, CORS preflight, and unauthenticated invite RPC smoke