### PR TITLE
fix: refresh wrapped analytics after uploads

### DIFF
--- a/apps/api/src/services/org-session.service.test.ts
+++ b/apps/api/src/services/org-session.service.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface ClickHouseQueryInput {
+	query: string;
+	query_params: Record<string, unknown>;
+}
+
+const query = mock((_input: ClickHouseQueryInput) => {
+	return Promise.resolve([{ count: "1" }]);
+});
+
+mock.module("@rudel/agent-adapters", () => ({
+	getAllAdapters: () => [
+		{ rawTableName: "rudel.claude_sessions" },
+		{ rawTableName: "rudel.codex_sessions" },
+	],
+}));
+
+mock.module("../clickhouse.js", () => ({
+	getClickhouse: () => ({ query }),
+	getSafeClickHouseTable: (table: string) => table,
+}));
+
+const { getOrgSessionCount } = await import("./org-session.service.js");
+
+describe("getOrgSessionCount", () => {
+	beforeEach(() => {
+		query.mockClear();
+	});
+
+	test("counts uploaded sessions by distinct session id for the current user", async () => {
+		const count = await getOrgSessionCount("org-1", "user-1");
+
+		expect(count).toBe(2);
+		expect(query).toHaveBeenCalledTimes(2);
+		for (const call of query.mock.calls) {
+			const input = call[0];
+			expect(input.query).toContain("uniqExact(session_id)");
+			expect(input.query).toContain("organization_id = {orgId:String}");
+			expect(input.query).toContain("user_id = {userId:String}");
+			expect(input.query_params).toEqual({
+				orgId: "org-1",
+				userId: "user-1",
+			});
+		}
+	});
+});

