### PR TITLE
feat: add team share card link

### DIFF
--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -17,6 +17,10 @@ const CARD_REFERENCE_PATH = "/card-reference";
 const WRAPPED_TEAM_CARD_PATH = "/wrapped";
 const DEV_WRAPPED_PATH = "/dev/wrapped";
 const WRAPPED_RESUME_PATH = "/resume";
+const WRAPPED_TEAM_CARD_STEP_QUERY_PARAM = "step";
+const WRAPPED_TEAM_CARD_FINAL_STEP = "card";
+export const WRAPPED_TEAM_CARD_STAGE_QUERY_PARAM = "stage";
+export const WRAPPED_TEAM_CARD_SHARE_STAGE = "share";
 export const WRAPPED_ROUTE_FLOW_QUERY_PARAM = "flow";
 export const WRAPPED_ROUTE_CARD_PROFILE_FLOW = "card-profile";
 export const WRAPPED_ROUTE_DESKTOP_READY_FLOW = "desktop-ready";
@@ -51,6 +55,7 @@ export const appRoutes = {
 	presetBaseline: () => PRESET_BASELINE_PATH,
 	cardReference: () => CARD_REFERENCE_PATH,
 	wrappedTeamCard: () => WRAPPED_TEAM_CARD_PATH,
+	wrappedTeamCardShare: () => getWrappedTeamCardSharePath(),
 	wrappedCardProfile: (search?: string) => getWrappedCardProfilePath(search),
 	wrappedDesktopReady: (search?: string) => getWrappedDesktopReadyPath(search),
 	wrappedSessionsLanded: (search?: string) =>
@@ -99,6 +104,21 @@ export function getWrappedSessionsLandedPath(search?: string) {
 function getWrappedFlowPath(flow: string, search?: string) {
 	const searchParams = new URLSearchParams(search);
 	searchParams.set(WRAPPED_ROUTE_FLOW_QUERY_PARAM, flow);
+
+	return `${WRAPPED_TEAM_CARD_PATH}?${searchParams.toString()}`;
+}
+
+function getWrappedTeamCardSharePath() {
+	const searchParams = new URLSearchParams();
+	searchParams.set(WRAPPED_ROUTE_FLOW_QUERY_PARAM, "story");
+	searchParams.set(
+		WRAPPED_TEAM_CARD_STEP_QUERY_PARAM,
+		WRAPPED_TEAM_CARD_FINAL_STEP,
+	);
+	searchParams.set(
+		WRAPPED_TEAM_CARD_STAGE_QUERY_PARAM,
+		WRAPPED_TEAM_CARD_SHARE_STAGE,
+	);
 
 	return `${WRAPPED_TEAM_CARD_PATH}?${searchParams.toString()}`;
 }

--- a/apps/web/src/features/team/TeamPage.tsx
+++ b/apps/web/src/features/team/TeamPage.tsx
@@ -254,6 +254,7 @@ function TeamPageRefreshButton({
 export function TeamPage() {
 	const {
 		canInviteTeamMembers,
+		currentUserId,
 		diagnostics,
 		error,
 		isInviteLinkPending,
@@ -284,6 +285,7 @@ export function TeamPage() {
 	let content = (
 		<TeamMembersCardGrid
 			canInviteTeamMembers={canInviteTeamMembers}
+			currentUserId={currentUserId}
 			isInviteLinkPending={isInviteLinkPending}
 			rows={teamMemberRows}
 			teamInviteLink={teamInviteLink}

--- a/apps/web/src/features/team/TeamPageManualRefreshSmoke.test.tsx
+++ b/apps/web/src/features/team/TeamPageManualRefreshSmoke.test.tsx
@@ -2,15 +2,23 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TeamPage } from "@/features/team/TeamPage";
 
-const { mockGetFullOrganization, mockUseDateRange, mockUseOrganization } =
-	vi.hoisted(() => ({
-		mockGetFullOrganization: vi.fn(),
-		mockUseDateRange: vi.fn(),
-		mockUseOrganization: vi.fn(),
-	}));
+const {
+	mockGetFullOrganization,
+	mockUseActiveMember,
+	mockUseDateRange,
+	mockUseOrganization,
+	mockUseSession,
+} = vi.hoisted(() => ({
+	mockGetFullOrganization: vi.fn(),
+	mockUseActiveMember: vi.fn(),
+	mockUseDateRange: vi.fn(),
+	mockUseOrganization: vi.fn(),
+	mockUseSession: vi.fn(),
+}));
 
 vi.mock("@/features/analytics/date-range/useDateRange", () => ({
 	useDateRange: mockUseDateRange,
@@ -25,6 +33,8 @@ vi.mock("@/lib/auth-client", () => ({
 		organization: {
 			getFullOrganization: mockGetFullOrganization,
 		},
+		useActiveMember: mockUseActiveMember,
+		useSession: mockUseSession,
 	},
 }));
 
@@ -92,7 +102,7 @@ function createWrapper(queryClient: QueryClient) {
 	}) {
 		return (
 			<QueryClientProvider client={queryClient}>
-				{props.children}
+				<MemoryRouter>{props.children}</MemoryRouter>
 			</QueryClientProvider>
 		);
 	};
@@ -102,8 +112,10 @@ describe("TeamPage manual refresh smoke", () => {
 	beforeEach(() => {
 		rawSessionCount = 12;
 		mockGetFullOrganization.mockReset();
+		mockUseActiveMember.mockReset();
 		mockUseDateRange.mockReset();
 		mockUseOrganization.mockReset();
+		mockUseSession.mockReset();
 
 		mockGetFullOrganization.mockResolvedValue({
 			data: {
@@ -118,6 +130,16 @@ describe("TeamPage manual refresh smoke", () => {
 						userId: "user-1",
 					},
 				],
+			},
+		});
+		mockUseActiveMember.mockReturnValue({
+			data: null,
+		});
+		mockUseSession.mockReturnValue({
+			data: {
+				user: {
+					id: "user-1",
+				},
 			},
 		});
 		mockUseDateRange.mockReturnValue({

--- a/apps/web/src/features/team/components/TeamMembersCardGrid.test.tsx
+++ b/apps/web/src/features/team/components/TeamMembersCardGrid.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
 import { TeamMembersCardGrid } from "./TeamMembersCardGrid";
@@ -31,6 +32,7 @@ describe("TeamMembersCardGrid", () => {
 		render(
 			<TeamMembersCardGrid
 				canInviteTeamMembers={false}
+				currentUserId={null}
 				isInviteLinkPending={false}
 				rows={[buildTeamMemberRow()]}
 				teamInviteLink={null}
@@ -51,6 +53,7 @@ describe("TeamMembersCardGrid", () => {
 		render(
 			<TeamMembersCardGrid
 				canInviteTeamMembers={false}
+				currentUserId={null}
 				isInviteLinkPending={false}
 				rows={[
 					buildTeamMemberRow({
@@ -67,5 +70,41 @@ describe("TeamMembersCardGrid", () => {
 
 		expect(screen.getByTitle("Smooth Operator")).toBeInTheDocument();
 		expect(screen.queryByText("To be revealed")).not.toBeInTheDocument();
+	});
+
+	it("wraps the current user's card with a hover-revealed secondary sharing page link", () => {
+		render(
+			<MemoryRouter>
+				<TeamMembersCardGrid
+					canInviteTeamMembers={false}
+					currentUserId="user-1"
+					isInviteLinkPending={false}
+					rows={[buildTeamMemberRow()]}
+					teamInviteLink={null}
+				/>
+			</MemoryRouter>,
+		);
+
+		const shareLink = screen.getByRole("link", {
+			name: "View sharing page",
+		});
+		expect(shareLink).toHaveAttribute(
+			"href",
+			"/wrapped?flow=story&step=card&stage=share",
+		);
+		expect(shareLink).toHaveAttribute("target", "_blank");
+		expect(shareLink).toHaveAttribute("rel", "noreferrer");
+		const shareLinkClassName = shareLink.getAttribute("class");
+		expect(shareLinkClassName).toContain("bg-secondary");
+		expect(shareLinkClassName).toContain("opacity-0");
+		expect(shareLinkClassName).toContain("absolute");
+		expect(shareLinkClassName).toContain("bottom-2");
+		expect(shareLinkClassName).toContain("rounded-[10px]");
+		expect(shareLinkClassName).toContain(
+			"group-hover/team-share-card:opacity-100",
+		);
+		expect(shareLink.parentElement?.getAttribute("class")).toContain(
+			"h-[358px] w-[233px]",
+		);
 	});
 });

--- a/apps/web/src/features/team/components/TeamMembersCardGrid.tsx
+++ b/apps/web/src/features/team/components/TeamMembersCardGrid.tsx
@@ -1,5 +1,9 @@
-import { LinkIcon } from "lucide-react";
+import { ArrowUpRightIcon, LinkIcon } from "lucide-react";
+import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { appRoutes } from "@/app/routes";
+import { buttonVariants } from "@/app/ui/button";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
 import { resolveWrappedArchetypeCardThemeByClassifierKey } from "@/features/wrapped/team-card/archetypes";
 import { WrappedTeamCardArtboardFrame } from "@/features/wrapped/team-card/artboard-frame";
@@ -152,6 +156,35 @@ function formatSpendValue(cost: number) {
 	return currencyFormatter.format(cost);
 }
 
+function isCurrentUserTeamCard(
+	row: TeamPageMemberRow,
+	currentUserId: string | null,
+) {
+	return currentUserId !== null && row.userId === currentUserId;
+}
+
+function TeamMemberShareCardShell({ children }: { children: ReactNode }) {
+	return (
+		<div className="group/team-share-card relative h-[358px] w-[233px]">
+			{children}
+			<Link
+				className={buttonVariants({
+					className:
+						"pointer-events-none absolute right-2 bottom-2 left-2 z-20 h-10 translate-y-1 rounded-[10px] px-3 text-sm font-semibold opacity-0 shadow-none transition-[opacity,transform] duration-150 [transition-timing-function:cubic-bezier(0.23,1,0.32,1)] active:scale-[0.98] group-hover/team-share-card:pointer-events-auto group-hover/team-share-card:translate-y-0 group-hover/team-share-card:opacity-100 group-focus-within/team-share-card:pointer-events-auto group-focus-within/team-share-card:translate-y-0 group-focus-within/team-share-card:opacity-100 focus-visible:pointer-events-auto focus-visible:translate-y-0 focus-visible:opacity-100",
+					size: "sm",
+					variant: "secondary",
+				})}
+				rel="noreferrer"
+				target="_blank"
+				to={appRoutes.wrappedTeamCardShare()}
+			>
+				<span>View sharing page</span>
+				<ArrowUpRightIcon aria-hidden="true" className="size-4" />
+			</Link>
+		</div>
+	);
+}
+
 function TeamCardShapePlaceholder({
 	isInviteLinkPending,
 	teamInviteLink,
@@ -271,11 +304,13 @@ function TeamLinkCopySurface({
 
 export function TeamMembersCardGrid({
 	canInviteTeamMembers,
+	currentUserId,
 	isInviteLinkPending,
 	rows,
 	teamInviteLink,
 }: {
 	canInviteTeamMembers: boolean;
+	currentUserId: string | null;
 	isInviteLinkPending: boolean;
 	rows: TeamPageMemberRow[];
 	teamInviteLink: string | null;
@@ -284,7 +319,7 @@ export function TeamMembersCardGrid({
 		<div className="team-lineup-surface-scope">
 			<ul className="grid justify-center gap-[10px] [grid-template-columns:repeat(auto-fit,minmax(233px,233px))]">
 				{canInviteTeamMembers ? (
-					<li className="list-none">
+					<li className="flex justify-center list-none">
 						<TeamCardShapePlaceholder
 							isInviteLinkPending={isInviteLinkPending}
 							teamInviteLink={teamInviteLink}
@@ -292,26 +327,34 @@ export function TeamMembersCardGrid({
 					</li>
 				) : null}
 				{rows.map((row) => {
+					const isCurrentUserCard = isCurrentUserTeamCard(row, currentUserId);
 					const teamCardPresentation = resolveTeamCardPresentation(row);
+					const card = (
+						<WrappedTeamMemberCard
+							disableOuterShadow={false}
+							headerLeftMetric={buildHeaderLeftMetric(row)}
+							headerRightMetric={buildHeaderRightMetric(
+								teamCardPresentation.archetypeLabel,
+							)}
+							hideHeaderLogo
+							layoutPreset="team-card-preview"
+							mediaPanelClassName="mx-auto"
+							row={row}
+							shellClassName={teamCardPresentation.shellClassName}
+							shellStyle={UNKNOWN_GUEST_CARD_PRESET.shellStyle}
+							statItems={buildTeamCardStats(row)}
+							statTileClassName=""
+							theme={teamCardPresentation.theme}
+						/>
+					);
 
 					return (
-						<li key={row.userId} className="list-none">
-							<WrappedTeamMemberCard
-								disableOuterShadow={false}
-								headerLeftMetric={buildHeaderLeftMetric(row)}
-								headerRightMetric={buildHeaderRightMetric(
-									teamCardPresentation.archetypeLabel,
-								)}
-								hideHeaderLogo
-								layoutPreset="team-card-preview"
-								mediaPanelClassName="mx-auto"
-								row={row}
-								shellClassName={teamCardPresentation.shellClassName}
-								shellStyle={UNKNOWN_GUEST_CARD_PRESET.shellStyle}
-								statItems={buildTeamCardStats(row)}
-								statTileClassName=""
-								theme={teamCardPresentation.theme}
-							/>
+						<li key={row.userId} className="flex justify-center list-none">
+							{isCurrentUserCard ? (
+								<TeamMemberShareCardShell>{card}</TeamMemberShareCardShell>
+							) : (
+								card
+							)}
 						</li>
 					);
 				})}

--- a/apps/web/src/features/team/use-team-page-data.ts
+++ b/apps/web/src/features/team/use-team-page-data.ts
@@ -49,6 +49,26 @@ export interface TeamPageMemberRow {
 	hasActivity: boolean;
 }
 
+function getSessionUserId(
+	session: ReturnType<typeof authClient.useSession>["data"],
+) {
+	return session?.user &&
+		"id" in session.user &&
+		typeof session.user.id === "string"
+		? session.user.id
+		: null;
+}
+
+function getActiveMemberUserId(
+	activeMember: ReturnType<typeof authClient.useActiveMember>["data"],
+) {
+	return activeMember &&
+		"userId" in activeMember &&
+		typeof activeMember.userId === "string"
+		? activeMember.userId
+		: null;
+}
+
 function formatMemberRole(role: string | null | undefined) {
 	if (!role) {
 		return "Member";
@@ -139,6 +159,8 @@ function buildTeamMemberRows(
 }
 
 export function useTeamPageData() {
+	const { data: session } = authClient.useSession();
+	const { data: activeMember } = authClient.useActiveMember();
 	const { state: dateRangeState, meta: dateRangeMeta } = useDateRange();
 	const { meta: workspaceMeta, state: workspaceState } = useOrganization();
 	const useFixtures = isFrontendFixturesEnabled();
@@ -146,6 +168,8 @@ export function useTeamPageData() {
 	const selectedDays = dateRangeMeta.dayCount;
 	const requestedDays = MAX_ANALYTICS_DAYS;
 	const activeOrganizationId = workspaceState.activeOrg?.id ?? null;
+	const currentUserId =
+		getSessionUserId(session) ?? getActiveMemberUserId(activeMember);
 	const canInviteTeamMembers =
 		activeOrganizationId !== null && workspaceMeta?.isOrgAdmin === true;
 	const {
@@ -261,6 +285,7 @@ export function useTeamPageData() {
 				isOrganizationPending),
 		teamMemberRows,
 		canInviteTeamMembers,
+		currentUserId,
 		isInviteLinkPending: teamInviteLinkQuery.isPending,
 		teamInviteLink: teamInviteLinkQuery.data?.invite_url ?? null,
 		requestedDays,

--- a/apps/web/src/features/wrapped/team-card/WrappedTeamCardPage.analytics.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/WrappedTeamCardPage.analytics.test.tsx
@@ -388,6 +388,33 @@ describe("WrappedTeamCardPage analytics", () => {
 		);
 	});
 
+	it("opens the final share screen directly from the team stats link", async () => {
+		render(
+			<MemoryRouter
+				initialEntries={["/wrapped?flow=story&step=card&stage=share"]}
+			>
+				<WrappedTeamCardPage />
+			</MemoryRouter>,
+		);
+
+		expect(
+			screen.queryByRole("button", { name: "Preview post" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Share post" }),
+		).toBeInTheDocument();
+
+		await waitFor(() => {
+			expect(mockEnsureShare).toHaveBeenCalledTimes(1);
+		});
+		expect(mockTrackWrappedStoryStarted).toHaveBeenCalledWith({
+			activationState: "share_direct",
+			entrySource: "wrapped_team_card",
+			sourceComponent: "wrapped_team_card_page",
+			sourceShareId: undefined,
+		});
+	});
+
 	it("tracks story start, share creation, and distribution from a source share", async () => {
 		const user = userEvent.setup();
 

--- a/apps/web/src/features/wrapped/team-card/page.tsx
+++ b/apps/web/src/features/wrapped/team-card/page.tsx
@@ -22,6 +22,8 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import {
 	appRoutes,
 	getWrappedShareIdFromSearch,
+	WRAPPED_TEAM_CARD_SHARE_STAGE,
+	WRAPPED_TEAM_CARD_STAGE_QUERY_PARAM,
 	WRAPPED_VARIANT_DECIMAL,
 	WRAPPED_VARIANT_NORMAL,
 	WRAPPED_VARIANT_QUERY_PARAM,
@@ -218,6 +220,18 @@ export function WrappedTeamCardPage(props: {
 	}
 
 	const activeStepParam = searchParams.get("step");
+	const activeFinalCardStage =
+		activeStepParam === "card"
+			? getRequestedFinalCardStage(searchParams)
+			: "reveal";
+	const wrappedActivationState = getWrappedTeamCardActivationState({
+		activeFinalCardStage,
+		activeStepParam,
+	});
+	const wrappedStageViewedState = getWrappedTeamCardStageViewedState({
+		activeFinalCardStage,
+		activeStepParam,
+	});
 	const estimatedSpendValue = formatCompactWholeCurrency(
 		visibleTeamCardRow.cost,
 	);
@@ -277,10 +291,10 @@ export function WrappedTeamCardPage(props: {
 		trackUtilityUsed({
 			sourceComponent: "wrapped_team_card_page",
 			utilityName: "wrappedStageViewed",
-			utilityState: activeStepParam === "card" ? "cardDirect" : "story",
+			utilityState: wrappedStageViewedState,
 		});
 		trackWrappedStoryStarted({
-			activationState: activeStepParam === "card" ? "card_direct" : "story",
+			activationState: wrappedActivationState,
 			entrySource: wrappedLoopEntrySource,
 			sourceComponent: "wrapped_team_card_page",
 			sourceShareId,
@@ -295,8 +309,9 @@ export function WrappedTeamCardPage(props: {
 		<WrappedTeamCardPageContent
 			// Re-mount on variant change so per-variant share state (in-flight
 			// requests, cached share record) does not bleed across switches.
-			key={`${activeStepParam === "card" ? "card" : "not-card"}:${variant}`}
+			key={`${activeStepParam === "card" ? activeFinalCardStage : "not-card"}:${variant}`}
 			activeArchetype={activeArchetype}
+			activeFinalCardStage={activeFinalCardStage}
 			debugControls={debugControls}
 			edition={cardEdition}
 			headerLeftMetric={headerLeftMetric}
@@ -354,8 +369,42 @@ function getWrappedDefaultDevPreviewArchetype() {
 	);
 }
 
+function getRequestedFinalCardStage(
+	searchParams: URLSearchParams,
+): FinalCardStage {
+	return searchParams.get(WRAPPED_TEAM_CARD_STAGE_QUERY_PARAM) ===
+		WRAPPED_TEAM_CARD_SHARE_STAGE
+		? "share"
+		: "reveal";
+}
+
+function getWrappedTeamCardActivationState(input: {
+	activeFinalCardStage: FinalCardStage;
+	activeStepParam: string | null;
+}) {
+	if (input.activeStepParam !== "card") {
+		return "story";
+	}
+
+	return input.activeFinalCardStage === "share"
+		? "share_direct"
+		: "card_direct";
+}
+
+function getWrappedTeamCardStageViewedState(input: {
+	activeFinalCardStage: FinalCardStage;
+	activeStepParam: string | null;
+}) {
+	if (input.activeStepParam !== "card") {
+		return "story";
+	}
+
+	return input.activeFinalCardStage === "share" ? "shareDirect" : "cardDirect";
+}
+
 function WrappedTeamCardPageContent(props: {
 	activeArchetype: WrappedArchetypeCardTheme;
+	activeFinalCardStage: FinalCardStage;
 	debugControls?: ReactNode;
 	edition?: WrappedTeamMemberCardEdition;
 	headerLeftMetric: WrappedTeamMemberCardHeaderMetric;
@@ -385,6 +434,7 @@ function WrappedTeamCardPageContent(props: {
 }) {
 	const {
 		activeArchetype,
+		activeFinalCardStage,
 		debugControls,
 		edition,
 		headerLeftMetric,
@@ -410,13 +460,14 @@ function WrappedTeamCardPageContent(props: {
 	const revealCardHandoffRef = useRef<HTMLDivElement>(null);
 	const shareCardHandoffRef = useRef<HTMLDivElement>(null);
 	const [finalCardStage, setFinalCardStage] =
-		useState<FinalCardStage>("reveal");
+		useState<FinalCardStage>(activeFinalCardStage);
 	const [finalCardHandoffPhase, setFinalCardHandoffPhase] =
 		useState<FinalCardHandoffPhase>("idle");
 	const [finalCardFlight, setFinalCardFlight] =
 		useState<FinalCardFlight | null>(null);
-	const [isRevealSequenceComplete, setIsRevealSequenceComplete] =
-		useState(false);
+	const [isRevealSequenceComplete, setIsRevealSequenceComplete] = useState(
+		activeFinalCardStage === "share",
+	);
 	const [isDownloadPending, setIsDownloadPending] = useState(false);
 	const [isProfileUrlCopyPending, setIsProfileUrlCopyPending] = useState(false);
 	const [isSharePending, setIsSharePending] = useState(false);


### PR DESCRIPTION
## Summary
- add a current-user team-card CTA that appears on hover/focus and opens the wrapped sharing page in a new tab
- add a direct wrapped route for `/wrapped?flow=story&step=card&stage=share`
- initialize the wrapped final screen directly in share mode and cover the route/team-card behavior with tests

## Test plan
- [x] bun run verify
- [x] bun run lint:wrapped:hig