### PR TITLE
fix: route YC review users to wrapped story

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "@/App";
 
@@ -111,6 +111,28 @@ describe("App wrapped routing", () => {
 		expect(screen.queryByText("Desktop only")).toBeNull();
 	});
 
+	it("canonicalizes YC review /wrapped visits to the wrapped story", async () => {
+		mockUseSession.mockReturnValue({
+			data: {
+				session: { userId: "user-1", ycReview: true },
+				user: { id: "user-1" },
+			},
+			isPending: false,
+		});
+
+		render(
+			<MemoryRouter initialEntries={["/wrapped?flow=desktop-ready"]}>
+				<App />
+				<LocationProbe />
+			</MemoryRouter>,
+		);
+
+		expect(await screen.findByText("Wrapped Route Gate")).toBeInTheDocument();
+		expect(
+			screen.getByText("Current route: /wrapped?flow=story"),
+		).toBeInTheDocument();
+	});
+
 	it("routes /wrapped/:id to the public wrapped route gate branch", async () => {
 		render(
 			<MemoryRouter initialEntries={["/wrapped/share-123"]}>
@@ -196,7 +218,30 @@ describe("App wrapped routing", () => {
 		expect(screen.queryByText("YC Password Login Page")).toBeNull();
 	});
 
-	it("routes YC review session root visits into wrapped first", async () => {
+	it("sends authenticated YC /yc visitors into the wrapped story", async () => {
+		mockUseSession.mockReturnValue({
+			data: {
+				session: { userId: "user-1", ycReview: true },
+				user: { id: "user-1" },
+			},
+			isPending: false,
+		});
+
+		render(
+			<MemoryRouter initialEntries={["/yc"]}>
+				<App />
+				<LocationProbe />
+			</MemoryRouter>,
+		);
+
+		expect(await screen.findByText("Wrapped Route Gate")).toBeInTheDocument();
+		expect(
+			screen.getByText("Current route: /wrapped?flow=story"),
+		).toBeInTheDocument();
+		expect(screen.queryByText("YC Password Login Page")).toBeNull();
+	});
+
+	it("routes YC review session root visits into the wrapped story first", async () => {
 		mockUseSession.mockReturnValue({
 			data: {
 				session: { userId: "user-1", ycReview: true },
@@ -212,6 +257,19 @@ describe("App wrapped routing", () => {
 		);
 
 		expect(await screen.findByText("Authenticated App")).toBeInTheDocument();
-		expect(screen.getByText("Root redirect: /wrapped")).toBeInTheDocument();
+		expect(
+			screen.getByText("Root redirect: /wrapped?flow=story"),
+		).toBeInTheDocument();
 	});
 });
+
+function LocationProbe() {
+	const location = useLocation();
+
+	return (
+		<div>
+			Current route: {location.pathname}
+			{location.search}
+		</div>
+	);
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -162,6 +162,24 @@ function App() {
 	}
 
 	if (isWrappedTeamCardPath) {
+		const ycWrappedStoryPath = appRoutes.wrappedStory(location.search);
+		const shouldRouteYcWrappedToStory =
+			!isPending &&
+			wrappedPublicId === null &&
+			session &&
+			isYcReviewSession(session) &&
+			`${location.pathname}${location.search}` !== ycWrappedStoryPath;
+
+		if (shouldRouteYcWrappedToStory) {
+			return (
+				<>
+					<ProductAnalyticsSessionSync session={session} />
+					<Navigate replace to={ycWrappedStoryPath} />
+					{showDesktopOnlyOverlay ? <DesktopOnlyOverlay /> : null}
+				</>
+			);
+		}
+
 		return (
 			<>
 				<ProductAnalyticsSessionSync session={session} />
@@ -178,13 +196,18 @@ function App() {
 	}
 
 	if (isYcLoginPath) {
+		const authenticatedYcLoginDestination =
+			session && isYcReviewSession(session)
+				? appRoutes.wrappedStory()
+				: appRoutes.wrappedTeamCard();
+
 		return (
 			<>
 				<ProductAnalyticsSessionSync session={session} />
 				{isPending ? (
 					<AppLoadingScreen />
 				) : session ? (
-					<Navigate replace to={appRoutes.wrappedTeamCard()} />
+					<Navigate replace to={authenticatedYcLoginDestination} />
 				) : (
 					<Suspense fallback={<FullscreenRouteLoadingScreen />}>
 						<YcPasswordLoginPage />
@@ -223,7 +246,7 @@ function App() {
 				<AuthenticatedApp
 					rootRedirectTarget={
 						isYcReviewSession(session)
-							? appRoutes.wrappedTeamCard()
+							? appRoutes.wrappedStory()
 							: rootRedirectTarget
 					}
 					session={session}

--- a/apps/web/src/app/AppRouter.test.tsx
+++ b/apps/web/src/app/AppRouter.test.tsx
@@ -36,7 +36,9 @@ describe("AppRouter", () => {
 		);
 
 		await waitFor(() => {
-			expect(screen.getByText("Current path: /wrapped")).toBeInTheDocument();
+			expect(
+				screen.getByText("Current path: /wrapped?flow=story"),
+			).toBeInTheDocument();
 		});
 	});
 
@@ -62,5 +64,10 @@ describe("AppRouter", () => {
 function LocationProbe() {
 	const location = useLocation();
 
-	return <div>Current path: {location.pathname}</div>;
+	return (
+		<div>
+			Current path: {location.pathname}
+			{location.search}
+		</div>
+	);
 }

--- a/apps/web/src/app/AppRouter.tsx
+++ b/apps/web/src/app/AppRouter.tsx
@@ -118,7 +118,7 @@ export function AppRouter({
 		isYcReview && location.pathname.startsWith(sessionDetailPath);
 
 	if (isYcSettingsPath) {
-		return <Navigate replace to={appRoutes.wrappedTeamCard()} />;
+		return <Navigate replace to={appRoutes.wrappedStory()} />;
 	}
 
 	if (isYcSessionDetailPath) {

--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -22,6 +22,7 @@ export const WRAPPED_ROUTE_FLOW_QUERY_PARAM = "flow";
 export const WRAPPED_ROUTE_CARD_PROFILE_FLOW = "card-profile";
 export const WRAPPED_ROUTE_DESKTOP_READY_FLOW = "desktop-ready";
 export const WRAPPED_ROUTE_SESSIONS_LANDED_FLOW = "sessions-landed";
+export const WRAPPED_ROUTE_STORY_FLOW = "story";
 // Decimal claim links arrive as ?claim=<token> on /wrapped. The token redeems
 // for server-side entitlement; the URL itself is not the permission.
 export const WRAPPED_DECIMAL_CLAIM_QUERY_PARAM = "claim";
@@ -57,6 +58,7 @@ export const appRoutes = {
 	wrappedDesktopReady: (search?: string) => getWrappedDesktopReadyPath(search),
 	wrappedSessionsLanded: (search?: string) =>
 		getWrappedSessionsLandedPath(search),
+	wrappedStory: (search?: string) => getWrappedStoryPath(search),
 	devWrapped: () => DEV_WRAPPED_PATH,
 	wrappedPublic: (publicId: string) =>
 		`${WRAPPED_TEAM_CARD_PATH}/${encodeURIComponent(publicId)}`,
@@ -96,6 +98,10 @@ export function getWrappedDesktopReadyPath(search?: string) {
 
 export function getWrappedSessionsLandedPath(search?: string) {
 	return getWrappedFlowPath(WRAPPED_ROUTE_SESSIONS_LANDED_FLOW, search);
+}
+
+export function getWrappedStoryPath(search?: string) {
+	return getWrappedFlowPath(WRAPPED_ROUTE_STORY_FLOW, search);
 }
 
 function getWrappedFlowPath(flow: string, search?: string) {

--- a/apps/web/src/features/auth/YcPasswordLoginPage.test.tsx
+++ b/apps/web/src/features/auth/YcPasswordLoginPage.test.tsx
@@ -100,7 +100,7 @@ describe("YcPasswordLoginPage", () => {
 		expect(screen.getByLabelText("Password")).toHaveValue("secret-password");
 	});
 
-	it("signs in with email and password and lands in wrapped", async () => {
+	it("signs in with email and password and lands in the wrapped story", async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify({ token: "session-token" }), {
 				headers: { "Content-Type": "application/json" },
@@ -143,7 +143,7 @@ describe("YcPasswordLoginPage", () => {
 		});
 		expect(mockRefreshAuthClientState).toHaveBeenCalledTimes(1);
 		expect(mockNavigateToDestination).toHaveBeenCalledWith(
-			appRoutes.wrappedTeamCard(),
+			appRoutes.wrappedStory(),
 		);
 		expect(
 			window.sessionStorage.getItem(YC_PASSWORD_LOGIN_DRAFT_STORAGE_KEY),

--- a/apps/web/src/features/auth/YcPasswordLoginPage.tsx
+++ b/apps/web/src/features/auth/YcPasswordLoginPage.tsx
@@ -127,7 +127,7 @@ function YcPasswordLoginForm() {
 
 		refreshAuthClientState();
 		clearYcPasswordLoginDraft();
-		navigateToDestination(appRoutes.wrappedTeamCard());
+		navigateToDestination(appRoutes.wrappedStory());
 	}
 
 	function handleDraftChange(nextDraft: YcPasswordLoginDraft) {

--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -274,6 +274,16 @@ const session: NonNullable<AppSession> = {
 	},
 };
 
+function buildYcReviewSession() {
+	return {
+		...session,
+		session: {
+			...session.session,
+			ycReview: true,
+		},
+	};
+}
+
 function markWrappedCardProfileComplete() {
 	writeWrappedGuestPreviewSnapshot({
 		cardProfileCompletedUserId: "user-1",
@@ -705,6 +715,63 @@ describe("WrappedRouteGate", () => {
 		expect(
 			screen.getByText("Wrapped mobile handoff: ada@example.com"),
 		).toBeInTheDocument();
+		expect(screen.queryByText("Wrapped story")).toBeNull();
+	});
+
+	it.each([
+		"/wrapped",
+		"/wrapped?flow=card-profile",
+		"/wrapped?flow=desktop-ready",
+		"/wrapped?flow=sessions-landed",
+	] as const)("routes YC review sessions directly to story from %s without prep screens", (initialEntry) => {
+		clearWrappedGuestPreviewSnapshot();
+		mockUseIsMobile.mockReturnValue(true);
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 100,
+		});
+
+		render(
+			<MemoryRouter initialEntries={[initialEntry]}>
+				<WrappedRouteGate
+					isPending={false}
+					publicId={null}
+					session={buildYcReviewSession()}
+				/>
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Wrapped story")).toBeInTheDocument();
+		expect(screen.queryByText("Wrapped card profile step")).toBeNull();
+		expect(
+			screen.queryByText("Wrapped mobile handoff: ada@example.com"),
+		).toBeNull();
+		expect(screen.queryByText("Wrapped setup page")).toBeNull();
+		expect(screen.queryByText("Wrapped setup complete page")).toBeNull();
+	});
+
+	it("keeps YC review sessions out of story until wrapped data is eligible", () => {
+		clearWrappedGuestPreviewSnapshot();
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 99,
+		});
+
+		render(
+			<MemoryRouter initialEntries={["/wrapped"]}>
+				<WrappedRouteGate
+					isPending={false}
+					publicId={null}
+					session={buildYcReviewSession()}
+				/>
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Wrapped setup complete page")).toBeInTheDocument();
+		expect(screen.getByText("Can continue: no")).toBeInTheDocument();
+		expect(screen.queryByText("Wrapped card profile step")).toBeNull();
 		expect(screen.queryByText("Wrapped story")).toBeNull();
 	});
 

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -11,6 +11,7 @@ import {
 	WRAPPED_ROUTE_DESKTOP_READY_FLOW,
 	WRAPPED_ROUTE_FLOW_QUERY_PARAM,
 	WRAPPED_ROUTE_SESSIONS_LANDED_FLOW,
+	WRAPPED_ROUTE_STORY_FLOW,
 } from "@/app/routes";
 import { useAnalyticsQuery } from "@/features/analytics/queries/useAnalyticsQuery";
 import { useAnalyticsTracking } from "@/features/analytics/tracking/useAnalyticsTracking";
@@ -19,6 +20,7 @@ import {
 	getSessionUserEmail,
 	getSessionUserId,
 	getSessionUserName,
+	isYcReviewSession,
 } from "@/features/auth/auth-route-utils";
 import { useCliSetupStatus } from "@/features/get-started/use-cli-setup-status";
 import { useSetupProgress } from "@/features/get-started/use-setup-progress";
@@ -66,7 +68,7 @@ type WrappedRouteFlowStage =
 	| "card-profile"
 	| "desktop-ready"
 	| "sessions-landed"
-	| "story";
+	| typeof WRAPPED_ROUTE_STORY_FLOW;
 
 const WRAPPED_SETUP_AUTH_STEP_ID = "install-and-login";
 const WRAPPED_SETUP_UPLOAD_STEP_ID = "enable-auto-upload";
@@ -99,6 +101,7 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const wrappedLoopEntrySource = shareId ? "share_redirect" : "direct";
 	const sessionUserId = getSessionUserId(session);
 	const sessionUserEmail = getSessionUserEmail(session);
+	const isYcReview = isYcReviewSession(session);
 	// Drives Decimal claim redemption + variant gating. Public share routes
 	// (publicId !== null) intentionally don't pass a userId here so the
 	// entitlement query stays disabled and the public flow is untouched.
@@ -131,6 +134,9 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const forcedFlowStage = getWrappedRouteFlowStage(
 		searchParams.get(WRAPPED_ROUTE_FLOW_QUERY_PARAM),
 	);
+	const shouldSkipYcReviewPrep = isYcReview && !publicId;
+	const isForcedStoryFlow =
+		forcedFlowStage === WRAPPED_ROUTE_STORY_FLOW || shouldSkipYcReviewPrep;
 	const isWrappedNewUserFlow =
 		forcedFlowStage === WRAPPED_ROUTE_CARD_PROFILE_FLOW;
 
@@ -186,6 +192,7 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		!hasCompletedCardProfileWithImage;
 	const shouldShowCardProfileStep =
 		!publicId &&
+		!shouldSkipYcReviewPrep &&
 		!isPending &&
 		!!session &&
 		sessionUserId !== null &&
@@ -196,8 +203,11 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		forcedFlowStage === WRAPPED_ROUTE_DESKTOP_READY_FLOW &&
 		hasCompletedCardProfile;
 	const shouldForceSessionsLanded =
-		forcedFlowStage === "sessions-landed" && setupProgress.hasUploadedSessions;
+		!shouldSkipYcReviewPrep &&
+		forcedFlowStage === WRAPPED_ROUTE_SESSIONS_LANDED_FLOW &&
+		setupProgress.hasUploadedSessions;
 	const shouldForceDesktopReady =
+		!shouldSkipYcReviewPrep &&
 		forcedFlowStage === WRAPPED_ROUTE_DESKTOP_READY_FLOW;
 	const hasMinimumSetupProgressSessionCount =
 		setupProgress.totalSessionCount >=
@@ -209,7 +219,8 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		setupProgress.hasUploadedSessions &&
 		hasMinimumSetupProgressSessionCount &&
 		hasSeenBelowMinimumSessions;
-	const signedInMobileHandoffEmail = isMobile ? sessionUserEmail : undefined;
+	const signedInMobileHandoffEmail =
+		isMobile && !shouldSkipYcReviewPrep ? sessionUserEmail : undefined;
 
 	function setWrappedRouteFlowStage(nextStage: WrappedRouteFlowStage) {
 		startTransition(() => {
@@ -229,7 +240,10 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 			setSearchParams(
 				(previousSearchParams) => {
 					const nextSearchParams = new URLSearchParams(previousSearchParams);
-					nextSearchParams.set(WRAPPED_ROUTE_FLOW_QUERY_PARAM, "story");
+					nextSearchParams.set(
+						WRAPPED_ROUTE_FLOW_QUERY_PARAM,
+						WRAPPED_ROUTE_STORY_FLOW,
+					);
 					nextSearchParams.delete(STEP_QUERY_PARAM);
 
 					for (const key of Array.from(nextSearchParams.keys())) {
@@ -418,7 +432,7 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 			setupProgress.hasUploadedSessions &&
 			!sessionGateState.hasMinimumSessionCount;
 		const shouldForceStory =
-			forcedFlowStage === "story" &&
+			isForcedStoryFlow &&
 			setupProgress.hasUploadedSessions &&
 			canContinueToWrappedStory;
 		const shouldShowSessionsLanded =
@@ -509,8 +523,10 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 			content = (
 				<WrappedTeamCardPage
 					isDecimalEntitled={decimalAccess.isDecimalEntitled}
-					onBackFromFirstStep={() =>
-						setWrappedRouteFlowStage("sessions-landed")
+					onBackFromFirstStep={
+						shouldSkipYcReviewPrep
+							? () => undefined
+							: () => setWrappedRouteFlowStage("sessions-landed")
 					}
 					variant={decimalAccess.variant}
 				/>
@@ -715,7 +731,7 @@ function getWrappedRouteFlowStage(
 	return flowStage === WRAPPED_ROUTE_CARD_PROFILE_FLOW ||
 		flowStage === WRAPPED_ROUTE_DESKTOP_READY_FLOW ||
 		flowStage === WRAPPED_ROUTE_SESSIONS_LANDED_FLOW ||
-		flowStage === "story"
+		flowStage === WRAPPED_ROUTE_STORY_FLOW
 		? flowStage
 		: null;
 }


### PR DESCRIPTION
## Summary
- send successful YC password login and existing YC review sessions to `/wrapped?flow=story`
- canonicalize direct YC `/wrapped` visits away from stale setup flow params
- skip card-profile, mobile handoff, and setup detours for eligible YC review sessions while preserving wrapped-data eligibility gates

## Test plan
- [x] bun run test src/App.test.tsx src/app/AppRouter.test.tsx src/features/auth/YcPasswordLoginPage.test.tsx src/features/wrapped/WrappedRouteGate.test.tsx
- [x] bun run lint:wrapped:hig
- [x] bun run verify