### PR TITLE
fix: require captured wrapped og image

### DIFF
--- a/apps/api/src/__tests__/wrapped-share-card-image.test.ts
+++ b/apps/api/src/__tests__/wrapped-share-card-image.test.ts
@@ -5,6 +5,8 @@ import type {
 } from "@rudel/api-routes";
 import {
 	buildWrappedShareCardSvg,
+	getWrappedShareCardImageMetadata,
+	getWrappedShareCardImagePng,
 	renderWrappedShareCardPng,
 } from "../services/wrapped-share-card-image.js";
 import {
@@ -14,6 +16,8 @@ import {
 
 const SAMPLE_DATA_IMAGE =
 	"data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=";
+const SAMPLE_SOCIAL_IMAGE_DATA_URL =
+	"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
 const sampleSnapshot: WrappedShareSnapshot = {
 	appearance: {
@@ -70,6 +74,29 @@ describe("wrapped share card image", () => {
 		expect(svg).toContain("Evren &lt;Dombak&gt;");
 		expect(svg).toContain("Maniac");
 	});
+
+	test("serves only the browser-captured social image for OG cards", () => {
+		const snapshot = {
+			...sampleSnapshot,
+			socialImageDataUrl: SAMPLE_SOCIAL_IMAGE_DATA_URL,
+		};
+		const png = getWrappedShareCardImagePng(snapshot);
+
+		expect(png).not.toBeNull();
+		expect([...(png ?? new Uint8Array()).subarray(0, 8)]).toEqual([
+			137, 80, 78, 71, 13, 10, 26, 10,
+		]);
+		expect(getWrappedShareCardImageMetadata(snapshot)).toEqual({
+			height: 1,
+			type: "image/png",
+			width: 1,
+		});
+	});
+
+	test("does not fall back to the server SVG card for OG images", () => {
+		expect(getWrappedShareCardImagePng(sampleSnapshot)).toBeNull();
+		expect(getWrappedShareCardImageMetadata(sampleSnapshot)).toBeNull();
+	});
 });
 
 describe("wrapped share page metadata", () => {
@@ -102,5 +129,29 @@ describe("wrapped share page metadata", () => {
 			'name="twitter:image" content="https://app.rudel.ai/wrapped/11111111-1111-4111-8111-111111111111/x-card.png"',
 		);
 		expect(html).toContain("Evren &lt;Dombak&gt; is a Maniac.");
+	});
+
+	test("omits social image tags when no captured share image exists", () => {
+		const metadata = buildWrappedSharePageMetadata({
+			publicUrl:
+				"https://app.rudel.ai/wrapped/11111111-1111-4111-8111-111111111111",
+			share: sampleShare,
+		});
+		const html = injectWrappedSharePageMetadata(
+			[
+				"<html>",
+				"<head>",
+				'<meta name="description" content="generic" />',
+				"<title>Rudel</title>",
+				"</head>",
+				"<body></body>",
+				"</html>",
+			].join(""),
+			metadata,
+		);
+
+		expect(html).toContain('property="og:title"');
+		expect(html).not.toContain("og:image");
+		expect(html).not.toContain("twitter:image");
 	});
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -409,6 +409,10 @@ async function handleWrappedShareCardImageRequest(input: {
 		}
 
 		const image = getWrappedShareCardImagePng(share.snapshot);
+		if (!image) {
+			return new Response("Not found", { headers: cors, status: 404 });
+		}
+
 		const headers = {
 			...cors,
 			"Cache-Control": "public, max-age=300, s-maxage=86400",
@@ -469,19 +473,22 @@ async function handleWrappedPublicPageRequest(input: {
 		}
 
 		const publicUrl = new URL(requestPathname, publicOrigin).toString();
-		const imageUrl = buildWrappedShareCardImageUrl({
-			publicOrigin,
-			requestPathname,
-			share,
-		});
 		const imageMetadata = getWrappedShareCardImageMetadata(share.snapshot);
 		const html = injectWrappedSharePageMetadata(
 			indexHtml,
 			buildWrappedSharePageMetadata({
-				imageHeight: imageMetadata.height,
-				imageType: imageMetadata.type,
-				imageUrl,
-				imageWidth: imageMetadata.width,
+				...(imageMetadata
+					? {
+							imageHeight: imageMetadata.height,
+							imageType: imageMetadata.type,
+							imageUrl: buildWrappedShareCardImageUrl({
+								publicOrigin,
+								requestPathname,
+								share,
+							}),
+							imageWidth: imageMetadata.width,
+						}
+					: {}),
 				publicUrl,
 				share,
 			}),

--- a/apps/api/src/services/wrapped-share-card-image.ts
+++ b/apps/api/src/services/wrapped-share-card-image.ts
@@ -61,10 +61,7 @@ const WRAPPED_SHARE_CARD_PALETTES: Record<
 };
 
 export function getWrappedShareCardImagePng(snapshot: WrappedShareSnapshot) {
-	return (
-		getWrappedShareSocialImagePng(snapshot) ??
-		renderWrappedShareCardPng(snapshot)
-	);
+	return getWrappedShareSocialImagePng(snapshot);
 }
 
 export function getWrappedShareCardImageMetadata(
@@ -73,10 +70,14 @@ export function getWrappedShareCardImageMetadata(
 	const image = getWrappedShareSocialImagePng(snapshot);
 	const size = image ? getPngImageSize(image) : null;
 
+	if (!size) {
+		return null;
+	}
+
 	return {
-		height: size?.height ?? CARD_HEIGHT,
+		height: size.height,
 		type: "image/png",
-		width: size?.width ?? CARD_WIDTH,
+		width: size.width,
 	};
 }
 

--- a/apps/api/src/services/wrapped-share-page-metadata.ts
+++ b/apps/api/src/services/wrapped-share-page-metadata.ts
@@ -7,12 +7,12 @@ const WRAPPED_SHARE_IMAGE_WIDTH = 1200;
 
 interface WrappedSharePageMetadata {
 	description: string;
-	imageAlt: string;
-	imageHeight: number;
+	imageAlt?: string;
+	imageHeight?: number;
 	imageSecureUrl?: string;
-	imageType: string;
-	imageUrl: string;
-	imageWidth: number;
+	imageType?: string;
+	imageUrl?: string;
+	imageWidth?: number;
 	publicUrl: string;
 	title: string;
 }
@@ -20,7 +20,7 @@ interface WrappedSharePageMetadata {
 export function buildWrappedSharePageMetadata(input: {
 	imageHeight?: number;
 	imageType?: string;
-	imageUrl: string;
+	imageUrl?: string;
 	imageWidth?: number;
 	publicUrl: string;
 	share: PublicWrappedShare;
@@ -37,18 +37,26 @@ export function buildWrappedSharePageMetadata(input: {
 	const displayName = snapshot.row.displayName;
 	const title = `${displayName}'s Rudel Wrapped`;
 	const description = `${displayName} is a ${snapshot.archetypeLabel}. ${formatCompactMetric(snapshot.row.totalTokens)} tokens across ${formatCompactMetric(snapshot.row.totalSessions)} sessions. Make yours.`;
+	const baseMetadata = {
+		description,
+		publicUrl,
+		title,
+	};
+
+	if (!imageUrl) {
+		return baseMetadata;
+	}
+
 	const imageSecureUrl = getSecureImageUrl(imageUrl);
 
 	return {
-		description,
+		...baseMetadata,
 		imageAlt: `${displayName}'s Rudel Wrapped card`,
 		imageHeight,
-		imageSecureUrl,
 		imageType: imageType || WRAPPED_SHARE_IMAGE_TYPE,
 		imageUrl,
 		imageWidth,
-		publicUrl,
-		title,
+		...(imageSecureUrl ? { imageSecureUrl } : {}),
 	};
 }
 
@@ -110,21 +118,33 @@ function buildWrappedShareMetadataTags(metadata: WrappedSharePageMetadata) {
 	const title = escapeHtmlAttribute(metadata.title);
 	const description = escapeHtmlAttribute(metadata.description);
 	const publicUrl = escapeHtmlAttribute(metadata.publicUrl);
-	const imageUrl = escapeHtmlAttribute(metadata.imageUrl);
-	const imageSecureUrl = metadata.imageSecureUrl
-		? escapeHtmlAttribute(metadata.imageSecureUrl)
-		: null;
-	const imageAlt = escapeHtmlAttribute(metadata.imageAlt);
-	const imageHeight = Math.round(metadata.imageHeight).toString();
-	const imageWidth = Math.round(metadata.imageWidth).toString();
-
-	return [
+	const baseTags = [
 		`    <meta property="og:type" content="website" />`,
 		`    <meta property="og:site_name" content="Rudel" />`,
 		`    <meta property="og:locale" content="en_US" />`,
 		`    <meta property="og:title" content="${title}" />`,
 		`    <meta property="og:description" content="${description}" />`,
 		`    <meta property="og:url" content="${publicUrl}" />`,
+	];
+
+	if (!metadata.imageUrl) {
+		return baseTags.join("\n");
+	}
+
+	const imageUrl = escapeHtmlAttribute(metadata.imageUrl);
+	const imageSecureUrl = metadata.imageSecureUrl
+		? escapeHtmlAttribute(metadata.imageSecureUrl)
+		: null;
+	const imageAlt = escapeHtmlAttribute(metadata.imageAlt ?? metadata.title);
+	const imageHeight = Math.round(
+		metadata.imageHeight ?? WRAPPED_SHARE_IMAGE_HEIGHT,
+	).toString();
+	const imageWidth = Math.round(
+		metadata.imageWidth ?? WRAPPED_SHARE_IMAGE_WIDTH,
+	).toString();
+
+	return [
+		...baseTags,
 		`    <meta property="og:image" content="${imageUrl}" />`,
 		`    <meta property="og:image:url" content="${imageUrl}" />`,
 		...(imageSecureUrl
@@ -132,7 +152,7 @@ function buildWrappedShareMetadataTags(metadata: WrappedSharePageMetadata) {
 					`    <meta property="og:image:secure_url" content="${imageSecureUrl}" />`,
 				]
 			: []),
-		`    <meta property="og:image:type" content="${escapeHtmlAttribute(metadata.imageType)}" />`,
+		`    <meta property="og:image:type" content="${escapeHtmlAttribute(metadata.imageType ?? WRAPPED_SHARE_IMAGE_TYPE)}" />`,
 		`    <meta property="og:image:width" content="${imageWidth}" />`,
 		`    <meta property="og:image:height" content="${imageHeight}" />`,
 		`    <meta property="og:image:alt" content="${imageAlt}" />`,


### PR DESCRIPTION
## Summary
- stop serving the server-rendered fallback SVG as the public wrapped OG image
- omit OG/Twitter image tags when a share does not have the captured browser social image
- keep serving metadata and the PNG only when the exact captured share-card image exists

## Test plan
- [x] bun run verify