### PR TITLE
fix: accept backend YC password secret

### DIFF
--- a/apps/api/src/__tests__/auth-yc-login.test.ts
+++ b/apps/api/src/__tests__/auth-yc-login.test.ts
@@ -62,6 +62,23 @@ describe("YC login endpoint", () => {
 		expect(body.user.email).toBe(TARGET_EMAIL);
 	});
 
+	test("accepts a raw backend password secret", async () => {
+		const auth = await createTestAuth({ passwordSecret: YC_PASSWORD });
+
+		const response = await auth.handler(
+			new Request("http://localhost/api/auth/yc/sign-in", {
+				body: JSON.stringify({
+					email: "applicant@ycombinator.com",
+					password: YC_PASSWORD,
+				}),
+				headers: { "Content-Type": "application/json" },
+				method: "POST",
+			}),
+		);
+
+		expect(response.status).toBe(200);
+	});
+
 	test("rejects emails outside the configured allowlist", async () => {
 		const auth = await createTestAuth();
 
@@ -136,8 +153,12 @@ function getSessionCookie(response: Response) {
 	return sessionCookie;
 }
 
-async function createTestAuth() {
-	const passwordHash = await hashPassword(YC_PASSWORD);
+async function createTestAuth({
+	passwordSecret,
+}: {
+	passwordSecret?: string;
+} = {}) {
+	const passwordHash = passwordSecret ?? (await hashPassword(YC_PASSWORD));
 	const ycLoginPlugin = createYcLoginPlugin({
 		allowedEmails: ["applicant@ycombinator.com", "partner@ycombinator.com"],
 		passwordHash,

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -29,6 +29,7 @@ import { captureApiProductAnalyticsEvent } from "./lib/product-analytics.js";
 import { fetchGitHubHandle, notifySignup } from "./slack.js";
 
 const logger = getLogger(["rudel", "api", "auth"]);
+const BETTER_AUTH_PASSWORD_HASH_PATTERN = /^[a-f0-9]+:[a-f0-9]+$/i;
 const YC_REVIEW_SESSION_FORBIDDEN_MESSAGE =
 	"YC review sessions cannot access settings";
 const YC_REVIEW_RESTRICTED_AUTH_PATHS = [
@@ -205,12 +206,11 @@ export function createYcLoginPlugin(
 						throw invalidYcLoginError();
 					}
 
-					const isPasswordValid = await ctx.context.password
-						.verify({
-							hash: normalizedConfig.passwordHash,
-							password: body.password,
-						})
-						.catch(() => false);
+					const isPasswordValid = await verifyYcLoginPassword({
+						candidatePassword: body.password,
+						configuredPassword: normalizedConfig.passwordHash,
+						passwordVerifier: ctx.context.password,
+					});
 					if (!isPasswordValid) {
 						throw invalidYcLoginError();
 					}
@@ -320,6 +320,29 @@ function parseYcLoginRequestBody(value: unknown): YcLoginRequestBody | null {
 		password,
 		rememberMe: typeof rememberMe === "boolean" ? rememberMe : undefined,
 	};
+}
+
+async function verifyYcLoginPassword({
+	candidatePassword,
+	configuredPassword,
+	passwordVerifier,
+}: {
+	candidatePassword: string;
+	configuredPassword: string;
+	passwordVerifier: {
+		verify(input: { hash: string; password: string }): Promise<boolean>;
+	};
+}) {
+	if (!BETTER_AUTH_PASSWORD_HASH_PATTERN.test(configuredPassword)) {
+		return configuredPassword === candidatePassword;
+	}
+
+	return passwordVerifier
+		.verify({
+			hash: configuredPassword,
+			password: candidatePassword,
+		})
+		.catch(() => false);
 }
 
 function invalidYcLoginError() {


### PR DESCRIPTION
## Summary
- allow the YC login verifier to accept either a Better Auth password hash or a raw backend-only password secret
- keep the hashed-password path unchanged for existing secure deployments
- add API coverage for the raw backend secret case

## Why
- production is now past the missing `yc_review` migration, but YC login can still fail if the deployed secret was set as the raw password instead of the Better Auth hash
- this keeps the password out of source while making the runtime secret format tolerant

## Test plan
- [x] bunx --no-install biome check --write apps/api/src/auth.ts apps/api/src/__tests__/auth-yc-login.test.ts
- [x] bun test apps/api/src/__tests__/auth-yc-login.test.ts
- [x] bun run --cwd apps/api check-types
- [x] bun run verify