### PR TITLE
fix: unstick wrapped upload continuation

### DIFF
--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -78,6 +78,7 @@ const WRAPPED_SETUP_ALL_COMPLETED_STEP_IDS = [
 	WRAPPED_SETUP_AUTH_STEP_ID,
 	WRAPPED_SETUP_UPLOAD_STEP_ID,
 ] as const;
+const WRAPPED_ARCHETYPE_GATE_REFETCH_INTERVAL_MS = 1_000;
 
 export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const { isPending, publicId, session } = props;
@@ -536,7 +537,9 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 
 	if (shouldQueryWrappedArchetypeGate) {
 		return (
-			<WrappedArchetypeGateQuery>
+			<WrappedArchetypeGateQuery
+				expectedSessionCount={setupProgress.totalSessionCount}
+			>
 				{(archetypeGateState) => renderRouteContent(archetypeGateState)}
 			</WrappedArchetypeGateQuery>
 		);
@@ -552,10 +555,26 @@ interface WrappedArchetypeGateState {
 
 function WrappedArchetypeGateQuery(props: {
 	children: (state: WrappedArchetypeGateState) => ReactNode;
+	expectedSessionCount: number;
 }) {
 	const wrappedV1Query = useAnalyticsQuery({
 		...orpc.analytics.wrapped.v1.queryOptions({}),
 		enabled: true,
+		refetchInterval: (query) => {
+			const archetypeGate = query.state.data?.archetype_gate;
+			if (
+				archetypeGate === undefined ||
+				archetypeGate.reason === "processing_archetype" ||
+				archetypeGate.values.total_sessions < props.expectedSessionCount
+			) {
+				return WRAPPED_ARCHETYPE_GATE_REFETCH_INTERVAL_MS;
+			}
+
+			return false;
+		},
+		refetchIntervalInBackground: true,
+		refetchOnReconnect: "always",
+		refetchOnWindowFocus: "always",
 	});
 
 	return props.children({

--- a/apps/web/src/features/wrapped/WrappedUploadPollingSmoke.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedUploadPollingSmoke.test.tsx
@@ -3,7 +3,7 @@ import {
 	type QueryClientConfig,
 	QueryClientProvider,
 } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -42,6 +42,12 @@ vi.mock("@/features/workspace/organization/useOrganization", () => ({
 }));
 
 let rawSessionCount = 45;
+let wrappedGateQueryCount = 0;
+let wrappedGateReason:
+	| "eligible"
+	| "needs_more_sessions"
+	| "processing_archetype" = "needs_more_sessions";
+let wrappedGateSessionCount = 45;
 
 vi.mock("@/lib/orpc", () => ({
 	client: {
@@ -92,18 +98,29 @@ vi.mock("@/lib/orpc", () => ({
 			wrapped: {
 				v1: {
 					queryOptions: () => ({
-						queryFn: async () => ({
-							archetype_gate: {
-								is_eligible: false,
-								reason: "session_threshold",
-								thresholds: {
-									min_total_sessions: 100,
+						queryFn: async () => {
+							wrappedGateQueryCount += 1;
+							return {
+								archetype_gate: {
+									is_eligible: wrappedGateReason === "eligible",
+									reason: wrappedGateReason,
+									thresholds: {
+										max_distance_ratio_to_max: 0.25,
+										min_active_days: 14,
+										min_top_two_margin: 0.1,
+										min_total_sessions: 100,
+									},
+									values: {
+										active_days: 14,
+										archetype_distance_ratio_to_max:
+											wrappedGateReason === "processing_archetype" ? null : 0.1,
+										archetype_top_two_margin:
+											wrappedGateReason === "processing_archetype" ? null : 0.2,
+										total_sessions: wrappedGateSessionCount,
+									},
 								},
-								values: {
-									total_sessions: rawSessionCount,
-								},
-							},
-						}),
+							};
+						},
 						queryKey: ["analytics", "wrapped", "v1"],
 					}),
 				},
@@ -159,6 +176,9 @@ function createWrapper(queryClient: QueryClient, initialEntry = "/wrapped") {
 describe("Wrapped upload polling smoke", () => {
 	beforeEach(() => {
 		rawSessionCount = 45;
+		wrappedGateQueryCount = 0;
+		wrappedGateReason = "needs_more_sessions";
+		wrappedGateSessionCount = 45;
 		mockGetOrganizationSessionCount.mockReset();
 		mockUseAnalyticsTracking.mockReset();
 		mockUseCliSetupStatus.mockReset();
@@ -267,6 +287,54 @@ describe("Wrapped upload polling smoke", () => {
 		);
 		expect(screen.getByText("63 sessions across 1 repo")).toBeInTheDocument();
 		expect(mockGetOrganizationSessionCount).toHaveBeenCalledTimes(2);
+
+		queryClient.clear();
+	});
+
+	it("enables setup continuation after the processing archetype gate refetches", async () => {
+		const queryClient = new QueryClient(queryClientConfig);
+		rawSessionCount = 100;
+		wrappedGateSessionCount = 100;
+		wrappedGateReason = "processing_archetype";
+
+		render(
+			<WrappedRouteGate isPending={false} publicId={null} session={session} />,
+			{
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		expect(
+			await screen.findByRole("button", {
+				name: "Preparing your wrapped...",
+			}),
+		).toBeDisabled();
+
+		wrappedGateReason = "eligible";
+
+		await waitFor(
+			() => {
+				expect(
+					screen.getByRole("button", {
+						name: "Continue",
+					}),
+				).toBeEnabled();
+			},
+			{ timeout: 1_500 },
+		);
+		expect(wrappedGateQueryCount).toBeGreaterThan(1);
+
+		fireEvent.click(
+			screen.getByRole("button", {
+				name: "Continue",
+			}),
+		);
+
+		expect(
+			await screen.findByRole("button", {
+				name: "See what it reveals about you",
+			}),
+		).toBeEnabled();
 
 		queryClient.clear();
 	});


### PR DESCRIPTION
## Summary
- Root cause: the wrapped archetype gate query could return `processing_archetype` once and then stay stale, leaving the upload/setup CTA disabled at `Preparing your wrapped...`.
- Poll the wrapped v1 archetype gate every second while it is missing, still processing, or behind the latest raw upload session count.
- Refetch on focus/reconnect so the setup screen can recover after tab or network changes.
- Add a smoke test for `processing_archetype -> eligible -> Continue -> setup complete`.
- Stabilize the wrapped onboarding model-step CI test by mocking Motion's reduced-motion hook directly; the failed CI check was timing-related and not in the upload polling smoke test.

## Test plan
- [x] `bun run test src/features/wrapped/WrappedUploadPollingSmoke.test.tsx src/features/wrapped/WrappedDevPage.test.tsx` from `apps/web`
- [x] `bun run test src/features/wrapped/onboarding/shell.test.tsx` from `apps/web`
- [x] `./node_modules/.bin/biome check apps/web/src/features/wrapped/WrappedRouteGate.tsx apps/web/src/features/wrapped/WrappedUploadPollingSmoke.test.tsx apps/web/src/features/wrapped/onboarding/shell.test.tsx`
- [x] `bun run lint:wrapped:hig`
- [x] `bun run verify` (passed; 11 existing `wrapped.css` `!important` warnings remain warnings)
