### PR TITLE
fix: use png card back on webkit

### DIFF
--- a/apps/web/src/features/wrapped/WrappedDesktopResumePreviewStage.tsx
+++ b/apps/web/src/features/wrapped/WrappedDesktopResumePreviewStage.tsx
@@ -10,6 +10,7 @@ import { WrappedDesktopResumePromptStage } from "./WrappedDesktopResumePromptSta
 const DEFAULT_WRAPPED_DESKTOP_SETUP_URL = "app.rudel.ai/wrapped";
 const DEFAULT_WRAPPED_DESKTOP_SETUP_DESCRIPTION =
 	"The next step will be to enable Rudel within the terminal on your desktop.";
+const COPY_FEEDBACK_DURATION_MS = 1800;
 const PRIMARY_BUTTON_LAUNCH_HOLD_MS = 180;
 const PREVIEW_PRIMARY_ACTION_DURATION_MS = 820;
 
@@ -96,6 +97,7 @@ export function WrappedDesktopResumePreviewStage(
 	const [copyPulseKey, setCopyPulseKey] = useState(0);
 	const [isPrimaryLaunching, setIsPrimaryLaunching] = useState(false);
 	const [primaryPulseKey, setPrimaryPulseKey] = useState(0);
+	const copyResetTimeoutRef = useRef<number | null>(null);
 	const primaryLaunchTimeoutRef = useRef<number | null>(null);
 	const previewPrimaryActionTimeoutRef = useRef<number | null>(null);
 	const [previewPrimaryActionState, setPreviewPrimaryActionState] = useState<
@@ -131,6 +133,10 @@ export function WrappedDesktopResumePreviewStage(
 
 	useMountEffect(() => {
 		return () => {
+			if (copyResetTimeoutRef.current !== null) {
+				window.clearTimeout(copyResetTimeoutRef.current);
+			}
+
 			if (primaryLaunchTimeoutRef.current !== null) {
 				window.clearTimeout(primaryLaunchTimeoutRef.current);
 			}
@@ -155,9 +161,14 @@ export function WrappedDesktopResumePreviewStage(
 		setCopyPulseKey((currentValue) => currentValue + 1);
 		setCopied(true);
 
-		window.setTimeout(() => {
+		if (copyResetTimeoutRef.current !== null) {
+			window.clearTimeout(copyResetTimeoutRef.current);
+		}
+
+		copyResetTimeoutRef.current = window.setTimeout(() => {
 			setCopied(false);
-		}, 1800);
+			copyResetTimeoutRef.current = null;
+		}, COPY_FEEDBACK_DURATION_MS);
 	}
 
 	function handlePrimaryActionClick() {

--- a/apps/web/src/features/wrapped/team-card/printed-card-flip.tsx
+++ b/apps/web/src/features/wrapped/team-card/printed-card-flip.tsx
@@ -47,20 +47,36 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 	const flipShellRef = useRef<HTMLDivElement | null>(null);
 	const animationFrameRef = useRef<number | null>(null);
 	const angleRef = useRef(isFrontVisible ? 0 : 180);
+	const captureKeyRef = useRef(captureKey);
 	const shadowVisibilityRef = useRef(1);
 	const [backUrl, setBackUrl] = useState<string | null>(null);
+	const [usesWebKitBackTextureOnly] = useState(isAppleWebKitBrowser);
 	const visualStyle = resolvePrintedCardVisualStyle(
 		angleRef.current,
 		shadowVisibilityRef.current,
 	);
+	const shouldRenderBackSource =
+		shouldCaptureBackSurface &&
+		(!usesWebKitBackTextureOnly || backUrl === null);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: captureKey intentionally invalidates the rendered back texture.
 	useEffect(() => {
 		let isCancelled = false;
 
-		setBackUrl(null);
-
 		if (!shouldCaptureBackSurface) {
+			setBackUrl(null);
+			return;
+		}
+
+		if (captureKeyRef.current !== captureKey) {
+			captureKeyRef.current = captureKey;
+
+			if (backUrl !== null) {
+				setBackUrl(null);
+				return;
+			}
+		}
+
+		if (backUrl !== null) {
 			return;
 		}
 
@@ -89,7 +105,7 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 		return () => {
 			isCancelled = true;
 		};
-	}, [captureKey, shouldCaptureBackSurface]);
+	}, [backUrl, captureKey, shouldCaptureBackSurface]);
 
 	useEffect(() => {
 		const targetAngle = isFrontVisible ? 0 : 180;
@@ -152,7 +168,7 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 
 	return (
 		<>
-			{shouldCaptureBackSurface ? (
+			{shouldRenderBackSource ? (
 				<div
 					aria-hidden="true"
 					className="mymind-wrapped-printed-card-flip__source-stage"
@@ -171,6 +187,9 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 				ref={flipShellRef}
 				className="mymind-wrapped-final-stage__flip-shell"
 				data-back-texture-ready={backUrl ? "true" : "false"}
+				data-back-texture-strategy={
+					usesWebKitBackTextureOnly ? "webkit-png-only" : "standard"
+				}
 				style={visualStyle}
 			>
 				<div className="mymind-wrapped-printed-card-flip__rotator">
@@ -202,6 +221,19 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 			</div>
 		</>
 	);
+}
+
+function isAppleWebKitBrowser() {
+	if (typeof navigator === "undefined") {
+		return false;
+	}
+
+	const { userAgent, vendor } = navigator;
+	const isAppleVendor = vendor.includes("Apple");
+	const isWebKit = userAgent.includes("AppleWebKit");
+	const isDesktopChromium = /\b(?:Chrome|Chromium|Edg|OPR)\//u.test(userAgent);
+
+	return isAppleVendor && isWebKit && !isDesktopChromium;
 }
 
 function resolvePrintedCardVisualStyle(


### PR DESCRIPTION
## Summary
- use the captured PNG card-back texture only on Safari/WebKit after it is ready
- keep Chromium/Firefox on the existing standard back-surface strategy
- clear the wrapped desktop resume copy timeout on unmount so full verification does not hit a teardown state update

## Test plan
- [x] bun ./node_modules/.bin/biome check apps/web/src/features/wrapped/team-card/printed-card-flip.tsx apps/web/src/features/wrapped/WrappedDesktopResumePreviewStage.tsx
- [x] cd apps/web && bun run test -- src/features/wrapped/WrappedDesktopResumePromptPage.test.tsx src/features/wrapped/WrappedAuthFlow.test.tsx src/features/wrapped/team-card/final-stages.test.tsx
- [x] bun run lint:wrapped:hig
- [x] Playwright WebKit smoke on /dev/wrapped?stage=public
- [x] bun run verify