### PR TITLE
fix: improve wrapped mobile auth layout

### DIFF
--- a/apps/web/src/features/auth/LoginForm.tsx
+++ b/apps/web/src/features/auth/LoginForm.tsx
@@ -184,7 +184,7 @@ export function LoginForm(props: LoginFormProps) {
 		setWrappedScene("credentials");
 		setFeedback({
 			kind: "success",
-			message: `We sent a 6-digit code to ${loginEmail}.`,
+			message: `Code sent to ${loginEmail}.`,
 		});
 	}
 

--- a/apps/web/src/features/auth/SignupForm.tsx
+++ b/apps/web/src/features/auth/SignupForm.tsx
@@ -230,7 +230,7 @@ export function SignupForm(props: SignupFormProps) {
 		setWrappedScene("credentials");
 		setFeedback({
 			kind: "success",
-			message: `We sent a 6-digit code to ${signupEmail}.`,
+			message: `Code sent to ${signupEmail}.`,
 		});
 	}
 

--- a/apps/web/src/features/wrapped/route-stage-shell.tsx
+++ b/apps/web/src/features/wrapped/route-stage-shell.tsx
@@ -120,6 +120,16 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 		!hideTopChromeControls && shouldUseReferenceTopChrome;
 	const hasTextStatus =
 		typeof status === "string" || typeof status === "number";
