### PR TITLE
fix: stabilize wrapped public share links

### DIFF
--- a/apps/api/src/__tests__/wrapped-share-slug.test.ts
+++ b/apps/api/src/__tests__/wrapped-share-slug.test.ts
@@ -2,32 +2,67 @@ import { describe, expect, test } from "bun:test";
 import {
 	buildWrappedShareIdBase,
 	getNextWrappedShareIdCandidate,
+	isWrappedShareIdAlignedWithBase,
 } from "../services/wrapped-share-slug.js";
 
 describe("wrapped share slugs", () => {
-	test("uses the provided username as the public id base", () => {
+	test("uses the public card display name as the share id base", () => {
 		expect(
 			buildWrappedShareIdBase({
-				fallbackLabel: "Evren Dombak",
-				username: "Evren_Dev",
-			}),
-		).toBe("Evren_Dev");
-	});
-
-	test("falls back to a route-safe label slug when username is missing", () => {
-		expect(
-			buildWrappedShareIdBase({
-				fallbackLabel: "Evren Dombak",
+				displayName: "Evren Dombak",
 			}),
 		).toBe("evren-dombak");
 	});
 
-	test("appends the lowest available dash suffix when the base is taken", () => {
+	test("falls back when the public card display name cannot become a slug", () => {
+		expect(
+			buildWrappedShareIdBase({
+				displayName: "!!!",
+			}),
+		).toBe("wrapped");
+	});
+
+	test("uses the bare card name when it is available", () => {
 		expect(
 			getNextWrappedShareIdCandidate({
-				baseId: "evren",
-				existingIds: ["evren", "evren-1", "evren-3"],
+				baseId: "evren-dombak",
+				existingIds: [],
 			}),
-		).toBe("evren-2");
+		).toBe("evren-dombak");
+	});
+
+	test("adds a cool adjective before the name when the card name is taken", () => {
+		expect(
+			getNextWrappedShareIdCandidate({
+				baseId: "evren-dombak",
+				existingIds: ["evren-dombak"],
+				randomValue: 0,
+			}),
+		).toBe("atomic-evren-dombak");
+	});
+
+	test("chooses an available adjective when another duplicate already used one", () => {
+		expect(
+			getNextWrappedShareIdCandidate({
+				baseId: "evren-dombak",
+				existingIds: ["evren-dombak", "atomic-evren-dombak"],
+				randomValue: 0,
+			}),
+		).toBe("brilliant-evren-dombak");
+	});
+
+	test("detects legacy uuid ids as not aligned with the card name", () => {
+		expect(
+			isWrappedShareIdAlignedWithBase({
+				baseId: "evren-dombak",
+				shareId: "atomic-evren-dombak",
+			}),
+		).toBe(true);
+		expect(
+			isWrappedShareIdAlignedWithBase({
+				baseId: "evren-dombak",
+				shareId: "c5f69df0-324a-4d15-a45a-3d32b87ac0c1",
+			}),
+		).toBe(false);
 	});
 });

--- a/apps/api/src/__tests__/wrapped-share.service.test.ts
+++ b/apps/api/src/__tests__/wrapped-share.service.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { WrappedShareSnapshot } from "@rudel/api-routes";
+
+interface SqlQuery {
+	sql: string;
+	values: unknown[];
+}
+
+const sqlQueries: SqlQuery[] = [];
+let selectRows: unknown[] = [];
+let insertRows: unknown[] = [];
+let updateRows: unknown[] = [];
+
+function sqlClient(strings: TemplateStringsArray, ...values: unknown[]) {
+	const sql = strings.join("?").replace(/\s+/gu, " ").trim();
+	sqlQueries.push({ sql, values });
+
+	if (sql.startsWith("SELECT")) {
+		return selectRows;
+	}
+
+	if (sql.startsWith("INSERT")) {
+		return insertRows;
+	}
+
+	if (sql.startsWith("UPDATE")) {
+		return updateRows;
+	}
+
+	throw new Error(`Unexpected SQL query: ${sql}`);
+}
+
+mock.module("../db.js", () => ({
+	sqlClient,
+}));
+
+const { createWrappedShare } = await import(
+	"../services/wrapped-share.service.js"
+);
+
+describe("wrapped share service", () => {
+	beforeEach(() => {
+		sqlQueries.length = 0;
+		selectRows = [];
+		insertRows = [];
+		updateRows = [];
+	});
+
+	test("creates a name-based link for a user without an existing share", async () => {
+		insertRows = [{ id: "evren" }];
+
+		const record = await createWrappedShare({
+			organizationId: "org-1",
+			snapshot: createSnapshot({ displayName: "Evren" }),
+			userId: "user-1",
+		});
+
+		expect(record.id).toBe("evren");
+		expect(getSqlQuery(0).sql.startsWith("SELECT id, created_at")).toBe(true);
+		expect(getSqlQuery(1).sql.startsWith("SELECT id FROM wrapped_share")).toBe(
+			true,
+		);
+		expect(getSqlQuery(1).values).toEqual(["evren", 6, "-evren", "-evren-"]);
+		expect(getSqlQuery(2).sql.startsWith("INSERT INTO wrapped_share")).toBe(
+			true,
+		);
+		expect(getSqlQuery(2).values[0]).toBe("evren");
+	});
+
+	test("keeps the same link for later creates by the same user", async () => {
+		const existingCreatedAt = "2026-04-22T10:00:00.000Z";
+		selectRows = [{ createdAt: existingCreatedAt, id: "evren" }];
+		updateRows = [{ id: "evren" }];
+
+		const record = await createWrappedShare({
+			organizationId: "org-1",
+			snapshot: createSnapshot({ displayName: "Evren" }),
+			userId: "user-1",
+		});
+
+		expect(record.id).toBe("evren");
+		expect(record.created_at).toBe(existingCreatedAt);
+		expect(sqlQueries).toHaveLength(2);
+		expect(getSqlQuery(1).sql.startsWith("UPDATE wrapped_share")).toBe(true);
+		expect(getSqlQuery(1).values[4]).toBe("evren");
+		expect(getSqlQuery(1).values[5]).toBe("user-1");
+	});
+
+	test("renames a legacy uuid link to the card name for the same user", async () => {
+		const existingCreatedAt = "2026-04-22T10:00:00.000Z";
+		const legacyShareId = "c5f69df0-324a-4d15-a45a-3d32b87ac0c1";
+		selectRows = [{ createdAt: existingCreatedAt, id: legacyShareId }];
+		updateRows = [{ id: "evren" }];
+
+		const record = await createWrappedShare({
+			organizationId: "org-1",
+			snapshot: createSnapshot({ displayName: "Evren" }),
+			userId: "user-1",
+		});
+
+		expect(record.id).toBe("evren");
+		expect(record.created_at).toBe(existingCreatedAt);
+		expect(sqlQueries).toHaveLength(3);
+		expect(getSqlQuery(1).values).toEqual([
+			"evren",
+			6,
+			"-evren",
+			"-evren-",
+			legacyShareId,
+		]);
+		expect(getSqlQuery(2).sql.startsWith("UPDATE wrapped_share")).toBe(true);
+		expect(getSqlQuery(2).values[0]).toBe("evren");
+		expect(getSqlQuery(2).values[5]).toBe(legacyShareId);
+		expect(getSqlQuery(2).values[6]).toBe("user-1");
+	});
+});
+
+function createSnapshot(input: { displayName: string }): WrappedShareSnapshot {
+	return {
+		archetypeLabel: "Builder",
+		backMetrics: [],
+		headerLeftMetric: { label: "Sessions", value: "12" },
+		headerRightMetric: { label: "Days", value: "6" },
+		row: {
+			activeDays: 6,
+			cost: 42,
+			displayName: input.displayName,
+			favoriteModel: "o3",
+			hasActivity: true,
+			imageUrl: null,
+			inputTokens: 120,
+			lastActiveDate: "2026-04-22",
+			outputTokens: 240,
+			role: "Builder",
+			totalSessions: 12,
+			totalTokens: 360,
+		},
+		shellClassName: "team-lineup-shell",
+		statItems: [],
+		theme: "light",
+	};
+}
+
+function getSqlQuery(index: number) {
+	const query = sqlQueries[index];
+
+	if (!query) {
+		throw new Error(`Expected SQL query at index ${index}`);
+	}
+
+	return query;
+}

--- a/apps/api/src/handlers/wrapped-share.ts
+++ b/apps/api/src/handlers/wrapped-share.ts
@@ -23,7 +23,6 @@ const create = os.wrappedShare.create
 			organizationId: context.organizationId,
 			snapshot: input.snapshot,
 			userId: context.user.id,
-			...(input.username ? { username: input.username } : {}),
 		};
 
 		return createWrappedShare(shareOptions);

--- a/apps/api/src/services/wrapped-share-slug.ts
+++ b/apps/api/src/services/wrapped-share-slug.ts
@@ -1,28 +1,60 @@
 interface BuildWrappedShareIdBaseInput {
-	fallbackLabel: string;
-	username?: string;
+	displayName: string;
 }
 
 const WRAPPED_SHARE_FALLBACK_ID_BASE = "wrapped";
 const WRAPPED_SHARE_FALLBACK_ID_BASE_MAX_LENGTH = 64;
-const WRAPPED_SHARE_ROUTE_SEGMENT_PATTERN = /^[A-Za-z0-9_-]+$/u;
+const WRAPPED_SHARE_DUPLICATE_ADJECTIVES = [
+	"atomic",
+	"brilliant",
+	"clever",
+	"cosmic",
+	"electric",
+	"fearless",
+	"golden",
+	"kinetic",
+	"legendary",
+	"luminous",
+	"magnetic",
+	"moonlit",
+	"mythic",
+	"neon",
+	"nova",
+	"prime",
+	"radiant",
+	"sapphire",
+	"solar",
+	"stellar",
+	"turbo",
+	"velvet",
+	"vivid",
+	"wild",
+] as const;
 
 export function buildWrappedShareIdBase(input: BuildWrappedShareIdBaseInput) {
-	const username = input.username?.trim().replace(/^@+/u, "");
+	return (
+		slugifyWrappedShareDisplayName(input.displayName) ??
+		WRAPPED_SHARE_FALLBACK_ID_BASE
+	);
+}
 
-	if (username && WRAPPED_SHARE_ROUTE_SEGMENT_PATTERN.test(username)) {
-		return username;
-	}
+export function isWrappedShareIdAlignedWithBase(input: {
+	baseId: string;
+	shareId: string;
+}) {
+	const { baseId, shareId } = input;
 
 	return (
-		slugifyWrappedShareFallbackLabel(input.fallbackLabel) ??
-		WRAPPED_SHARE_FALLBACK_ID_BASE
+		shareId === baseId ||
+		shareId.endsWith(`-${baseId}`) ||
+		shareId.includes(`-${baseId}-`)
 	);
 }
 
 export function getNextWrappedShareIdCandidate(input: {
 	baseId: string;
 	existingIds: readonly string[];
+	randomValue?: number;
 }) {
 	const { baseId, existingIds } = input;
 	const existingIdSet = new Set(existingIds);
@@ -31,18 +63,41 @@ export function getNextWrappedShareIdCandidate(input: {
 		return baseId;
 	}
 
-	let suffix = 1;
-	let candidateId = `${baseId}-${suffix}`;
+	const availableAdjectives = WRAPPED_SHARE_DUPLICATE_ADJECTIVES.filter(
+		(adjective) => !existingIdSet.has(`${adjective}-${baseId}`),
+	);
 
-	while (existingIdSet.has(candidateId)) {
-		suffix += 1;
-		candidateId = `${baseId}-${suffix}`;
+	if (availableAdjectives.length > 0) {
+		const randomValue = input.randomValue ?? Math.random();
+		const normalizedRandomValue = Number.isFinite(randomValue)
+			? Math.abs(randomValue % 1)
+			: 0;
+		const adjectiveIndex = Math.floor(
+			normalizedRandomValue * availableAdjectives.length,
+		);
+		const adjective = availableAdjectives[adjectiveIndex];
+
+		if (adjective) {
+			return `${adjective}-${baseId}`;
+		}
 	}
 
-	return candidateId;
+	let suffix = 2;
+
+	while (true) {
+		for (const adjective of WRAPPED_SHARE_DUPLICATE_ADJECTIVES) {
+			const candidateId = `${adjective}-${baseId}-${suffix}`;
+
+			if (!existingIdSet.has(candidateId)) {
+				return candidateId;
+			}
+		}
+
+		suffix += 1;
+	}
 }
 
-function slugifyWrappedShareFallbackLabel(value: string) {
+function slugifyWrappedShareDisplayName(value: string) {
 	const slug = value
 		.trim()
 		.toLowerCase()

--- a/apps/api/src/services/wrapped-share.service.ts
+++ b/apps/api/src/services/wrapped-share.service.ts
@@ -11,13 +11,13 @@ import { sqlClient } from "../db.js";
 import {
 	buildWrappedShareIdBase,
 	getNextWrappedShareIdCandidate,
+	isWrappedShareIdAlignedWithBase,
 } from "./wrapped-share-slug.js";
 
 interface CreateWrappedShareOptions {
 	organizationId: string;
 	snapshot: WrappedShareSnapshot;
 	userId: string;
-	username?: string;
 }
 
 const WRAPPED_SHARE_TTL_DAYS = 30;
@@ -30,15 +30,42 @@ const WRAPPED_SHARE_ID_INSERT_ATTEMPTS = 20;
 export async function createWrappedShare(
 	options: CreateWrappedShareOptions,
 ): Promise<WrappedShareRecord> {
-	const { organizationId, snapshot, userId, username } = options;
+	const { organizationId, snapshot, userId } = options;
+	const existingShare = await getWrappedShareForUser(userId);
 	const shareIdBase = buildWrappedShareIdBase({
-		fallbackLabel: snapshot.row.displayName,
-		username,
+		displayName: snapshot.row.displayName,
 	});
 	const createdAt = new Date();
 	const expiresAt = createWrappedShareExpiry(createdAt);
-	const createdAtIso = createdAt.toISOString();
 	const expiresAtIso = expiresAt.toISOString();
+
+	if (existingShare) {
+		if (
+			!isWrappedShareIdAlignedWithBase({
+				baseId: shareIdBase,
+				shareId: existingShare.id,
+			})
+		) {
+			return renameWrappedShareAndUpdateSnapshot({
+				expiresAtIso,
+				organizationId,
+				share: existingShare,
+				shareIdBase,
+				snapshot,
+				userId,
+			});
+		}
+
+		return updateWrappedShareSnapshot({
+			expiresAtIso,
+			organizationId,
+			share: existingShare,
+			snapshot,
+			userId,
+		});
+	}
+
+	const createdAtIso = createdAt.toISOString();
 
 	for (
 		let attempt = 0;
@@ -65,7 +92,7 @@ export async function createWrappedShare(
 				${createdAtIso},
 				${expiresAtIso}
 			)
-			ON CONFLICT (id) DO NOTHING
+			ON CONFLICT DO NOTHING
 			RETURNING id
 		`;
 
@@ -78,9 +105,127 @@ export async function createWrappedShare(
 				id: insertedShareId,
 			};
 		}
+
+		const concurrentlyCreatedShare = await getWrappedShareForUser(userId);
+
+		if (concurrentlyCreatedShare) {
+			return updateWrappedShareSnapshot({
+				expiresAtIso,
+				organizationId,
+				share: concurrentlyCreatedShare,
+				snapshot,
+				userId,
+			});
+		}
 	}
 
 	throw new Error("Could not allocate a wrapped share id");
+}
+
+async function updateWrappedShareSnapshot(input: {
+	expiresAtIso: string;
+	organizationId: string;
+	share: { createdAt: Date; id: string };
+	snapshot: WrappedShareSnapshot;
+	userId: string;
+}) {
+	const { expiresAtIso, organizationId, share, snapshot, userId } = input;
+	const updatedRows = await sqlClient<Array<{ id: string }>>`
+		UPDATE wrapped_share
+		SET
+			organization_id = ${organizationId},
+			payload_version = ${WRAPPED_SHARE_PAYLOAD_VERSION},
+			snapshot_json = ${JSON.stringify(snapshot)},
+			expires_at = ${expiresAtIso}
+		WHERE id = ${share.id}
+			AND user_id = ${userId}
+		RETURNING id
+	`;
+	const updatedShareId = updatedRows[0]?.id;
+
+	if (!updatedShareId) {
+		throw new Error("Could not update wrapped share");
+	}
+
+	return {
+		created_at: share.createdAt.toISOString(),
+		expires_at: expiresAtIso,
+		id: updatedShareId,
+	};
+}
+
+async function renameWrappedShareAndUpdateSnapshot(input: {
+	expiresAtIso: string;
+	organizationId: string;
+	share: { createdAt: Date; id: string };
+	shareIdBase: string;
+	snapshot: WrappedShareSnapshot;
+	userId: string;
+}) {
+	const { expiresAtIso, organizationId, share, shareIdBase, snapshot, userId } =
+		input;
+
+	for (
+		let attempt = 0;
+		attempt < WRAPPED_SHARE_ID_INSERT_ATTEMPTS;
+		attempt += 1
+	) {
+		const shareId = await buildAvailableWrappedShareId(shareIdBase, share.id);
+		const updatedRows = await sqlClient<Array<{ id: string }>>`
+			UPDATE wrapped_share
+			SET
+				id = ${shareId},
+				organization_id = ${organizationId},
+				payload_version = ${WRAPPED_SHARE_PAYLOAD_VERSION},
+				snapshot_json = ${JSON.stringify(snapshot)},
+				expires_at = ${expiresAtIso}
+			WHERE id = ${share.id}
+				AND user_id = ${userId}
+				AND NOT EXISTS (
+					SELECT 1
+					FROM wrapped_share
+					WHERE id = ${shareId}
+				)
+			RETURNING id
+		`;
+		const updatedShareId = updatedRows[0]?.id;
+
+		if (updatedShareId) {
+			return {
+				created_at: share.createdAt.toISOString(),
+				expires_at: expiresAtIso,
+				id: updatedShareId,
+			};
+		}
+	}
+
+	throw new Error("Could not rename wrapped share");
+}
+
+async function getWrappedShareForUser(userId: string) {
+	const [row] = await sqlClient<
+		Array<{
+			createdAt: Date | string;
+			id: string;
+		}>
+	>`
+		SELECT
+			id,
+			created_at AS "createdAt"
+		FROM wrapped_share
+		WHERE user_id = ${userId}
+		ORDER BY created_at ASC
+		LIMIT 1
+	`;
+
+	if (!row) {
+		return null;
+	}
+
+	return {
+		createdAt: toDate(row.createdAt),
+		id: row.id,
+	};
 }
 
 // Public share lookup deliberately returns only the persisted snapshot payload.
@@ -138,8 +283,14 @@ function parseWrappedShareSnapshot(snapshotJson: string): WrappedShareSnapshot {
 	return WrappedShareSnapshotSchema.parse(parsedSnapshot);
 }
 
-async function buildAvailableWrappedShareId(baseId: string) {
-	const existingIds = await getExistingWrappedShareIdsForBase(baseId);
+async function buildAvailableWrappedShareId(
+	baseId: string,
+	excludedId?: string,
+) {
+	const existingIds = await getExistingWrappedShareIdsForBase(
+		baseId,
+		excludedId,
+	);
 
 	return getNextWrappedShareIdCandidate({
 		baseId,
@@ -147,14 +298,28 @@ async function buildAvailableWrappedShareId(baseId: string) {
 	});
 }
 
-async function getExistingWrappedShareIdsForBase(baseId: string) {
-	const suffixPrefix = `${baseId}-`;
-	const rows = await sqlClient<Array<{ id: string }>>`
-		SELECT id
-		FROM wrapped_share
-		WHERE id = ${baseId}
-			OR left(id, ${suffixPrefix.length}) = ${suffixPrefix}
-	`;
+async function getExistingWrappedShareIdsForBase(
+	baseId: string,
+	excludedId?: string,
+) {
+	const prefixSuffix = `-${baseId}`;
+	const prefixSuffixWithNumber = `-${baseId}-`;
+	const rows = excludedId
+		? await sqlClient<Array<{ id: string }>>`
+			SELECT id
+			FROM wrapped_share
+			WHERE (id = ${baseId}
+				OR right(id, ${prefixSuffix.length}) = ${prefixSuffix}
+				OR position(${prefixSuffixWithNumber} IN id) > 0)
+				AND id != ${excludedId}
+		`
+		: await sqlClient<Array<{ id: string }>>`
+			SELECT id
+			FROM wrapped_share
+			WHERE id = ${baseId}
+				OR right(id, ${prefixSuffix.length}) = ${prefixSuffix}
+				OR position(${prefixSuffixWithNumber} IN id) > 0
+		`;
 
 	return rows.map((row) => row.id);
 }

--- a/apps/web/src/features/auth/LoginForm.tsx
+++ b/apps/web/src/features/auth/LoginForm.tsx
@@ -184,7 +184,7 @@ export function LoginForm(props: LoginFormProps) {
 		setWrappedScene("credentials");
 		setFeedback({
 			kind: "success",
-			message: `We sent a 6-digit code to ${loginEmail}.`,
+			message: `Code sent to ${loginEmail}.`,
 		});
 	}
 

--- a/apps/web/src/features/auth/SignupForm.tsx
+++ b/apps/web/src/features/auth/SignupForm.tsx
@@ -230,7 +230,7 @@ export function SignupForm(props: SignupFormProps) {
 		setWrappedScene("credentials");
 		setFeedback({
 			kind: "success",
-			message: `We sent a 6-digit code to ${signupEmail}.`,
+			message: `Code sent to ${signupEmail}.`,
 		});
 	}
 

--- a/apps/web/src/features/wrapped/onboarding/shell.test.tsx
+++ b/apps/web/src/features/wrapped/onboarding/shell.test.tsx
@@ -1,4 +1,10 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WrappedTeamCardOnboarding } from "@/features/wrapped/onboarding/shell";
@@ -45,10 +51,10 @@ describe("WrappedTeamCardOnboarding model step", () => {
 		expect(
 			await screen.findByRole("heading", { name: "Claude pilled." }),
 		).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Continue" })).not.toBeDisabled();
+		const continueButton = await findEnabledContinueButton();
 
 		act(() => {
-			fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+			fireEvent.click(continueButton);
 		});
 
 		expect(
@@ -83,10 +89,10 @@ describe("WrappedTeamCardOnboarding model step", () => {
 		expect(
 			await screen.findByRole("heading", { name: "Claude pilled." }),
 		).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Continue" })).not.toBeDisabled();
+		const continueButton = await findEnabledContinueButton();
 
 		act(() => {
-			fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+			fireEvent.click(continueButton);
 		});
 
 		expect(
@@ -99,6 +105,16 @@ describe("WrappedTeamCardOnboarding model step", () => {
 		).toHaveAttribute("aria-current", "step");
 	});
 });
+
+async function findEnabledContinueButton() {
+	const continueButton = screen.getByRole("button", { name: "Continue" });
+
+	await waitFor(() => {
+		expect(continueButton).not.toBeDisabled();
+	});
+
+	return continueButton;
+}
 
 function renderWrappedTeamCardOnboarding(
 	onboardingMetrics: WrappedOnboardingMetrics,

--- a/apps/web/src/features/wrapped/route-stage-shell.tsx
+++ b/apps/web/src/features/wrapped/route-stage-shell.tsx
@@ -120,6 +120,16 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 		!hideTopChromeControls && shouldUseReferenceTopChrome;
 	const hasTextStatus =
 		typeof status === "string" || typeof status === "number";
+	const hasDefaultLeadingControl =
+		leadingControl === undefined && !hideTopChromeControls;
+	const hasCustomLeadingControl =
+		leadingControl !== undefined && leadingControl !== null;
+	const hasTopTrayContent =
+		hasDefaultLeadingControl ||
+		hasCustomLeadingControl ||
+		shouldUseReferenceTopChrome ||
+		progressView !== null ||
+		status !== undefined;
 	const animatedCopy =
 		title === undefined || title === null ? null : (
 			<WrappedStageCopy
@@ -200,9 +210,17 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 					className={cn(
 						"mymind-wrapped-shell__frame",
 						!hasFooter ? "mymind-wrapped-shell__frame--no-footer" : null,
+						!hasTopTrayContent
+							? "mymind-wrapped-shell__frame--empty-top-tray"
+							: null,
 					)}
 				>
-					<header className="mymind-wrapped-top-tray">
+					<header
+						className={cn(
+							"mymind-wrapped-top-tray",
+							!hasTopTrayContent ? "mymind-wrapped-top-tray--empty" : null,
+						)}
+					>
 						{/* Keep the top chrome static on setup: the back button, progress bar,
 						    and help button should anchor the screen instead of joining the entrance motion. */}
 						<div className="mymind-wrapped-top-tray__row">

--- a/apps/web/src/features/wrapped/team-card/WrappedTeamCardPage.analytics.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/WrappedTeamCardPage.analytics.test.tsx
@@ -208,7 +208,6 @@ vi.mock("@/features/wrapped/team-card/use-page-data", () => ({
 			totalSessions: 12,
 			totalTokens: 360,
 		},
-		publicUsername: "ada",
 		statItems: [],
 		visibleTeamCardRow: {
 			activeDays: 6,

--- a/apps/web/src/features/wrapped/team-card/page.tsx
+++ b/apps/web/src/features/wrapped/team-card/page.tsx
@@ -111,7 +111,6 @@ export function WrappedTeamCardPage(props: {
 		completionUserId,
 		liveArchetype,
 		onboardingMetrics,
-		publicUsername,
 		statItems,
 		visibleTeamCardRow,
 	} = useWrappedTeamCardPageData();
@@ -237,7 +236,6 @@ export function WrappedTeamCardPage(props: {
 			onboardingMetrics={onboardingMetrics}
 			onBackFromFirstStep={onBackFromFirstStep}
 			onContinueToDashboard={handleContinueToDashboard}
-			publicUsername={publicUsername}
 			shareAppearance={resolveWrappedShareAppearance(shareAppearance)}
 			shareCardCreatedAtLabel={shareCardCreatedAtLabel}
 			shellStyle={TEAM_CARD_SHELL_STYLE}
@@ -259,7 +257,6 @@ function WrappedTeamCardPageContent(props: {
 	onboardingMetrics: WrappedOnboardingMetrics;
 	onBackFromFirstStep?: () => void;
 	onContinueToDashboard: () => void;
-	publicUsername: string | undefined;
 	setDevOverrideIndex: (
 		nextValue: number | null | ((currentValue: number | null) => number | null),
 	) => void;
@@ -284,7 +281,6 @@ function WrappedTeamCardPageContent(props: {
 		onboardingMetrics,
 		onBackFromFirstStep,
 		onContinueToDashboard,
-		publicUsername,
 		setDevOverrideIndex,
 		setShareAppearance,
 		shareAppearance,
@@ -376,22 +372,26 @@ function WrappedTeamCardPageContent(props: {
 	// Share creation lives behind a hook so the page can stay focused on stage
 	// orchestration. The hook owns caching/deduping, while this page only decides
 	// when the product has crossed the line from "previewing" to "real share made".
-	const { ensureShare, isCreatingShare, shareUrl, shareUrlLabel } =
-		useWrappedTeamCardShare(shareSnapshot, {
-			// This fires once a persistent public record exists. The share screen
-			// warms that record so the profile URL is visible before any copy action.
-			onShareCreated: (shareRecord) => {
-				trackWrappedShareCreated({
-					archetypeId: activeArchetype.id,
-					entrySource: wrappedLoopEntrySource,
-					publicPayloadVersion: WRAPPED_SHARE_PAYLOAD_VERSION,
-					shareId: shareRecord.id,
-					sourceComponent: "wrapped_team_card_page",
-					sourceShareId,
-				});
-			},
-			username: publicUsername,
-		});
+	const {
+		ensureShare,
+		hasShareError,
+		isCreatingShare,
+		shareUrl,
+		shareUrlLabel,
+	} = useWrappedTeamCardShare(shareSnapshot, {
+		// This fires once a persistent public record exists. The share screen
+		// warms that record so the profile URL is visible before any copy action.
+		onShareCreated: (shareRecord) => {
+			trackWrappedShareCreated({
+				archetypeId: activeArchetype.id,
+				entrySource: wrappedLoopEntrySource,
+				publicPayloadVersion: WRAPPED_SHARE_PAYLOAD_VERSION,
+				shareId: shareRecord.id,
+				sourceComponent: "wrapped_team_card_page",
+				sourceShareId,
+			});
+		},
+	});
 	// The share action helpers stay presentational from the page's perspective.
 	// We pass analytics hooks in, but keep the details of clipboard/native share/
 	// download behavior inside the share module.
@@ -431,12 +431,12 @@ function WrappedTeamCardPageContent(props: {
 	});
 
 	useEffect(() => {
-		if (!showShareStage || shareUrl || isCreatingShare) {
+		if (!showShareStage || shareUrl || isCreatingShare || hasShareError) {
 			return;
 		}
 
 		void ensureShare().catch(() => undefined);
-	}, [ensureShare, isCreatingShare, shareUrl, showShareStage]);
+	}, [ensureShare, hasShareError, isCreatingShare, shareUrl, showShareStage]);
 
 	useMountEffect(() => () => {
 		clearFinalCardHandoffTimer(finalCardHandoffTimerRef);

--- a/apps/web/src/features/wrapped/team-card/printed-card-flip.tsx
+++ b/apps/web/src/features/wrapped/team-card/printed-card-flip.tsx
@@ -47,20 +47,36 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 	const flipShellRef = useRef<HTMLDivElement | null>(null);
 	const animationFrameRef = useRef<number | null>(null);
 	const angleRef = useRef(isFrontVisible ? 0 : 180);
+	const captureKeyRef = useRef(captureKey);
 	const shadowVisibilityRef = useRef(1);
 	const [backUrl, setBackUrl] = useState<string | null>(null);
+	const [usesWebKitBackTextureOnly] = useState(isAppleWebKitBrowser);
 	const visualStyle = resolvePrintedCardVisualStyle(
 		angleRef.current,
 		shadowVisibilityRef.current,
 	);
+	const shouldRenderBackSource =
+		shouldCaptureBackSurface &&
+		(!usesWebKitBackTextureOnly || backUrl === null);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: captureKey intentionally invalidates the rendered back texture.
 	useEffect(() => {
 		let isCancelled = false;
 
-		setBackUrl(null);
-
 		if (!shouldCaptureBackSurface) {
+			setBackUrl(null);
+			return;
+		}
+
+		if (captureKeyRef.current !== captureKey) {
+			captureKeyRef.current = captureKey;
+
+			if (backUrl !== null) {
+				setBackUrl(null);
+				return;
+			}
+		}
+
+		if (backUrl !== null) {
 			return;
 		}
 
@@ -89,7 +105,7 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 		return () => {
 			isCancelled = true;
 		};
-	}, [captureKey, shouldCaptureBackSurface]);
+	}, [backUrl, captureKey, shouldCaptureBackSurface]);
 
 	useEffect(() => {
 		const targetAngle = isFrontVisible ? 0 : 180;
@@ -152,7 +168,7 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 
 	return (
 		<>
-			{shouldCaptureBackSurface ? (
+			{shouldRenderBackSource ? (
 				<div
 					aria-hidden="true"
 					className="mymind-wrapped-printed-card-flip__source-stage"
@@ -171,6 +187,9 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 				ref={flipShellRef}
 				className="mymind-wrapped-final-stage__flip-shell"
 				data-back-texture-ready={backUrl ? "true" : "false"}
+				data-back-texture-strategy={
+					usesWebKitBackTextureOnly ? "webkit-png-only" : "standard"
+				}
 				style={visualStyle}
 			>
 				<div className="mymind-wrapped-printed-card-flip__rotator">
@@ -202,6 +221,19 @@ export function WrappedPrintedCardFlip(props: WrappedPrintedCardFlipProps) {
 			</div>
 		</>
 	);
+}
+
+function isAppleWebKitBrowser() {
+	if (typeof navigator === "undefined") {
+		return false;
+	}
+
+	const { userAgent, vendor } = navigator;
+	const isAppleVendor = vendor.includes("Apple");
+	const isWebKit = userAgent.includes("AppleWebKit");
+	const isDesktopChromium = /\b(?:Chrome|Chromium|Edg|OPR)\//u.test(userAgent);
+
+	return isAppleVendor && isWebKit && !isDesktopChromium;
 }
 
 function resolvePrintedCardVisualStyle(

--- a/apps/web/src/features/wrapped/team-card/use-page-data.ts
+++ b/apps/web/src/features/wrapped/team-card/use-page-data.ts
@@ -23,7 +23,6 @@ interface UseWrappedTeamCardPageDataResult {
 	completionUserId: string | null;
 	liveArchetype: WrappedArchetypeCardTheme | null;
 	onboardingMetrics: WrappedOnboardingMetrics;
-	publicUsername: string | undefined;
 	statItems: readonly WrappedTeamMemberCardStatItem[];
 	visibleTeamCardRow: TeamPageMemberRow;
 }
@@ -52,7 +51,6 @@ export function useWrappedTeamCardPageData(): UseWrappedTeamCardPageDataResult {
 	);
 	const guestPreviewDisplayName = guestPreviewSnapshot?.profile.displayName;
 	const guestPreviewImageUrl = guestPreviewSnapshot?.profile.imageUrl;
-	const guestPreviewUsername = guestPreviewSnapshot?.profile.username;
 	const { data: activeMember } = authClient.useActiveMember();
 	const activeMemberUserId = getActiveMemberUserId(activeMember);
 	const resolvedUserId = sessionUserId ?? activeMemberUserId;
@@ -178,27 +176,10 @@ export function useWrappedTeamCardPageData(): UseWrappedTeamCardPageDataResult {
 		() => resolveLiveArchetype(wrappedData?.archetype?.key),
 		[wrappedData?.archetype?.key],
 	);
-	const publicUsername = useMemo(
-		() =>
-			resolveWrappedPublicUsername({
-				fallbackDisplayName: visibleTeamCardRow.displayName,
-				guestPreviewUsername,
-				sessionUserEmail,
-				sessionUserName,
-			}),
-		[
-			guestPreviewUsername,
-			sessionUserEmail,
-			sessionUserName,
-			visibleTeamCardRow.displayName,
-		],
-	);
-
 	return {
 		completionUserId,
 		liveArchetype,
 		onboardingMetrics,
-		publicUsername,
 		statItems,
 		visibleTeamCardRow,
 	};
@@ -263,59 +244,4 @@ function getSessionUserImage(
 		session.user.image.trim().length > 0
 		? session.user.image.trim()
 		: undefined;
-}
-
-function getEmailHandle(email: string | undefined) {
-	if (!email) {
-		return undefined;
-	}
-
-	const [emailHandle] = email.split("@");
-	return emailHandle?.trim() || undefined;
-}
-
-function resolveWrappedPublicUsername(input: {
-	fallbackDisplayName: string;
-	guestPreviewUsername: string | undefined;
-	sessionUserEmail: string | undefined;
-	sessionUserName: string | undefined;
-}) {
-	const guestPreviewUsername = input.guestPreviewUsername?.trim();
-
-	if (guestPreviewUsername && isWrappedPublicUsername(guestPreviewUsername)) {
-		return guestPreviewUsername;
-	}
-
-	const candidates = [
-		getEmailHandle(input.sessionUserEmail),
-		input.sessionUserName,
-		input.fallbackDisplayName,
-	];
-
-	for (const candidate of candidates) {
-		const username = normalizeWrappedPublicUsernameCandidate(candidate);
-
-		if (username) {
-			return username;
-		}
-	}
-
-	return undefined;
-}
-
-function normalizeWrappedPublicUsernameCandidate(value: string | undefined) {
-	const username = value
-		?.trim()
-		.replace(/^@+/u, "")
-		.replace(/[^A-Za-z0-9_-]+/gu, "-")
-		.replace(/-+/gu, "-")
-		.replace(/^-|-$/gu, "")
-		.slice(0, 64)
-		.replace(/-$/u, "");
-
-	return username && isWrappedPublicUsername(username) ? username : undefined;
-}
-
-function isWrappedPublicUsername(value: string) {
-	return /^[A-Za-z0-9_-]{1,64}$/u.test(value);
 }

--- a/apps/web/src/features/wrapped/team-card/use-share.ts
+++ b/apps/web/src/features/wrapped/team-card/use-share.ts
@@ -2,11 +2,10 @@ import type {
 	WrappedShareRecord,
 	WrappedShareSnapshot,
 } from "@rudel/api-routes";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { appRoutes } from "@/app/routes";
 import { client } from "@/lib/orpc";
 
-type ShareRecordLookup = Record<string, WrappedShareRecord>;
 const SHARE_URL_LABEL_MAX_LENGTH = 30;
 const SHARE_URL_LABEL_PUBLIC_PATH_MARKER = "/wrapped/";
 
@@ -15,7 +14,6 @@ interface UseWrappedTeamCardShareOptions {
 	// We keep that callback optional so the hook stays reusable and does not own
 	// analytics directly.
 	onShareCreated?: (shareRecord: WrappedShareRecord) => void;
-	username?: string;
 }
 
 // This hook owns the "create a real share only when needed" behavior for the
@@ -27,67 +25,63 @@ export function useWrappedTeamCardShare(
 ) {
 	// Multiple buttons can ask for a share at roughly the same time. We keep the
 	// in-flight promise in a ref so copy/share/download all collapse onto one
-	// request per snapshot instead of creating duplicate share records.
-	const shareRequestByKeyRef = useRef(
-		new Map<string, Promise<WrappedShareRecord>>(),
+	// request for the user's stable public link instead of creating duplicates.
+	const shareRequestRef = useRef<Promise<WrappedShareRecord> | null>(null);
+	const [shareRecord, setShareRecord] = useState<WrappedShareRecord | null>(
+		null,
 	);
-	const [shareRecordsByKey, setShareRecordsByKey] = useState<ShareRecordLookup>(
-		{},
-	);
-	const [pendingShareKey, setPendingShareKey] = useState<string | null>(null);
-	const { onShareCreated, username } = options ?? {};
-	const shareKey = useMemo(
-		() => JSON.stringify({ snapshot, username: username ?? null }),
-		[snapshot, username],
-	);
-	const activeShareRecord = shareRecordsByKey[shareKey] ?? null;
-	const shareUrl = activeShareRecord
-		? buildWrappedShareUrl(activeShareRecord.id)
+	const [isCreatingShare, setIsCreatingShare] = useState(false);
+	const [hasShareError, setHasShareError] = useState(false);
+	const { onShareCreated } = options ?? {};
+	const shareUrl = shareRecord
+		? buildWrappedShareUrl(shareRecord.id)
 		: undefined;
-	const isCreatingShare = pendingShareKey === shareKey;
 
 	// ensureShare is the single entry point for "make sure this card has a real
 	// public URL". It first reuses cached data, then reuses any in-flight request,
 	// and only finally creates a new share if nothing exists yet.
 	const ensureShare = useCallback(async () => {
-		if (activeShareRecord) {
-			return activeShareRecord;
+		if (shareRecord) {
+			return shareRecord;
 		}
 
-		const pendingShareRequest = shareRequestByKeyRef.current.get(shareKey);
-		if (pendingShareRequest) {
-			return pendingShareRequest;
+		if (shareRequestRef.current) {
+			return shareRequestRef.current;
 		}
 
-		setPendingShareKey(shareKey);
+		setIsCreatingShare(true);
+		setHasShareError(false);
 
-		const createShareInput = username ? { snapshot, username } : { snapshot };
 		const shareRequest = client.wrappedShare
-			.create(createShareInput)
+			.create({ snapshot })
 			.then((createdShare) => {
-				setShareRecordsByKey((currentRecords) => ({
-					...currentRecords,
-					[shareKey]: createdShare,
-				}));
+				setShareRecord(createdShare);
 				onShareCreated?.(createdShare);
 				return createdShare;
 			})
+			.catch((error: unknown) => {
+				setHasShareError(true);
+				throw error;
+			})
 			.finally(() => {
-				shareRequestByKeyRef.current.delete(shareKey);
-				setPendingShareKey((currentPendingShareKey) =>
-					currentPendingShareKey === shareKey ? null : currentPendingShareKey,
-				);
+				shareRequestRef.current = null;
+				setIsCreatingShare(false);
 			});
 
-		shareRequestByKeyRef.current.set(shareKey, shareRequest);
+		shareRequestRef.current = shareRequest;
 		return shareRequest;
-	}, [activeShareRecord, onShareCreated, shareKey, snapshot, username]);
+	}, [onShareCreated, shareRecord, snapshot]);
 
 	return {
 		ensureShare,
+		hasShareError,
 		isCreatingShare,
 		shareUrl,
-		shareUrlLabel: formatShareUrlLabel(shareUrl, isCreatingShare),
+		shareUrlLabel: formatShareUrlLabel(
+			shareUrl,
+			isCreatingShare,
+			hasShareError,
+		),
 	};
 }
 
@@ -110,9 +104,14 @@ function buildWrappedShareUrl(shareId: string) {
 function formatShareUrlLabel(
 	shareUrl: string | undefined,
 	isCreatingShare: boolean,
+	hasShareError: boolean,
 ) {
 	if (isCreatingShare) {
 		return "Creating link...";
+	}
+
+	if (hasShareError) {
+		return appRoutes.wrappedTeamCard();
 	}
 
 	if (!shareUrl) {

--- a/apps/web/src/features/wrapped/wrapped-auth-card-position.ts
+++ b/apps/web/src/features/wrapped/wrapped-auth-card-position.ts
@@ -58,9 +58,18 @@ export function useWrappedAuthViewportSize() {
 		function updateViewportSize() {
 			const metrics = getWrappedAuthViewportMetrics();
 
-			setViewportSize({
-				height: metrics.height,
-				width: metrics.width,
+			setViewportSize((currentViewportSize) => {
+				if (
+					currentViewportSize.height === metrics.height &&
+					currentViewportSize.width === metrics.width
+				) {
+					return currentViewportSize;
+				}
+
+				return {
+					height: metrics.height,
+					width: metrics.width,
+				};
 			});
 			applyWrappedAuthViewportMetrics(metrics);
 

--- a/apps/web/src/features/wrapped/wrapped-auth-card-position.ts
+++ b/apps/web/src/features/wrapped/wrapped-auth-card-position.ts
@@ -6,6 +6,13 @@ export interface WrappedAuthViewportSize {
 	width: number;
 }
 
+interface WrappedAuthViewportMetrics extends WrappedAuthViewportSize {
+	bottomOcclusion: number;
+	isBottomOccluded: boolean;
+	isInputFocused: boolean;
+	isShortVisualViewport: boolean;
+}
+
 export interface WrappedAuthFormCardYValues {
 	compact: number;
 	medium: number;
@@ -21,6 +28,13 @@ const WRAPPED_AUTH_NARROW_DESKTOP_MAX_WIDTH = 1200;
 const WRAPPED_AUTH_SHORT_MAX_HEIGHT = 760;
 const WRAPPED_AUTH_MEDIUM_MAX_HEIGHT = 820;
 const WRAPPED_AUTH_TALL_TARGET_HEIGHT = 1025;
+const WRAPPED_AUTH_PHONE_MAX_WIDTH = 768;
+const WRAPPED_AUTH_KEYBOARD_SAFE_MAX_WIDTH =
+	WRAPPED_AUTH_NARROW_DESKTOP_MIN_WIDTH;
+const WRAPPED_AUTH_BOTTOM_OCCLUSION_THRESHOLD = 80;
+const WRAPPED_AUTH_KEYBOARD_SCROLL_DELAYS_MS = [0, 120, 320] as const;
+const WRAPPED_AUTH_FOCUSED_INPUT_SELECTOR =
+	".mymind-wrapped-auth-form__input, .mymind-wrapped-auth-form input, .mymind-wrapped-auth-form textarea, .mymind-wrapped-auth-form select";
 
 const WRAPPED_AUTH_DEFAULT_VIEWPORT_SIZE: WrappedAuthViewportSize = {
 	height: WRAPPED_AUTH_MEDIUM_MAX_HEIGHT,
@@ -42,15 +56,49 @@ export function useWrappedAuthViewportSize() {
 
 	useMountEffect(() => {
 		function updateViewportSize() {
-			setViewportSize(getWrappedAuthViewportSize());
+			const metrics = getWrappedAuthViewportMetrics();
+
+			setViewportSize({
+				height: metrics.height,
+				width: metrics.width,
+			});
+			applyWrappedAuthViewportMetrics(metrics);
+
+			if (metrics.isInputFocused) {
+				revealWrappedAuthFocusedInput();
+			}
 		}
 
+		function updateViewportSizeAndRevealFocusedInput() {
+			updateViewportSize();
+			queueWrappedAuthFocusedInputReveal();
+		}
+
+		updateViewportSize();
+
+		const visualViewport = window.visualViewport;
+
 		window.addEventListener("resize", updateViewportSize);
-		window.visualViewport?.addEventListener("resize", updateViewportSize);
+		window.addEventListener("orientationchange", updateViewportSize);
+		visualViewport?.addEventListener("resize", updateViewportSize);
+		visualViewport?.addEventListener("scroll", updateViewportSize);
+		document.addEventListener(
+			"focusin",
+			updateViewportSizeAndRevealFocusedInput,
+		);
+		document.addEventListener("focusout", updateViewportSize);
 
 		return () => {
 			window.removeEventListener("resize", updateViewportSize);
-			window.visualViewport?.removeEventListener("resize", updateViewportSize);
+			window.removeEventListener("orientationchange", updateViewportSize);
+			visualViewport?.removeEventListener("resize", updateViewportSize);
+			visualViewport?.removeEventListener("scroll", updateViewportSize);
+			document.removeEventListener(
+				"focusin",
+				updateViewportSizeAndRevealFocusedInput,
+			);
+			document.removeEventListener("focusout", updateViewportSize);
+			clearWrappedAuthViewportMetrics();
 		};
 	});
 
@@ -93,16 +141,126 @@ export function getWrappedAuthFormCardOffsetY(input: {
 }
 
 function getWrappedAuthViewportSize(): WrappedAuthViewportSize {
+	const metrics = getWrappedAuthViewportMetrics();
+
+	return {
+		height: metrics.height,
+		width: metrics.width,
+	};
+}
+
+function getWrappedAuthViewportMetrics(): WrappedAuthViewportMetrics {
 	if (typeof window === "undefined") {
-		return WRAPPED_AUTH_DEFAULT_VIEWPORT_SIZE;
+		return {
+			...WRAPPED_AUTH_DEFAULT_VIEWPORT_SIZE,
+			bottomOcclusion: 0,
+			isBottomOccluded: false,
+			isInputFocused: false,
+			isShortVisualViewport: false,
+		};
 	}
 
 	const viewport = window.visualViewport;
+	const height = viewport?.height ?? window.innerHeight;
+	const width = viewport?.width ?? window.innerWidth;
+	const bottomOcclusion = viewport
+		? Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop)
+		: 0;
+	const isKeyboardSafeViewport = isWrappedAuthKeyboardSafeViewport(width);
+	const isPhoneViewport = isWrappedAuthPhoneViewport(width);
 
 	return {
-		height: viewport?.height ?? window.innerHeight,
-		width: viewport?.width ?? window.innerWidth,
+		bottomOcclusion,
+		height,
+		isBottomOccluded:
+			isKeyboardSafeViewport &&
+			bottomOcclusion >= WRAPPED_AUTH_BOTTOM_OCCLUSION_THRESHOLD,
+		isInputFocused:
+			isKeyboardSafeViewport &&
+			isWrappedAuthInputFocused(document.activeElement),
+		isShortVisualViewport: isPhoneViewport && height <= 720,
+		width,
 	};
+}
+
+function applyWrappedAuthViewportMetrics(metrics: WrappedAuthViewportMetrics) {
+	document.body.style.setProperty(
+		"--wrapped-live-viewport-height",
+		`${Math.round(metrics.height)}px`,
+	);
+	document.body.style.setProperty(
+		"--wrapped-visual-viewport-bottom-occlusion",
+		`${Math.round(metrics.bottomOcclusion)}px`,
+	);
+	document.body.dataset.wrappedBottomOccluded = metrics.isBottomOccluded
+		? "true"
+		: "false";
+	document.body.dataset.wrappedInputFocused = metrics.isInputFocused
+		? "true"
+		: "false";
+	document.body.dataset.wrappedShortVisualViewport =
+		metrics.isShortVisualViewport ? "true" : "false";
+}
+
+function clearWrappedAuthViewportMetrics() {
+	document.body.style.removeProperty("--wrapped-live-viewport-height");
+	document.body.style.removeProperty(
+		"--wrapped-visual-viewport-bottom-occlusion",
+	);
+	delete document.body.dataset.wrappedBottomOccluded;
+	delete document.body.dataset.wrappedInputFocused;
+	delete document.body.dataset.wrappedShortVisualViewport;
+}
+
+function queueWrappedAuthFocusedInputReveal() {
+	for (const delayMs of WRAPPED_AUTH_KEYBOARD_SCROLL_DELAYS_MS) {
+		window.setTimeout(() => {
+			revealWrappedAuthFocusedInput();
+		}, delayMs);
+	}
+}
+
+function revealWrappedAuthFocusedInput() {
+	if (!isWrappedAuthKeyboardSafeViewport(getWrappedAuthVisualViewportWidth())) {
+		return;
+	}
+
+	const activeElement = document.activeElement;
+
+	if (!isWrappedAuthInputFocused(activeElement)) {
+		return;
+	}
+
+	activeElement.scrollIntoView({
+		behavior: "smooth",
+		block: "center",
+		inline: "nearest",
+	});
+}
+
+function isWrappedAuthInputFocused(
+	element: Element | null,
+): element is HTMLElement {
+	if (!(element instanceof HTMLElement)) {
+		return false;
+	}
+
+	return (
+		element.closest(".mymind-wrapped-route") !== null &&
+		element.matches(WRAPPED_AUTH_FOCUSED_INPUT_SELECTOR)
+	);
+}
+
+function getWrappedAuthVisualViewportWidth() {
+	return window.visualViewport?.width ?? window.innerWidth;
+}
+
+function isWrappedAuthKeyboardSafeViewport(width: number) {
+	return width < WRAPPED_AUTH_KEYBOARD_SAFE_MAX_WIDTH;
+}
+
+function isWrappedAuthPhoneViewport(width: number) {
+	return width <= WRAPPED_AUTH_PHONE_MAX_WIDTH;
 }
 
 function getWrappedAuthNarrowDesktopWeight(width: number) {

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -1,5 +1,7 @@
 body.mymind-wrapped-body {
 	--wrapped-shell-bg: #f4f5f7;
+	--wrapped-live-viewport-height: 100svh;
+	--wrapped-visual-viewport-bottom-occlusion: 0px;
 	--wrapped-chatwoot-shell-max-width: 78rem;
 	--wrapped-chatwoot-right-offset: calc(
 		max(0px, (100vw - var(--wrapped-chatwoot-shell-max-width)) / 2) +
@@ -8,16 +10,18 @@ body.mymind-wrapped-body {
 	);
 	--wrapped-chatwoot-top-offset: calc(env(safe-area-inset-top, 0px) + 80px);
 	background: var(--wrapped-shell-bg);
-	height: 100svh;
-	min-height: 100svh;
-	overflow: clip;
+	height: var(--wrapped-live-viewport-height);
+	min-height: var(--wrapped-live-viewport-height);
+	overflow-x: clip;
+	overflow-y: auto;
 	overscroll-behavior: none;
 }
 
 body.mymind-wrapped-body #root {
 	height: 100%;
 	min-height: 0;
-	overflow: clip;
+	overflow-x: clip;
+	overflow-y: visible;
 	overscroll-behavior: none;
 }
 
@@ -54,10 +58,11 @@ body.mymind-wrapped-body .woot-widget-bubble {
 .mymind-wrapped-route {
 	position: relative;
 	display: flex;
-	height: 100%;
+	height: var(--wrapped-live-viewport-height);
 	min-height: 0;
 	isolation: isolate;
-	overflow: clip;
+	overflow-x: clip;
+	overflow-y: auto;
 	overscroll-behavior: none;
 	scrollbar-gutter: stable;
 	background: var(--wrapped-shell-bg);
@@ -138,6 +143,10 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	grid-template-rows: auto minmax(0, 1fr);
 }
 
+.mymind-wrapped-shell__frame--empty-top-tray {
+	grid-template-rows: 0 minmax(0, 1fr);
+}
+
 .mymind-wrapped-top-tray {
 	display: grid;
 	align-items: start;
@@ -145,6 +154,12 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	padding-top: 0.2rem;
 	width: 100%;
 	min-width: 0;
+}
+
+.mymind-wrapped-top-tray--empty {
+	min-height: 0;
+	overflow: clip;
+	padding-top: 0;
 }
 
 .mymind-wrapped-top-tray__row {
@@ -265,6 +280,18 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	width: 23px;
 	height: 23px;
 	stroke-width: 1.7;
+}
+
+.mymind-wrapped-top-tray--empty .mymind-wrapped-top-tray__row {
+	min-height: 0;
+}
+
+.mymind-wrapped-top-tray--empty .mymind-wrapped-top-tray__slot {
+	min-height: 0;
+}
+
+.mymind-wrapped-top-tray--empty .mymind-wrapped-top-tray__utility-placeholder {
+	height: 0;
 }
 
 .mymind-wrapped-back-button {
@@ -5376,6 +5403,8 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	font-family: var(--font-sans);
 	font-weight: 600;
 	letter-spacing: -0.01em;
+	overflow: visible;
+	white-space: nowrap;
 }
 
 .mymind-wrapped-auth-form__scene-link {
@@ -5401,6 +5430,8 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	background: #fefefe;
 	padding-inline: 1rem;
 	color: #1d1a18;
+	overflow: visible;
+	white-space: nowrap;
 }
 
 .mymind-wrapped-auth-form__input::placeholder {
@@ -5432,6 +5463,28 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	border: 1px solid rgb(15 23 42 / 0.06);
 	background: #fefefe;
 	color: #57524d;
+}
+
+.mymind-wrapped-auth-form__feedback--code-note {
+	width: 100%;
+	max-width: 100%;
+	padding: 6px 0;
+	border: 0;
+	border-radius: 0;
+	background: transparent;
+	box-shadow: none;
+	font-size: clamp(0.72rem, 2.8vw, 0.82rem);
+	line-height: 1;
+	overflow: clip;
+	text-overflow: ellipsis;
+	text-wrap: nowrap;
+	white-space: nowrap;
+}
+
+.mymind-wrapped-auth-form__feedback--code-note.is-success {
+	border: 0;
+	background: transparent;
+	color: #7a736c;
 }
 
 .mymind-wrapped-auth-form__divider {
@@ -5494,6 +5547,295 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	font-weight: 500;
 	text-decoration: underline;
 	text-underline-offset: 0.24rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-shell {
+	--wrapped-shell-top-inset: 24px;
+	--wrapped-shell-bottom-inset: 24px;
+	--wrapped-shell-stage-gap: 0.5rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-top-tray {
+	padding-top: 0;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-entry-stage--auth {
+	gap: 0.45rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-stage-copy {
+	gap: 0.35rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-entry-stage__copy {
+	transform: none;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-entry-stage__headline--auth {
+	font-size: clamp(1.74rem, 6.8vw, 2.1rem);
+	line-height: 0.98;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-auth-panel--intro {
+	grid-template-rows: auto auto;
+	gap: 0.24rem;
+	min-height: auto;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-auth-panel--intro
+	.mymind-wrapped-auth-panel__card {
+	align-self: center;
+	margin-block: 0;
+	padding-top: 0;
+	padding-bottom: 0;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-auth-form__terms {
+	align-self: end;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-auth-panel__cta-region {
+	gap: 0.28rem;
+	margin-top: 0;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-auth-panel__actions {
+	gap: 0;
+}
+
+body.mymind-wrapped-body[data-wrapped-short-visual-viewport="true"]
+	.mymind-wrapped-auth-panel--intro
+	.mymind-wrapped-auth-card-preview--hero
+	.mymind-wrapped-auth-card-preview__tilt {
+	--wrapped-card-render-scale: 0.72;
+	--wrapped-short-card-scale: 0.72;
+}
+
+@media (max-width: 47.999rem) and (max-height: 760px) {
+	body.mymind-wrapped-body .mymind-wrapped-auth-panel--intro {
+		grid-template-rows: auto auto;
+		gap: 0.24rem;
+		min-height: auto;
+	}
+
+	body.mymind-wrapped-body
+		.mymind-wrapped-auth-panel--intro
+		.mymind-wrapped-auth-panel__card {
+		align-self: center;
+		margin-block: 0;
+		padding-top: 0;
+		padding-bottom: 0;
+	}
+
+	body.mymind-wrapped-body .mymind-wrapped-auth-form__terms {
+		align-self: end;
+	}
+
+	body.mymind-wrapped-body .mymind-wrapped-auth-panel__cta-region {
+		gap: 0.28rem;
+		margin-top: 0;
+	}
+
+	body.mymind-wrapped-body .mymind-wrapped-auth-panel__actions {
+		gap: 0;
+	}
+
+	body.mymind-wrapped-body
+		.mymind-wrapped-auth-panel--intro
+		.mymind-wrapped-auth-card-preview--hero
+		.mymind-wrapped-auth-card-preview__tilt {
+		--wrapped-card-render-scale: 0.72;
+		--wrapped-short-card-scale: 0.72;
+	}
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-shell {
+	--wrapped-shell-top-inset: 16px;
+	--wrapped-shell-bottom-inset: 16px;
+	--wrapped-shell-stage-gap: 0.35rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-stage-area,
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-stage-slot {
+	overflow-y: auto;
+	overscroll-behavior-y: contain;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-entry-stage {
+	min-height: auto;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-entry-stage__copy {
+	transform: translateY(-0.2rem);
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-entry-stage__headline--auth {
+	font-size: clamp(1.72rem, 6.8vw, 2.1rem);
+	line-height: 1;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-entry-stage--auth {
+	gap: 0.35rem;
+	transform: translateY(-0.2rem);
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-panel--form {
+	--wrapped-auth-form-overlap: 0.35rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-panel--form
+	.mymind-wrapped-auth-panel__card {
+	padding-top: 0;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-panel--form
+	.mymind-wrapped-auth-card-preview__tilt {
+	--wrapped-card-render-scale: 0.72;
+	--wrapped-short-card-scale: 0.72;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form {
+	gap: 0.42rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__scene,
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__scene-form {
+	gap: 0.5rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__scene--email {
+	padding-top: clamp(0.35rem, 2svh, 0.7rem);
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__scene--credentials {
+	--wrapped-auth-credentials-bottom-space: calc(
+		env(safe-area-inset-bottom, 0px) +
+		0.55rem
+	);
+	padding-top: clamp(0.3rem, 1.8svh, 0.65rem);
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__scene-fields {
+	gap: 0.5rem;
+}
+
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__action-item--primary,
+body.mymind-wrapped-body[data-wrapped-bottom-occluded="true"]
+	.mymind-wrapped-auth-form__choice-footer {
+	margin-top: 0;
+}
+
+@media (max-width: 63.999rem) {
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-stage-area,
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-stage-slot {
+		overflow-x: visible;
+		overflow-y: visible;
+		overscroll-behavior-y: contain;
+		-webkit-overflow-scrolling: touch;
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-entry-stage {
+		min-height: auto;
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-panel--form {
+		min-height: auto;
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-panel--form
+		.mymind-wrapped-auth-panel__body--form {
+		overflow: visible;
+		overscroll-behavior-y: contain;
+		padding-bottom: max(
+			1rem,
+			calc(var(--wrapped-visual-viewport-bottom-occlusion, 0px) + 1rem)
+		);
+		scroll-padding-block: 3rem
+			max(
+				7rem,
+				calc(var(--wrapped-visual-viewport-bottom-occlusion, 0px) + 5rem)
+			);
+		-webkit-overflow-scrolling: touch;
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__scene-shell {
+		overflow: visible;
+		overscroll-behavior-y: contain;
+		padding-bottom: max(
+			1rem,
+			calc(var(--wrapped-visual-viewport-bottom-occlusion, 0px) + 1rem)
+		);
+		scroll-padding-block: 3rem
+			max(
+				7rem,
+				calc(var(--wrapped-visual-viewport-bottom-occlusion, 0px) + 5rem)
+			);
+		-webkit-overflow-scrolling: touch;
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__input {
+		scroll-margin-block: 3rem
+			max(
+				7rem,
+				calc(var(--wrapped-visual-viewport-bottom-occlusion, 0px) + 5rem)
+			);
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__scene--email,
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__scene--credentials {
+		padding-top: clamp(0.25rem, 1.4svh, 0.55rem);
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__scene,
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__scene-form {
+		gap: 0.5rem;
+	}
+
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__action-item--primary,
+	body.mymind-wrapped-body[data-wrapped-input-focused="true"]
+		.mymind-wrapped-auth-form__choice-footer {
+		margin-top: 0;
+	}
 }
 
 .mymind-wrapped-card-profile-step__card {

--- a/packages/api-routes/src/schemas/wrapped-share.ts
+++ b/packages/api-routes/src/schemas/wrapped-share.ts
@@ -15,12 +15,6 @@ export const WrappedShareIdSchema = z
 	.min(1)
 	.max(128)
 	.regex(/^[A-Za-z0-9_-]+$/u);
-export const WrappedShareUsernameSchema = z
-	.string()
-	.trim()
-	.min(1)
-	.max(64)
-	.regex(/^[A-Za-z0-9_-]+$/u);
 
 export const WrappedShareHeaderMetricSchema = z.object({
 	label: z.string().optional(),
@@ -83,11 +77,10 @@ export const WrappedShareSnapshotSchema = z.object({
 
 export const CreateWrappedShareInputSchema = z.object({
 	snapshot: WrappedShareSnapshotSchema,
-	username: WrappedShareUsernameSchema.optional(),
 });
 
 export const GetPublicWrappedShareInputSchema = z.object({
-	// This accepts both new username-style share ids and older UUID rows.
+	// This accepts both current display-name share ids and older UUID rows.
 	shareId: WrappedShareIdSchema,
 });
 

--- a/packages/sql-schema/db/migrations/0009_wrapped_share_user_unique.sql
+++ b/packages/sql-schema/db/migrations/0009_wrapped_share_user_unique.sql
@@ -1,0 +1,16 @@
+DELETE FROM "wrapped_share"
+WHERE "id" IN (
+	SELECT "id"
+	FROM (
+		SELECT
+			"id",
+			row_number() OVER (
+				PARTITION BY "user_id"
+				ORDER BY "created_at" ASC, "id" ASC
+			) AS "share_rank"
+		FROM "wrapped_share"
+	) AS "ranked_wrapped_share"
+	WHERE "share_rank" > 1
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "wrapped_share_user_id_unique" ON "wrapped_share" USING btree ("user_id");

--- a/packages/sql-schema/db/migrations/meta/_journal.json
+++ b/packages/sql-schema/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
 			"when": 1776806310870,
 			"tag": "0008_wrapped_resume",
 			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1777816100000,
+			"tag": "0009_wrapped_share_user_unique",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/sql-schema/src/wrapped-share-schema.ts
+++ b/packages/sql-schema/src/wrapped-share-schema.ts
@@ -1,32 +1,42 @@
-import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import {
+	integer,
+	pgTable,
+	text,
+	timestamp,
+	uniqueIndex,
+} from "drizzle-orm/pg-core";
 import { organization, user } from "./auth-schema.js";
 
 // wrapped_share stores the public replay payload for the Saturday growth loop.
 // The table is intentionally snapshot-based: we persist exactly what the public
 // route should render so anonymous replay never has to reach back into private
 // analytics tables or user-scoped queries.
-export const wrappedShare = pgTable("wrapped_share", {
-	id: text("id").primaryKey(),
-	organizationId: text("organization_id")
-		.notNull()
-		.references(() => organization.id, { onDelete: "cascade" }),
-	// payload_version lets us invalidate older persisted shapes cleanly if the
-	// public share contract changes after launch.
-	payloadVersion: integer("payload_version").notNull().default(1),
-	snapshotJson: text("snapshot_json").notNull(),
-	userId: text("user_id")
-		.notNull()
-		.references(() => user.id, { onDelete: "cascade" }),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
-		.defaultNow()
-		.notNull(),
-	// expires_at gives the public route an explicit end-of-life instead of
-	// letting share links survive forever by accident.
-	expiresAt: timestamp("expires_at", {
-		withTimezone: true,
-		mode: "date",
-	}).notNull(),
-});
+export const wrappedShare = pgTable(
+	"wrapped_share",
+	{
+		id: text("id").primaryKey(),
+		organizationId: text("organization_id")
+			.notNull()
+			.references(() => organization.id, { onDelete: "cascade" }),
+		// payload_version lets us invalidate older persisted shapes cleanly if the
+		// public share contract changes after launch.
+		payloadVersion: integer("payload_version").notNull().default(1),
+		snapshotJson: text("snapshot_json").notNull(),
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
+			.defaultNow()
+			.notNull(),
+		// expires_at gives the public route an explicit end-of-life instead of
+		// letting share links survive forever by accident.
+		expiresAt: timestamp("expires_at", {
+			withTimezone: true,
+			mode: "date",
+		}).notNull(),
+	},
+	(table) => [uniqueIndex("wrapped_share_user_id_unique").on(table.userId)],
+);
 
 export type WrappedShareSelect = typeof wrappedShare.$inferSelect;
 export type WrappedShareInsert = typeof wrappedShare.$inferInsert;


### PR DESCRIPTION
## Summary
- make wrapped public links stable per user and derived from the card display name instead of email/username
- allocate duplicate display-name links with an adjective before the name, and migrate legacy UUID links to the name-based id on the next create
- enforce one wrapped share row per user with a migration, update the frontend share cache to use the user link, and stop retry loops after failed creation
- keep the wrapped desktop resume preview copy-feedback cleanup that is still present on this branch

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig