### PR TITLE
fix: route YC review sessions to wrapped

### DIFF
--- a/apps/api/src/__tests__/analytics-sessions-yc.test.ts
+++ b/apps/api/src/__tests__/analytics-sessions-yc.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { assertSessionDetailAccessEnabled } from "../handlers/analytics/session-detail-access.js";
+
+describe("analytics session detail YC access", () => {
+	test("blocks session detail access for YC review sessions", () => {
+		expect(() => assertSessionDetailAccessEnabled({ ycReview: true })).toThrow(
+			"Session detail disabled for demo.",
+		);
+	});
+
+	test("allows session detail access for normal sessions", () => {
+		expect(() =>
+			assertSessionDetailAccessEnabled({ ycReview: false }),
+		).not.toThrow();
+	});
+});

--- a/apps/api/src/__tests__/auth-yc-login.test.ts
+++ b/apps/api/src/__tests__/auth-yc-login.test.ts
@@ -3,7 +3,11 @@ import assert from "node:assert";
 import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { hashPassword } from "better-auth/crypto";
-import { createYcLoginPlugin, getYcLoginConfigFromEnv } from "../auth.js";
+import {
+	createYcLoginPlugin,
+	getYcLoginConfigFromEnv,
+	isYcReviewSessionRecord,
+} from "../auth.js";
 
 const TARGET_EMAIL = "evren@example.com";
 const TARGET_PASSWORD = "target-password";
@@ -46,6 +50,13 @@ describe("YC login endpoint", () => {
 		expect(response.headers.get("Set-Cookie")).toContain(
 			"better-auth.session_token",
 		);
+		const sessionCookie = getSessionCookie(response);
+		const session = await auth.api.getSession({
+			headers: new Headers({ cookie: sessionCookie }),
+		});
+		assert(session);
+		expect(isYcReviewSessionRecord(session.session)).toBe(true);
+
 		const body: unknown = await response.json();
 		assert(isYcLoginResponse(body));
 		expect(body.user.email).toBe(TARGET_EMAIL);
@@ -86,7 +97,44 @@ describe("YC login endpoint", () => {
 		expect(response.status).toBe(401);
 		expect(response.headers.get("Set-Cookie")).toBeNull();
 	});
+
+	test("blocks account settings endpoints for YC review sessions", async () => {
+		const auth = await createTestAuth();
+		const signInResponse = await auth.handler(
+			new Request("http://localhost/api/auth/yc/sign-in", {
+				body: JSON.stringify({
+					email: "applicant@ycombinator.com",
+					password: YC_PASSWORD,
+				}),
+				headers: { "Content-Type": "application/json" },
+				method: "POST",
+			}),
+		);
+		const sessionCookie = getSessionCookie(signInResponse);
+
+		const response = await auth.handler(
+			new Request("http://localhost/api/auth/update-user", {
+				body: JSON.stringify({ name: "Changed Name" }),
+				headers: {
+					"Content-Type": "application/json",
+					cookie: sessionCookie,
+				},
+				method: "POST",
+			}),
+		);
+
+		expect(response.status).toBe(403);
+	});
 });