+	const hasDefaultLeadingControl =
+		leadingControl === undefined && !hideTopChromeControls;
+	const hasCustomLeadingControl =
+		leadingControl !== undefined && leadingControl !== null;
+	const hasTopTrayContent =
+		hasDefaultLeadingControl ||
+		hasCustomLeadingControl ||
+		shouldUseReferenceTopChrome ||
+		progressView !== null ||
+		status !== undefined;
 	const animatedCopy =
 		title === undefined || title === null ? null : (
 			<WrappedStageCopy
@@ -200,9 +210,17 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 					className={cn(
 						"mymind-wrapped-shell__frame",
 						!hasFooter ? "mymind-wrapped-shell__frame--no-footer" : null,
+						!hasTopTrayContent
+							? "mymind-wrapped-shell__frame--empty-top-tray"
+							: null,
 					)}
 				>
-					<header className="mymind-wrapped-top-tray">
+					<header
+						className={cn(
+							"mymind-wrapped-top-tray",
+							!hasTopTrayContent ? "mymind-wrapped-top-tray--empty" : null,
+						)}
+					>
 						{/* Keep the top chrome static on setup: the back button, progress bar,
 						    and help button should anchor the screen instead of joining the entrance motion. */}
 						<div className="mymind-wrapped-top-tray__row">

--- a/apps/web/src/features/wrapped/wrapped-auth-card-position.ts
+++ b/apps/web/src/features/wrapped/wrapped-auth-card-position.ts
@@ -58,9 +58,18 @@ export function useWrappedAuthViewportSize() {
 		function updateViewportSize() {
 			const metrics = getWrappedAuthViewportMetrics();
 
-			setViewportSize({
-				height: metrics.height,
-				width: metrics.width,
+			setViewportSize((currentViewportSize) => {
+				if (
+					currentViewportSize.height === metrics.height &&
+					currentViewportSize.width === metrics.width
+				) {
+					return currentViewportSize;
+				}
+
+				return {
+					height: metrics.height,
+					width: metrics.width,
+				};
 			});
 			applyWrappedAuthViewportMetrics(metrics);
 

--- a/apps/web/src/features/wrapped/wrapped-auth-card-position.ts
+++ b/apps/web/src/features/wrapped/wrapped-auth-card-position.ts
@@ -6,6 +6,13 @@ export interface WrappedAuthViewportSize {
 	width: number;
 }
 
+interface WrappedAuthViewportMetrics extends WrappedAuthViewportSize {
+	bottomOcclusion: number;
+	isBottomOccluded: boolean;
+	isInputFocused: boolean;
+	isShortVisualViewport: boolean;
+}
+
 export interface WrappedAuthFormCardYValues {
 	compact: number;
 	medium: number;
@@ -21,6 +28,13 @@ const WRAPPED_AUTH_NARROW_DESKTOP_MAX_WIDTH = 1200;
 const WRAPPED_AUTH_SHORT_MAX_HEIGHT = 760;
 const WRAPPED_AUTH_MEDIUM_MAX_HEIGHT = 820;
 const WRAPPED_AUTH_TALL_TARGET_HEIGHT = 1025;
+const WRAPPED_AUTH_PHONE_MAX_WIDTH = 768;
+const WRAPPED_AUTH_KEYBOARD_SAFE_MAX_WIDTH =
+	WRAPPED_AUTH_NARROW_DESKTOP_MIN_WIDTH;
+const WRAPPED_AUTH_BOTTOM_OCCLUSION_THRESHOLD = 80;
+const WRAPPED_AUTH_KEYBOARD_SCROLL_DELAYS_MS = [0, 120, 320] as const;
+const WRAPPED_AUTH_FOCUSED_INPUT_SELECTOR =
+	".mymind-wrapped-auth-form__input, .mymind-wrapped-auth-form input, .mymind-wrapped-auth-form textarea, .mymind-wrapped-auth-form select";
 
 const WRAPPED_AUTH_DEFAULT_VIEWPORT_SIZE: WrappedAuthViewportSize = {
 	height: WRAPPED_AUTH_MEDIUM_MAX_HEIGHT,
@@ -42,15 +56,49 @@ export function useWrappedAuthViewportSize() {
 
 	useMountEffect(() => {
 		function updateViewportSize() {
-			setViewportSize(getWrappedAuthViewportSize());
+			const metrics = getWrappedAuthViewportMetrics();
+
+			setViewportSize({
+				height: metrics.height,
+				width: metrics.width,
+			});
+			applyWrappedAuthViewportMetrics(metrics);
+
+			if (metrics.isInputFocused) {
+				revealWrappedAuthFocusedInput();
+			}
 		}
 
+		function updateViewportSizeAndRevealFocusedInput() {
+			updateViewportSize();
+			queueWrappedAuthFocusedInputReveal();
+		}
+
+		updateViewportSize();
+
+		const visualViewport = window.visualViewport;
+
 		window.addEventListener("resize", updateViewportSize);
-		window.visualViewport?.addEventListener("resize", updateViewportSize);
+		window.addEventListener("orientationchange", updateViewportSize);
+		visualViewport?.addEventListener("resize", updateViewportSize);
+		visualViewport?.addEventListener("scroll", updateViewportSize);
+		document.addEventListener(
+			"focusin",
+			updateViewportSizeAndRevealFocusedInput,
+		);
+		document.addEventListener("focusout", updateViewportSize);
 
 		return () => {
 			window.removeEventListener("resize", updateViewportSize);
-			window.visualViewport?.removeEventListener("resize", updateViewportSize);
+			window.removeEventListener("orientationchange", updateViewportSize);
+			visualViewport?.removeEventListener("resize", updateViewportSize);
+			visualViewport?.removeEventListener("scroll", updateViewportSize);
+			document.removeEventListener(
+				"focusin",
+				updateViewportSizeAndRevealFocusedInput,
+			);
+			document.removeEventListener("focusout", updateViewportSize);
+			clearWrappedAuthViewportMetrics();
 		};
 	});
 
@@ -93,16 +141,126 @@ export function getWrappedAuthFormCardOffsetY(input: {
 }
 
 function getWrappedAuthViewportSize(): WrappedAuthViewportSize {
+	const metrics = getWrappedAuthViewportMetrics();
+
+	return {
+		height: metrics.height,
+		width: metrics.width,
+	};
+}
+
+function getWrappedAuthViewportMetrics(): WrappedAuthViewportMetrics {
 	if (typeof window === "undefined") {
-		return WRAPPED_AUTH_DEFAULT_VIEWPORT_SIZE;
+		return {
+			...WRAPPED_AUTH_DEFAULT_VIEWPORT_SIZE,
+			bottomOcclusion: 0,
+			isBottomOccluded: false,
+			isInputFocused: false,
+			isShortVisualViewport: false,
+		};
 	}
 
 	const viewport = window.visualViewport;
+	const height = viewport?.height ?? window.innerHeight;
+	const width = viewport?.width ?? window.innerWidth;
+	const bottomOcclusion = viewport
+		? Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop)
+		: 0;
+	const isKeyboardSafeViewport = isWrappedAuthKeyboardSafeViewport(width);
+	const isPhoneViewport = isWrappedAuthPhoneViewport(width);
 
 	return {
-		height: viewport?.height ?? window.innerHeight,
-		width: viewport?.width ?? window.innerWidth,
+		bottomOcclusion,
+		height,
+		isBottomOccluded:
+			isKeyboardSafeViewport &&
+			bottomOcclusion >= WRAPPED_AUTH_BOTTOM_OCCLUSION_THRESHOLD,
+		isInputFocused:
+			isKeyboardSafeViewport &&
+			isWrappedAuthInputFocused(document.activeElement),
+		isShortVisualViewport: isPhoneViewport && height <= 720,
+		width,
 	};
+}
+
+function applyWrappedAuthViewportMetrics(metrics: WrappedAuthViewportMetrics) {
+	document.body.style.setProperty(
+		"--wrapped-live-viewport-height",
+		`${Math.round(metrics.height)}px`,
+	);
+	document.body.style.setProperty(
+		"--wrapped-visual-viewport-bottom-occlusion",
+		`${Math.round(metrics.bottomOcclusion)}px`,
+	);
+	document.body.dataset.wrappedBottomOccluded = metrics.isBottomOccluded
+		? "true"
+		: "false";
+	document.body.dataset.wrappedInputFocused = metrics.isInputFocused
+		? "true"
+		: "false";
+	document.body.dataset.wrappedShortVisualViewport =
+		metrics.isShortVisualViewport ? "true" : "false";
+}
+
+function clearWrappedAuthViewportMetrics() {
+	document.body.style.removeProperty("--wrapped-live-viewport-height");
+	document.body.style.removeProperty(
+		"--wrapped-visual-viewport-bottom-occlusion",
+	);
+	delete document.body.dataset.wrappedBottomOccluded;
+	delete document.body.dataset.wrappedInputFocused;
+	delete document.body.dataset.wrappedShortVisualViewport;
+}
+
+function queueWrappedAuthFocusedInputReveal() {
+	for (const delayMs of WRAPPED_AUTH_KEYBOARD_SCROLL_DELAYS_MS) {
+		window.setTimeout(() => {
+			revealWrappedAuthFocusedInput();
+		}, delayMs);
+	}
+}
+
+function revealWrappedAuthFocusedInput() {
+	if (!isWrappedAuthKeyboardSafeViewport(getWrappedAuthVisualViewportWidth())) {
+		return;
+	}
+
+	const activeElement = document.activeElement;
+
+	if (!isWrappedAuthInputFocused(activeElement)) {
+		return;
+	}
+
+	activeElement.scrollIntoView({
+		behavior: "smooth",
+		block: "center",
+		inline: "nearest",
+	});
+}
+
+function isWrappedAuthInputFocused(
+	element: Element | null,
+): element is HTMLElement {
+	if (!(element instanceof HTMLElement)) {
+		return false;
+	}
+
+	return (
+		element.closest(".mymind-wrapped-route") !== null &&
+		element.matches(WRAPPED_AUTH_FOCUSED_INPUT_SELECTOR)
+	);
+}
+
+function getWrappedAuthVisualViewportWidth() {
+	return window.visualViewport?.width ?? window.innerWidth;
+}
+
+function isWrappedAuthKeyboardSafeViewport(width: number) {
+	return width < WRAPPED_AUTH_KEYBOARD_SAFE_MAX_WIDTH;
+}
+
+function isWrappedAuthPhoneViewport(width: number) {
+	return width <= WRAPPED_AUTH_PHONE_MAX_WIDTH;
 }
 
 function getWrappedAuthNarrowDesktopWeight(width: number) {

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -1,5 +1,7 @@
 body.mymind-wrapped-body {
 	--wrapped-shell-bg: #f4f5f7;
+	--wrapped-live-viewport-height: 100svh;
+	--wrapped-visual-viewport-bottom-occlusion: 0px;
 	--wrapped-chatwoot-shell-max-width: 78rem;
 	--wrapped-chatwoot-right-offset: calc(
 		max(0px, (100vw - var(--wrapped-chatwoot-shell-max-width)) / 2) +
@@ -8,16 +10,18 @@ body.mymind-wrapped-body {
 	);
 	--wrapped-chatwoot-top-offset: calc(env(safe-area-inset-top, 0px) + 80px);
 	background: var(--wrapped-shell-bg);
-	height: 100svh;
-	min-height: 100svh;
-	overflow: clip;
+	height: var(--wrapped-live-viewport-height);
+	min-height: var(--wrapped-live-viewport-height);
+	overflow-x: clip;
+	overflow-y: auto;
 	overscroll-behavior: none;
 }
 
 body.mymind-wrapped-body #root {
 	height: 100%;
 	min-height: 0;
-	overflow: clip;
+	overflow-x: clip;
+	overflow-y: visible;
 	overscroll-behavior: none;
 }
 
@@ -54,10 +58,11 @@ body.mymind-wrapped-body .woot-widget-bubble {
 .mymind-wrapped-route {
 	position: relative;
 	display: flex;
-	height: 100%;
+	height: var(--wrapped-live-viewport-height);
 	min-height: 0;
 	isolation: isolate;
-	overflow: clip;
+	overflow-x: clip;
+	overflow-y: auto;
 	overscroll-behavior: none;
 	scrollbar-gutter: stable;
 	background: var(--wrapped-shell-bg);
@@ -138,6 +143,10 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	grid-template-rows: auto minmax(0, 1fr);
 }
 
+.mymind-wrapped-shell__frame--empty-top-tray {
+	grid-template-rows: 0 minmax(0, 1fr);
+}
+
 .mymind-wrapped-top-tray {
 	display: grid;
 	align-items: start;
@@ -145,6 +154,12 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	padding-top: 0.2rem;
 	width: 100%;
 	min-width: 0;
+}
+
+.mymind-wrapped-top-tray--empty {
+	min-height: 0;
+	overflow: clip;
+	padding-top: 0;
 }
 
 .mymind-wrapped-top-tray__row {
@@ -265,6 +280,18 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	width: 23px;
 	height: 23px;
 	stroke-width: 1.7;
+}
+
+.mymind-wrapped-top-tray--empty .mymind-wrapped-top-tray__row {
+	min-height: 0;
+}
+
+.mymind-wrapped-top-tray--empty .mymind-wrapped-top-tray__slot {
+	min-height: 0;
+}
+
+.mymind-wrapped-top-tray--empty .mymind-wrapped-top-tray__utility-placeholder {
+	height: 0;
 }
 
 .mymind-wrapped-back-button {
@@ -5376,6 +5403,8 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	font-family: var(--font-sans);
 	font-weight: 600;
 	letter-spacing: -0.01em;
+	overflow: visible;
+	white-space: nowrap;
 }
 
 .mymind-wrapped-auth-form__scene-link {
@@ -5401,6 +5430,8 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	background: #fefefe;
 	padding-inline: 1rem;
 	color: #1d1a18;
+	overflow: visible;
+	white-space: nowrap;
 }
 
 .mymind-wrapped-auth-form__input::placeholder {
@@ -5432,6 +5463,28 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	border: 1px solid rgb(15 23 42 / 0.06);
 	background: #fefefe;
 	color: #57524d;
+}
+
+.mymind-wrapped-auth-form__feedback--code-note {
+	width: 100%;
+	max-width: 100%;
+	padding: 6px 0;
+	border: 0;
+	border-radius: 0;
+	background: transparent;
+	box-shadow: none;
+	font-size: clamp(0.72rem, 2.8vw, 0.82rem);
+	line-height: 1;
+	overflow: clip;
+	text-overflow: ellipsis;
+	text-wrap: nowrap;
+	white-space: nowrap;
+}
+
+.mymind-wrapped-auth-form__feedback--code-note.is-success {
+	border: 0;
+	background: transparent;
+	color: #7a736c;
 }
 
 .mymind-wrapped-auth-form__divider {
@@ -5494,6 +5547,295 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	font-weight: 500;
 	text-decoration: underline;
 	text-underline-offset: 0.24rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-shell {
+	--wrapped-shell-top-inset: 24px;
+	--wrapped-shell-bottom-inset: 24px;
+	--wrapped-shell-stage-gap: 0.5rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-top-tray {
+	padding-top: 0;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-entry-stage--auth {
+	gap: 0.45rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-stage-copy {
+	gap: 0.35rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-entry-stage__copy {
+	transform: none;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-entry-stage__headline--auth {
+	font-size: clamp(1.74rem, 6.8vw, 2.1rem);
+	line-height: 0.98;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-auth-panel--intro {
+	grid-template-rows: auto auto;
+	gap: 0.24rem;
+	min-height: auto;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-auth-panel--intro
+	.mymind-wrapped-auth-panel__card {
+	align-self: center;
+	margin-block: 0;
+	padding-top: 0;
+	padding-bottom: 0;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-auth-form__terms {
+	align-self: end;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-auth-panel__cta-region {
+	gap: 0.28rem;
+	margin-top: 0;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-auth-panel__actions {
+	gap: 0;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-auth-panel--intro
+	.mymind-wrapped-auth-card-preview--hero
+	.mymind-wrapped-auth-card-preview__tilt {
+	--wrapped-card-render-scale: 0.72;
+	--wrapped-short-card-scale: 0.72;
+}
+
+@media (max-width: 47.999rem) and (max-height: 760px) {
+	body.mymind-wrapped-body .mymind-wrapped-auth-panel--intro {
+		grid-template-rows: auto auto;
+		gap: 0.24rem;
+		min-height: auto;
+	}
+
+	body.mymind-wrapped-body
+		.mymind-wrapped-auth-panel--intro
+		.mymind-wrapped-auth-panel__card {
+		align-self: center;
+		margin-block: 0;
+		padding-top: 0;
+		padding-bottom: 0;
+	}
+
+	body.mymind-wrapped-body .mymind-wrapped-auth-form__terms {
+		align-self: end;
+	}
+
+	body.mymind-wrapped-body .mymind-wrapped-auth-panel__cta-region {
+		gap: 0.28rem;
+		margin-top: 0;
+	}
+
+	body.mymind-wrapped-body .mymind-wrapped-auth-panel__actions {
+		gap: 0;
+	}
+
+	body.mymind-wrapped-body
+		.mymind-wrapped-auth-panel--intro
+		.mymind-wrapped-auth-card-preview--hero
+		.mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-card-render-scale: 0.72;
+		--wrapped-short-card-scale: 0.72;
+	}
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-shell {
+	--wrapped-shell-top-inset: 16px;
+	--wrapped-shell-bottom-inset: 16px;
+	--wrapped-shell-stage-gap: 0.35rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-stage-area,
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-stage-slot {
+	overflow-y: auto;
+	overscroll-behavior-y: contain;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-entry-stage {
+	min-height: auto;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-entry-stage__copy {
+	transform: translateY(-0.2rem);
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-entry-stage__headline--auth {
+	font-size: clamp(1.72rem, 6.8vw, 2.1rem);
+	line-height: 1;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-entry-stage--auth {
+	gap: 0.35rem;
+	transform: translateY(-0.2rem);
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-panel--form {
+	--wrapped-auth-form-overlap: 0.35rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-panel--form
+	.mymind-wrapped-auth-panel__card {
+	padding-top: 0;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-panel--form
+	.mymind-wrapped-auth-card-preview__tilt {
+	--wrapped-card-render-scale: 0.72;
+	--wrapped-short-card-scale: 0.72;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form {
+	gap: 0.42rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__scene,
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__scene-form {
+	gap: 0.5rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__scene--email {
+	padding-top: clamp(0.35rem, 2svh, 0.7rem);
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__scene--credentials {
+	--wrapped-auth-credentials-bottom-space: calc(
+		env(safe-area-inset-bottom, 0px) +
+		0.55rem
+	);
+	padding-top: clamp(0.3rem, 1.8svh, 0.65rem);
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__scene-fields {
+	gap: 0.5rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__action-item--primary,
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__choice-footer {
+	margin-top: 0;
+}
+
+@media (max-width: 63.999rem) {
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-stage-area,
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-stage-slot {
+		overflow-x: visible;
+		overflow-y: visible;
+		overscroll-behavior-y: contain;
+		-webkit-overflow-scrolling: touch;
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-entry-stage {
+		min-height: auto;
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-panel--form {
+		min-height: auto;
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-panel--form
+		.mymind-wrapped-auth-panel__body--form {
+		overflow: visible;
+		overscroll-behavior-y: contain;
+		padding-bottom: max(
+			1rem,
+			calc(var(--wrapped-visual-viewport-bottom-occlusion, 0px) + 1rem)
+		);
+		scroll-padding-block: 3rem
+			max(
+				7rem,
+				calc(var(--wrapped-visual-viewport-bottom-occlusion, 0px) + 5rem)
+			);
+		-webkit-overflow-scrolling: touch;
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__scene-shell {
+		overflow: visible;
+		overscroll-behavior-y: contain;
+		padding-bottom: max(
+			1rem,
+			calc(var(--wrapped-visual-viewport-bottom-occlusion, 0px) + 1rem)
+		);
+		scroll-padding-block: 3rem
+			max(
+				7rem,
+				calc(var(--wrapped-visual-viewport-bottom-occlusion, 0px) + 5rem)
+			);
+		-webkit-overflow-scrolling: touch;
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__input {
+		scroll-margin-block: 3rem
+			max(
+				7rem,
+				calc(var(--wrapped-visual-viewport-bottom-occlusion, 0px) + 5rem)
+			);
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__scene--email,
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__scene--credentials {
+		padding-top: clamp(0.25rem, 1.4svh, 0.55rem);
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__scene,
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__scene-form {
+		gap: 0.5rem;
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__action-item--primary,
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__choice-footer {
+		margin-top: 0;
+	}
 }
 
 .mymind-wrapped-card-profile-step__card {


### PR DESCRIPTION
## Summary
- make the wrapped auth shell respond to visual viewport height, safe areas, and X/browser bottom chrome on short mobile screens
- keep the intro title, card, terms, and auth buttons balanced in shortened phone-height layouts without affecting desktop
- keep email/code auth inputs visible above the mobile keyboard and compact the code-sent note to one truncated row with the typed email

## Test plan
- [x] bun run lint:wrapped:hig
- [x] bun run verify

Generated with Codex.