### PR TITLE
ci: sync YC login secrets to Fly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,18 @@ jobs:
       - name: Setup Fly.io
         uses: superfly/flyctl-actions/setup-flyctl@master
 
+      - name: Stage Fly runtime secrets
+        run: |
+          flyctl secrets set --stage \
+            YC_LOGIN_ALLOWED_EMAILS="${YC_LOGIN_ALLOWED_EMAILS}" \
+            YC_LOGIN_PASSWORD_HASH="${YC_LOGIN_PASSWORD_HASH}" \
+            YC_LOGIN_TARGET_EMAIL="${YC_LOGIN_TARGET_EMAIL}"
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          YC_LOGIN_ALLOWED_EMAILS: ${{ secrets.YC_LOGIN_ALLOWED_EMAILS }}
+          YC_LOGIN_PASSWORD_HASH: ${{ secrets.YC_LOGIN_PASSWORD_HASH }}
+          YC_LOGIN_TARGET_EMAIL: ${{ secrets.YC_LOGIN_TARGET_EMAIL }}
+
       - name: Deploy
         run: |
           flyctl deploy --remote-only \


### PR DESCRIPTION
## Summary
- stage YC login runtime secrets into Fly during the main deploy job
- use GitHub Actions secrets sourced from Doppler for the YC allowlist, password hash, and target email

## Why
- rotating the YC password in Doppler/GitHub does not update Fly runtime secrets by itself
- staging secrets before deploy ensures the running app receives the rotated backend password hash

## Test plan
- [x] ruby YAML parse for `.github/workflows/ci.yml`
- [x] diff scan for raw YC password/hash values
- [x] bun run verify