+
+function getSessionCookie(response: Response) {
+	const setCookie = response.headers.get("Set-Cookie");
+	assert(setCookie);
+	const sessionCookie = setCookie.split(";")[0];
+	assert(sessionCookie);
+
+	return sessionCookie;
+}
 
 async function createTestAuth() {
 	const passwordHash = await hashPassword(YC_PASSWORD);

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -5,7 +5,12 @@ import * as schema from "@rudel/sql-schema";
 import type { BetterAuthPlugin } from "better-auth";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { APIError, createAuthEndpoint } from "better-auth/api";
+import {
+	APIError,
+	createAuthEndpoint,
+	createAuthMiddleware,
+	getSessionFromCtx,
+} from "better-auth/api";
 import { setSessionCookie } from "better-auth/cookies";
 import {
 	bearer,
@@ -24,6 +29,28 @@ import { captureApiProductAnalyticsEvent } from "./lib/product-analytics.js";
 import { fetchGitHubHandle, notifySignup } from "./slack.js";
 
 const logger = getLogger(["rudel", "api", "auth"]);
+const YC_REVIEW_SESSION_FORBIDDEN_MESSAGE =
+	"YC review sessions cannot access settings";
+const YC_REVIEW_RESTRICTED_AUTH_PATHS = [
+	"/change-email",
+	"/change-password",
+	"/delete-user",
+	"/link-social",
+	"/organization/accept-invitation",
+	"/organization/cancel-invitation",
+	"/organization/create",
+	"/organization/delete",
+	"/organization/invite-member",
+	"/organization/leave",
+	"/organization/reject-invitation",
+	"/organization/remove-member",
+	"/organization/set-active",
+	"/organization/update",
+	"/organization/update-member-role",
+	"/set-password",
+	"/unlink-account",
+	"/update-user",
+] as const;
 
 function inferSignupMethod(
 	accounts: Array<{ providerId?: string | null }>,
@@ -147,6 +174,18 @@ export function createYcLoginPlugin(
 
 	return {
 		id: "rudel-yc-login",
+		schema: {
+			session: {
+				fields: {
+					ycReview: {
+						type: "boolean",
+						required: false,
+						input: false,
+						defaultValue: false,
+					},
+				},
+			},
+		},
 		endpoints: {
 			ycSignIn: createAuthEndpoint(
 				"/yc/sign-in",
@@ -187,6 +226,8 @@ export function createYcLoginPlugin(
 					const session = await ctx.context.internalAdapter.createSession(
 						user.user.id,
 						body.rememberMe === false,
+						{ ycReview: true },
+						true,
 					);
 					if (!session) {
 						ctx.context.logger.error("Failed to create YC login session");
@@ -211,7 +252,33 @@ export function createYcLoginPlugin(
 				},
 			),
 		},
+		hooks: {
+			before: [
+				{
+					matcher(context) {
+						return (
+							typeof context.path === "string" &&
+							isYcReviewRestrictedAuthPath(context.path)
+						);
+					},
+					handler: createAuthMiddleware(async (ctx) => {
+						const session = await getSessionFromCtx(ctx).catch(() => null);
+						if (!isYcReviewSessionRecord(session?.session)) {
+							return;
+						}
+
+						throw new APIError("FORBIDDEN", {
+							message: YC_REVIEW_SESSION_FORBIDDEN_MESSAGE,
+						});
+					}),
+				},
+			],
+		},
 	};
+}
+
+export function isYcReviewSessionRecord(value: unknown) {
+	return isRecord(value) && value.ycReview === true;
 }
 
 function normalizeYcLoginConfig(
@@ -279,6 +346,21 @@ function isValidEmail(value: string) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isYcReviewRestrictedAuthPath(path: string) {
+	const authEndpointPath =
+		path === "/api/auth"
+			? "/"
+			: path.startsWith("/api/auth/")
+				? path.slice("/api/auth".length)
+				: path;
+
+	return YC_REVIEW_RESTRICTED_AUTH_PATHS.some(
+		(restrictedPath) =>
+			authEndpointPath === restrictedPath ||
+			authEndpointPath.startsWith(`${restrictedPath}/`),
+	);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- drizzleAdapter accepts { [key: string]: any }

--- a/apps/api/src/handlers/analytics/session-detail-access.ts
+++ b/apps/api/src/handlers/analytics/session-detail-access.ts
@@ -1,0 +1,10 @@
+import { ORPCError } from "@orpc/server";
+import { isYcReviewSessionRecord } from "../../auth.js";
+
+export function assertSessionDetailAccessEnabled(session: unknown) {
+	if (isYcReviewSessionRecord(session)) {
+		throw new ORPCError("FORBIDDEN", {
+			message: "Session detail disabled for demo.",
+		});
+	}
+}

--- a/apps/api/src/handlers/analytics/sessions.ts
+++ b/apps/api/src/handlers/analytics/sessions.ts
@@ -7,6 +7,7 @@ import {
 	getSessionDetail,
 	getSessionDimensionAnalysis,
 } from "../../services/session-analytics.service.js";
+import { assertSessionDetailAccessEnabled } from "./session-detail-access.js";
 
 const sortByMap: Record<string, "date" | "duration" | "interactions"> = {
 	session_date: "date",
@@ -63,6 +64,8 @@ const dimensionAnalysis = os.analytics.sessions.dimensionAnalysis
 const detail = os.analytics.sessions.detail
 	.use(orgMiddleware)
 	.handler(async ({ input, context }) => {
+		assertSessionDetailAccessEnabled(context.session);
+
 		const result = await getSessionDetail(
 			context.organizationId,
 			input.sessionId,

--- a/apps/api/src/handlers/profile.ts
+++ b/apps/api/src/handlers/profile.ts
@@ -5,7 +5,11 @@ import {
 } from "@rudel/api-routes";
 import type { Sql } from "postgres";
 import { sqlClient } from "../db.js";
-import { authMiddleware, os } from "../middleware.js";
+import {
+	authMiddleware,
+	os,
+	settingsMutationMiddleware,
+} from "../middleware.js";
 import {
 	deleteUserAvatarInTx,
 	getUserAvatarOwnerByPublicId,
@@ -13,6 +17,7 @@ import {
 
 const updateMine = os.profile.updateMine
 	.use(authMiddleware)
+	.use(settingsMutationMiddleware)
 	.handler(async ({ context, input }) => {
 		const trimmedName = input.name.trim();
 		const validatedImage = await validateProfileImage({

--- a/apps/api/src/middleware.ts
+++ b/apps/api/src/middleware.ts
@@ -1,6 +1,6 @@
 import { implement, ORPCError } from "@orpc/server";
 import { contract } from "@rudel/api-routes";
-import type { Session } from "./auth.js";
+import { isYcReviewSessionRecord, type Session } from "./auth.js";
 import { sqlClient } from "./db.js";
 import { checkAnalyticsRateLimit } from "./rate-limit.js";
 
@@ -31,6 +31,29 @@ export const authMiddleware = os.middleware(async ({ context, next }) => {
 		},
 	});
 });
+
+export const settingsMutationMiddleware = os.middleware(
+	async ({ context, next }) => {
+		if (!context.user || !context.session) {
+			throw new ORPCError("UNAUTHORIZED");
+		}
+
+		if (isYcReviewSessionRecord(context.session)) {
+			throw new ORPCError("FORBIDDEN", {
+				message: "YC review sessions cannot access settings",
+			});
+		}
+
+		return next({
+			context: {
+				user: context.user,
+				session: context.session,
+				apiKeyId: context.apiKeyId,
+				authFailure: context.authFailure,
+			},
+		});
+	},
+);
 
 export const orgMiddleware = os.middleware(async ({ context, next }) => {
 	if (!context.user || !context.session) {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -18,7 +18,12 @@ import {
 	captureApiProductAnalyticsEvent,
 	hashProjectPath,
 } from "./lib/product-analytics.js";
-import { authMiddleware, ingestAuthMiddleware, os } from "./middleware.js";
+import {
+	authMiddleware,
+	ingestAuthMiddleware,
+	os,
+	settingsMutationMiddleware,
+} from "./middleware.js";
 import {
 	checkHookIngestRateLimit,
 	checkManualIngestRateLimit,
@@ -254,6 +259,7 @@ const getOrganizationSessionCount = os.getOrganizationSessionCount
 
 const deleteOrganization = os.deleteOrganization
 	.use(authMiddleware)
+	.use(settingsMutationMiddleware)
 	.handler(async ({ input, context }) => {
 		const orgId = input.organizationId;
 		const userId = context.user.id;

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -26,7 +26,16 @@ vi.mock("@/features/auth/DeviceAuthorizationApp", () => ({
 }));
 
 vi.mock("@/features/auth/AuthenticatedApp", () => ({
-	AuthenticatedApp: () => <div>Authenticated App</div>,
+	AuthenticatedApp: ({
+		rootRedirectTarget,
+	}: {
+		rootRedirectTarget: string | null;
+	}) => (
+		<div>
+			<div>Authenticated App</div>
+			<div>Root redirect: {rootRedirectTarget ?? "none"}</div>
+		</div>
+	),
 }));
 
 vi.mock("@/features/wrapped/WrappedRouteGate", () => ({
@@ -170,7 +179,7 @@ describe("App wrapped routing", () => {
 		expect(screen.queryByText("Desktop only")).toBeNull();
 	});
 
-	it("sends authenticated /yc visitors into the normal app", async () => {
+	it("sends authenticated /yc visitors into wrapped", async () => {
 		mockUseSession.mockReturnValue({
 			data: { session: { userId: "user-1" }, user: { id: "user-1" } },
 			isPending: false,
@@ -182,7 +191,27 @@ describe("App wrapped routing", () => {
 			</MemoryRouter>,
 		);
 
-		expect(await screen.findByText("Authenticated App")).toBeInTheDocument();
+		expect(await screen.findByText("Wrapped Route Gate")).toBeInTheDocument();
+		expect(screen.getByText("Public id: none")).toBeInTheDocument();
 		expect(screen.queryByText("YC Password Login Page")).toBeNull();
+	});
+
+	it("routes YC review session root visits into wrapped first", async () => {
+		mockUseSession.mockReturnValue({
+			data: {
+				session: { userId: "user-1", ycReview: true },
+				user: { id: "user-1" },
+			},
+			isPending: false,
+		});
+
+		render(
+			<MemoryRouter initialEntries={["/"]}>
+				<App />
+			</MemoryRouter>,
+		);
+
+		expect(await screen.findByText("Authenticated App")).toBeInTheDocument();
+		expect(screen.getByText("Root redirect: /wrapped")).toBeInTheDocument();
 	});
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,6 +16,7 @@ import {
 	getValidRedirect,
 	isGetStartedPath,
 	isResetPasswordPath,
+	isYcReviewSession,
 } from "@/features/auth/auth-route-utils";
 import { DeviceAuthorizationApp } from "@/features/auth/DeviceAuthorizationApp";
 import { GuestApp } from "@/features/auth/GuestApp";
@@ -183,7 +184,7 @@ function App() {
 				{isPending ? (
 					<AppLoadingScreen />
 				) : session ? (
-					<Navigate replace to={appRoutes.dashboard()} />
+					<Navigate replace to={appRoutes.wrappedTeamCard()} />
 				) : (
 					<Suspense fallback={<FullscreenRouteLoadingScreen />}>
 						<YcPasswordLoginPage />
@@ -219,7 +220,14 @@ function App() {
 		return (
 			<>
 				<ProductAnalyticsSessionSync session={session} />
-				<AuthenticatedApp rootRedirectTarget={rootRedirectTarget} />
+				<AuthenticatedApp
+					rootRedirectTarget={
+						isYcReviewSession(session)
+							? appRoutes.wrappedTeamCard()
+							: rootRedirectTarget
+					}
+					session={session}
+				/>
 				{showDesktopOnlyOverlay ? <DesktopOnlyOverlay /> : null}
 			</>
 		);

--- a/apps/web/src/app/AppRouter.test.tsx
+++ b/apps/web/src/app/AppRouter.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { AppRouter } from "./AppRouter";
 
@@ -11,7 +11,7 @@ describe("AppRouter", () => {
 	it("preserves explicit authenticated root redirects", async () => {
 		render(
 			<MemoryRouter initialEntries={["/"]}>
-				<AppRouter rootRedirectTarget="/invitation/123" />
+				<AppRouter rootRedirectTarget="/invitation/123" session={null} />
 			</MemoryRouter>,
 		);
 
@@ -19,4 +19,26 @@ describe("AppRouter", () => {
 			expect(screen.getByText("Invitation Page")).toBeInTheDocument();
 		});
 	});
+
+	it("redirects YC review sessions away from settings", async () => {
+		render(
+			<MemoryRouter initialEntries={["/settings/account"]}>
+				<AppRouter
+					rootRedirectTarget={null}
+					session={{ session: { ycReview: true } }}
+				/>
+				<LocationProbe />
+			</MemoryRouter>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByText("Current path: /wrapped")).toBeInTheDocument();
+		});
+	});
 });
+
+function LocationProbe() {
+	const location = useLocation();
+
+	return <div>Current path: {location.pathname}</div>;
+}

--- a/apps/web/src/app/AppRouter.test.tsx
+++ b/apps/web/src/app/AppRouter.test.tsx
@@ -7,6 +7,10 @@ vi.mock("@/features/invitations/AcceptInvitationPage", () => ({
 	AcceptInvitationPage: () => <div>Invitation Page</div>,
 }));
 
+vi.mock("@/features/shell/AppShellLayout", () => ({
+	AppShellLayout: () => <div>App shell</div>,
+}));
+
 describe("AppRouter", () => {
 	it("preserves explicit authenticated root redirects", async () => {
 		render(
@@ -33,6 +37,24 @@ describe("AppRouter", () => {
 
 		await waitFor(() => {
 			expect(screen.getByText("Current path: /wrapped")).toBeInTheDocument();
+		});
+	});
+
+	it("redirects YC review sessions away from session details", async () => {
+		render(
+			<MemoryRouter initialEntries={["/dashboard/sessions/session-123"]}>
+				<AppRouter
+					rootRedirectTarget={null}
+					session={{ session: { ycReview: true } }}
+				/>
+				<LocationProbe />
+			</MemoryRouter>,
+		);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText("Current path: /dashboard/sessions"),
+			).toBeInTheDocument();
 		});
 	});
 });

--- a/apps/web/src/app/AppRouter.tsx
+++ b/apps/web/src/app/AppRouter.tsx
@@ -1,6 +1,8 @@
 import { type ComponentType, lazy, type ReactNode, Suspense } from "react";
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
+import { appRoutes } from "@/app/routes";
 import { NotFoundPage } from "@/app/system/NotFoundPage";
+import { isYcReviewSession } from "@/features/auth/auth-route-utils";
 import { AcceptInvitationPage } from "@/features/invitations/AcceptInvitationPage";
 import { settingsRouteMap } from "@/features/settings/config/settings-routes";
 import { SettingsIndexRedirect } from "@/features/settings/SettingsIndexRedirect";
@@ -96,12 +98,24 @@ function LazyRoute({
 
 export function AppRouter({
 	rootRedirectTarget,
+	session,
 }: {
 	rootRedirectTarget: string | null;
+	session: unknown;
 }) {
+	const location = useLocation();
 	const rootRedirect = rootRedirectTarget || shellRouteMap.dashboard.path;
 	const canonicalWorkspaceSettingsPath = settingsRouteMap.workspace.path;
 	const canonicalAccountSettingsPath = settingsRouteMap.account.path;
+	const settingsPath = shellRouteMap.settings.path;
+	const isYcSettingsPath =
+		isYcReviewSession(session) &&
+		(location.pathname === settingsPath ||
+			location.pathname.startsWith(`${settingsPath}/`));
+
+	if (isYcSettingsPath) {
+		return <Navigate replace to={appRoutes.wrappedTeamCard()} />;
+	}
 
 	return (
 		<Routes>

--- a/apps/web/src/app/AppRouter.tsx
+++ b/apps/web/src/app/AppRouter.tsx
@@ -108,13 +108,21 @@ export function AppRouter({
 	const canonicalWorkspaceSettingsPath = settingsRouteMap.workspace.path;
 	const canonicalAccountSettingsPath = settingsRouteMap.account.path;
 	const settingsPath = shellRouteMap.settings.path;
+	const sessionDetailPath = `${appRoutes.dashboardSessions()}/`;
+	const isYcReview = isYcReviewSession(session);
 	const isYcSettingsPath =
-		isYcReviewSession(session) &&
+		isYcReview &&
 		(location.pathname === settingsPath ||
 			location.pathname.startsWith(`${settingsPath}/`));
+	const isYcSessionDetailPath =
+		isYcReview && location.pathname.startsWith(sessionDetailPath);
 
 	if (isYcSettingsPath) {
 		return <Navigate replace to={appRoutes.wrappedTeamCard()} />;
+	}
+
+	if (isYcSessionDetailPath) {
+		return <Navigate replace to={appRoutes.dashboardSessions()} />;
 	}
 
 	return (

--- a/apps/web/src/features/auth/AuthenticatedApp.tsx
+++ b/apps/web/src/features/auth/AuthenticatedApp.tsx
@@ -2,8 +2,12 @@ import { AppRouter } from "@/app/AppRouter";
 
 export function AuthenticatedApp({
 	rootRedirectTarget,
+	session,
 }: {
 	rootRedirectTarget: string | null;
+	session: unknown;
 }) {
-	return <AppRouter rootRedirectTarget={rootRedirectTarget} />;
+	return (
+		<AppRouter rootRedirectTarget={rootRedirectTarget} session={session} />
+	);
 }

--- a/apps/web/src/features/auth/YcPasswordLoginPage.test.tsx
+++ b/apps/web/src/features/auth/YcPasswordLoginPage.test.tsx
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { appRoutes } from "@/app/routes";
 import { YcPasswordLoginPage } from "./YcPasswordLoginPage";
 
+const YC_PASSWORD_LOGIN_DRAFT_STORAGE_KEY = "rudel:yc-password-login-draft";
+
 const {
 	mockNavigateToDestination,
 	mockRefreshAuthClientState,
@@ -41,6 +43,7 @@ describe("YcPasswordLoginPage", () => {
 		mockRefreshAuthClientState.mockReset();
 		mockTrackAuthenticationAction.mockReset();
 		vi.unstubAllGlobals();
+		window.sessionStorage.clear();
 	});
 
 	it("renders only the email and password auth option", () => {
@@ -67,6 +70,34 @@ describe("YcPasswordLoginPage", () => {
 		expect(
 			screen.queryByRole("button", { name: /create account/i }),
 		).not.toBeInTheDocument();
+	});
+
+	it("restores typed credentials after a brief remount", async () => {
+		const user = userEvent.setup();
+		const view = render(
+			<MemoryRouter initialEntries={["/yc"]}>
+				<YcPasswordLoginPage />
+			</MemoryRouter>,
+		);
+
+		await user.type(
+			screen.getByLabelText("Email"),
+			"applicant@ycombinator.com",
+		);
+		await user.type(screen.getByLabelText("Password"), "secret-password");
+
+		view.unmount();
+
+		render(
+			<MemoryRouter initialEntries={["/yc"]}>
+				<YcPasswordLoginPage />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByLabelText("Email")).toHaveValue(
+			"applicant@ycombinator.com",
+		);
+		expect(screen.getByLabelText("Password")).toHaveValue("secret-password");
 	});
 
 	it("signs in with email and password and lands in wrapped", async () => {
@@ -114,5 +145,8 @@ describe("YcPasswordLoginPage", () => {
 		expect(mockNavigateToDestination).toHaveBeenCalledWith(
 			appRoutes.wrappedTeamCard(),
 		);
+		expect(
+			window.sessionStorage.getItem(YC_PASSWORD_LOGIN_DRAFT_STORAGE_KEY),
+		).toBeNull();
 	});
 });

--- a/apps/web/src/features/auth/YcPasswordLoginPage.test.tsx
+++ b/apps/web/src/features/auth/YcPasswordLoginPage.test.tsx
@@ -69,7 +69,7 @@ describe("YcPasswordLoginPage", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("signs in with email and password and lands in the dashboard", async () => {
+	it("signs in with email and password and lands in wrapped", async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify({ token: "session-token" }), {
 				headers: { "Content-Type": "application/json" },
@@ -112,7 +112,7 @@ describe("YcPasswordLoginPage", () => {
 		});
 		expect(mockRefreshAuthClientState).toHaveBeenCalledTimes(1);
 		expect(mockNavigateToDestination).toHaveBeenCalledWith(
-			appRoutes.dashboard(),
+			appRoutes.wrappedTeamCard(),
 		);
 	});
 });

--- a/apps/web/src/features/auth/YcPasswordLoginPage.tsx
+++ b/apps/web/src/features/auth/YcPasswordLoginPage.tsx
@@ -23,6 +23,8 @@ import {
 
 const YC_PASSWORD_LOGIN_EMAIL_INPUT_ID = "yc-password-login-email";
 const YC_PASSWORD_LOGIN_PASSWORD_INPUT_ID = "yc-password-login-password";
+const YC_PASSWORD_LOGIN_DRAFT_STORAGE_KEY = "rudel:yc-password-login-draft";
+const YC_PASSWORD_LOGIN_DRAFT_MAX_AGE_MS = 10 * 60 * 1000;
 const YC_WRAPPED_PREVIEW_PROFILE = {
 	displayName: "Evren",
 	followerCount: null,
@@ -31,6 +33,11 @@ const YC_WRAPPED_PREVIEW_PROFILE = {
 	username: "evren",
 	verified: false,
 } satisfies WrappedGuestPreviewProfile;
+
+interface YcPasswordLoginDraft {
+	email: string;
+	password: string;
+}
 
 export function YcPasswordLoginPage() {
 	return (
@@ -64,10 +71,10 @@ function YcPasswordLoginStage() {
 }
 
 function YcPasswordLoginForm() {
-	const [email, setEmail] = useState("");
-	const [password, setPassword] = useState("");
+	const [draft, setDraft] = useState(readYcPasswordLoginDraft);
 	const [feedback, setFeedback] = useState<EmailAuthFeedback>(null);
 	const [loading, setLoading] = useState(false);
+	const { email, password } = draft;
 	const motionState = useWrappedPasswordAuthMotion();
 	const shellMotion = motionState.shellMotion;
 	const fieldMotion = motionState.sceneMotion;
@@ -119,7 +126,13 @@ function YcPasswordLoginForm() {
 		}
 
 		refreshAuthClientState();
+		clearYcPasswordLoginDraft();
 		navigateToDestination(appRoutes.wrappedTeamCard());
+	}
+
+	function handleDraftChange(nextDraft: YcPasswordLoginDraft) {
+		setDraft(nextDraft);
+		writeYcPasswordLoginDraft(nextDraft);
 	}
 
 	return (
@@ -161,7 +174,10 @@ function YcPasswordLoginForm() {
 									placeholder="you@example.com"
 									value={email}
 									onChange={(event) => {
-										setEmail(event.target.value);
+										handleDraftChange({
+											...draft,
+											email: event.target.value,
+										});
 										if (feedback) {
 											setFeedback(null);
 										}
@@ -183,7 +199,10 @@ function YcPasswordLoginForm() {
 									placeholder="Password"
 									value={password}
 									onChange={(event) => {
-										setPassword(event.target.value);
+										handleDraftChange({
+											...draft,
+											password: event.target.value,
+										});
 										if (feedback?.kind === "error") {
 											setFeedback(null);
 										}
@@ -263,6 +282,90 @@ async function readYcLoginErrorMessage(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readYcPasswordLoginDraft(): YcPasswordLoginDraft {
+	if (typeof window === "undefined") {
+		return { email: "", password: "" };
+	}
+
+	const rawDraft = window.sessionStorage.getItem(
+		YC_PASSWORD_LOGIN_DRAFT_STORAGE_KEY,
+	);
+	if (!rawDraft) {
+		return { email: "", password: "" };
+	}
+
+	try {
+		const parsed: unknown = JSON.parse(rawDraft);
+		if (!isStoredYcPasswordLoginDraft(parsed)) {
+			clearYcPasswordLoginDraft();
+			return { email: "", password: "" };
+		}
+
+		const isExpired =
+			Date.now() - parsed.updatedAt > YC_PASSWORD_LOGIN_DRAFT_MAX_AGE_MS;
+		if (isExpired) {
+			clearYcPasswordLoginDraft();
+			return { email: "", password: "" };
+		}
+
+		return {
+			email: parsed.email,
+			password: parsed.password,
+		};
+	} catch {
+		clearYcPasswordLoginDraft();
+		return { email: "", password: "" };
+	}
+}
+
+function writeYcPasswordLoginDraft(draft: YcPasswordLoginDraft) {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	if (!draft.email && !draft.password) {
+		clearYcPasswordLoginDraft();
+		return;
+	}
+
+	try {
+		window.sessionStorage.setItem(
+			YC_PASSWORD_LOGIN_DRAFT_STORAGE_KEY,
+			JSON.stringify({
+				...draft,
+				updatedAt: Date.now(),
+			}),
+		);
+	} catch {
+		// Best effort only: the controlled inputs still retain state in memory.
+	}
+}
+
+function clearYcPasswordLoginDraft() {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	try {
+		window.sessionStorage.removeItem(YC_PASSWORD_LOGIN_DRAFT_STORAGE_KEY);
+	} catch {
+		// Ignore blocked storage.
+	}
+}
+
+function isStoredYcPasswordLoginDraft(
+	value: unknown,
+): value is YcPasswordLoginDraft & {
+	updatedAt: number;
+} {
+	return (
+		isRecord(value) &&
+		typeof value.email === "string" &&
+		typeof value.password === "string" &&
+		typeof value.updatedAt === "number"
+	);
 }
 
 interface WrappedPasswordAuthMotionState {

--- a/apps/web/src/features/auth/YcPasswordLoginPage.tsx
+++ b/apps/web/src/features/auth/YcPasswordLoginPage.tsx
@@ -119,7 +119,7 @@ function YcPasswordLoginForm() {
 		}
 
 		refreshAuthClientState();
-		navigateToDestination(appRoutes.dashboard());
+		navigateToDestination(appRoutes.wrappedTeamCard());
 	}
 
 	return (

--- a/apps/web/src/features/auth/auth-route-utils.ts
+++ b/apps/web/src/features/auth/auth-route-utils.ts
@@ -264,3 +264,15 @@ export function getSessionUserName(
 		? session.user.name
 		: undefined;
 }
+
+export function isYcReviewSession(session: unknown): boolean {
+	if (!isRecord(session) || !isRecord(session.session)) {
+		return false;
+	}
+
+	return "ycReview" in session.session && session.session.ycReview === true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/web/src/features/dashboard/components/DashboardSessionsSnapshotSection.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardSessionsSnapshotSection.tsx
@@ -252,6 +252,7 @@ export function DashboardSessionsSnapshotSection({
 	metrics,
 	onSessionClick,
 	sessions,
+	sessionDetailDisabledNote,
 	showDelta = false,
 	startDate,
 	totalSessionCount,
@@ -266,6 +267,7 @@ export function DashboardSessionsSnapshotSection({
 	metrics: DashboardHeadlineMetric[];
 	onSessionClick?: (session: SessionAnalytics) => void;
 	sessions: SessionAnalytics[] | undefined;
+	sessionDetailDisabledNote?: string;
 	showDelta?: boolean;
 	startDate: string;
 	totalSessionCount: number;
@@ -313,6 +315,7 @@ export function DashboardSessionsSnapshotSection({
 					isLoading={isSessionsPending}
 					onSessionClick={onSessionClick}
 					sessions={latestSessions}
+					sessionDetailDisabledNote={sessionDetailDisabledNote}
 					showHeader={false}
 					totalSessionCount={
 						useRolling24Hours ? snapshotSessions.length : totalSessionCount

--- a/apps/web/src/features/dashboard/components/DashboardTokenRecentSessionsTable.test.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardTokenRecentSessionsTable.test.tsx
@@ -1,0 +1,58 @@
+import type { SessionAnalytics } from "@rudel/api-routes";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DashboardTokenRecentSessionsTable } from "./DashboardTokenRecentSessionsTable";
+
+vi.mock("@/hooks/useUserMap", () => ({
+	useUserMap: () => ({
+		userMap: { "user-1": "Evren" },
+		isLoading: false,
+	}),
+}));
+
+const session: SessionAnalytics = {
+	session_id: "session-1",
+	user_id: "user-1",
+	session_date: "2026-05-04T10:00:00.000Z",
+	project_path: "/Users/evren/rudel",
+	repository: "obsessiondb/rudel",
+	duration_min: 12,
+	total_tokens: 10_000,
+	input_tokens: 6_000,
+	output_tokens: 4_000,
+	success_score: 80,
+	total_interactions: 7,
+	avg_period_sec: 45,
+	subagent_types: [],
+	skills: [],
+	slash_commands: [],
+	has_commit: true,
+	session_archetype: "builder",
+	model_used: "gpt-5",
+	used_plan_mode: false,
+};
+
+describe("DashboardTokenRecentSessionsTable", () => {
+	it("shows the demo-disabled note and does not open disabled rows", () => {
+		const handleSessionClick = vi.fn();
+
+		render(
+			<DashboardTokenRecentSessionsTable
+				canOpenSession={() => false}
+				onSessionClick={handleSessionClick}
+				sessions={[session]}
+				sessionDetailDisabledNote="Session detail disabled for demo."
+				totalSessionCount={1}
+			/>,
+		);
+
+		expect(
+			screen.getByText("Session detail disabled for demo."),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("button")).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByText("obsessiondb/rudel"));
+
+		expect(handleSessionClick).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/features/dashboard/components/DashboardTokenRecentSessionsTable.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardTokenRecentSessionsTable.tsx
@@ -166,6 +166,7 @@ export function DashboardTokenRecentSessionsTable({
 	onHighlightSessionChange,
 	onSessionClick,
 	sessions,
+	sessionDetailDisabledNote,
 	showHeader = true,
 	totalSessionCount,
 }: {
@@ -176,6 +177,7 @@ export function DashboardTokenRecentSessionsTable({
 	onHighlightSessionChange?: (sessionId: string | null) => void;
 	onSessionClick?: (session: SessionAnalytics) => void;
 	sessions: SessionAnalytics[] | undefined;
+	sessionDetailDisabledNote?: string;
 	showHeader?: boolean;
 	totalSessionCount: number;
 }) {
@@ -230,6 +232,11 @@ export function DashboardTokenRecentSessionsTable({
 						Showing {visibleSessions.length} of {recentSessions.length} sessions
 					</p>
 				</div>
+			) : null}
+			{sessionDetailDisabledNote ? (
+				<p className="px-1 text-[13px] font-medium text-[color:var(--dashboardy-muted)]">
+					{sessionDetailDisabledNote}
+				</p>
 			) : null}
 			<DashboardGridTable
 				columns={[

--- a/apps/web/src/features/sessions/SessionsPage.tsx
+++ b/apps/web/src/features/sessions/SessionsPage.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useDateRange } from "@/features/analytics/date-range/useDateRange";
 import { useAnalyticsQuery } from "@/features/analytics/queries/useAnalyticsQuery";
 import { useAnalyticsTracking } from "@/features/analytics/tracking/useAnalyticsTracking";
+import { isYcReviewSession } from "@/features/auth/auth-route-utils";
 import { DashboardSessionsSnapshotSection } from "@/features/dashboard/components/DashboardSessionsSnapshotSection";
 import { buildDashboardSessionTabMetrics } from "@/features/dashboard/data/dashboard-tab-adapters";
 import { SessionDetailSheet } from "@/features/sessions/components/SessionDetailSheet";
@@ -9,6 +10,7 @@ import { SessionsDateRangeControls } from "@/features/sessions/components/Sessio
 import { resolveActiveSessionDateRangeOptionId } from "@/features/sessions/session-date-ranges";
 import { useCanViewSession } from "@/features/workspace/hooks/useCanViewSession";
 import { useTrackDashboardView } from "@/hooks/useTrackDashboardView";
+import { authClient } from "@/lib/auth-client";
 import { orpc } from "@/lib/orpc";
 import { getSessionDetailPath } from "@/lib/session-paths";
 
@@ -18,6 +20,8 @@ export function SessionsPage() {
 		state: { endDate, startDate },
 	} = useDateRange();
 	const canViewSession = useCanViewSession();
+	const { data: session } = authClient.useSession();
+	const isYcReview = isYcReviewSession(session);
 	const { trackDrilldown } = useAnalyticsTracking();
 	const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
 		null,
@@ -111,7 +115,7 @@ export function SessionsPage() {
 		session_id: string;
 		user_id: string;
 	}) {
-		if (!canViewSession(session.user_id)) {
+		if (isYcReview || !canViewSession(session.user_id)) {
 			return;
 		}
 
@@ -148,6 +152,9 @@ export function SessionsPage() {
 								metrics={headlineMetrics}
 								onSessionClick={handleSessionClick}
 								sessions={snapshotSessionsData}
+								sessionDetailDisabledNote={
+									isYcReview ? "Session detail disabled for demo." : undefined
+								}
 								showDelta
 								startDate={startDate}
 								totalSessionCount={

--- a/apps/web/src/features/shell/AppShellLayout.tsx
+++ b/apps/web/src/features/shell/AppShellLayout.tsx
@@ -6,6 +6,7 @@ import { AppToaster } from "@/app/ui/AppToaster";
 import "@/app/app-surface.css";
 import { SidebarInset, SidebarProvider } from "@/app/ui/sidebar";
 import { TooltipProvider } from "@/app/ui/tooltip";
+import { isYcReviewSession } from "@/features/auth/auth-route-utils";
 import "@/features/dashboard/dashboard-theme.css";
 import { AppSidebar } from "@/features/shell/components/AppSidebar";
 import { SiteHeader } from "@/features/shell/components/SiteHeader";
@@ -15,6 +16,7 @@ import {
 } from "@/features/shell/config/shell-routes";
 import { SHOW_SIDEBAR_NEWS_MODE } from "@/features/shell/config/sidebar-news";
 import { getDefaultSidebarShellTuningState } from "@/features/shell/config/sidebar-shell-debug";
+import { authClient } from "@/lib/auth-client";
 
 const defaultDashboardChromeValues = {
 	turbulence: {
@@ -94,6 +96,8 @@ function isEditableTarget(target: EventTarget | null) {
 export function AppShellLayout() {
 	const navigate = useNavigate();
 	const location = useLocation();
+	const { data: session } = authClient.useSession();
+	const isYcReview = isYcReviewSession(session);
 	const isSidebarNewsModeEnabled = SHOW_SIDEBAR_NEWS_MODE;
 	const isSettingsShellRoute =
 		location.pathname === shellRouteMap.settings.path ||
@@ -115,6 +119,9 @@ export function AppShellLayout() {
 
 			const nextPath = shellShortcutRouteByKey[event.key.toLowerCase()];
 			if (!nextPath || location.pathname === nextPath) {
+				return;
+			}
+			if (isYcReview && nextPath === shellRouteMap.settings.path) {
 				return;
 			}
 
@@ -181,6 +188,7 @@ export function AppShellLayout() {
 				>
 					<AppSidebar
 						navigationMode={isSettingsShellRoute ? "settings" : "app"}
+						restrictSettings={isYcReview}
 					/>
 					<SidebarInset className="dashboard-01-window min-h-0 overflow-hidden overscroll-none bg-[var(--dashboard-01-content-background)] md:m-2 md:ml-0 md:rounded-[12px] md:shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)]">
 						<SiteHeader />

--- a/apps/web/src/features/shell/components/AppSidebar.tsx
+++ b/apps/web/src/features/shell/components/AppSidebar.tsx
@@ -146,13 +146,18 @@ function SidebarEdgeHotspot({
 function SidebarNavigation({
 	mode,
 	navigationMode,
+	restrictSettings,
 }: {
 	mode: SidebarDisplayMode;
 	navigationMode: SidebarNavigationMode;
+	restrictSettings: boolean;
 }) {
 	const currentShellRoute = useCurrentShellRoute();
 	const location = useLocation();
 	const activeSettingsRouteId = getActiveSettingsRouteId(location.pathname);
+	const visibleShellRoutes = restrictSettings
+		? shellRoutes.filter((route) => route.id !== "settings")
+		: shellRoutes;
 
 	if (navigationMode === "settings") {
 		return (
@@ -177,7 +182,7 @@ function SidebarNavigation({
 	return (
 		<nav aria-label="Primary">
 			<ul className="flex flex-col gap-1">
-				{shellRoutes.map((route) => (
+				{visibleShellRoutes.map((route) => (
 					<RailLink
 						key={route.id}
 						to={route.path}
@@ -196,8 +201,10 @@ function SidebarNavigation({
 
 export function AppSidebar({
 	navigationMode = "app",
+	restrictSettings = false,
 }: {
 	navigationMode?: SidebarNavigationMode;
+	restrictSettings?: boolean;
 }) {
 	const { state, isMobile, openMobile, toggleSidebar } = useSidebar();
 	const isSidebarExpanded = isMobile ? openMobile : state === "expanded";
@@ -288,6 +295,7 @@ export function AppSidebar({
 						<SidebarNavigation
 							mode={displayMode}
 							navigationMode={navigationMode}
+							restrictSettings={restrictSettings}
 						/>
 					</div>
 				</div>

--- a/apps/web/src/features/shell/components/UserRailButton.tsx
+++ b/apps/web/src/features/shell/components/UserRailButton.tsx
@@ -10,6 +10,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/app/ui/dropdown-menu";
+import { isYcReviewSession } from "@/features/auth/auth-route-utils";
 import {
 	getInitials,
 	getUtilityRailItemClassName,
@@ -26,6 +27,7 @@ export function UserRailButton({
 }) {
 	const navigate = useNavigate();
 	const { data: session } = authClient.useSession();
+	const isYcReview = isYcReviewSession(session);
 
 	const name =
 		session?.user &&
@@ -91,11 +93,17 @@ export function UserRailButton({
 				</span>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent className="min-w-48" side="right" align="end">
-				<DropdownMenuItem onClick={() => navigate(appRoutes.settingsAccount())}>
-					<Settings2Icon />
-					Account settings
-				</DropdownMenuItem>
-				<DropdownMenuSeparator />
+				{isYcReview ? null : (
+					<>
+						<DropdownMenuItem
+							onClick={() => navigate(appRoutes.settingsAccount())}
+						>
+							<Settings2Icon />
+							Account settings
+						</DropdownMenuItem>
+						<DropdownMenuSeparator />
+					</>
+				)}
 				<DropdownMenuItem
 					onClick={async () => {
 						await signOut();

--- a/apps/web/src/features/shell/components/WorkspaceMenuButton.tsx
+++ b/apps/web/src/features/shell/components/WorkspaceMenuButton.tsx
@@ -10,12 +10,14 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/app/ui/dropdown-menu";
+import { isYcReviewSession } from "@/features/auth/auth-route-utils";
 import {
 	getUtilityRailItemClassName,
 	getUtilityRailLabelClassName,
 	type SidebarRowMode,
 } from "@/features/shell/components/shell-rail";
 import { useOrganization } from "@/features/workspace/organization/useOrganization";
+import { authClient } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 
 function WorkspaceMark({ className }: { className?: string }) {
@@ -50,8 +52,10 @@ export function WorkspaceMenuButton({
 	mode?: SidebarRowMode;
 }) {
 	const navigate = useNavigate();
+	const { data: session } = authClient.useSession();
 	const { state, actions } = useOrganization();
 	const workspaceName = state.activeOrg?.name ?? "Workspace";
+	const isYcReview = isYcReviewSession(session);
 
 	return (
 		<DropdownMenu>
@@ -100,21 +104,25 @@ export function WorkspaceMenuButton({
 				) : (
 					<DropdownMenuItem disabled>No workspaces yet</DropdownMenuItem>
 				)}
-				<DropdownMenuSeparator />
-				<DropdownMenuItem
-					onClick={() => navigate(appRoutes.settingsWorkspace())}
-				>
-					<Settings2Icon />
-					Workspace settings
-				</DropdownMenuItem>
-				<DropdownMenuItem
-					onClick={() =>
-						navigate(`${appRoutes.settingsWorkspace()}#new-workspace`)
-					}
-				>
-					<CommandIcon />
-					Create workspace
-				</DropdownMenuItem>
+				{isYcReview ? null : (
+					<>
+						<DropdownMenuSeparator />
+						<DropdownMenuItem
+							onClick={() => navigate(appRoutes.settingsWorkspace())}
+						>
+							<Settings2Icon />
+							Workspace settings
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							onClick={() =>
+								navigate(`${appRoutes.settingsWorkspace()}#new-workspace`)
+							}
+						>
+							<CommandIcon />
+							Create workspace
+						</DropdownMenuItem>
+					</>
+				)}
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/apps/web/src/features/workspace/hooks/useCanViewSession.ts
+++ b/apps/web/src/features/workspace/hooks/useCanViewSession.ts
@@ -1,3 +1,4 @@
+import { isYcReviewSession } from "@/features/auth/auth-route-utils";
 import { useOrganization } from "@/features/workspace/organization/useOrganization";
 import { authClient } from "@/lib/auth-client";
 
@@ -5,8 +6,10 @@ export function useCanViewSession() {
 	const { meta } = useOrganization();
 	const { data: session } = authClient.useSession();
 	const currentUserId = session?.user.id;
+	const isYcReview = isYcReviewSession(session);
 
 	return (sessionUserId: string) => {
+		if (isYcReview) return false;
 		if (meta.isOrgAdmin) return true;
 		return currentUserId === sessionUserId;
 	};

--- a/apps/web/src/hooks/useCanViewSession.ts
+++ b/apps/web/src/hooks/useCanViewSession.ts
@@ -1,4 +1,5 @@
 import { useOrganization } from "@/contexts/OrganizationContext";
+import { isYcReviewSession } from "@/features/auth/auth-route-utils";
 import { authClient } from "@/lib/auth-client";
 
 /**
@@ -9,8 +10,10 @@ export function useCanViewSession() {
 	const { isOrgAdmin } = useOrganization();
 	const { data: session } = authClient.useSession();
 	const currentUserId = session?.user.id;
+	const isYcReview = isYcReviewSession(session);
 
 	return (sessionUserId: string) => {
+		if (isYcReview) return false;
 		if (isOrgAdmin) return true;
 		return currentUserId === sessionUserId;
 	};

--- a/packages/sql-schema/db/migrations/0012_yc_review_sessions.sql
+++ b/packages/sql-schema/db/migrations/0012_yc_review_sessions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "session" ADD COLUMN "yc_review" boolean DEFAULT false NOT NULL;

--- a/packages/sql-schema/db/migrations/meta/_journal.json
+++ b/packages/sql-schema/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
 			"when": 1777876185261,
 			"tag": "0011_decimal_wrapped_claims",
 			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1777929079000,
+			"tag": "0012_yc_review_sessions",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/sql-schema/src/auth-schema.ts
+++ b/packages/sql-schema/src/auth-schema.ts
@@ -41,6 +41,7 @@ export const session = pgTable("session", {
 		.notNull()
 		.references(() => user.id, { onDelete: "cascade" }),
 	activeOrganizationId: text("active_organization_id"),
+	ycReview: boolean("yc_review").default(false).notNull(),
 });
 
 export const account = pgTable("account", {


### PR DESCRIPTION
## Summary
- route successful YC password login and authenticated /yc visits to /wrapped
- mark YC sessions with a backend ycReview session flag and add the DB migration
- hide/redirect settings for YC review sessions and block settings mutations server-side
- disable session detail access for YC review sessions, including row opening, direct detail URLs, and backend detail RPC calls
- show "Session detail disabled for demo." in the sessions table for YC review sessions
- keep the YC login email/password draft across brief remounts and clear it after successful sign-in

## Test plan
- bun run verify
- bun run lint:wrapped:hig