### PR TITLE
fix: route team share card deep links

### DIFF
--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -131,6 +131,18 @@ function getWrappedTeamCardSharePath() {
 	return `${WRAPPED_TEAM_CARD_PATH}?${searchParams.toString()}`;
 }
 
+export function isWrappedTeamCardShareTarget(search: string | URLSearchParams) {
+	const searchParams =
+		search instanceof URLSearchParams ? search : new URLSearchParams(search);
+
+	return (
+		searchParams.get(WRAPPED_TEAM_CARD_STEP_QUERY_PARAM) ===
+			WRAPPED_TEAM_CARD_FINAL_STEP &&
+		searchParams.get(WRAPPED_TEAM_CARD_STAGE_QUERY_PARAM) ===
+			WRAPPED_TEAM_CARD_SHARE_STAGE
+	);
+}
+
 // Public wrapped pages live at /wrapped/:id. New links use username-style ids,
 // while older UUID ids still resolve because the backend key is plain text.
 export function getWrappedPublicIdFromPath(pathname: string) {

--- a/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.test.tsx
@@ -247,6 +247,7 @@ vi.mock("@/features/wrapped/team-card/page", () => ({
 			<div>
 				<div>Wrapped story</div>
 				<div>Story step: {searchParams.get("step") ?? "none"}</div>
+				<div>Story stage: {searchParams.get("stage") ?? "none"}</div>
 				<div>Story variant: {variant ?? "none"}</div>
 				<div>Story Decimal entitled: {isDecimalEntitled ? "yes" : "no"}</div>
 				<button type="button" onClick={onBackFromFirstStep}>
@@ -1039,6 +1040,27 @@ describe("WrappedRouteGate", () => {
 		expect(screen.getByText("Readiness: missing")).toBeInTheDocument();
 		expect(screen.getByText("Total sessions: 99")).toBeInTheDocument();
 		expect(screen.queryByText("Wrapped story")).toBeNull();
+	});
+
+	it("opens an auth-normalized share-card deep link at the final share page when eligible", () => {
+		mockUseSetupProgress.mockReturnValue({
+			hasUploadedSessions: true,
+			isLoading: false,
+			totalSessionCount: 100,
+		});
+
+		render(
+			<MemoryRouter
+				initialEntries={["/wrapped?flow=sessions-landed&step=card&stage=share"]}
+			>
+				<WrappedRouteGate isPending={false} publicId={null} session={session} />
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("Wrapped story")).toBeInTheDocument();
+		expect(screen.getByText("Story step: card")).toBeInTheDocument();
+		expect(screen.getByText("Story stage: share")).toBeInTheDocument();
+		expect(screen.queryByText("Wrapped setup complete page")).toBeNull();
 	});
 
 	it("uses wrapped gate count when raw uploads already outrun wrapped data on entry", () => {

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -7,6 +7,7 @@ import { useLocation, useSearchParams } from "react-router-dom";
 import { useIsMobile } from "@/app/hooks/use-mobile";
 import {
 	getWrappedShareIdFromSearch,
+	isWrappedTeamCardShareTarget,
 	WRAPPED_ROUTE_CARD_PROFILE_FLOW,
 	WRAPPED_ROUTE_DESKTOP_READY_FLOW,
 	WRAPPED_ROUTE_FLOW_QUERY_PARAM,
@@ -145,6 +146,7 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const shouldSkipYcReviewPrep = isYcReview && !publicId;
 	const isForcedStoryFlow =
 		forcedFlowStage === WRAPPED_ROUTE_STORY_FLOW || shouldSkipYcReviewPrep;
+	const shouldRespectShareTarget = isWrappedTeamCardShareTarget(searchParams);
 	const isWrappedNewUserFlow =
 		forcedFlowStage === WRAPPED_ROUTE_CARD_PROFILE_FLOW;
 
@@ -439,13 +441,14 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 		const shouldHoldForMinimumSessions =
 			setupProgress.hasUploadedSessions &&
 			!sessionGateState.hasMinimumSessionCount;
-		const shouldForceStory =
-			isForcedStoryFlow &&
+		const shouldOpenWrappedStoryDirectly =
+			(isForcedStoryFlow || shouldRespectShareTarget) &&
 			setupProgress.hasUploadedSessions &&
 			canContinueToWrappedStory;
 		const shouldShowSessionsLanded =
 			sessionUserId !== null &&
 			setupProgress.hasUploadedSessions &&
+			!shouldOpenWrappedStoryDirectly &&
 			(shouldForceSessionsLanded ||
 				shouldHoldForMinimumSessions ||
 				shouldWaitForWrappedStoryData ||
@@ -523,7 +526,7 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 				/>
 			);
 		} else if (
-			shouldForceStory ||
+			shouldOpenWrappedStoryDirectly ||
 			(setupProgress.hasUploadedSessions &&
 				hasCompletedSetup &&
 				canContinueToWrappedStory)

--- a/apps/web/src/features/wrapped/WrappedRouteGate.tsx
+++ b/apps/web/src/features/wrapped/WrappedRouteGate.tsx
@@ -146,7 +146,7 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 	const shouldSkipYcReviewPrep = isYcReview && !publicId;
 	const isForcedStoryFlow =
 		forcedFlowStage === WRAPPED_ROUTE_STORY_FLOW || shouldSkipYcReviewPrep;
-	const shouldRespectShareTarget = isWrappedTeamCardShareTarget(searchParams);
+	const isShareTargetRequested = isWrappedTeamCardShareTarget(searchParams);
 	const isWrappedNewUserFlow =
 		forcedFlowStage === WRAPPED_ROUTE_CARD_PROFILE_FLOW;
 
@@ -442,7 +442,7 @@ export function WrappedRouteGate(props: WrappedRouteGateProps) {
 			setupProgress.hasUploadedSessions &&
 			!sessionGateState.hasMinimumSessionCount;
 		const shouldOpenWrappedStoryDirectly =
-			(isForcedStoryFlow || shouldRespectShareTarget) &&
+			(isForcedStoryFlow || isShareTargetRequested) &&
 			setupProgress.hasUploadedSessions &&
 			canContinueToWrappedStory;
 		const shouldShowSessionsLanded =

--- a/apps/web/src/features/wrapped/team-card/page.tsx
+++ b/apps/web/src/features/wrapped/team-card/page.tsx
@@ -22,8 +22,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import {
 	appRoutes,
 	getWrappedShareIdFromSearch,
-	WRAPPED_TEAM_CARD_SHARE_STAGE,
-	WRAPPED_TEAM_CARD_STAGE_QUERY_PARAM,
+	isWrappedTeamCardShareTarget,
 	WRAPPED_VARIANT_DECIMAL,
 	WRAPPED_VARIANT_NORMAL,
 	type WrappedVariant,
@@ -337,10 +336,7 @@ function getWrappedDefaultDevPreviewArchetype() {
 function getRequestedFinalCardStage(
 	searchParams: URLSearchParams,
 ): FinalCardStage {
-	return searchParams.get(WRAPPED_TEAM_CARD_STAGE_QUERY_PARAM) ===
-		WRAPPED_TEAM_CARD_SHARE_STAGE
-		? "share"
-		: "reveal";
+	return isWrappedTeamCardShareTarget(searchParams) ? "share" : "reveal";
 }
 
 function getWrappedTeamCardActivationState(input: {


### PR DESCRIPTION
## Summary
- add a canonical helper for detecting the wrapped final share-card query target
- let eligible wrapped share-card deep links open the final share page directly, including after auth normalizes flow=sessions-landed
- reuse the same target helper inside the final card page stage resolver

## Test plan
- [x] bun run verify