### PR TITLE
fix: dedupe wrapped analytics reads

### DIFF
--- a/apps/api/src/services/wrapped.service.test.ts
+++ b/apps/api/src/services/wrapped.service.test.ts
@@ -9,6 +9,10 @@ let summaryActiveDays = 0;
 let archetypeRows: unknown[] = [];
 
 const queryClickhouse = mock((input: QueryClickhouseInput) => {
+	expect(input.query).not.toMatch(
+		/FROM\s+rudel\.session_analytics(?!\s+FINAL\b)/u,
+	);
+
 	if (input.query.includes("count() AS total_sessions")) {
 		return Promise.resolve([
 			{

--- a/apps/api/src/services/wrapped.service.ts
+++ b/apps/api/src/services/wrapped.service.ts
@@ -155,7 +155,7 @@ async function getWrappedSummary(
 				ifNull(maxOrNull(actual_duration_min), 0) AS longest_session_min,
 				countIf(source = 'claude_code') AS claude_session_count,
 				countIf(source = 'codex') AS codex_session_count
-			FROM rudel.session_analytics
+			FROM rudel.session_analytics FINAL
 			WHERE organization_id = {orgId:String}
 				AND user_id = {userId:String}
 		`,
@@ -178,7 +178,7 @@ async function getMonthlyModelUsage(
 				formatDateTime(toStartOfMonth(session_date), '%Y-%m') AS month,
 				model_used AS model,
 				count() AS session_count
-			FROM rudel.session_analytics
+			FROM rudel.session_analytics FINAL
 			WHERE organization_id = {orgId:String}
 				AND user_id = {userId:String}
 				AND model_used != ''
@@ -211,7 +211,7 @@ async function getFavoriteModel(
 					model_used AS favorite_model,
 					count() AS session_count,
 					sum(ifNull(input_tokens, 0) + ifNull(output_tokens, 0)) AS total_tokens
-				FROM rudel.session_analytics
+				FROM rudel.session_analytics FINAL
 				WHERE organization_id = {orgId:String}
 					AND user_id = {userId:String}
 					AND model_used != ''


### PR DESCRIPTION
## Summary
- Read wrapped v1 session analytics through ClickHouse FINAL so wrapped totals, model split, and token metrics use the same deduped truth as the card/team data
- Add a wrapped service test guard that fails if a wrapped query reads session_analytics without FINAL

## Test plan
- [x] bun test apps/api/src/services/wrapped.service.test.ts
- [x] bun run verify