### PR TITLE
fix: keep YC review on normal wrapped card

### DIFF
--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -21,6 +21,7 @@ const {
 	mockTrackWrappedReferredSignupCompleted,
 	mockUseAnalyticsQuery,
 	mockUseCliSetupStatus,
+	mockUseWrappedDecimalAccess,
 	mockUseIsMobile,
 	mockUseSetupProgress,
 } = vi.hoisted(() => ({
@@ -32,6 +33,7 @@ const {
 	mockTrackWrappedReferredSignupCompleted: vi.fn(),
 	mockUseAnalyticsQuery: vi.fn(),
 	mockUseCliSetupStatus: vi.fn(),
+	mockUseWrappedDecimalAccess: vi.fn(),
 	mockUseIsMobile: vi.fn(),
 	mockUseSetupProgress: vi.fn(),
 }));
@@ -64,11 +66,7 @@ vi.mock("@/lib/orpc", () => ({
 // These tests cover unrelated route-gate behavior, so we stub the hook to a
 // non-entitled, no-op result instead of standing up a QueryClientProvider.
 vi.mock("@/features/wrapped/use-wrapped-decimal-access", () => ({
-	useWrappedDecimalAccess: () => ({
-		variant: "normal" as const,
-		isDecimalEntitled: false,
-		isEntitlementLoading: false,
-	}),
+	useWrappedDecimalAccess: mockUseWrappedDecimalAccess,
 }));
 
 vi.mock("@/lib/auth-client", () => ({
@@ -235,9 +233,13 @@ vi.mock("@/features/wrapped/WrappedSetupCompletePage", () => ({
 
 vi.mock("@/features/wrapped/team-card/page", () => ({
 	WrappedTeamCardPage: ({
+		isDecimalEntitled,
 		onBackFromFirstStep,
+		variant,
 	}: {
+		isDecimalEntitled?: boolean;
 		onBackFromFirstStep?: () => void;
+		variant?: "normal" | "decimal";
 	}) => {
 		const [searchParams] = useSearchParams();
 
@@ -245,6 +247,8 @@ vi.mock("@/features/wrapped/team-card/page", () => ({
 			<div>
 				<div>Wrapped story</div>
 				<div>Story step: {searchParams.get("step") ?? "none"}</div>
+				<div>Story variant: {variant ?? "none"}</div>
+				<div>Story Decimal entitled: {isDecimalEntitled ? "yes" : "no"}</div>
 				<button type="button" onClick={onBackFromFirstStep}>
 					Back to upload
 				</button>
@@ -317,6 +321,7 @@ describe("WrappedRouteGate", () => {
 		mockUseAnalyticsQuery.mockReset();
 		mockUseIsMobile.mockReset();
 		mockUseCliSetupStatus.mockReset();
+		mockUseWrappedDecimalAccess.mockReset();
 		mockUseSetupProgress.mockReset();
 		window.localStorage.clear();
 
@@ -329,6 +334,11 @@ describe("WrappedRouteGate", () => {
 			hasUploadedSessions: false,
 			isLoading: false,
 			totalSessionCount: 0,
+		});
+		mockUseWrappedDecimalAccess.mockReturnValue({
+			isDecimalEntitled: false,
+			isEntitlementLoading: false,
+			variant: "normal",
 		});
 		mockUseAnalyticsQuery.mockReturnValue({
 			data: {
@@ -749,6 +759,62 @@ describe("WrappedRouteGate", () => {
 		).toBeNull();
 		expect(screen.queryByText("Wrapped setup page")).toBeNull();
 		expect(screen.queryByText("Wrapped setup complete page")).toBeNull();
+	});
+
+	it("keeps YC review sessions on the normal wrapped card even when the target account has Decimal", () => {
+		mockUseWrappedDecimalAccess.mockReturnValue({
+			isDecimalEntitled: true,
+			isEntitlementLoading: false,
+			variant: "decimal",
+		});
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 100,
+		});
+
+		render(
+			<MemoryRouter initialEntries={["/wrapped?flow=story&variant=decimal"]}>
+				<WrappedRouteGate
+					isPending={false}
+					publicId={null}
+					session={buildYcReviewSession()}
+				/>
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Wrapped story")).toBeInTheDocument();
+		expect(screen.getByText("Story variant: normal")).toBeInTheDocument();
+		expect(screen.getByText("Story Decimal entitled: no")).toBeInTheDocument();
+		expect(mockUseWrappedDecimalAccess).toHaveBeenCalledWith({
+			userId: null,
+		});
+	});
+
+	it("keeps Decimal available for normal entitled wrapped sessions", () => {
+		mockUseWrappedDecimalAccess.mockReturnValue({
+			isDecimalEntitled: true,
+			isEntitlementLoading: false,
+			variant: "decimal",
+		});
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 100,
+		});
+
+		render(
+			<MemoryRouter initialEntries={["/wrapped?flow=story&variant=decimal"]}>
+				<WrappedRouteGate isPending={false} publicId={null} session={session} />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Wrapped story")).toBeInTheDocument();
+		expect(screen.getByText("Story variant: decimal")).toBeInTheDocument();
+		expect(screen.getByText("Story Decimal entitled: yes")).toBeInTheDocument();
+		expect(mockUseWrappedDecimalAccess).toHaveBeenCalledWith({
+			userId: "user-1",
+		});
 	});
 
 	it("keeps YC review sessions out of story until wrapped data is eligible", () => {

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -12,6 +12,7 @@ import {
 	WRAPPED_ROUTE_FLOW_QUERY_PARAM,
 	WRAPPED_ROUTE_SESSIONS_LANDED_FLOW,
 	WRAPPED_ROUTE_STORY_FLOW,
+	WRAPPED_VARIANT_NORMAL,
 } from "@/app/routes";
 import { useAnalyticsQuery } from "@/features/analytics/queries/useAnalyticsQuery";
 import { useAnalyticsTracking } from "@/features/analytics/tracking/useAnalyticsTracking";
@@ -104,10 +105,17 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const isYcReview = isYcReviewSession(session);
 	// Drives Decimal claim redemption + variant gating. Public share routes
 	// (publicId !== null) intentionally don't pass a userId here so the
-	// entitlement query stays disabled and the public flow is untouched.
+	// entitlement query stays disabled and the public flow is untouched. YC
+	// review sessions also stay on the normal card even though they simulate the
+	// target account.
 	const decimalAccess = useWrappedDecimalAccess({
-		userId: publicId ? null : sessionUserId,
+		userId: publicId || isYcReview ? null : sessionUserId,
 	});
+	const wrappedStoryVariant = isYcReview
+		? WRAPPED_VARIANT_NORMAL
+		: decimalAccess.variant;
+	const isWrappedStoryDecimalEntitled =
+		!isYcReview && decimalAccess.isDecimalEntitled;
 	const cliSetupStatus = useCliSetupStatus({
 		enabled: !publicId && !!session,
 	});
@@ -522,13 +530,13 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		) {
 			content = (
 				<WrappedTeamCardPage
-					isDecimalEntitled={decimalAccess.isDecimalEntitled}
+					isDecimalEntitled={isWrappedStoryDecimalEntitled}
 					onBackFromFirstStep={
 						shouldSkipYcReviewPrep
 							? () => undefined
 							: () => setWrappedRouteFlowStage("sessions-landed")
 					}
-					variant={decimalAccess.variant}
+					variant={wrappedStoryVariant}
 				/>
 			);
 		} else {

--- a/apps/web/src/features/wrapped/team-card/WrappedTeamCardPage.analytics.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/WrappedTeamCardPage.analytics.test.tsx
@@ -313,6 +313,28 @@ describe("WrappedTeamCardPage analytics", () => {
 		);
 	});
 
+	it("shows the Decimal switcher only when the user is entitled", () => {
+		const { rerender } = render(
+			<MemoryRouter initialEntries={["/wrapped"]}>
+				<WrappedTeamCardPage isDecimalEntitled variant="normal" />
+			</MemoryRouter>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: "View Decimal card" }),
+		).toBeInTheDocument();
+
+		rerender(
+			<MemoryRouter initialEntries={["/wrapped"]}>
+				<WrappedTeamCardPage isDecimalEntitled={false} variant="normal" />
+			</MemoryRouter>,
+		);
+
+		expect(
+			screen.queryByRole("button", { name: "View Decimal card" }),
+		).toBeNull();
+	});
+
 	it("uses a dev preview archetype when the auth bypass has no live classifier", () => {
 		mockLiveArchetype.mockReturnValue(null);
 


### PR DESCRIPTION
## Summary
- Keep YC review sessions on the normal Wrapped card, even if the target account has Decimal entitlement.
- Disable the Decimal entitlement hook for YC review sessions so the Decimal switcher does not appear.
- Add regression coverage for YC normal-card routing and the Decimal switcher visibility gate.

## Test plan
- [x] bun run test -- src/features/wrapped/WrappedRouteGate.test.tsx src/features/wrapped/team-card/WrappedTeamCardPage.analytics.test.tsx (apps/web)
- [x] bun run lint:wrapped:hig
- [x] bun run verify --filter=@rudel/web
- [x] bun run lint
- [x] bun run verify