### PR TITLE
ci: run postgres migrations before deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Bun
+        uses: ./.github/actions/setup
+
+      - name: Run Postgres migrations
+        run: bun run --cwd packages/sql-schema migrate
+        env:
+          PG_CONNECTION_STRING: ${{ secrets.PG_CONNECTION_STRING }}
+
       - name: Setup Fly.io
         uses: superfly/flyctl-actions/setup-flyctl@master
 


### PR DESCRIPTION
## Summary
- run the SQL schema migrations in the main deploy job before Fly deploys the app
- install Bun dependencies in the deploy job so the migration script can execute

## Why
- PR #320 added the `session.yc_review` column used by Better Auth session reads
- without running migrations before deploy, production can start code that expects the column before the database has it

## Test plan
- [x] bun run verify
- [x] ruby YAML parse for `.github/workflows/ci.yml`
- [x] bun run --cwd packages/sql-schema check-types