### PR TITLE
fix: polish public wrapped share copy

### DIFF
--- a/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
@@ -840,6 +840,14 @@ function WrappedAuthTitle(props: WrappedAuthTitleProps) {
 										)}
 										<span className="mymind-wrapped-auth-intro-title__word-label">
 											{introTool}
+											{introTool === "Claude" ? (
+												<span
+													aria-hidden="true"
+													className="mymind-wrapped-auth-intro-title__word-sublabel"
+												>
+													Code
+												</span>
+											) : null}
 										</span>
 									</motion.span>
 								</AnimatePresence>

--- a/apps/web/src/features/wrapped/WrappedPublicCardScreen.tsx
+++ b/apps/web/src/features/wrapped/WrappedPublicCardScreen.tsx
@@ -2,15 +2,9 @@ import type { WrappedShareRevealMetrics } from "@rudel/api-routes";
 import { ChevronRight } from "lucide-react";
 import type { CSSProperties, ReactNode } from "react";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
-import {
-	WRAPPED_SATURDAY_STEPS,
-	type WrappedPrimaryStep,
-} from "@/features/wrapped/onboarding/config";
+import { WRAPPED_SATURDAY_STEPS } from "@/features/wrapped/onboarding/config";
 import { WrappedOnboardingFooter } from "@/features/wrapped/onboarding/controls";
