### PR TITLE
test: stabilize wrapped onboarding motion

### DIFF
--- a/apps/web/src/features/wrapped/onboarding/shell.test.tsx
+++ b/apps/web/src/features/wrapped/onboarding/shell.test.tsx
@@ -10,6 +10,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { WrappedTeamCardOnboarding } from "@/features/wrapped/onboarding/shell";
 import type { WrappedOnboardingMetrics } from "@/features/wrapped/onboarding/types";
 
+vi.mock("motion/react", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("motion/react")>();
+
+	return {
+		...actual,
+		useReducedMotion: () => true,
+	};
+});
+
 Object.defineProperty(window, "matchMedia", {
 	writable: true,
 	value: vi.fn().mockImplementation((query: string) => ({


### PR DESCRIPTION
## Summary
- Stabilize the wrapped onboarding model-step tests by mocking Motion's `useReducedMotion` hook to `true`.
- Keep the tests aligned with their reduced-motion setup so the Continue button does not depend on the full model comparison animation sequence in CI.
- Follow-up to #321: the upload polling smoke test passed; the failed check was this separate onboarding timing case.

## Test plan
- [x] `bun run verify` (passed; 11 existing `wrapped.css` `!important` warnings remain warnings)
