### PR TITLE
fix: hide decimal variant switcher

### DIFF
--- a/apps/web/src/features/wrapped/team-card/WrappedTeamCardPage.analytics.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/WrappedTeamCardPage.analytics.test.tsx
@@ -299,6 +299,12 @@ describe("WrappedTeamCardPage analytics", () => {
 			"Roadrunner",
 		);
 		expect(screen.getByTestId("reveal-edition")).toHaveTextContent("decimal");
+		expect(
+			screen.queryByRole("button", { name: "View Decimal card" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "View normal card" }),
+		).not.toBeInTheDocument();
 		expect(mockUseWrappedTeamCardShare.mock.calls[0]?.[0]).toEqual(
 			expect.objectContaining({
 				archetypeLabel: "Roadrunner",
@@ -313,26 +319,19 @@ describe("WrappedTeamCardPage analytics", () => {
 		);
 	});
 
-	it("shows the Decimal switcher only when the user is entitled", () => {
-		const { rerender } = render(
+	it("does not show a Decimal variant switcher to entitled users", () => {
+		render(
 			<MemoryRouter initialEntries={["/wrapped"]}>
 				<WrappedTeamCardPage isDecimalEntitled variant="normal" />
 			</MemoryRouter>,
 		);
 
 		expect(
-			screen.getByRole("button", { name: "View Decimal card" }),
-		).toBeInTheDocument();
-
-		rerender(
-			<MemoryRouter initialEntries={["/wrapped"]}>
-				<WrappedTeamCardPage isDecimalEntitled={false} variant="normal" />
-			</MemoryRouter>,
-		);
-
-		expect(
 			screen.queryByRole("button", { name: "View Decimal card" }),
-		).toBeNull();
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "View normal card" }),
+		).not.toBeInTheDocument();
 	});
 
 	it("uses a dev preview archetype when the auth bypass has no live classifier", () => {

--- a/apps/web/src/features/wrapped/team-card/page.tsx
+++ b/apps/web/src/features/wrapped/team-card/page.tsx
@@ -24,7 +24,6 @@ import {
 	getWrappedShareIdFromSearch,
 	WRAPPED_VARIANT_DECIMAL,
 	WRAPPED_VARIANT_NORMAL,
-	WRAPPED_VARIANT_QUERY_PARAM,
 	type WrappedVariant,
 } from "@/app/routes";
 import { Button } from "@/app/ui/button";
@@ -118,12 +117,11 @@ export function WrappedTeamCardPage(props: {
 		devPreviewPublicId,
 		devPreviewUserEmail,
 		devPreviewUserId,
-		isDecimalEntitled = false,
 		onBackFromFirstStep,
 		variant = WRAPPED_VARIANT_NORMAL,
 	} = props;
 	const navigate = useNavigate();
-	const [searchParams, setSearchParams] = useSearchParams();
+	const [searchParams] = useSearchParams();
 	const { trackUtilityUsed, trackWrappedStoryStarted } = useAnalyticsTracking({
 		pageName: "wrapped_team_card",
 	});
@@ -186,36 +184,6 @@ export function WrappedTeamCardPage(props: {
 		variant === WRAPPED_VARIANT_DECIMAL ? "decimal" : "normal";
 	const cardEdition: WrappedTeamMemberCardEdition | undefined =
 		shareVariant === "decimal" ? "decimal" : undefined;
-
-	function setWrappedVariant(nextVariant: WrappedVariant) {
-		setSearchParams(
-			(previousSearchParams) => {
-				const nextSearchParams = new URLSearchParams(previousSearchParams);
-				if (nextVariant === WRAPPED_VARIANT_DECIMAL) {
-					nextSearchParams.set(
-						WRAPPED_VARIANT_QUERY_PARAM,
-						WRAPPED_VARIANT_DECIMAL,
-					);
-				} else if (
-					import.meta.env.DEV &&
-					hasWrappedDevPreviewTarget({
-						devPreviewPublicId,
-						devPreviewUserEmail,
-						devPreviewUserId,
-					})
-				) {
-					nextSearchParams.set(
-						WRAPPED_VARIANT_QUERY_PARAM,
-						WRAPPED_VARIANT_NORMAL,
-					);
-				} else {
-					nextSearchParams.delete(WRAPPED_VARIANT_QUERY_PARAM);
-				}
-				return nextSearchParams;
-			},
-			{ replace: true },
-		);
-	}
 
 	const activeStepParam = searchParams.get("step");
 	const estimatedSpendValue = formatCompactWholeCurrency(
@@ -301,11 +269,9 @@ export function WrappedTeamCardPage(props: {
 			edition={cardEdition}
 			headerLeftMetric={headerLeftMetric}
 			headerRightMetric={headerRightMetric}
-			isDecimalEntitled={isDecimalEntitled}
 			onboardingMetrics={onboardingMetrics}
 			onBackFromFirstStep={onBackFromFirstStep}
 			onContinueToDashboard={handleContinueToDashboard}
-			onSelectVariant={setWrappedVariant}
 			shareAppearance={resolveWrappedShareAppearance(shareAppearance)}
 			shareCardCreatedAtLabel={shareCardCreatedAtLabel}
 			shareVariant={shareVariant}
@@ -315,7 +281,6 @@ export function WrappedTeamCardPage(props: {
 			setDevOverrideIndex={setDevOverrideIndex}
 			setShareAppearance={setShareAppearance}
 			tiltController={tiltController}
-			variant={variant}
 			visibleTeamCardRow={visibleTeamCardRow}
 		/>
 	);
@@ -360,11 +325,9 @@ function WrappedTeamCardPageContent(props: {
 	edition?: WrappedTeamMemberCardEdition;
 	headerLeftMetric: WrappedTeamMemberCardHeaderMetric;
 	headerRightMetric: WrappedTeamMemberCardHeaderMetric;
-	isDecimalEntitled: boolean;
 	onboardingMetrics: WrappedOnboardingMetrics;
 	onBackFromFirstStep?: () => void;
 	onContinueToDashboard: () => void;
-	onSelectVariant: (variant: WrappedVariant) => void;
 	setDevOverrideIndex: (
 		nextValue: number | null | ((currentValue: number | null) => number | null),
 	) => void;
@@ -380,7 +343,6 @@ function WrappedTeamCardPageContent(props: {
 	statItems: readonly WrappedTeamMemberCardStatItem[];
 	statLayerOpacities: WrappedTeamMemberCardStatLayerOpacities;
 	tiltController: WrappedCardTiltController;
-	variant: WrappedVariant;
 	visibleTeamCardRow: TeamPageMemberRow;
 }) {
 	const {
@@ -389,11 +351,9 @@ function WrappedTeamCardPageContent(props: {
 		edition,
 		headerLeftMetric,
 		headerRightMetric,
-		isDecimalEntitled,
 		onboardingMetrics,
 		onBackFromFirstStep,
 		onContinueToDashboard,
-		onSelectVariant,
 		setDevOverrideIndex,
 		setShareAppearance,
 		shareAppearance,
@@ -403,7 +363,6 @@ function WrappedTeamCardPageContent(props: {
 		statItems,
 		statLayerOpacities,
 		tiltController,
-		variant,
 		visibleTeamCardRow,
 	} = props;
 	const sharePostRef = useRef<HTMLDivElement>(null);
@@ -834,39 +793,7 @@ function WrappedTeamCardPageContent(props: {
 				statLayerOpacities={statLayerOpacities}
 				theme={activeArchetype.theme}
 			/>
-			{isDecimalEntitled ? (
-				<WrappedVariantSwitcher
-					onSelectVariant={onSelectVariant}
-					variant={variant}
-				/>
-			) : null}
 		</>
-	);
-}
-
-function WrappedVariantSwitcher(props: {
-	onSelectVariant: (variant: WrappedVariant) => void;
-	variant: WrappedVariant;
-}) {
-	const { onSelectVariant, variant } = props;
-	const isOnDecimal = variant === WRAPPED_VARIANT_DECIMAL;
-	const nextVariant: WrappedVariant = isOnDecimal
-		? WRAPPED_VARIANT_NORMAL
-		: WRAPPED_VARIANT_DECIMAL;
-	const label = isOnDecimal ? "View normal card" : "View Decimal card";
-
-	return (
-		<div className="fixed top-3 right-3 z-50">
-			<Button
-				type="button"
-				size="sm"
-				variant="outline"
-				className="bg-black/60 text-white border-white/20 backdrop-blur-md hover:bg-black/80"
-				onClick={() => onSelectVariant(nextVariant)}
-			>
-				{label}
-			</Button>
-		</div>
 	);
 }
 


### PR DESCRIPTION
## Summary
- remove the fixed top-right Decimal/normal variant switcher from the wrapped team card page
- keep Decimal links rendering the Decimal edition directly without exposing a user-facing toggle
- update wrapped analytics coverage to assert the Decimal switcher buttons are absent

## Test plan
- [x] bun run lint:wrapped:hig
- [x] bun run --cwd apps/web test src/features/wrapped/team-card/WrappedTeamCardPage.analytics.test.tsx
- [x] bun run verify