### PR TITLE
fix: keep wrapped repo overview visible

### DIFF
--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -859,7 +859,7 @@ describe("WrappedRouteGate", () => {
 		expect(screen.queryByText("Wrapped story")).toBeNull();
 	});
 
-	it("waits when user-scoped raw uploads outrun cached wrapped gate data", () => {
+	it("uses wrapped gate count when raw uploads already outrun wrapped data on entry", () => {
 		mockUseSetupProgress.mockReturnValue({
 			hasUploadedSessions: true,
 			isLoading: false,
@@ -893,12 +893,15 @@ describe("WrappedRouteGate", () => {
 			</MemoryRouter>,
 		);
 
-		expect(screen.getByText("Preparing your wrapped...")).toBeInTheDocument();
+		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
+		expect(screen.getByText("Can continue: no")).toBeInTheDocument();
+		expect(screen.getByText("Readiness: missing")).toBeInTheDocument();
+		expect(screen.getByText("Total sessions: 38")).toBeInTheDocument();
+		expect(screen.queryByText("Preparing your wrapped...")).toBeNull();
 		expect(screen.queryByText("Wrapped story")).toBeNull();
-		expect(screen.queryByText("Wrapped setup complete page")).toBeNull();
 	});
 
-	it("waits when fresh uploads outrun cached wrapped gate data", async () => {
+	it("shows repos while fresh uploads outrun cached wrapped gate data", async () => {
 		mockUseSetupProgress.mockReturnValue({
 			hasUploadedSessions: true,
 			isLoading: false,
@@ -951,9 +954,12 @@ describe("WrappedRouteGate", () => {
 			</MemoryRouter>,
 		);
 
-		expect(screen.getByText("Preparing your wrapped...")).toBeInTheDocument();
+		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
+		expect(screen.getByText("Can continue: no")).toBeInTheDocument();
+		expect(screen.getByText("Readiness: enough-landed")).toBeInTheDocument();
+		expect(screen.getByText("Total sessions: 132")).toBeInTheDocument();
+		expect(screen.queryByText("Preparing your wrapped...")).toBeNull();
 		expect(screen.queryByText("Wrapped story")).toBeNull();
-		expect(screen.queryByText("Wrapped setup complete page")).toBeNull();
 	});
 
 	it("treats a legacy non-session gate reason as ready after 100 sessions", () => {
@@ -997,7 +1003,7 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByRole("button", { name: "Start story" })).toBeEnabled();
 	});
 
-	it("keeps processing archetype users off the upload title screen", () => {
+	it("keeps processing archetype users on the repos screen with story locked", () => {
 		mockUseSetupProgress.mockReturnValue({
 			hasUploadedSessions: true,
 			isLoading: false,
@@ -1031,8 +1037,11 @@ describe("WrappedRouteGate", () => {
 			</MemoryRouter>,
 		);
 
-		expect(screen.getByText("Preparing your wrapped...")).toBeInTheDocument();
-		expect(screen.queryByText("Wrapped setup complete page")).toBeNull();
+		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
+		expect(screen.getByText("Can continue: no")).toBeInTheDocument();
+		expect(screen.getByText("Readiness: enough-landed")).toBeInTheDocument();
+		expect(screen.getByText("Total sessions: 100")).toBeInTheDocument();
+		expect(screen.queryByText("Preparing your wrapped...")).toBeNull();
 	});
 
 	it("enables setup continue when sessions land during setup", async () => {

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -392,6 +392,13 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 			forcedFlowStage === "story" &&
 			setupProgress.hasUploadedSessions &&
 			canContinueToWrappedStory;
+		const shouldShowSessionsLanded =
+			sessionUserId !== null &&
+			setupProgress.hasUploadedSessions &&
+			(shouldForceSessionsLanded ||
+				shouldHoldForMinimumSessions ||
+				shouldWaitForWrappedStoryData ||
+				sessionGateState.hasReachedMinimumAfterMissing);
 
 		let content: ReactNode;
 
@@ -446,42 +453,11 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 					onContinue={handleSetupContinue}
 				/>
 			);
-		} else if (shouldWaitForWrappedStoryData) {
-			content = <WrappedRouteLoadingState body="Preparing your wrapped..." />;
-		} else if (sessionUserId && shouldForceSessionsLanded) {
+		} else if (shouldShowSessionsLanded) {
 			content = (
 				<WrappedSetupCompletePage
 					canContinueToStory={canContinueToWrappedStory}
 					defaultUploadMoreVisible={sessionGateState.defaultUploadMoreVisible}
-					minimumSessionCount={sessionGateState.minimumSessionCount}
-					onBack={() => setWrappedRouteFlowStage("desktop-ready")}
-					onContinue={() => handleSetupComplete(canContinueToWrappedStory)}
-					sessionReadinessState={sessionGateState.sessionReadinessState}
-					totalSessionCount={sessionGateState.totalSessionCount}
-					userId={sessionUserId}
-				/>
-			);
-		} else if (sessionUserId && shouldHoldForMinimumSessions) {
-			content = (
-				<WrappedSetupCompletePage
-					canContinueToStory={canContinueToWrappedStory}
-					defaultUploadMoreVisible={sessionGateState.defaultUploadMoreVisible}
-					minimumSessionCount={sessionGateState.minimumSessionCount}
-					onBack={() => setWrappedRouteFlowStage("desktop-ready")}
-					onContinue={() => handleSetupComplete(canContinueToWrappedStory)}
-					sessionReadinessState={sessionGateState.sessionReadinessState}
-					totalSessionCount={sessionGateState.totalSessionCount}
-					userId={sessionUserId}
-				/>
-			);
-		} else if (
-			sessionUserId &&
-			sessionGateState.hasReachedMinimumAfterMissing
-		) {
-			content = (
-				<WrappedSetupCompletePage
-					canContinueToStory={canContinueToWrappedStory}
-					defaultUploadMoreVisible={false}
 					minimumSessionCount={sessionGateState.minimumSessionCount}
 					onBack={() => setWrappedRouteFlowStage("desktop-ready")}
 					onContinue={() => handleSetupComplete(canContinueToWrappedStory)}
@@ -703,6 +679,7 @@ function getWrappedRouteSessionGateState(input: {
 	const archetypeGateSessionCount =
 		input.archetypeGate?.values.total_sessions ?? null;
 	const isWaitingForFreshWrappedData =
+		input.hasReachedMinimumAfterMissing &&
 		archetypeGateSessionCount !== null &&
 		archetypeGateSessionCount < input.setupProgressTotalSessionCount;
 	const totalSessionCount =

--- a/apps/web/src/features/wrapped/WrappedSetupCompletePage.tsx
+++ b/apps/web/src/features/wrapped/WrappedSetupCompletePage.tsx
@@ -86,6 +86,10 @@ export function WrappedSetupCompletePage(props: WrappedSetupCompletePageProps) {
 		state: props.sessionReadinessState ?? "default",
 		totalSessionCount: props.totalSessionCount,
 	});
+	const primaryActionLabel = getWrappedSetupCompletePrimaryActionLabel({
+		canContinueToStory,
+		sessionReadinessState,
+	});
 	const titleCopy = getWrappedSetupCompleteTitle({
 		minimumSessionCount: props.minimumSessionCount,
 		state: sessionReadinessState,
@@ -233,9 +237,7 @@ export function WrappedSetupCompletePage(props: WrappedSetupCompletePageProps) {
 								disabled={isContinuingToStory || !canContinueToStory}
 								onClick={handleContinue}
 							>
-								{canContinueToStory
-									? "See what it reveals about you"
-									: "Upload more to unlock"}
+								{primaryActionLabel}
 							</WrappedPrimaryAction>
 						</motion.div>
 						<motion.div
@@ -560,6 +562,20 @@ function getWrappedSetupCompleteDescription(
 	return state === "missing"
 		? "to create an accurate picture"
 		: "Are you ready to see what the sessions tell about you?";
+}
+
+function getWrappedSetupCompletePrimaryActionLabel(input: {
+	canContinueToStory: boolean;
+	sessionReadinessState: WrappedSetupSessionReadinessState;
+}) {
+	if (input.canContinueToStory) {
+		return "See what it reveals about you";
+	}
+
+	return input.sessionReadinessState === "enough-landed" ||
+		input.sessionReadinessState === "enough-uploaded"
+		? "Preparing your wrapped..."
+		: "Upload more to unlock";
 }
 
 function getWrappedSetupCompleteResolvedReadinessState(input: {


### PR DESCRIPTION
## Summary
- keep the wrapped repo overview visible while wrapped story data catches up
- avoid treating old raw-only uploads as a permanent stale wrapped state
- show a disabled “Preparing your wrapped...” CTA when enough sessions landed but the story is still locked

## Test plan
- [x] bun run lint:wrapped:hig
- [x] bun run verify

## Notes
- This intentionally does not backfill old beta/raw-only sessions; it only fixes the stuck route UX.