-import {
-	getWrappedArchetypeCardBackgroundValue,
-	type WrappedArchetypeCardTheme,
-} from "@/features/wrapped/team-card/archetypes";
+import type { WrappedArchetypeCardTheme } from "@/features/wrapped/team-card/archetypes";
 import type {
 	WrappedTeamMemberCardHeaderMetric,
 	WrappedTeamMemberCardStatItem,
@@ -20,8 +14,6 @@ import type {
 import type { WrappedTeamMemberCardBackMetric } from "@/features/wrapped/team-card/card-back";
 import { WrappedTeamCardPublicStage } from "@/features/wrapped/team-card/final-stages";
 import { useWrappedCardTilt } from "@/features/wrapped/team-card/tilt/use-card-tilt";
-import { WrappedProgress } from "@/features/wrapped/WrappedProgress";
-import { getWrappedOnboardingProgressView } from "@/features/wrapped/wrapped-onboarding-progress";
 import { cn } from "@/lib/utils";
 
 interface WrappedPublicCardScreenProps {
@@ -57,8 +49,6 @@ export function WrappedPublicCardScreen(props: WrappedPublicCardScreenProps) {
 		theme,
 	} = props;
 	const cardStep = getWrappedPublicCardStep();
-	const rewardCardBackground =
-		getWrappedArchetypeCardBackgroundValue(activeArchetype) ?? undefined;
 	const tiltController = useWrappedCardTilt();
 
 	return (
@@ -70,10 +60,7 @@ export function WrappedPublicCardScreen(props: WrappedPublicCardScreenProps) {
 						debugControls ? null : "mymind-wrapped-shell__frame--no-footer",
 					)}
 				>
-					<WrappedPublicCardHeader
-						activeStep={cardStep}
-						rewardCardBackground={rewardCardBackground}
-					/>
+					<WrappedPublicCardTopTraySpacer />
 
 					<div className="mymind-wrapped-stage-area">
 						<div className="mymind-wrapped-stage-slot">
@@ -143,36 +130,12 @@ export function WrappedPublicCardAction(props: {
 	);
 }
 
-function WrappedPublicCardHeader(props: {
-	activeStep: WrappedPrimaryStep;
-	rewardCardBackground?: string;
-}) {
-	const { activeStep, rewardCardBackground } = props;
-	const progressView = getWrappedOnboardingProgressView(activeStep.id);
-
+function WrappedPublicCardTopTraySpacer() {
 	return (
-		<header className="mymind-wrapped-top-tray mymind-wrapped-public-card-header">
-			<div className="mymind-wrapped-top-tray__row">
-				<div className="mymind-wrapped-top-tray__slot mymind-wrapped-top-tray__slot--start">
-					<span className="mymind-wrapped-top-tray__utility-placeholder" />
-				</div>
-				<div className="mymind-wrapped-top-tray__center">
-					<WrappedProgress
-						ariaLabel="Wrapped public card progress"
-						disabled
-						items={progressView.items.map((item) => ({
-							ariaLabel: `Wrapped step ${item.stepNumber}: ${item.label}`,
-							id: item.id,
-							isActive: item.isActive,
-						}))}
-						rewardCardBackground={rewardCardBackground}
-					/>
-				</div>
-				<div className="mymind-wrapped-top-tray__slot mymind-wrapped-top-tray__slot--end">
-					<span className="mymind-wrapped-top-tray__utility-placeholder" />
-				</div>
-			</div>
-		</header>
+		<div
+			aria-hidden="true"
+			className="mymind-wrapped-top-tray mymind-wrapped-top-tray--empty"
+		/>
 	);
 }
 

--- a/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.test.tsx
@@ -162,6 +162,65 @@ const tiltController: WrappedCardTiltController = {
 	isGyroscopeSupported: false,
 };
 
+const PUBLIC_VIEWER_COPY_PATTERN =
+	/\b(?:you|your|yours|yourself|they|them|their|theirs|themselves)\b/iu;
+
+const PUBLIC_ARCHETYPE_DESCRIPTION_EXPECTATIONS = [
+	{
+		archetypeId: "roadrunner",
+		description:
+			"Avery Chen is here. Meep meep. Avery Chen is gone. Active 12 out of 180 days. When Avery Chen showed up, we noticed. $1.14 a session. Meep Meep. Gone again. Where? Nobody knows",
+	},
+	{
+		archetypeId: "hit_and_runner",
+		description:
+			"24 minutes average. 6 repos. 41% of sessions shipped something. Veni, vidi, commit. In at 24 minutes. Out before anyone noticed. Avery Chen could be a hitman.",
+	},
+	{
+		archetypeId: "adhd_brain",
+		description:
+			"12 out of 180 days. 6 repos. 41% of sessions shipped something. Avery Chen would call this a DaVinci. We're just worried about the 6 repos.",
+	},
+	{
+		archetypeId: "cheapskate",
+		description:
+			"$1.14 a session. 41% of those shipped something. Mr. Krabs is very proud of Avery Chen. But Avery Chen has never once picked up the check.",
+	},
+	{
+		archetypeId: "company_card",
+		description:
+			"37 sessions. 41% of sessions shipped something. $1.14 a session. $42 in total. Not saying it's a problem. We don't judge. Avery Chen spends as much as Avery Chen wants. Dario's happy to have Avery Chen.",
+	},
+	{
+		archetypeId: "decimal",
+		description:
+			"For the rare edition energy: polished, expensive-looking, and very aware of the room.",
+	},
+	{
+		archetypeId: "tourist",
+		description:
+			"37 sessions. 41% shipped something. $1.14 a session. At least Avery Chen tried it out! There's no prize for participation though",
+	},
+	{
+		archetypeId: "smooth_operator",
+		description:
+			"12 out of 180 days. 24 minutes average. 88 at Avery Chen's longest. Avery Chen starts. Avery Chen builds. Avery Chen stops. 3.1 sessions a day, $1.14 a session, no chaos. A little to bit too smooth... bit suspicious.",
+	},
+	{
+		archetypeId: "obsessed",
+		description:
+			"6 repo. That's it. 12 out of 180 days. All of it, same place. 41% of Avery Chen's sessions shipped something. At $1.14 a session. May god help anyone who tries to distract Avery Chen.",
+	},
+	{
+		archetypeId: "maniac",
+		description:
+			"12 out of 180 days. 6 repos. Most people are consistent. Some people are everywhere at once. Avery Chen is both. Somehow. 3.1 sessions every time Avery Chen is active. We're a little scared honestly. Pls don't hurt someone",
+	},
+] satisfies readonly {
+	archetypeId: (typeof WRAPPED_ARCHETYPE_CARD_THEMES)[number]["id"];
+	description: string;
+}[];
+
 const REVEAL_INTRO_READY_MS = 2_140;
 const REVEAL_CARD_DROP_DURATION_MS = 1_020;
 const REVEAL_CARD_FLIP_DURATION_MS = 680;
@@ -1577,6 +1636,62 @@ describe("WrappedTeamCardRevealStage", () => {
 });
 
 describe("WrappedTeamCardPublicStage", () => {
+	it("renders every public archetype description in third person", () => {
+		for (const expectation of PUBLIC_ARCHETYPE_DESCRIPTION_EXPECTATIONS) {
+			const activeArchetype = WRAPPED_ARCHETYPE_CARD_THEMES.find(
+				(archetype) => archetype.id === expectation.archetypeId,
+			);
+			assert(activeArchetype);
+
+			const { container, unmount } = render(
+				<WrappedTeamCardPublicStage
+					action={<button type="button">Make yours</button>}
+					activeArchetype={activeArchetype}
+					backMetrics={buildWrappedTeamCardBackMetrics({
+						onboardingMetrics,
+						row,
+						shareCardCreatedAtLabel: "04/24/2026",
+					})}
+					headerLeftMetric={{ title: "$42 estimated spend", value: "$42" }}
+					headerRightMetric={{
+						title: activeArchetype.displayLabel,
+						value: activeArchetype.displayLabel,
+					}}
+					revealMetrics={{
+						avgSessionMin: 24,
+						commitRate: 41,
+						daysSinceFirst: 180,
+						distinctProjectCount: 6,
+						longestSessionMin: 88,
+					}}
+					row={row}
+					shellClassName={activeArchetype.shellClassName}
+					shellStyle={{}}
+					statItems={[]}
+					statLayerOpacities={{
+						rainbowShineOpacity: 0.3,
+						textureOpacity: 1,
+						tileBorderOpacity: 1,
+						tileFillOpacity: 0.08,
+						tileInsetShadowOpacity: 0.5,
+						tileTopStrokeOpacity: 0.08,
+					}}
+					theme={activeArchetype.theme}
+					tiltController={tiltController}
+				/>,
+			);
+			const description = container.querySelector(
+				".mymind-wrapped-final-stage__archetype-description",
+			);
+			assert(description);
+
+			expect(description.textContent).toBe(expectation.description);
+			expect(description.textContent).not.toMatch(PUBLIC_VIEWER_COPY_PATTERN);
+
+			unmount();
+		}
+	});
+
 	it("renders public ADHD copy from saved reveal metrics", () => {
 		const activeArchetype = WRAPPED_ARCHETYPE_CARD_THEMES.find(
 			(archetype) => archetype.id === "adhd_brain",
@@ -1631,7 +1746,7 @@ describe("WrappedTeamCardPublicStage", () => {
 		).toBeInTheDocument();
 		expect(
 			screen.getByText(
-				"12 out of 180 days. 6 repos. 48% of sessions shipped something. You'd call yourself a DaVinci. We're just worried about the 6 repos.",
+				"12 out of 180 days. 6 repos. 48% of sessions shipped something. Avery Chen would call this a DaVinci. We're just worried about the 6 repos.",
 			),
 		).toBeInTheDocument();
 	});
@@ -1685,7 +1800,7 @@ describe("WrappedTeamCardPublicStage", () => {
 
 		expect(
 			screen.getByText(
-				"12 out of 12 days. 6 repos. 48% of sessions shipped something. You'd call yourself a DaVinci. We're just worried about the 6 repos.",
+				"12 out of 12 days. 6 repos. 48% of sessions shipped something. Avery Chen would call this a DaVinci. We're just worried about the 6 repos.",
 			),
 		).toBeInTheDocument();
 	});
@@ -1732,7 +1847,7 @@ describe("WrappedTeamCardPublicStage", () => {
 		);
 
 		expect(
-			screen.getByText(/24 minutes average\. 88 at your longest\./u),
+			screen.getByText(/24 minutes average\. 88 at Avery Chen's longest\./u),
 		).toBeInTheDocument();
 	});
 

--- a/apps/web/src/features/wrapped/team-card/final-stages.tsx
+++ b/apps/web/src/features/wrapped/team-card/final-stages.tsx
@@ -1644,7 +1644,13 @@ function buildRoadrunnerRevealDescription(input: WrappedRevealCopyInput) {
 }
 
 function buildManiacRevealDescription(input: WrappedRevealCopyInput) {
-	const { onboardingMetrics, revealMetrics, row, statItems } = input;
+	const {
+		audience = "owner",
+		onboardingMetrics,
+		revealMetrics,
+		row,
+		statItems,
+	} = input;
 	const activeDays = formatWrappedRevealInteger(row.activeDays);
 	const daysSinceFirst = formatWrappedRevealInteger(
 		resolveWrappedRevealDaysSinceFirst(input),
@@ -1660,18 +1666,23 @@ function buildManiacRevealDescription(input: WrappedRevealCopyInput) {
 		activeDays: row.activeDays,
 		totalSessions: row.totalSessions,
 	});
+	const publicName = row.displayName;
 
 	return [
 		`${activeDays} out of ${daysSinceFirst} days. ${distinctProjectCount} repos.`,
 		"Most people are consistent. Some people are everywhere at once.",
-		"You're both. Somehow.",
-		`${sessionsPerActiveDay} sessions every time you're active.`,
+		audience === "public"
+			? `${publicName} is both. Somehow.`
+			: "You're both. Somehow.",
+		`${sessionsPerActiveDay} sessions every time ${
+			audience === "public" ? `${publicName} is` : "you're"
+		} active.`,
 		"We're a little scared honestly. Pls don't hurt someone",
 	].join(" ");
 }
 
 function buildCompanyCardRevealDescription(input: WrappedRevealCopyInput) {
-	const { onboardingMetrics, row } = input;
+	const { audience = "owner", onboardingMetrics, row } = input;
 	const totalSessions = formatWrappedRevealInteger(row.totalSessions);
 	const commitRate = formatWrappedRevealInteger(
 		resolveWrappedRevealCommitRate(input),
@@ -1681,21 +1692,33 @@ function buildCompanyCardRevealDescription(input: WrappedRevealCopyInput) {
 	);
 	const totalCost = formatWrappedRevealWholeCurrency(row.cost);
 	const happyLine = formatWrappedRevealCompanyCardHappyLine({
+		audience,
 		favoriteModel: row.favoriteModel,
 		onboardingMetrics,
+		rowDisplayName: row.displayName,
 	});
 
 	return [
-		`${totalSessions} sessions. ${commitRate}% of them shipped something.`,
+		audience === "public"
+			? `${totalSessions} sessions. ${commitRate}% of sessions shipped something.`
+			: `${totalSessions} sessions. ${commitRate}% of them shipped something.`,
 		`${costPerSession} a session. ${totalCost} in total.`,
 		"Not saying it's a problem. We don't judge.",
-		"Spend as much as you want.",
+		audience === "public"
+			? `${row.displayName} spends as much as ${row.displayName} wants.`
+			: "Spend as much as you want.",
 		happyLine,
 	].join(" ");
 }
 
 function buildAdhdBrainRevealDescription(input: WrappedRevealCopyInput) {
-	const { onboardingMetrics, revealMetrics, row, statItems } = input;
+	const {
+		audience = "owner",
+		onboardingMetrics,
+		revealMetrics,
+		row,
+		statItems,
+	} = input;
 	const activeDays = formatWrappedRevealInteger(row.activeDays);
 	const daysSinceFirst = formatWrappedRevealInteger(
 		resolveWrappedRevealDaysSinceFirst(input),
@@ -1713,13 +1736,21 @@ function buildAdhdBrainRevealDescription(input: WrappedRevealCopyInput) {
 
 	return [
 		`${activeDays} out of ${daysSinceFirst} days. ${distinctProjectCount} repos. ${commitRate}% of sessions shipped something.`,
-		"You'd call yourself a DaVinci.",
+		audience === "public"
+			? `${row.displayName} would call this a DaVinci.`
+			: "You'd call yourself a DaVinci.",
 		`We're just worried about the ${distinctProjectCount} repos.`,
 	].join(" ");
 }
 
 function buildHitAndRunnerRevealDescription(input: WrappedRevealCopyInput) {
-	const { onboardingMetrics, revealMetrics, statItems } = input;
+	const {
+		audience = "owner",
+		onboardingMetrics,
+		revealMetrics,
+		row,
+		statItems,
+	} = input;
 	const avgSessionMin = formatWrappedRevealInteger(
 		resolveWrappedRevealAvgSessionMin(input),
 	);
@@ -1738,12 +1769,14 @@ function buildHitAndRunnerRevealDescription(input: WrappedRevealCopyInput) {
 		`${avgSessionMin} minutes average. ${distinctProjectCount} repos. ${commitRate}% of sessions shipped something.`,
 		"Veni, vidi, commit.",
 		`In at ${avgSessionMin} minutes. Out before anyone noticed.`,
-		"You could be a hitman.",
+		audience === "public"
+			? `${row.displayName} could be a hitman.`
+			: "You could be a hitman.",
 	].join(" ");
 }
 
 function buildCheapskateRevealDescription(input: WrappedRevealCopyInput) {
-	const { row } = input;
+	const { audience = "owner", row } = input;
 	const commitRate = formatWrappedRevealInteger(
 		resolveWrappedRevealCommitRate(input),
 	);
@@ -1753,12 +1786,20 @@ function buildCheapskateRevealDescription(input: WrappedRevealCopyInput) {
 
 	return [
 		`${costPerSession} a session. ${commitRate}% of those shipped something.`,
-		"Mr. Krabs is very proud of you. But you've never once picked up the check.",
+		audience === "public"
+			? `Mr. Krabs is very proud of ${row.displayName}. But ${row.displayName} has never once picked up the check.`
+			: "Mr. Krabs is very proud of you. But you've never once picked up the check.",
 	].join(" ");
 }
 
 function buildObsessedRevealDescription(input: WrappedRevealCopyInput) {
-	const { onboardingMetrics, revealMetrics, row, statItems } = input;
+	const {
+		audience = "owner",
+		onboardingMetrics,
+		revealMetrics,
+		row,
+		statItems,
+	} = input;
 	const activeDays = formatWrappedRevealInteger(row.activeDays);
 	const daysSinceFirst = formatWrappedRevealInteger(
 		resolveWrappedRevealDaysSinceFirst(input),
@@ -1776,17 +1817,24 @@ function buildObsessedRevealDescription(input: WrappedRevealCopyInput) {
 	const costPerSession = formatCurrency(
 		row.totalSessions > 0 ? row.cost / row.totalSessions : 0,
 	);
+	const publicPossessiveName = formatWrappedPublicPossessiveName(
+		row.displayName,
+	);
 
 	return [
 		`${distinctProjectCount} repo. That's it.`,
 		`${activeDays} out of ${daysSinceFirst} days. All of it, same place.`,
-		`${commitRate}% of your sessions shipped something. At ${costPerSession} a session.`,
-		"May god help anyone who tries to distract you.",
+		`${commitRate}% of ${
+			audience === "public" ? publicPossessiveName : "your"
+		} sessions shipped something. At ${costPerSession} a session.`,
+		audience === "public"
+			? `May god help anyone who tries to distract ${row.displayName}.`
+			: "May god help anyone who tries to distract you.",
 	].join(" ");
 }
 
 function buildSmoothOperatorRevealDescription(input: WrappedRevealCopyInput) {
-	const { row } = input;
+	const { audience = "owner", row } = input;
 	const activeDays = formatWrappedRevealInteger(row.activeDays);
 	const daysSinceFirst = formatWrappedRevealInteger(
 		resolveWrappedRevealDaysSinceFirst(input),
@@ -1804,18 +1852,25 @@ function buildSmoothOperatorRevealDescription(input: WrappedRevealCopyInput) {
 	const costPerSession = formatCurrency(
 		row.totalSessions > 0 ? row.cost / row.totalSessions : 0,
 	);
+	const publicPossessiveName = formatWrappedPublicPossessiveName(
+		row.displayName,
+	);
 
 	return [
 		`${activeDays} out of ${daysSinceFirst} days.`,
-		`${avgSessionMin} minutes average. ${longestSessionMin} at your longest.`,
-		"You start. You build. You stop.",
+		`${avgSessionMin} minutes average. ${longestSessionMin} at ${
+			audience === "public" ? publicPossessiveName : "your"
+		} longest.`,
+		audience === "public"
+			? `${row.displayName} starts. ${row.displayName} builds. ${row.displayName} stops.`
+			: "You start. You build. You stop.",
 		`${sessionsPerActiveDay} sessions a day, ${costPerSession} a session, no chaos.`,
 		"A little to bit too smooth... bit suspicious.",
 	].join(" ");
 }
 
 function buildTouristRevealDescription(input: WrappedRevealCopyInput) {
-	const { row } = input;
+	const { audience = "owner", row } = input;
 	const totalSessions = formatWrappedRevealInteger(row.totalSessions);
 	const commitRate = formatWrappedRevealInteger(
 		resolveWrappedRevealCommitRate(input),
@@ -1826,8 +1881,14 @@ function buildTouristRevealDescription(input: WrappedRevealCopyInput) {
 
 	return [
 		`${totalSessions} sessions. ${commitRate}% shipped something. ${costPerSession} a session.`,
-		"At least you tried it out! There's no prize for participation though",
+		audience === "public"
+			? `At least ${row.displayName} tried it out! There's no prize for participation though`
+			: "At least you tried it out! There's no prize for participation though",
 	].join(" ");
+}
+
+function formatWrappedPublicPossessiveName(displayName: string) {
+	return displayName.endsWith("s") ? `${displayName}'` : `${displayName}'s`;
 }
 
 function formatWrappedRevealInteger(value: number) {
@@ -1941,20 +2002,26 @@ function resolveWrappedRevealBackMetricNumber(
 }
 
 function formatWrappedRevealCompanyCardHappyLine(input: {
+	audience?: "owner" | "public";
 	favoriteModel: string | null;
 	onboardingMetrics?: WrappedOnboardingMetrics;
+	rowDisplayName?: string;
 }) {
+	const objectLabel =
+		input.audience === "public"
+			? (input.rowDisplayName ?? "this person")
+			: "you";
 	const usageSource = getWrappedRevealCompanyCardUsageSource(input);
 
 	if (usageSource === "claude") {
-		return "Dario's happy to have you.";
+		return `Dario's happy to have ${objectLabel}.`;
 	}
 
 	if (usageSource === "codex") {
-		return "Sam's happy to have you.";
+		return `Sam's happy to have ${objectLabel}.`;
 	}
 
-	return "Dario & Sam are happy to have you.";
+	return `Dario & Sam are happy to have ${objectLabel}.`;
 }
 
 function getWrappedRevealCompanyCardUsageSource(input: {

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -4186,7 +4186,7 @@ body.mymind-wrapped-body .woot-widget-bubble {
 
 .mymind-wrapped-auth-intro-title__word.is-claude {
 	background: #da7757;
-	color: #fffaf5;
+	color: #fff;
 }
 
 .mymind-wrapped-auth-intro-title__word.is-codex {
@@ -4204,10 +4204,31 @@ body.mymind-wrapped-body .woot-widget-bubble {
 	flex: 0 0 auto;
 }
 
+.mymind-wrapped-auth-intro-title__word.is-claude
+	.mymind-wrapped-auth-intro-title__word-icon {
+	color: #fff;
+	fill: #fff;
+}
+
 .mymind-wrapped-auth-intro-title__word-label {
+	position: relative;
 	display: inline-flex;
 	align-items: center;
+	justify-content: center;
 	min-width: 0;
+}
+
+.mymind-wrapped-auth-intro-title__word-sublabel {
+	position: absolute;
+	top: calc(100% + 0.08em);
+	right: 0;
+	color: #fff;
+	font-size: 0.32em;
+	font-weight: 700;
+	letter-spacing: 0;
+	line-height: 1;
+	pointer-events: none;
+	white-space: nowrap;
 }
 
 .mymind-wrapped-auth-launch-links {


### PR DESCRIPTION
## Summary
- remove the top progress stepper from public Wrapped share pages
- keep public archetype reveal descriptions in third person using the card display name instead of viewer-facing pronouns
- add public archetype coverage so all share descriptions stay name-based

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig