### PR TITLE
fix: align wrapped upload freshness

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -239,7 +239,13 @@ const getOrganizationSessionCount = os.getOrganizationSessionCount
 			});
 		}
 
-		const count = await getOrgSessionCount(input.organizationId);
+		if (input.userId && input.userId !== context.user.id) {
+			throw new ORPCError("FORBIDDEN", {
+				message: "Cannot read another user's raw session count",
+			});
+		}
+
+		const count = await getOrgSessionCount(input.organizationId, input.userId);
 		return { count };
 	});
 

--- a/apps/api/src/services/org-session.service.ts
+++ b/apps/api/src/services/org-session.service.ts
@@ -1,15 +1,20 @@
 import { getAllAdapters } from "@rudel/agent-adapters";
 import { getClickhouse, getSafeClickHouseTable } from "../clickhouse.js";
 
-export async function getOrgSessionCount(orgId: string): Promise<number> {
+export async function getOrgSessionCount(
+	orgId: string,
+	userId?: string,
+): Promise<number> {
 	const ch = getClickhouse();
 	const tables = getAllAdapters().map((a) => a.rawTableName);
+	const userFilter = userId ? " AND user_id = {userId:String}" : "";
 	const results = await Promise.all(
 		tables.map((table) =>
 			ch.query<{ count: string }>({
-				query: `SELECT count() as count FROM ${getSafeClickHouseTable(table)} WHERE organization_id = {orgId:String}`,
+				query: `SELECT count() as count FROM ${getSafeClickHouseTable(table)} WHERE organization_id = {orgId:String}${userFilter}`,
 				query_params: {
 					orgId,
+					...(userId ? { userId } : {}),
 				},
 			}),
 		),

--- a/apps/api/src/services/wrapped.service.test.ts
+++ b/apps/api/src/services/wrapped.service.test.ts
@@ -40,7 +40,72 @@ const queryClickhouse = mock((input: QueryClickhouseInput) => {
 	throw new Error(`Unexpected ClickHouse query: ${input.query.slice(0, 120)}`);
 });
 
+const allowedClickHouseTables = new Set([
+	"rudel.claude_sessions",
+	"rudel.codex_sessions",
+	"rudel.session_analytics",
+]);
+
+function getSafeClickHouseTable(table: string): string {
+	if (!allowedClickHouseTables.has(table)) {
+		throw new Error(`Unsupported ClickHouse table: ${table}`);
+	}
+
+	return table;
+}
+
+function addOptionalStringEqFilter(
+	where: string[],
+	query_params: Record<string, unknown>,
+	column: string,
+	paramName: string,
+	value?: string,
+): void {
+	if (!value) {
+		return;
+	}
+
+	where.push(`${column} = {${paramName}:String}`);
+	query_params[paramName] = value;
+}
+
+function addOptionalStringInFilter(
+	where: string[],
+	query_params: Record<string, unknown>,
+	column: string,
+	paramBase: string,
+	values?: string[],
+): void {
+	if (!values || values.length === 0) {
+		return;
+	}
+
+	const placeholders = values.map((value, index) => {
+		const paramName = `${paramBase}_${index}`;
+		query_params[paramName] = value;
+		return `{${paramName}:String}`;
+	});
+	where.push(`${column} IN (${placeholders.join(", ")})`);
+}
+
+function buildDateFilter(paramName: string, column = "session_date"): string {
+	return `${column} >= now64(3) - toIntervalDay({${paramName}:UInt32}) AND ${column} <= now64(3)`;
+}
+
+function buildAbsoluteDateFilter(
+	startParamName: string,
+	endParamName: string,
+	column = "session_date",
+): string {
+	return `toDate(${column}) >= toDate({${startParamName}:String}) AND toDate(${column}) <= toDate({${endParamName}:String})`;
+}
+
 mock.module("../clickhouse.js", () => ({
+	addOptionalStringEqFilter,
+	addOptionalStringInFilter,
+	buildAbsoluteDateFilter,
+	buildDateFilter,
+	getSafeClickHouseTable,
 	queryClickhouse,
 }));
 

--- a/apps/web/src/features/analytics/queries/use-upload-analytics-refresh.ts
+++ b/apps/web/src/features/analytics/queries/use-upload-analytics-refresh.ts
@@ -8,11 +8,13 @@ const UPLOAD_ANALYTICS_REFRESH_INTERVAL_MS = 1_000;
 interface UseUploadAnalyticsRefreshOptions {
 	enabled?: boolean;
 	keepPollingAfterUpload?: boolean;
+	userId?: string | null;
 }
 
 export function useUploadAnalyticsRefresh({
 	enabled = true,
 	keepPollingAfterUpload = false,
+	userId = null,
 }: UseUploadAnalyticsRefreshOptions = {}) {
 	const { state } = useOrganization();
 	const activeOrganizationId = state.activeOrg?.id;
@@ -23,6 +25,7 @@ export function useUploadAnalyticsRefresh({
 			"upload-analytics-refresh",
 			"raw-session-count",
 			activeOrganizationId,
+			userId,
 		],
 		queryFn: async () => {
 			if (!activeOrganizationId) {
@@ -31,6 +34,7 @@ export function useUploadAnalyticsRefresh({
 
 			return client.getOrganizationSessionCount({
 				organizationId: activeOrganizationId,
+				...(userId ? { userId } : {}),
 			});
 		},
 		enabled: enabled && !!activeOrganizationId,

--- a/apps/web/src/features/get-started/use-setup-progress.test.tsx
+++ b/apps/web/src/features/get-started/use-setup-progress.test.tsx
@@ -210,6 +210,49 @@ describe("useSetupProgress", () => {
 		).toBe(1_000);
 	});
 
+	it("scopes raw uploaded session counts to the current wrapped user", async () => {
+		renderHook(() =>
+			useSetupProgress({
+				userId: "user-1",
+			}),
+		);
+
+		const rawOptions = getCapturedRawQueryOptions();
+
+		await rawOptions.queryFn?.();
+
+		expect(mockGetOrganizationSessionCount).toHaveBeenCalledWith({
+			organizationId: "org-1",
+			userId: "user-1",
+		});
+	});
+
+	it("ignores the organization summary count when reading wrapped user progress", () => {
+		summaryQueryResult = {
+			data: {
+				total_sessions: 135,
+			},
+			isFetched: true,
+			isPending: false,
+		};
+		rawCountQueryResult = {
+			data: {
+				count: 73,
+			},
+			isFetched: true,
+			isPending: false,
+		};
+
+		const { result } = renderHook(() =>
+			useSetupProgress({
+				userId: "user-1",
+			}),
+		);
+
+		expect(result.current.totalSessionCount).toBe(73);
+		expect(getCapturedSummaryQueryOptions().enabled).toBe(false);
+	});
+
 	it("stops raw polling after sessions are detected", () => {
 		renderHook(() => useSetupProgress());
 

--- a/apps/web/src/features/get-started/use-setup-progress.ts
+++ b/apps/web/src/features/get-started/use-setup-progress.ts
@@ -9,16 +9,20 @@ const SETUP_PROGRESS_REFETCH_INTERVAL_MS = 3_000;
 interface UseSetupProgressOptions {
 	enabled?: boolean;
 	keepPollingAfterUpload?: boolean;
+	userId?: string | null;
 }
 
 export function useSetupProgress({
 	enabled = true,
 	keepPollingAfterUpload = false,
+	userId = null,
 }: UseSetupProgressOptions = {}) {
 	const { state } = useOrganization();
+	const shouldUseOrganizationSummary = !userId;
 	const { rawSessionCount, rawSessionCountQuery } = useUploadAnalyticsRefresh({
 		enabled,
 		keepPollingAfterUpload,
+		userId,
 	});
 
 	const summaryQuery = useAnalyticsQuery({
@@ -28,10 +32,14 @@ export function useSetupProgress({
 		refetchIntervalInBackground: true,
 		refetchOnReconnect: "always",
 		refetchOnWindowFocus: "always",
-		enabled,
+		enabled: enabled && shouldUseOrganizationSummary,
 		refetchInterval: (query) => {
 			const totalSessions = query.state.data?.total_sessions ?? 0;
-			if (!enabled || (totalSessions > 0 && !keepPollingAfterUpload)) {
+			if (
+				!enabled ||
+				!shouldUseOrganizationSummary ||
+				(totalSessions > 0 && !keepPollingAfterUpload)
+			) {
 				return false;
 			}
 
@@ -40,16 +48,19 @@ export function useSetupProgress({
 	});
 
 	const totalSessionCount = Math.max(
-		summaryQuery.data?.total_sessions ?? 0,
+		shouldUseOrganizationSummary ? (summaryQuery.data?.total_sessions ?? 0) : 0,
 		rawSessionCount,
 	);
+	const hasFetchedSetupProgress =
+		rawSessionCountQuery.isFetched &&
+		(!shouldUseOrganizationSummary || summaryQuery.isFetched);
+	const hasPendingSetupProgress =
+		rawSessionCountQuery.isPending ||
+		(shouldUseOrganizationSummary && summaryQuery.isPending);
 	const isInitialLoading =
 		enabled &&
-		!summaryQuery.isFetched &&
-		!rawSessionCountQuery.isFetched &&
-		(state.isLoading ||
-			summaryQuery.isPending ||
-			rawSessionCountQuery.isPending);
+		!hasFetchedSetupProgress &&
+		(state.isLoading || hasPendingSetupProgress);
 
 	return {
 		hasUploadedSessions: totalSessionCount > 0,

--- a/apps/web/src/features/team/TeamPage.test.tsx
+++ b/apps/web/src/features/team/TeamPage.test.tsx
@@ -1,16 +1,11 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TeamPage } from "@/features/team/TeamPage";
 
-const { mockUseTeamPageData, mockUseUploadAnalyticsRefresh } = vi.hoisted(
-	() => ({
-		mockUseTeamPageData: vi.fn(),
-		mockUseUploadAnalyticsRefresh: vi.fn(),
-	}),
-);
-
-vi.mock("@/features/analytics/queries/use-upload-analytics-refresh", () => ({
-	useUploadAnalyticsRefresh: mockUseUploadAnalyticsRefresh,
+const { mockRefetch, mockUseTeamPageData } = vi.hoisted(() => ({
+	mockRefetch: vi.fn(),
+	mockUseTeamPageData: vi.fn(),
 }));
 
 vi.mock("@/features/team/components/TeamMembersCardGrid", () => ({
@@ -25,8 +20,9 @@ vi.mock("@/features/team/use-team-page-data", () => ({
 
 describe("TeamPage", () => {
 	beforeEach(() => {
+		mockRefetch.mockReset();
+		mockRefetch.mockResolvedValue(undefined);
 		mockUseTeamPageData.mockReset();
-		mockUseUploadAnalyticsRefresh.mockReset();
 		mockUseTeamPageData.mockReturnValue({
 			diagnostics: {
 				days: 365,
@@ -41,7 +37,7 @@ describe("TeamPage", () => {
 			error: null,
 			isError: false,
 			isPending: false,
-			refetch: vi.fn(),
+			refetch: mockRefetch,
 			teamCards: [],
 			teamMemberRows: [
 				{
@@ -64,12 +60,14 @@ describe("TeamPage", () => {
 		});
 	});
 
-	it("keeps team cards fresh when new uploads arrive", () => {
+	it("refreshes team cards when the user asks for fresh data", async () => {
+		const user = userEvent.setup();
+
 		render(<TeamPage />);
 
 		expect(screen.getByText("Team card grid: 1")).toBeInTheDocument();
-		expect(mockUseUploadAnalyticsRefresh).toHaveBeenCalledWith({
-			keepPollingAfterUpload: true,
-		});
+		await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+		expect(mockRefetch).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/web/src/features/team/TeamPage.tsx
+++ b/apps/web/src/features/team/TeamPage.tsx
@@ -1,4 +1,5 @@
-import { AlertCircleIcon } from "lucide-react";
+import { AlertCircleIcon, RefreshCwIcon } from "lucide-react";
+import { useState } from "react";
 import { Button } from "@/app/ui/button";
 import {
 	Card,
@@ -8,7 +9,6 @@ import {
 	CardTitle,
 } from "@/app/ui/card";
 import { Skeleton } from "@/app/ui/skeleton";
-import { useUploadAnalyticsRefresh } from "@/features/analytics/queries/use-upload-analytics-refresh";
 import { TeamMembersCardGrid } from "@/features/team/components/TeamMembersCardGrid";
 import {
 	type TeamPageDiagnostics,
@@ -226,8 +226,32 @@ function TeamPageEmpty() {
 	);
 }
 
+function TeamPageRefreshButton({
+	isRefreshing,
+	onRefresh,
+}: {
+	isRefreshing: boolean;
+	onRefresh: () => void;
+}) {
+	return (
+		<div className="mb-4 flex justify-end">
+			<Button
+				size="sm"
+				variant="outline"
+				disabled={isRefreshing}
+				onClick={onRefresh}
+			>
+				<RefreshCwIcon
+					data-icon="inline-start"
+					className={isRefreshing ? "animate-spin" : undefined}
+				/>
+				{isRefreshing ? "Refreshing" : "Refresh"}
+			</Button>
+		</div>
+	);
+}
+
 export function TeamPage() {
-	useUploadAnalyticsRefresh({ keepPollingAfterUpload: true });
 	const {
 		diagnostics,
 		error,
@@ -237,6 +261,22 @@ export function TeamPage() {
 		refetch,
 		teamCards,
 	} = useTeamPageData();
+	const [isRefreshing, setIsRefreshing] = useState(false);
+
+	async function handleRefresh() {
+		if (isRefreshing) {
+			return;
+		}
+
+		setIsRefreshing(true);
+		try {
+			await refetch();
+		} catch {
+			// The query state renders the error panel; keep the button usable.
+		} finally {
+			setIsRefreshing(false);
+		}
+	}
 
 	let content = <TeamMembersCardGrid rows={teamMemberRows} />;
 
@@ -254,5 +294,15 @@ export function TeamPage() {
 		content = <TeamPageEmpty />;
 	}
 
-	return <div className="px-4 lg:px-6">{content}</div>;
+	return (
+		<div className="px-4 lg:px-6">
+			<TeamPageRefreshButton
+				isRefreshing={isRefreshing}
+				onRefresh={() => {
+					void handleRefresh();
+				}}
+			/>
+			{content}
+		</div>
+	);
 }

--- a/apps/web/src/features/team/TeamPageManualRefreshSmoke.test.tsx
+++ b/apps/web/src/features/team/TeamPageManualRefreshSmoke.test.tsx
@@ -1,20 +1,16 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TeamPage } from "@/features/team/TeamPage";
 
-const {
-	mockGetFullOrganization,
-	mockGetOrganizationSessionCount,
-	mockUseDateRange,
-	mockUseOrganization,
-} = vi.hoisted(() => ({
-	mockGetFullOrganization: vi.fn(),
-	mockGetOrganizationSessionCount: vi.fn(),
-	mockUseDateRange: vi.fn(),
-	mockUseOrganization: vi.fn(),
-}));
+const { mockGetFullOrganization, mockUseDateRange, mockUseOrganization } =
+	vi.hoisted(() => ({
+		mockGetFullOrganization: vi.fn(),
+		mockUseDateRange: vi.fn(),
+		mockUseOrganization: vi.fn(),
+	}));
 
 vi.mock("@/features/analytics/date-range/useDateRange", () => ({
 	useDateRange: mockUseDateRange,
@@ -69,9 +65,6 @@ function buildTeamCard() {
 }
 
 vi.mock("@/lib/orpc", () => ({
-	client: {
-		getOrganizationSessionCount: mockGetOrganizationSessionCount,
-	},
 	orpc: {
 		analytics: {
 			developers: {
@@ -93,7 +86,7 @@ vi.mock("@/lib/orpc", () => ({
 }));
 
 function createWrapper(queryClient: QueryClient) {
-	return function TeamPageUploadFreshnessSmokeWrapper(props: {
+	return function TeamPageManualRefreshSmokeWrapper(props: {
 		children: ReactNode;
 	}) {
 		return (
@@ -104,11 +97,10 @@ function createWrapper(queryClient: QueryClient) {
 	};
 }
 
-describe("TeamPage upload freshness smoke", () => {
+describe("TeamPage manual refresh smoke", () => {
 	beforeEach(() => {
 		rawSessionCount = 12;
 		mockGetFullOrganization.mockReset();
-		mockGetOrganizationSessionCount.mockReset();
 		mockUseDateRange.mockReset();
 		mockUseOrganization.mockReset();
 
@@ -127,9 +119,6 @@ describe("TeamPage upload freshness smoke", () => {
 				],
 			},
 		});
-		mockGetOrganizationSessionCount.mockImplementation(async () => ({
-			count: rawSessionCount,
-		}));
 		mockUseDateRange.mockReturnValue({
 			actions: {
 				setDateRange: vi.fn(),
@@ -158,11 +147,8 @@ describe("TeamPage upload freshness smoke", () => {
 		});
 	});
 
-	afterEach(() => {
-		vi.useRealTimers();
-	});
-
-	it("updates the visible team card stats on the next poll after new uploads land", async () => {
+	it("updates the visible team card stats when the user refreshes after new uploads land", async () => {
+		const user = userEvent.setup();
 		const queryClient = new QueryClient({
 			defaultOptions: {
 				queries: {
@@ -181,15 +167,14 @@ describe("TeamPage upload freshness smoke", () => {
 		expect(screen.getByTitle("12 sessions")).toBeInTheDocument();
 
 		rawSessionCount = 63;
+		expect(screen.getByTitle("12 sessions")).toBeInTheDocument();
 
-		await waitFor(
-			() => {
-				expect(screen.getByTitle("63 sessions")).toBeInTheDocument();
-			},
-			{ timeout: 1_500 },
-		);
+		await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+		await waitFor(() => {
+			expect(screen.getByTitle("63 sessions")).toBeInTheDocument();
+		});
 		expect(screen.queryByTitle("12 sessions")).not.toBeInTheDocument();
-		expect(mockGetOrganizationSessionCount).toHaveBeenCalledTimes(2);
 
 		queryClient.clear();
 	});

--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -833,6 +833,7 @@ describe("WrappedRouteGate", () => {
 		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
 			enabled: true,
 			keepPollingAfterUpload: true,
+			userId: "user-1",
 		});
 		expect(mockUseAnalyticsQuery).not.toHaveBeenCalled();
 	});
@@ -858,7 +859,7 @@ describe("WrappedRouteGate", () => {
 		expect(screen.queryByText("Wrapped story")).toBeNull();
 	});
 
-	it("uses wrapped gate totals when setup progress overcounts uploaded sessions", () => {
+	it("waits when user-scoped raw uploads outrun cached wrapped gate data", () => {
 		mockUseSetupProgress.mockReturnValue({
 			hasUploadedSessions: true,
 			isLoading: false,
@@ -892,12 +893,9 @@ describe("WrappedRouteGate", () => {
 			</MemoryRouter>,
 		);
 
-		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
-		expect(screen.getByText("Can continue: no")).toBeInTheDocument();
-		expect(screen.getByText("Upload more default: yes")).toBeInTheDocument();
-		expect(screen.getByText("Readiness: missing")).toBeInTheDocument();
-		expect(screen.getByText("Total sessions: 38")).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Start story" })).toBeDisabled();
+		expect(screen.getByText("Preparing your wrapped...")).toBeInTheDocument();
+		expect(screen.queryByText("Wrapped story")).toBeNull();
+		expect(screen.queryByText("Wrapped setup complete page")).toBeNull();
 	});
 
 	it("waits when fresh uploads outrun cached wrapped gate data", async () => {
@@ -1160,6 +1158,7 @@ describe("WrappedRouteGate", () => {
 		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
 			enabled: true,
 			keepPollingAfterUpload: true,
+			userId: "user-1",
 		});
 	});
 
@@ -1187,6 +1186,7 @@ describe("WrappedRouteGate", () => {
 		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
 			enabled: true,
 			keepPollingAfterUpload: true,
+			userId: "user-1",
 		});
 	});
 
@@ -1226,6 +1226,7 @@ describe("WrappedRouteGate", () => {
 		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
 			enabled: true,
 			keepPollingAfterUpload: true,
+			userId: "user-1",
 		});
 	});
 
@@ -1255,6 +1256,7 @@ describe("WrappedRouteGate", () => {
 		expect(mockUseSetupProgress).toHaveBeenLastCalledWith({
 			enabled: true,
 			keepPollingAfterUpload: true,
+			userId: "user-1",
 		});
 	});
 

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -132,6 +132,7 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const setupProgress = useSetupProgress({
 		enabled: shouldReadPrivateWrappedData,
 		keepPollingAfterUpload: shouldReadPrivateWrappedData,
+		userId: sessionUserId,
 	});
 	const shouldQueryWrappedArchetypeGate =
 		shouldReadPrivateWrappedData &&
@@ -702,7 +703,6 @@ function getWrappedRouteSessionGateState(input: {
 	const archetypeGateSessionCount =
 		input.archetypeGate?.values.total_sessions ?? null;
 	const isWaitingForFreshWrappedData =
-		input.hasReachedMinimumAfterMissing &&
 		archetypeGateSessionCount !== null &&
 		archetypeGateSessionCount < input.setupProgressTotalSessionCount;
 	const totalSessionCount =

--- a/apps/web/src/features/wrapped/team-card/onboarding-metrics.test.ts
+++ b/apps/web/src/features/wrapped/team-card/onboarding-metrics.test.ts
@@ -1,0 +1,74 @@
+import type { DeveloperDetails, WrappedV1 } from "@rudel/api-routes";
+import { describe, expect, it } from "vitest";
+import { buildWrappedOnboardingMetrics } from "./onboarding-metrics";
+
+describe("buildWrappedOnboardingMetrics", () => {
+	it("uses wrapped all-time totals when recent developer details lag", () => {
+		const metrics = buildWrappedOnboardingMetrics({
+			commitBreakdown: undefined,
+			developerDetails: createDeveloperDetails({
+				active_days: 9,
+				cost: 42,
+				total_sessions: 73,
+				total_tokens: 12_000,
+			}),
+			developerFeatures: undefined,
+			developerProjects: undefined,
+			developerSessions: undefined,
+			wrappedMetrics: createWrappedMetrics({
+				active_days: 14,
+				estimated_spend_usd: 91,
+				total_sessions: 135,
+				total_tokens: 38_000,
+			}),
+		});
+
+		expect(metrics.totalSessions).toBe(135);
+		expect(metrics.activeDays).toBe(14);
+		expect(metrics.totalTokens).toBe(38_000);
+		expect(metrics.estimatedCostUsd).toBe(91);
+		expect(metrics.estimatedCostTokenBasis).toBe(38_000);
+	});
+});
+
+function createDeveloperDetails(
+	overrides: Partial<DeveloperDetails> = {},
+): DeveloperDetails {
+	return {
+		active_days: 1,
+		avg_session_duration_min: 10,
+		cost: 1,
+		distinct_projects: 1,
+		error_count: 0,
+		favorite_model: null,
+		input_tokens: 100,
+		last_active_date: "2026-04-21",
+		output_tokens: 200,
+		success_rate: 100,
+		success_rate_trend: 0,
+		total_duration_min: 10,
+		total_sessions: 1,
+		total_tokens: 300,
+		user_id: "user_1",
+		...overrides,
+	} satisfies DeveloperDetails;
+}
+
+function createWrappedMetrics(
+	overrides: Partial<WrappedV1["metrics"]> = {},
+): WrappedV1["metrics"] {
+	return {
+		active_days: 1,
+		days_since_first_session: 1,
+		estimated_spend_usd: 1,
+		favorite_model: null,
+		first_session_at: "2026-04-20T00:00:00Z",
+		last_session_at: "2026-04-21T00:00:00Z",
+		longest_session_min: 10,
+		model_by_month: [],
+		source_split: [],
+		total_sessions: 1,
+		total_tokens: 300,
+		...overrides,
+	} satisfies WrappedV1["metrics"];
+}

--- a/apps/web/src/features/wrapped/team-card/onboarding-metrics.ts
+++ b/apps/web/src/features/wrapped/team-card/onboarding-metrics.ts
@@ -29,17 +29,21 @@ export function buildWrappedOnboardingMetrics(
 		developerSessions,
 		wrappedMetrics,
 	} = input;
-	const totalSessions =
-		developerDetails?.total_sessions ?? wrappedMetrics?.total_sessions ?? 0;
+	const totalSessions = Math.max(
+		developerDetails?.total_sessions ?? 0,
+		wrappedMetrics?.total_sessions ?? 0,
+	);
 	const commitSessions = findBooleanDimensionCount(commitBreakdown, true);
 	const topProject = findTopProject(developerProjects);
 	const estimatedCostTokenBasis = Math.max(
 		0,
-		developerDetails?.total_tokens ?? wrappedMetrics?.total_tokens ?? 0,
+		developerDetails?.total_tokens ?? 0,
+		wrappedMetrics?.total_tokens ?? 0,
 	);
 	const estimatedCostUsdRaw = Math.max(
 		0,
-		developerDetails?.cost ?? wrappedMetrics?.estimated_spend_usd ?? 0,
+		developerDetails?.cost ?? 0,
+		wrappedMetrics?.estimated_spend_usd ?? 0,
 	);
 	const estimatedCostUsd = Math.round(estimatedCostUsdRaw);
 	const repoPulse = buildRepoPulse(developerSessions, {
@@ -48,8 +52,10 @@ export function buildWrappedOnboardingMetrics(
 	});
 
 	return {
-		activeDays:
-			wrappedMetrics?.active_days ?? developerDetails?.active_days ?? 0,
+		activeDays: Math.max(
+			developerDetails?.active_days ?? 0,
+			wrappedMetrics?.active_days ?? 0,
+		),
 		avgSessionMin: developerDetails?.avg_session_duration_min ?? null,
 		commitRate:
 			totalSessions > 0 ? (commitSessions / totalSessions) * 100 : null,
@@ -126,8 +132,10 @@ export function buildWrappedOnboardingMetrics(
 				) ?? [],
 		topSubagentCount: developerFeatures?.top_subagents[0]?.count ?? null,
 		totalSessions,
-		totalTokens:
-			wrappedMetrics?.total_tokens ?? developerDetails?.total_tokens ?? 0,
+		totalTokens: Math.max(
+			developerDetails?.total_tokens ?? 0,
+			wrappedMetrics?.total_tokens ?? 0,
+		),
 	};
 }
 

--- a/apps/web/src/features/wrapped/team-card/row.test.ts
+++ b/apps/web/src/features/wrapped/team-card/row.test.ts
@@ -1,3 +1,4 @@
+import type { DeveloperDetails, WrappedV1 } from "@rudel/api-routes";
 import { describe, expect, it } from "vitest";
 import {
 	buildResolvedTeamCardRow,
@@ -43,6 +44,40 @@ describe("buildResolvedTeamCardRow", () => {
 		expect(row.imageUrl).toBe("https://avatars.githubusercontent.com/u/1?v=4");
 	});
 
+	it("keeps the visible card on the freshest wrapped totals when developer details lag", () => {
+		const row = buildResolvedTeamCardRow({
+			accountLabel: "Session User",
+			developerDetails: createDeveloperDetails({
+				active_days: 9,
+				cost: 42,
+				favorite_model: "recent-model",
+				total_sessions: 73,
+				total_tokens: 12_000,
+			}),
+			guestPreviewDisplayName: undefined,
+			guestPreviewImageUrl: undefined,
+			profileImageFallbackSrc: "/favicon-dark.png",
+			sessionUserEmail: "session@example.com",
+			sessionUserId: "user_1",
+			sessionUserImage: undefined,
+			sessionUserName: "Session User",
+			teamMemberRows: [],
+			wrappedMetrics: createWrappedMetrics({
+				active_days: 14,
+				estimated_spend_usd: 91,
+				favorite_model: "all-time-model",
+				total_sessions: 135,
+				total_tokens: 38_000,
+			}),
+		});
+
+		expect(row.totalSessions).toBe(135);
+		expect(row.activeDays).toBe(14);
+		expect(row.totalTokens).toBe(38_000);
+		expect(row.cost).toBe(91);
+		expect(row.favoriteModel).toBe("all-time-model");
+	});
+
 	it("keeps edited profile images ahead of session profile images", () => {
 		expect(
 			resolveTeamCardProfileImageSrc({
@@ -63,3 +98,45 @@ describe("buildResolvedTeamCardRow", () => {
 		).toBe("/favicon-dark.png");
 	});
 });
+
+function createDeveloperDetails(
+	overrides: Partial<DeveloperDetails> = {},
+): DeveloperDetails {
+	return {
+		active_days: 1,
+		avg_session_duration_min: 10,
+		cost: 1,
+		distinct_projects: 1,
+		error_count: 0,
+		favorite_model: null,
+		input_tokens: 100,
+		last_active_date: "2026-04-21",
+		output_tokens: 200,
+		success_rate: 100,
+		success_rate_trend: 0,
+		total_duration_min: 10,
+		total_sessions: 1,
+		total_tokens: 300,
+		user_id: "user_1",
+		...overrides,
+	} satisfies DeveloperDetails;
+}
+
+function createWrappedMetrics(
+	overrides: Partial<WrappedV1["metrics"]> = {},
+): WrappedV1["metrics"] {
+	return {
+		active_days: 1,
+		days_since_first_session: 1,
+		estimated_spend_usd: 1,
+		favorite_model: null,
+		first_session_at: "2026-04-20T00:00:00Z",
+		last_session_at: "2026-04-21T00:00:00Z",
+		longest_session_min: 10,
+		model_by_month: [],
+		source_split: [],
+		total_sessions: 1,
+		total_tokens: 300,
+		...overrides,
+	} satisfies WrappedV1["metrics"];
+}

--- a/apps/web/src/features/wrapped/team-card/row.ts
+++ b/apps/web/src/features/wrapped/team-card/row.ts
@@ -51,7 +51,7 @@ export function buildResolvedTeamCardRow(
 	const email = currentUserRow?.email ?? sessionUserEmail ?? null;
 
 	if (developerDetails && sessionUserId) {
-		return {
+		const developerRow = {
 			activeDays: developerDetails.active_days,
 			cost: developerDetails.cost,
 			displayName,
@@ -69,6 +69,11 @@ export function buildResolvedTeamCardRow(
 			totalSessions: developerDetails.total_sessions,
 			totalTokens: developerDetails.total_tokens,
 			userId: sessionUserId,
+		};
+
+		return {
+			...developerRow,
+			...getWrappedMetricFallbackFields(wrappedMetrics, developerRow),
 		};
 	}
 
@@ -147,7 +152,7 @@ function getWrappedMetricFallbackFields(
 		activeDays,
 		cost,
 		favoriteModel:
-			currentRow?.favoriteModel ?? wrappedMetrics?.favorite_model ?? null,
+			wrappedMetrics?.favorite_model ?? currentRow?.favoriteModel ?? null,
 		hasActivity:
 			Boolean(currentRow?.hasActivity) ||
 			totalSessions > 0 ||

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -180,7 +180,9 @@ export const contract = {
 		.input(IngestSessionInputSchema)
 		.output(IngestSessionOutputSchema),
 	getOrganizationSessionCount: oc
-		.input(z.object({ organizationId: z.string() }))
+		.input(
+			z.object({ organizationId: z.string(), userId: z.string().optional() }),
+		)
 		.output(z.object({ count: z.number() })),
 	deleteOrganization: oc
 		.input(z.object({ organizationId: z.string() }))


### PR DESCRIPTION
## Summary
- scope the raw uploaded-session count to the current wrapped user instead of mixing in org-wide upload totals
- keep wrapped setup progress from using the org-wide summary fallback when it is rendering user-scoped wrapped progress
- hold the wrapped story while cached wrapped gate data is behind the latest raw upload count
- render wrapped story/card totals from the freshest all-time wrapped metrics when recent developer details lag
- make the wrapped service ClickHouse mock export the helper surface so API tests stay deterministic when caches are invalidated

## Test plan
- [x] `bun --cwd apps/web test src/features/get-started/use-setup-progress.test.tsx src/features/get-started/use-setup-progress.polling.test.tsx src/features/wrapped/WrappedRouteGate.test.tsx src/features/wrapped/WrappedUploadPollingSmoke.test.tsx src/features/team/TeamPageUploadFreshnessSmoke.test.tsx src/features/wrapped/team-card/row.test.ts src/features/wrapped/team-card/onboarding-metrics.test.ts`
- [x] `bun --cwd apps/web check-types`
- [x] `bun --cwd apps/api check-types`
- [x] `bun --cwd apps/api test`
- [x] `bunx --no-install biome check <changed files>`
- [x] `bun run lint:wrapped:hig`
- [x] `doppler run --project rudel --config ci -- bunx --no-install turbo run check-types test build`
- [x] `bun run verify`