### PR TITLE
fix: stabilize team share card

### DIFF
--- a/apps/web/src/features/team/components/TeamMembersCardGrid.test.tsx
+++ b/apps/web/src/features/team/components/TeamMembersCardGrid.test.tsx
@@ -103,8 +103,11 @@ describe("TeamMembersCardGrid", () => {
 		expect(shareLinkClassName).toContain(
 			"group-hover/team-share-card:opacity-100",
 		);
-		expect(shareLink.parentElement?.getAttribute("class")).toContain(
-			"h-[358px] w-[233px]",
+		expect(shareLinkClassName).not.toContain(
+			"group-focus-within/team-share-card:opacity-100",
 		);
+		const cardShell = shareLink.parentElement;
+		expect(cardShell?.getAttribute("class")).toContain("h-[358px] w-[233px]");
+		expect(cardShell?.getAttribute("class")).toContain("group/team-share-card");
 	});
 });

--- a/apps/web/src/features/team/components/TeamMembersCardGrid.tsx
+++ b/apps/web/src/features/team/components/TeamMembersCardGrid.tsx
@@ -163,24 +163,32 @@ function isCurrentUserTeamCard(
 	return currentUserId !== null && row.userId === currentUserId;
 }
 
-function TeamMemberShareCardShell({ children }: { children: ReactNode }) {
+function TeamMemberShareCardShell({
+	children,
+	isCurrentUserCard,
+}: {
+	children: ReactNode;
+	isCurrentUserCard: boolean;
+}) {
 	return (
 		<div className="group/team-share-card relative h-[358px] w-[233px]">
 			{children}
-			<Link
-				className={buttonVariants({
-					className:
-						"pointer-events-none absolute right-2 bottom-2 left-2 z-20 h-10 translate-y-1 rounded-[10px] px-3 text-sm font-semibold opacity-0 shadow-none transition-[opacity,transform] duration-150 [transition-timing-function:cubic-bezier(0.23,1,0.32,1)] active:scale-[0.98] group-hover/team-share-card:pointer-events-auto group-hover/team-share-card:translate-y-0 group-hover/team-share-card:opacity-100 group-focus-within/team-share-card:pointer-events-auto group-focus-within/team-share-card:translate-y-0 group-focus-within/team-share-card:opacity-100 focus-visible:pointer-events-auto focus-visible:translate-y-0 focus-visible:opacity-100",
-					size: "sm",
-					variant: "secondary",
-				})}
-				rel="noreferrer"
-				target="_blank"
-				to={appRoutes.wrappedTeamCardShare()}
-			>
-				<span>View sharing page</span>
-				<ArrowUpRightIcon aria-hidden="true" className="size-4" />
-			</Link>
+			{isCurrentUserCard ? (
+				<Link
+					className={buttonVariants({
+						className:
+							"pointer-events-none absolute right-2 bottom-2 left-2 z-20 h-10 translate-y-1 rounded-[10px] px-3 text-sm font-semibold opacity-0 shadow-none transition-[opacity,transform] duration-150 [transition-timing-function:cubic-bezier(0.23,1,0.32,1)] active:scale-[0.98] group-hover/team-share-card:pointer-events-auto group-hover/team-share-card:translate-y-0 group-hover/team-share-card:opacity-100 focus-visible:pointer-events-auto focus-visible:translate-y-0 focus-visible:opacity-100",
+						size: "sm",
+						variant: "secondary",
+					})}
+					rel="noreferrer"
+					target="_blank"
+					to={appRoutes.wrappedTeamCardShare()}
+				>
+					<span>View sharing page</span>
+					<ArrowUpRightIcon aria-hidden="true" className="size-4" />
+				</Link>
+			) : null}
 		</div>
 	);
 }
@@ -350,11 +358,9 @@ export function TeamMembersCardGrid({
 
 					return (
 						<li key={row.userId} className="flex justify-center list-none">
-							{isCurrentUserCard ? (
-								<TeamMemberShareCardShell>{card}</TeamMemberShareCardShell>
-							) : (
-								card
-							)}
+							<TeamMemberShareCardShell isCurrentUserCard={isCurrentUserCard}>
+								{card}
+							</TeamMemberShareCardShell>
 						</li>
 					);
 				})}

--- a/apps/web/src/features/team/use-team-page-data.ts
+++ b/apps/web/src/features/team/use-team-page-data.ts
@@ -159,7 +159,8 @@ function buildTeamMemberRows(
 }
 
 export function useTeamPageData() {
-	const { data: session } = authClient.useSession();
+	const { data: session, isPending: isSessionPending } =
+		authClient.useSession();
 	const { data: activeMember } = authClient.useActiveMember();
 	const { state: dateRangeState, meta: dateRangeMeta } = useDateRange();
 	const { meta: workspaceMeta, state: workspaceState } = useOrganization();
@@ -251,6 +252,14 @@ export function useTeamPageData() {
 		[members, teamCards, developerSummaries],
 	);
 	const hasRosterData = teamMemberRows.length > 0;
+	const isInitialTeamDataPending =
+		!useFixtures &&
+		(workspaceState.isLoading ||
+			(activeOrganizationId !== null &&
+				(teamCardsQuery.isPending ||
+					developersQuery.isPending ||
+					isOrganizationPending)) ||
+			isSessionPending);
 	const diagnostics: TeamPageDiagnostics = {
 		endDate: dateRangeState.endDate,
 		endpoint: "analytics.developers.teamCards",
@@ -277,12 +286,7 @@ export function useTeamPageData() {
 			(teamCardsQuery.isError ||
 				developersQuery.isError ||
 				isOrganizationError),
-		isPending:
-			!useFixtures &&
-			!hasRosterData &&
-			(teamCardsQuery.isPending ||
-				developersQuery.isPending ||
-				isOrganizationPending),
+		isPending: isInitialTeamDataPending,
 		teamMemberRows,
 		canInviteTeamMembers,
 		currentUserId,


### PR DESCRIPTION
## Summary
- keep every team card in the same shell so the current-user card does not swap structure after auth resolves
- make the sharing CTA appear only for actual card hover while preserving keyboard focus visibility
- keep the team page in its initial loading state until session/org/analytics data is ready to avoid partial old-card flicker
- route explicit share-card deep links directly to the final share stage once existing wrapped eligibility checks pass

## Test plan
- [x] bun run test -- src/features/wrapped/WrappedRouteGate.test.tsx src/features/wrapped/team-card/WrappedTeamCardPage.analytics.test.tsx
- [x] bunx --no-install biome check src/app/routes.ts src/features/wrapped/WrappedRouteGate.tsx src/features/wrapped/WrappedRouteGate.test.tsx src/features/wrapped/team-card/page.tsx
- [x] bun run check-types (apps/web)
- [x] bun run verify
- [x] screenshot harness for unhovered, hovered, and hover-off states