--- a/apps/api/src/services/org-session.service.ts
+++ b/apps/api/src/services/org-session.service.ts
@@ -11,7 +11,7 @@ export async function getOrgSessionCount(
 	const results = await Promise.all(
 		tables.map((table) =>
 			ch.query<{ count: string }>({
-				query: `SELECT count() as count FROM ${getSafeClickHouseTable(table)} WHERE organization_id = {orgId:String}${userFilter}`,
+				query: `SELECT uniqExact(session_id) as count FROM ${getSafeClickHouseTable(table)} WHERE organization_id = {orgId:String}${userFilter}`,
 				query_params: {
 					orgId,
 					...(userId ? { userId } : {}),

--- a/apps/web/src/features/analytics/queries/use-upload-analytics-refresh.ts
+++ b/apps/web/src/features/analytics/queries/use-upload-analytics-refresh.ts
@@ -60,11 +60,12 @@ export function useUploadAnalyticsRefresh({
 
 		const previousRawSessionCount = previousRawSessionCountRef.current;
 		previousRawSessionCountRef.current = rawSessionCount;
+		const hasFreshUploads =
+			previousRawSessionCount === null
+				? keepPollingAfterUpload && rawSessionCount > 0
+				: rawSessionCount > previousRawSessionCount;
 
-		if (
-			previousRawSessionCount === null ||
-			rawSessionCount <= previousRawSessionCount
-		) {
+		if (!hasFreshUploads) {
 			return;
 		}
 
@@ -77,11 +78,17 @@ export function useUploadAnalyticsRefresh({
 			queryKey: analyticsQueryKey,
 			type: "inactive",
 		});
-		void queryClient.resetQueries({
+		void queryClient.invalidateQueries({
 			queryKey: analyticsQueryKey,
-			type: "active",
+			refetchType: "active",
 		});
-	}, [activeOrganizationId, enabled, queryClient, rawSessionCount]);
+	}, [
+		activeOrganizationId,
+		enabled,
+		keepPollingAfterUpload,
+		queryClient,
+		rawSessionCount,
+	]);
 
 	return {
 		rawSessionCount,

--- a/apps/web/src/features/get-started/use-setup-progress.test.tsx
+++ b/apps/web/src/features/get-started/use-setup-progress.test.tsx
@@ -4,16 +4,16 @@ import { useSetupProgress } from "@/features/get-started/use-setup-progress";
 
 const {
 	mockGetOrganizationSessionCount,
+	mockInvalidateQueries,
 	mockRemoveQueries,
-	mockResetQueries,
 	mockSummaryQueryOptions,
 	mockUseAnalyticsQuery,
 	mockUseOrganization,
 	mockUseQuery,
 } = vi.hoisted(() => ({
 	mockGetOrganizationSessionCount: vi.fn(),
+	mockInvalidateQueries: vi.fn(),
 	mockRemoveQueries: vi.fn(),
-	mockResetQueries: vi.fn(),
 	mockSummaryQueryOptions: vi.fn(),
 	mockUseAnalyticsQuery: vi.fn(),
 	mockUseOrganization: vi.fn(),
@@ -23,8 +23,8 @@ const {
 vi.mock("@tanstack/react-query", () => ({
 	useQuery: mockUseQuery,
 	useQueryClient: () => ({
+		invalidateQueries: mockInvalidateQueries,
 		removeQueries: mockRemoveQueries,
-		resetQueries: mockResetQueries,
 	}),
 }));
 
@@ -136,8 +136,8 @@ describe("useSetupProgress", () => {
 		rawCountQueryResult = defaultRawCountQueryResult;
 
 		mockGetOrganizationSessionCount.mockReset();
+		mockInvalidateQueries.mockReset();
 		mockRemoveQueries.mockReset();
-		mockResetQueries.mockReset();
 		mockSummaryQueryOptions.mockReset();
 		mockUseAnalyticsQuery.mockReset();
 		mockUseOrganization.mockReset();
@@ -165,7 +165,7 @@ describe("useSetupProgress", () => {
 			capturedRawQueryOptions = options;
 			return rawCountQueryResult;
 		});
-		mockResetQueries.mockResolvedValue(undefined);
+		mockInvalidateQueries.mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
@@ -327,7 +327,7 @@ describe("useSetupProgress", () => {
 		const { rerender } = renderHook(() => useSetupProgress());
 
 		expect(mockRemoveQueries).not.toHaveBeenCalled();
-		expect(mockResetQueries).not.toHaveBeenCalled();
+		expect(mockInvalidateQueries).not.toHaveBeenCalled();
 
 		rawCountQueryResult = {
 			data: {
@@ -344,9 +344,9 @@ describe("useSetupProgress", () => {
 				type: "inactive",
 			});
 		});
-		expect(mockResetQueries).toHaveBeenCalledWith({
+		expect(mockInvalidateQueries).toHaveBeenCalledWith({
 			queryKey: ["org", "org-1", "analytics"],
-			type: "active",
+			refetchType: "active",
 		});
 	});
 });

--- a/apps/web/src/features/team/use-team-page-data.ts
+++ b/apps/web/src/features/team/use-team-page-data.ts
@@ -112,7 +112,7 @@ function buildTeamMemberRows(
 				imageUrl: member?.imageUrl,
 				cost,
 				favoriteModel:
-					teamCard?.favorite_model ?? developerSummary?.favorite_model ?? null,
+					developerSummary?.favorite_model ?? teamCard?.favorite_model ?? null,
 				inputTokens,
 				outputTokens,
 				totalSessions,

--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -951,9 +951,40 @@ describe("WrappedRouteGate", () => {
 			</MemoryRouter>,
 		);
 
-		expect(screen.getByText("Preparing your wrapped...")).toBeInTheDocument();
+		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
+		expect(screen.getByText("Total sessions: 132")).toBeInTheDocument();
+		expect(screen.getByText("Can continue: no")).toBeInTheDocument();
+		expect(screen.getByText("Readiness: enough-landed")).toBeInTheDocument();
 		expect(screen.queryByText("Wrapped story")).toBeNull();
-		expect(screen.queryByText("Wrapped setup complete page")).toBeNull();
+		expect(screen.queryByText("Preparing your wrapped...")).toBeNull();
+
+		const wrappedQueryOptions = mockUseAnalyticsQuery.mock.calls.at(-1)?.[0];
+		expect(
+			wrappedQueryOptions.refetchInterval({
+				state: {
+					data: {
+						archetype_gate: {
+							values: {
+								total_sessions: 72,
+							},
+						},
+					},
+				},
+			}),
+		).toBe(1_000);
+		expect(
+			wrappedQueryOptions.refetchInterval({
+				state: {
+					data: {
+						archetype_gate: {
+							values: {
+								total_sessions: 132,
+							},
+						},
+					},
+				},
+			}),
+		).toBe(false);
 	});
 
 	it("treats a legacy non-session gate reason as ready after 100 sessions", () => {
@@ -1031,8 +1062,10 @@ describe("WrappedRouteGate", () => {
 			</MemoryRouter>,
 		);
 
-		expect(screen.getByText("Preparing your wrapped...")).toBeInTheDocument();
-		expect(screen.queryByText("Wrapped setup complete page")).toBeNull();
+		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
+		expect(screen.getByText("Can continue: no")).toBeInTheDocument();
+		expect(screen.getByText("Readiness: enough-landed")).toBeInTheDocument();
+		expect(screen.queryByText("Preparing your wrapped...")).toBeNull();
 	});
 
 	it("enables setup continue when sessions land during setup", async () => {

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -446,8 +446,6 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 					onContinue={handleSetupContinue}
 				/>
 			);
-		} else if (shouldWaitForWrappedStoryData) {
-			content = <WrappedRouteLoadingState body="Preparing your wrapped..." />;
 		} else if (sessionUserId && shouldForceSessionsLanded) {
 			content = (
 				<WrappedSetupCompletePage
@@ -461,6 +459,8 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 					userId={sessionUserId}
 				/>
 			);
+		} else if (shouldWaitForWrappedStoryData) {
+			content = <WrappedRouteLoadingState body="Preparing your wrapped..." />;
 		} else if (sessionUserId && shouldHoldForMinimumSessions) {
 			content = (
 				<WrappedSetupCompletePage
@@ -525,7 +525,9 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 
 	if (shouldQueryWrappedArchetypeGate) {
 		return (
-			<WrappedArchetypeGateQuery>
+			<WrappedArchetypeGateQuery
+				setupProgressTotalSessionCount={setupProgress.totalSessionCount}
+			>
 				{(archetypeGateState) => renderRouteContent(archetypeGateState)}
 			</WrappedArchetypeGateQuery>
 		);
@@ -541,10 +543,27 @@ interface WrappedArchetypeGateState {
 
 function WrappedArchetypeGateQuery(props: {
 	children: (state: WrappedArchetypeGateState) => ReactNode;
+	setupProgressTotalSessionCount: number;
 }) {
 	const wrappedV1Query = useAnalyticsQuery({
 		...orpc.analytics.wrapped.v1.queryOptions({}),
 		enabled: true,
+		refetchInterval: (query) => {
+			const wrappedSessionCount =
+				query.state.data?.archetype_gate.values.total_sessions ?? null;
+
+			if (
+				wrappedSessionCount === null ||
+				wrappedSessionCount < props.setupProgressTotalSessionCount
+			) {
+				return 1_000;
+			}
+
+			return false;
+		},
+		refetchIntervalInBackground: true,
+		refetchOnReconnect: "always",
+		refetchOnWindowFocus: "always",
 	});
 
 	return props.children({

--- a/apps/web/src/features/wrapped/WrappedUploadPollingSmoke.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedUploadPollingSmoke.test.tsx
@@ -42,6 +42,8 @@ vi.mock("@/features/workspace/organization/useOrganization", () => ({
 }));
 
 let rawSessionCount = 45;
+let wrappedGateSessionCount = 45;
+let wrappedV1QueryCallCount = 0;
 
 vi.mock("@/lib/orpc", () => ({
 	client: {
@@ -81,18 +83,31 @@ vi.mock("@/lib/orpc", () => ({
 			wrapped: {
 				v1: {
 					queryOptions: () => ({
-						queryFn: async () => ({
-							archetype_gate: {
-								is_eligible: false,
-								reason: "session_threshold",
-								thresholds: {
-									min_total_sessions: 100,
+						queryFn: async () => {
+							wrappedV1QueryCallCount += 1;
+
+							return {
+								archetype_gate: {
+									is_eligible: wrappedGateSessionCount >= 100,
+									reason:
+										wrappedGateSessionCount >= 100
+											? "eligible"
+											: "needs_more_sessions",
+									thresholds: {
+										max_distance_ratio_to_max: 0.25,
+										min_active_days: 14,
+										min_top_two_margin: 0.1,
+										min_total_sessions: 100,
+									},
+									values: {
+										active_days: 14,
+										archetype_distance_ratio_to_max: 0.1,
+										archetype_top_two_margin: 0.2,
+										total_sessions: wrappedGateSessionCount,
+									},
 								},
-								values: {
-									total_sessions: rawSessionCount,
-								},
-							},
-						}),
+							};
+						},
 						queryKey: ["analytics", "wrapped", "v1"],
 					}),
 				},
@@ -148,6 +163,8 @@ function createWrapper(queryClient: QueryClient, initialEntry = "/wrapped") {
 describe("Wrapped upload polling smoke", () => {
 	beforeEach(() => {
 		rawSessionCount = 45;
+		wrappedGateSessionCount = 45;
+		wrappedV1QueryCallCount = 0;
 		mockGetOrganizationSessionCount.mockReset();
 		mockUseAnalyticsTracking.mockReset();
 		mockUseCliSetupStatus.mockReset();
@@ -256,6 +273,43 @@ describe("Wrapped upload polling smoke", () => {
 		);
 		expect(screen.getByText("63 sessions across 1 repo")).toBeInTheDocument();
 		expect(mockGetOrganizationSessionCount).toHaveBeenCalledTimes(2);
+
+		queryClient.clear();
+	});
+
+	it("refetches wrapped v1 every second until the wrapped gate catches uploaded sessions", async () => {
+		const queryClient = new QueryClient(queryClientConfig);
+		rawSessionCount = 132;
+		wrappedGateSessionCount = 72;
+		markSetupCompleted();
+
+		render(
+			<WrappedRouteGate isPending={false} publicId={null} session={session} />,
+			{
+				wrapper: createWrapper(queryClient, "/wrapped?flow=sessions-landed"),
+			},
+		);
+
+		expect(
+			await screen.findByRole("button", { name: "Upload more to unlock" }),
+		).toBeDisabled();
+		expect(screen.queryByText("Preparing your wrapped...")).toBeNull();
+
+		wrappedGateSessionCount = 132;
+
+		await waitFor(
+			() => {
+				expect(wrappedV1QueryCallCount).toBeGreaterThanOrEqual(2);
+			},
+			{ timeout: 1_500 },
+		);
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", {
+					name: "See what it reveals about you",
+				}),
+			).toBeEnabled();
+		});
 
 		queryClient.clear();
 	});

--- a/apps/web/src/features/wrapped/team-card/onboarding-metrics.ts
+++ b/apps/web/src/features/wrapped/team-card/onboarding-metrics.ts
@@ -33,6 +33,9 @@ export function buildWrappedOnboardingMetrics(
 		developerDetails?.total_sessions ?? 0,
 		wrappedMetrics?.total_sessions ?? 0,
 	);
+	const shouldUseWrappedModel =
+		(wrappedMetrics?.total_sessions ?? 0) >
+		(developerDetails?.total_sessions ?? 0);
 	const commitSessions = findBooleanDimensionCount(commitBreakdown, true);
 	const topProject = findTopProject(developerProjects);
 	const estimatedCostTokenBasis = Math.max(
@@ -66,9 +69,13 @@ export function buildWrappedOnboardingMetrics(
 		estimatedCostTokenBasis,
 		estimatedCostUsd,
 		favoriteModel: formatWrappedLabel(
-			wrappedMetrics?.favorite_model ??
-				developerDetails?.favorite_model ??
-				undefined,
+			shouldUseWrappedModel
+				? (wrappedMetrics?.favorite_model ??
+						developerDetails?.favorite_model ??
+						undefined)
+				: (developerDetails?.favorite_model ??
+						wrappedMetrics?.favorite_model ??
+						undefined),
 		),
 		longestSessionMin: wrappedMetrics?.longest_session_min ?? null,
 		modelByMonth: wrappedMetrics?.model_by_month ?? [],

--- a/apps/web/src/features/wrapped/team-card/one-truth-smoke.test.ts
+++ b/apps/web/src/features/wrapped/team-card/one-truth-smoke.test.ts
@@ -1,0 +1,285 @@
+import type {
+	DeveloperDetails,
+	DeveloperFeatureUsage,
+	DeveloperProject,
+	DeveloperSession,
+	DimensionAnalysisDataPoint,
+	WrappedV1,
+} from "@rudel/api-routes";
+import { describe, expect, it } from "vitest";
+import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
+import { buildWrappedTeamCardBackMetrics } from "./back-metrics";
+import { buildWrappedOnboardingMetrics } from "./onboarding-metrics";
+import { buildResolvedTeamCardRow } from "./row";
+import { buildWrappedStatItems } from "./stat-items";
+
+describe("wrapped one-truth smoke", () => {
+	it("keeps reveal, share card, and team card data on the newest uploaded-session snapshot", () => {
+		const freshWrappedMetrics = createWrappedMetrics({
+			active_days: 14,
+			days_since_first_session: 44,
+			estimated_spend_usd: 91,
+			favorite_model: "gpt-5.1-codex",
+			longest_session_min: 48,
+			source_split: [
+				{
+					session_count: 79,
+					session_share_percent: 60,
+					source: "claude_code",
+				},
+				{
+					session_count: 53,
+					session_share_percent: 40,
+					source: "codex",
+				},
+			],
+			total_sessions: 132,
+			total_tokens: 3_800_000,
+		});
+		const newDeveloperDetails = createDeveloperDetails({
+			active_days: 14,
+			avg_session_duration_min: 24,
+			cost: 91,
+			distinct_projects: 8,
+			favorite_model: "gpt-5.1-codex",
+			input_tokens: 1_500_000,
+			output_tokens: 2_300_000,
+			success_rate: 96,
+			total_duration_min: 3_168,
+			total_sessions: 132,
+			total_tokens: 3_800_000,
+		});
+		const newDeveloperFeatures = createDeveloperFeatures();
+		const newDeveloperProjects = [
+			createDeveloperProject({
+				project_path: "/repos/new-repo",
+				sessions: 88,
+				total_tokens: 2_400_000,
+			}),
+			createDeveloperProject({
+				project_path: "/repos/old-repo",
+				sessions: 44,
+				total_tokens: 1_400_000,
+			}),
+		];
+		const newDeveloperSessions = [
+			createDeveloperSession({
+				duration_min: 24,
+				project_path: "/repos/new-repo",
+				session_id: "new-session-1",
+				total_tokens: 1_900_000,
+			}),
+			createDeveloperSession({
+				duration_min: 18,
+				project_path: "/repos/new-repo",
+				session_id: "new-session-2",
+				total_tokens: 1_900_000,
+			}),
+		];
+		const newCommitBreakdown = [
+			{
+				dimension_value: "true",
+				metric_value: 73,
+			},
+		] satisfies DimensionAnalysisDataPoint[];
+
+		const row = buildResolvedTeamCardRow({
+			accountLabel: "Session User",
+			developerDetails: newDeveloperDetails,
+			guestPreviewDisplayName: undefined,
+			guestPreviewImageUrl: undefined,
+			profileImageFallbackSrc: "/favicon-dark.png",
+			sessionUserEmail: "session@example.com",
+			sessionUserId: "user_1",
+			sessionUserImage: undefined,
+			sessionUserName: "Session User",
+			teamMemberRows: [],
+			wrappedMetrics: freshWrappedMetrics,
+		});
+		const onboardingMetrics = buildWrappedOnboardingMetrics({
+			commitBreakdown: newCommitBreakdown,
+			developerDetails: newDeveloperDetails,
+			developerFeatures: newDeveloperFeatures,
+			developerProjects: newDeveloperProjects,
+			developerSessions: newDeveloperSessions,
+			wrappedMetrics: freshWrappedMetrics,
+		});
+		const statItems = buildWrappedStatItems(
+			row,
+			onboardingMetrics.distinctProjectCount,
+			onboardingMetrics.sourceSplit,
+		);
+		const backMetrics = buildWrappedTeamCardBackMetrics({
+			onboardingMetrics,
+			row,
+			shareCardCreatedAtLabel: "May 3, 2026",
+		});
+
+		expect.soft(row.totalSessions).toBe(132);
+		expect.soft(row.activeDays).toBe(14);
+		expect.soft(row.totalTokens).toBe(3_800_000);
+		expect.soft(row.cost).toBe(91);
+		expect.soft(row.favoriteModel).toBe("gpt-5.1-codex");
+
+		expect.soft(onboardingMetrics.totalSessions).toBe(132);
+		expect.soft(onboardingMetrics.activeDays).toBe(14);
+		expect.soft(onboardingMetrics.totalTokens).toBe(3_800_000);
+		expect.soft(onboardingMetrics.estimatedCostUsd).toBe(91);
+		expect.soft(onboardingMetrics.favoriteModel).toBe("Gpt 5.1 Codex");
+		expect.soft(onboardingMetrics.topProjectName).toBe("/repos/new-repo");
+		expect.soft(onboardingMetrics.topSkills[0]?.name).toBe("New Skill");
+		expect.soft(onboardingMetrics.sourceSplit).toEqual([
+			{
+				session_count: 79,
+				session_share_percent: 60,
+				source: "claude_code",
+			},
+			{
+				session_count: 53,
+				session_share_percent: 40,
+				source: "codex",
+			},
+		]);
+
+		expect.soft(findStatItemValue(statItems, "sessions")).toBe("132");
+		expect.soft(findStatItemValue(statItems, "repos")).toBe("8");
+		expect.soft(findStatItemValue(statItems, "claude-share")).toBe("60%");
+		expect.soft(findStatItemValue(statItems, "codex-share")).toBe("40%");
+
+		expect.soft(findBackMetricValue(backMetrics, "Sessions")).toBe("132");
+		expect.soft(findBackMetricValue(backMetrics, "Active days")).toBe("14");
+		expect
+			.soft(findBackMetricValue(backMetrics, "Claude/Codex %"))
+			.toBe("60%/40%");
+		expect
+			.soft(findBackMetricValue(backMetrics, "FAV SKILL"))
+			.toBe("New Skill");
+
+		const teamOverviewRow = createTeamOverviewRow(newDeveloperDetails);
+		expect.soft(teamOverviewRow.totalSessions).toBe(132);
+		expect.soft(teamOverviewRow.favoriteModel).toBe("gpt-5.1-codex");
+	});
+});
+
+function findStatItemValue(
+	items: readonly { key: string; value: string }[],
+	key: string,
+) {
+	return items.find((item) => item.key === key)?.value;
+}
+
+function findBackMetricValue(
+	items: readonly { label: string; value: string }[],
+	label: string,
+) {
+	return items.find((item) => item.label === label)?.value;
+}
+
+function createDeveloperDetails(
+	overrides: Partial<DeveloperDetails> = {},
+): DeveloperDetails {
+	return {
+		active_days: 1,
+		avg_session_duration_min: 10,
+		cost: 1,
+		distinct_projects: 1,
+		error_count: 0,
+		favorite_model: null,
+		input_tokens: 100,
+		last_active_date: "2026-05-03",
+		output_tokens: 200,
+		success_rate: 100,
+		success_rate_trend: 0,
+		total_duration_min: 10,
+		total_sessions: 1,
+		total_tokens: 300,
+		user_id: "user_1",
+		...overrides,
+	} satisfies DeveloperDetails;
+}
+
+function createDeveloperFeatures(
+	overrides: Partial<DeveloperFeatureUsage> = {},
+): DeveloperFeatureUsage {
+	return {
+		skills_adoption_rate: 55,
+		slash_commands_adoption_rate: 44,
+		subagents_adoption_rate: 33,
+		top_skills: [{ count: 44, name: "new-skill" }],
+		top_slash_commands: [{ count: 22, name: "new-command" }],
+		top_subagents: [{ count: 18, name: "new-agent" }],
+		...overrides,
+	} satisfies DeveloperFeatureUsage;
+}
+
+function createDeveloperProject(
+	overrides: Partial<DeveloperProject> = {},
+): DeveloperProject {
+	return {
+		first_session: "2026-04-20T00:00:00Z",
+		last_session: "2026-05-03T00:00:00Z",
+		project_path: "/repos/new-repo",
+		sessions: 1,
+		total_duration_min: 10,
+		total_tokens: 300,
+		...overrides,
+	} satisfies DeveloperProject;
+}
+
+function createDeveloperSession(
+	overrides: Partial<DeveloperSession> = {},
+): DeveloperSession {
+	return {
+		duration_min: 10,
+		has_errors: false,
+		has_skills: true,
+		has_slash_commands: true,
+		has_subagents: true,
+		likely_success: true,
+		project_path: "/repos/new-repo",
+		session_date: "2026-05-03",
+		session_id: "session_1",
+		total_tokens: 300,
+		...overrides,
+	} satisfies DeveloperSession;
+}
+
+function createWrappedMetrics(
+	overrides: Partial<WrappedV1["metrics"]> = {},
+): WrappedV1["metrics"] {
+	return {
+		active_days: 1,
+		days_since_first_session: 1,
+		estimated_spend_usd: 1,
+		favorite_model: null,
+		first_session_at: "2026-04-20T00:00:00Z",
+		last_session_at: "2026-04-21T00:00:00Z",
+		longest_session_min: 10,
+		model_by_month: [],
+		source_split: [],
+		total_sessions: 1,
+		total_tokens: 300,
+		...overrides,
+	} satisfies WrappedV1["metrics"];
+}
+
+function createTeamOverviewRow(
+	developerDetails: DeveloperDetails,
+): TeamPageMemberRow {
+	return {
+		activeDays: developerDetails.active_days,
+		cost: developerDetails.cost,
+		displayName: "Session User",
+		email: "session@example.com",
+		favoriteModel: developerDetails.favorite_model,
+		hasActivity: developerDetails.total_sessions > 0,
+		imageUrl: "/favicon-dark.png",
+		inputTokens: developerDetails.input_tokens,
+		lastActiveDate: developerDetails.last_active_date,
+		outputTokens: developerDetails.output_tokens,
+		role: "Tracked collaborator",
+		totalSessions: developerDetails.total_sessions,
+		totalTokens: developerDetails.total_tokens,
+		userId: developerDetails.user_id,
+	};
+}

--- a/apps/web/src/features/wrapped/team-card/row.ts
+++ b/apps/web/src/features/wrapped/team-card/row.ts
@@ -131,10 +131,11 @@ function getWrappedMetricFallbackFields(
 	wrappedMetrics: WrappedV1["metrics"] | undefined,
 	currentRow?: TeamPageMemberRow,
 ) {
-	const totalSessions = Math.max(
-		currentRow?.totalSessions ?? 0,
-		wrappedMetrics?.total_sessions ?? 0,
-	);
+	const wrappedTotalSessions = wrappedMetrics?.total_sessions ?? 0;
+	const currentTotalSessions = currentRow?.totalSessions ?? 0;
+	const shouldUseWrappedFavoriteModel =
+		wrappedTotalSessions > currentTotalSessions;
+	const totalSessions = Math.max(currentTotalSessions, wrappedTotalSessions);
 	const activeDays = Math.max(
 		currentRow?.activeDays ?? 0,
 		wrappedMetrics?.active_days ?? 0,
@@ -151,8 +152,9 @@ function getWrappedMetricFallbackFields(
 	return {
 		activeDays,
 		cost,
-		favoriteModel:
-			wrappedMetrics?.favorite_model ?? currentRow?.favoriteModel ?? null,
+		favoriteModel: shouldUseWrappedFavoriteModel
+			? (wrappedMetrics?.favorite_model ?? currentRow?.favoriteModel ?? null)
+			: (currentRow?.favoriteModel ?? wrappedMetrics?.favorite_model ?? null),
 		hasActivity:
 			Boolean(currentRow?.hasActivity) ||
 			totalSessions > 0 ||

--- a/apps/web/src/features/wrapped/team-card/use-page-data.ts
+++ b/apps/web/src/features/wrapped/team-card/use-page-data.ts
@@ -166,12 +166,12 @@ export function useWrappedTeamCardPageData(): UseWrappedTeamCardPageDataResult {
 			buildWrappedStatItems(
 				visibleTeamCardRow,
 				onboardingMetrics.distinctProjectCount,
-				wrappedData?.metrics.source_split ?? [],
+				onboardingMetrics.sourceSplit,
 			),
 		[
 			onboardingMetrics.distinctProjectCount,
+			onboardingMetrics.sourceSplit,
 			visibleTeamCardRow,
-			wrappedData?.metrics.source_split,
 		],
 	);
 	const liveArchetype = useMemo(


### PR DESCRIPTION
## Summary
- count uploaded sessions by distinct session id so re-uploads do not inflate setup readiness
- invalidate active org analytics when upload polling sees new sessions, and poll wrapped v1 every second until it catches the uploaded-session count
- keep the sessions-landed repo screen visible while wrapped data catches up, and align card/team fallback metrics with the freshest snapshot
- add backend, route, upload polling, and one-truth smoke coverage

## Test plan
- [x] bun run verify
- [x] bun --cwd apps/web test
- [x] bun --cwd apps/api test
- [x] bun --cwd apps/web check-types
- [x] bun --cwd apps/api check-types
- [x] bun run lint:wrapped:hig
- [x] Playwright visual screenshots for wrapped setup/card refs