### PR TITLE
fix: reveal team card archetypes to current users

### DIFF
--- a/apps/api/src/services/developer.service.ts
+++ b/apps/api/src/services/developer.service.ts
@@ -10,7 +10,13 @@ import type {
 	DeveloperTrendDataPoint,
 } from "@rudel/api-routes";
 import {
+	WRAPPED_ARCHETYPE_CENTROID_VERSION,
+	WRAPPED_ARCHETYPE_PIPELINE_VERSION,
+	WRAPPED_ARCHETYPE_SCOPE,
+} from "@rudel/ch-schema/wrapped-archetype-constants";
+import {
 	addOptionalStringEqFilter,
+	addOptionalStringInFilter,
 	buildDateFilter,
 	queryClickhouse,
 } from "../clickhouse.js";
@@ -56,6 +62,12 @@ interface FavoriteModelRow {
 	favorite_model: string;
 }
 
+interface TeamCardArchetypeRow {
+	user_id: string;
+	archetype_key: string;
+	archetype_name: string;
+}
+
 async function getFavoriteModelByUser(orgId: string, days: number) {
 	const rows = await queryClickhouse<FavoriteModelRow>({
 		query: `
@@ -85,6 +97,80 @@ async function getFavoriteModelByUser(orgId: string, days: number) {
 	});
 
 	return new Map(rows.map((row) => [row.user_id, row.favorite_model] as const));
+}
+
+async function getLatestWrappedArchetypeByUser(
+	orgId: string,
+	userIds: readonly string[],
+) {
+	if (userIds.length === 0) {
+		return new Map<string, NonNullable<DeveloperTeamCard["archetype"]>>();
+	}
+
+	const where = [
+		"s.scope = {scope:String}",
+		"s.organization_id = {orgId:String}",
+	];
+	const query_params: Record<string, unknown> = {
+		centroidVersion: WRAPPED_ARCHETYPE_CENTROID_VERSION,
+		orgId,
+		pipelineVersion: WRAPPED_ARCHETYPE_PIPELINE_VERSION,
+		scope: WRAPPED_ARCHETYPE_SCOPE,
+	};
+	addOptionalStringInFilter(
+		where,
+		query_params,
+		"s.user_id",
+		"userId",
+		Array.from(userIds),
+	);
+
+	try {
+		const rows = await queryClickhouse<TeamCardArchetypeRow>({
+			query: `
+				WITH latest_run AS (
+					SELECT snapshot_id
+					FROM rudel.wrapped_user_archetype_runs_v1
+					WHERE scope = {scope:String}
+						AND pipeline_version = {pipelineVersion:String}
+						AND centroid_version = {centroidVersion:String}
+					ORDER BY snapshot_created_at DESC
+					LIMIT 1
+				)
+				SELECT
+					s.user_id AS user_id,
+					s.archetype_key AS archetype_key,
+					s.archetype_name AS archetype_name
+				FROM latest_run AS r
+				INNER JOIN rudel.wrapped_user_archetype_snapshots_v1 AS s
+					ON s.snapshot_id = r.snapshot_id
+				WHERE ${where.join("\n\t\t\t\t\tAND ")}
+			`,
+			query_params,
+		});
+
+		const archetypeByUser = new Map<
+			string,
+			NonNullable<DeveloperTeamCard["archetype"]>
+		>();
+		for (const row of rows) {
+			const key = row.archetype_key.trim();
+			const name = row.archetype_name.trim();
+			if (key.length === 0 || name.length === 0) {
+				continue;
+			}
+
+			archetypeByUser.set(row.user_id, { key, name });
+		}
+
+		return archetypeByUser;
+	} catch (error) {
+		console.warn(
+			"[developer.service] getLatestWrappedArchetypeByUser failed, returning null archetypes",
+			error,
+		);
+		return new Map<string, NonNullable<DeveloperTeamCard["archetype"]>>();
+	}
 }
 
 /**
@@ -254,19 +340,22 @@ export async function getDeveloperTeamCards(
 	}
 
 	const userIds = summaryRows.map((row) => row.user_id);
-	const users = await sqlClient.unsafe<
-		Array<{
-			id: string;
-			name: string | null;
-		}>
-	>(
-		`
-			SELECT id, name
-			FROM "user"
-			WHERE id = ANY($1::text[])
-		`,
-		[userIds],
-	);
+	const [users, archetypeByUser] = await Promise.all([
+		sqlClient.unsafe<
+			Array<{
+				id: string;
+				name: string | null;
+			}>
+		>(
+			`
+				SELECT id, name
+				FROM "user"
+				WHERE id = ANY($1::text[])
+			`,
+			[userIds],
+		),
+		getLatestWrappedArchetypeByUser(orgId, userIds),
+	]);
 	const displayNameByUserId = new Map(
 		users
 			.map((entry) => [entry.id, entry.name?.trim() ?? ""] as const)
@@ -283,6 +372,7 @@ export async function getDeveloperTeamCards(
 			{
 				user_id: row.user_id,
 				display_name: displayName,
+				archetype: archetypeByUser.get(row.user_id) ?? null,
 				cost: Number(row.cost) || 0,
 				input_tokens: Number(row.total_input_tokens) || 0,
 				output_tokens: Number(row.total_output_tokens) || 0,

--- a/apps/web/src/dev/frontend-fixtures.ts
+++ b/apps/web/src/dev/frontend-fixtures.ts
@@ -17,6 +17,12 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const MAX_FIXTURE_DAYS = 14;
 const FIXTURE_MODELS = ["claude-sonnet-4.5", "gpt-5.1-codex"];
 const FIXTURE_REPOSITORIES = ["rudel/web", "rudel/api"];
+const FIXTURE_TEAM_CARD_ARCHETYPES = [
+	{ key: "maniac", name: "Maniac" },
+	{ key: "smooth_operator", name: "Smooth Operator" },
+	{ key: "roadrunner", name: "Roadrunner" },
+	{ key: "obsessed", name: "Obsessed" },
+];
 
 export interface FrontendFixtureMember {
 	userId: string;
@@ -458,6 +464,8 @@ function buildDeveloperTeamCard(
 
 	return {
 		active_days: 8 - Math.min(index, 4),
+		archetype:
+			FIXTURE_TEAM_CARD_ARCHETYPES[index % FIXTURE_TEAM_CARD_ARCHETYPES.length],
 		cost: Number((inputTokens * 0.000003 + outputTokens * 0.000015).toFixed(2)),
 		display_name: member.displayName,
 		favorite_model: FIXTURE_MODELS[index % FIXTURE_MODELS.length],

--- a/apps/web/src/features/team/TeamPageManualRefreshSmoke.test.tsx
+++ b/apps/web/src/features/team/TeamPageManualRefreshSmoke.test.tsx
@@ -51,6 +51,7 @@ function buildDeveloperSummary() {
 function buildTeamCard() {
 	return {
 		active_days: 4,
+		archetype: { key: "smooth_operator", name: "Smooth Operator" },
 		cost: 18,
 		display_name: "Ada Lovelace",
 		favorite_model: "claude-sonnet-4-5",

--- a/apps/web/src/features/team/components/TeamMembersCardGrid.test.tsx
+++ b/apps/web/src/features/team/components/TeamMembersCardGrid.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
+import { TeamMembersCardGrid } from "./TeamMembersCardGrid";
+
+function buildTeamMemberRow(
+	overrides: Partial<TeamPageMemberRow> = {},
+): TeamPageMemberRow {
+	return {
+		activeDays: 14,
+		archetype: { key: "obsessed", name: "Obsessed" },
+		cost: 42,
+		displayName: "Ada Lovelace",
+		email: "ada@example.com",
+		favoriteModel: "claude-sonnet-4-5",
+		hasActivity: true,
+		imageUrl: null,
+		inputTokens: 120_000,
+		lastActiveDate: "2026-04-22",
+		outputTokens: 60_000,
+		role: "Member",
+		totalSessions: 120,
+		totalTokens: 180_000,
+		userId: "user-1",
+		...overrides,
+	};
+}
+
+describe("TeamMembersCardGrid", () => {
+	it("shows real archetypes and applies the matching card theme", () => {
+		render(
+			<TeamMembersCardGrid
+				canInviteTeamMembers={false}
+				isInviteLinkPending={false}
+				rows={[buildTeamMemberRow()]}
+				teamInviteLink={null}
+			/>,
+		);
+
+		expect(screen.queryByText("To be revealed")).not.toBeInTheDocument();
+		expect(screen.getByTitle("Obsessed")).toBeInTheDocument();
+
+		const archetypeBadge = screen.getByTitle("Obsessed");
+		const card = archetypeBadge.closest("article");
+		expect(card).not.toBeNull();
+		expect(card?.getAttribute("class")).toContain("#191919");
+		expect(card?.getAttribute("class")).toContain("text-[#f5f1ec]");
+	});
+
+	it("uses the current product label for known classifier keys", () => {
+		render(
+			<TeamMembersCardGrid
+				canInviteTeamMembers={false}
+				isInviteLinkPending={false}
+				rows={[
+					buildTeamMemberRow({
+						archetype: {
+							key: "smooth_operator",
+							name: "Smooth Operator",
+						},
+						userId: "user-2",
+					}),
+				]}
+				teamInviteLink={null}
+			/>,
+		);
+
+		expect(screen.getByTitle("Smooth Operator")).toBeInTheDocument();
+		expect(screen.queryByText("To be revealed")).not.toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/team/components/TeamMembersCardGrid.tsx
+++ b/apps/web/src/features/team/components/TeamMembersCardGrid.tsx
@@ -1,6 +1,7 @@
 import { LinkIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
+import { resolveWrappedArchetypeCardThemeByClassifierKey } from "@/features/wrapped/team-card/archetypes";
 import { WrappedTeamCardArtboardFrame } from "@/features/wrapped/team-card/artboard-frame";
 import {
 	WrappedTeamMemberCard,
@@ -11,7 +12,7 @@ import { UNKNOWN_GUEST_CARD_PRESET } from "@/features/wrapped/wrapped-guest-card
 import { copyTextToClipboardWithResult } from "@/lib/clipboard";
 import "@/features/wrapped/wrapped.css";
 
-const TEAM_CARD_PENDING_ARCHETYPE_LABEL = "To be revealed";
+const TEAM_CARD_UNCLASSIFIED_ARCHETYPE_LABEL = "Unclassified";
 const TEAM_LINK_COPY_RESET_MS = 1800;
 
 const compactCurrencyFormatter = new Intl.NumberFormat("en-US", {
@@ -37,11 +38,6 @@ const shortDateFormatter = new Intl.DateTimeFormat("en-US", {
 	month: "short",
 });
 
-const pendingArchetypeMetric = {
-	title: TEAM_CARD_PENDING_ARCHETYPE_LABEL,
-	value: TEAM_CARD_PENDING_ARCHETYPE_LABEL,
-} satisfies WrappedTeamMemberCardHeaderMetric;
-
 function buildHeaderLeftMetric(row: TeamPageMemberRow) {
 	const formattedSpend = formatSpendValue(row.cost);
 
@@ -49,6 +45,31 @@ function buildHeaderLeftMetric(row: TeamPageMemberRow) {
 		title: `${currencyFormatter.format(row.cost)} estimated spend`,
 		value: formattedSpend,
 	} satisfies WrappedTeamMemberCardHeaderMetric;
+}
+
+function buildHeaderRightMetric(label: string) {
+	return {
+		title: label,
+		value: label,
+	} satisfies WrappedTeamMemberCardHeaderMetric;
+}
+
+function resolveTeamCardPresentation(row: TeamPageMemberRow) {
+	const archetypeTheme = resolveWrappedArchetypeCardThemeByClassifierKey(
+		row.archetype?.key,
+	);
+	const archetypeLabel =
+		archetypeTheme?.displayLabel ??
+		row.archetype?.name ??
+		TEAM_CARD_UNCLASSIFIED_ARCHETYPE_LABEL;
+
+	return {
+		archetypeLabel,
+		shellClassName:
+			archetypeTheme?.shellClassName ??
+			UNKNOWN_GUEST_CARD_PRESET.shellClassName,
+		theme: archetypeTheme?.theme ?? UNKNOWN_GUEST_CARD_PRESET.theme,
+	};
 }
 
 function buildTeamCardStats(
@@ -270,24 +291,30 @@ export function TeamMembersCardGrid({
 						/>
 					</li>
 				) : null}
-				{rows.map((row) => (
-					<li key={row.userId} className="list-none">
-						<WrappedTeamMemberCard
-							disableOuterShadow={false}
-							headerLeftMetric={buildHeaderLeftMetric(row)}
-							headerRightMetric={pendingArchetypeMetric}
-							hideHeaderLogo
-							layoutPreset="team-card-preview"
-							mediaPanelClassName="mx-auto"
-							row={row}
-							shellClassName={UNKNOWN_GUEST_CARD_PRESET.shellClassName}
-							shellStyle={UNKNOWN_GUEST_CARD_PRESET.shellStyle}
-							statItems={buildTeamCardStats(row)}
-							statTileClassName=""
-							theme={UNKNOWN_GUEST_CARD_PRESET.theme}
-						/>
-					</li>
-				))}
+				{rows.map((row) => {
+					const teamCardPresentation = resolveTeamCardPresentation(row);
+
+					return (
+						<li key={row.userId} className="list-none">
+							<WrappedTeamMemberCard
+								disableOuterShadow={false}
+								headerLeftMetric={buildHeaderLeftMetric(row)}
+								headerRightMetric={buildHeaderRightMetric(
+									teamCardPresentation.archetypeLabel,
+								)}
+								hideHeaderLogo
+								layoutPreset="team-card-preview"
+								mediaPanelClassName="mx-auto"
+								row={row}
+								shellClassName={teamCardPresentation.shellClassName}
+								shellStyle={UNKNOWN_GUEST_CARD_PRESET.shellStyle}
+								statItems={buildTeamCardStats(row)}
+								statTileClassName=""
+								theme={teamCardPresentation.theme}
+							/>
+						</li>
+					);
+				})}
 			</ul>
 		</div>
 	);

--- a/apps/web/src/features/team/use-team-page-data.ts
+++ b/apps/web/src/features/team/use-team-page-data.ts
@@ -26,12 +26,18 @@ export interface TeamPageDiagnostics {
 	requestedDays: number;
 }
 
+export interface TeamPageMemberArchetype {
+	key: string;
+	name: string;
+}
+
 export interface TeamPageMemberRow {
 	userId: string;
 	displayName: string;
 	email: string | null;
 	role: string;
 	imageUrl?: string | null;
+	archetype?: TeamPageMemberArchetype | null;
 	cost: number;
 	favoriteModel: string | null;
 	inputTokens: number;
@@ -110,6 +116,7 @@ function buildTeamMemberRows(
 					? formatMemberRole(member.role)
 					: "Tracked collaborator",
 				imageUrl: member?.imageUrl,
+				archetype: teamCard?.archetype ?? null,
 				cost,
 				favoriteModel:
 					teamCard?.favorite_model ?? developerSummary?.favorite_model ?? null,

--- a/packages/api-routes/src/schemas/analytics.ts
+++ b/packages/api-routes/src/schemas/analytics.ts
@@ -157,6 +157,12 @@ export const DeveloperSummarySchema = z.object({
 export const DeveloperTeamCardSchema = z.object({
 	user_id: z.string(),
 	display_name: z.string(),
+	archetype: z
+		.object({
+			key: z.string(),
+			name: z.string(),
+		})
+		.nullable(),
 	cost: z.number(),
 	input_tokens: z.number(),
 	output_tokens: z.number(),


### PR DESCRIPTION
## Summary
- Add classifier-backed archetype data to developer team card API responses.
- Render the real archetype label on team cards and apply the matching wrapped archetype card theme.
- Add team card fixture archetypes and regression coverage for label/theme rendering.

## Test plan
- [x] `bun run verify`
- [x] `bun run lint:wrapped:hig`

Generated with Codex.