### PR TITLE
fix: preserve pending email login codes

### DIFF
--- a/apps/web/src/features/auth/AuthStateRefresh.test.tsx
+++ b/apps/web/src/features/auth/AuthStateRefresh.test.tsx
@@ -14,6 +14,7 @@ import {
 	isGetStartedPath,
 	primePendingSignupRedirect,
 } from "./auth-route-utils";
+import { readPendingEmailLoginCodeDraft } from "./email-code-auth";
 import { LoginForm } from "./LoginForm";
 import { SignupForm } from "./SignupForm";
 
@@ -74,6 +75,7 @@ describe("auth state refresh", () => {
 		mockNavigateToDestination.mockReset();
 		mockRefreshAuthClientState.mockReset();
 		mockTrackAuthenticationAction.mockReset();
+		window.sessionStorage.clear();
 	});
 
 	it("routes homepage email signups to the wrapped card profile flow", () => {
@@ -432,6 +434,45 @@ describe("auth state refresh", () => {
 
 		expect(mockRefreshAuthClientState).toHaveBeenCalledTimes(1);
 		expect(window.location.search).toBe("");
+	});
+
+	it("restores a pending email sign in code after remounting", async () => {
+		mockSendVerificationOtp.mockResolvedValue({ error: null });
+		mockSignInEmailOtp.mockResolvedValue({ error: null });
+
+		const user = userEvent.setup();
+		const view = render(<LoginForm onSwitchToSignup={vi.fn()} />);
+
+		await user.click(screen.getByRole("button", { name: "Log in with Email" }));
+		await user.type(screen.getByLabelText("Email"), "ada@example.com");
+		await user.click(screen.getByRole("button", { name: "Send code" }));
+
+		await waitFor(() => {
+			expect(mockSendVerificationOtp).toHaveBeenCalledWith({
+				email: "ada@example.com",
+				type: "sign-in",
+			});
+		});
+
+		view.unmount();
+		render(<LoginForm onSwitchToSignup={vi.fn()} />);
+
+		expect(screen.getByLabelText("Email")).toHaveValue("ada@example.com");
+		expect(screen.getByLabelText("Email code")).toHaveValue("");
+		expect(
+			screen.getByRole("button", { name: "Verify code" }),
+		).toBeInTheDocument();
+
+		await user.type(screen.getByLabelText("Email code"), "123456");
+		await user.click(screen.getByRole("button", { name: "Verify code" }));
+
+		await waitFor(() => {
+			expect(mockSignInEmailOtp).toHaveBeenCalledWith({
+				email: "ada@example.com",
+				otp: "123456",
+			});
+		});
+		expect(readPendingEmailLoginCodeDraft()).toBeNull();
 	});
 
 	it("hard-navigates wrapped logins back into wrapped", async () => {

--- a/apps/web/src/features/auth/GuestApp.test.tsx
+++ b/apps/web/src/features/auth/GuestApp.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { writePendingEmailLoginCodeDraft } from "./email-code-auth";
 import { GuestApp } from "./GuestApp";
 
 vi.mock("./LoginForm", () => ({
@@ -11,10 +12,23 @@ vi.mock("./SignupForm", () => ({
 }));
 
 describe("GuestApp", () => {
+	beforeEach(() => {
+		window.sessionStorage.clear();
+	});
+
 	it("shows sign up first", () => {
 		render(<GuestApp />);
 
 		expect(screen.getByText("Signup form")).toBeInTheDocument();
 		expect(screen.queryByText("Login form")).not.toBeInTheDocument();
+	});
+
+	it("shows login first when an email login code is pending", () => {
+		writePendingEmailLoginCodeDraft("ada@example.com");
+
+		render(<GuestApp />);
+
+		expect(screen.getByText("Login form")).toBeInTheDocument();
+		expect(screen.queryByText("Signup form")).not.toBeInTheDocument();
 	});
 });

--- a/apps/web/src/features/auth/GuestApp.tsx
+++ b/apps/web/src/features/auth/GuestApp.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { hasPendingEmailLoginCodeDraft } from "@/features/auth/email-code-auth";
 import { LoginForm } from "@/features/auth/LoginForm";
 import { SignupForm } from "@/features/auth/SignupForm";
 
@@ -14,7 +15,9 @@ interface GuestAppProps {
 
 export function GuestApp(props: GuestAppProps = {}) {
 	const { description, eyebrow, showLogo = true, title } = props;
-	const [page, setPage] = useState<Page>("signup");
+	const [page, setPage] = useState<Page>(() =>
+		hasPendingEmailLoginCodeDraft() ? "login" : "signup",
+	);
 
 	return (
 		<div className="flex min-h-screen flex-col items-center justify-center gap-6">

--- a/apps/web/src/features/auth/LoginForm.tsx
+++ b/apps/web/src/features/auth/LoginForm.tsx
@@ -14,12 +14,15 @@ import {
 	getSocialLoginRedirectOptions,
 } from "./auth-route-utils";
 import {
+	clearPendingEmailLoginCodeDraft,
 	type EmailAuthFeedback,
 	type EmailCodeStage,
 	isValidAuthEmail,
 	isValidEmailCode,
 	normalizeAuthEmail,
+	readPendingEmailLoginCodeDraft,
 	sanitizeEmailCodeInput,
+	writePendingEmailLoginCodeDraft,
 } from "./email-code-auth";
 import {
 	recordOAuthRedirectResult,
@@ -50,13 +53,27 @@ export function LoginForm(props: LoginFormProps) {
 		onSwitchToSignup,
 		variant = "default",
 	} = props;
-	const [email, setEmail] = useState("");
+	const [initialLoginDraft] = useState(readPendingEmailLoginCodeDraft);
+	const [email, setEmail] = useState(() => initialLoginDraft?.email ?? "");
 	const [emailCode, setEmailCode] = useState("");
-	const [emailCodeStage, setEmailCodeStage] = useState<EmailCodeStage>("email");
-	const [feedback, setFeedback] = useState<EmailAuthFeedback>(null);
+	const [emailCodeStage, setEmailCodeStage] = useState<EmailCodeStage>(() =>
+		initialLoginDraft ? "code" : "email",
+	);
+	const [feedback, setFeedback] = useState<EmailAuthFeedback>(() =>
+		initialLoginDraft
+			? {
+					kind: "success",
+					message: `Code sent to ${initialLoginDraft.email}.`,
+				}
+			: null,
+	);
 	const [loading, setLoading] = useState(false);
-	const [showEmailForm, setShowEmailForm] = useState(false);
-	const [wrappedScene, setWrappedScene] = useState<WrappedAuthScene>("choice");
+	const [showEmailForm, setShowEmailForm] = useState(
+		() => initialLoginDraft !== null,
+	);
+	const [wrappedScene, setWrappedScene] = useState<WrappedAuthScene>(() =>
+		initialLoginDraft ? "credentials" : "choice",
+	);
 	const { trackAuthenticationAction } = useAnalyticsTracking({
 		pageName: "login",
 	});
@@ -132,6 +149,7 @@ export function LoginForm(props: LoginFormProps) {
 			return;
 		}
 
+		clearPendingEmailLoginCodeDraft();
 		refreshAuthClientState();
 		navigateToDestination(successDestination);
 	}
@@ -182,6 +200,7 @@ export function LoginForm(props: LoginFormProps) {
 		setEmailCode("");
 		setEmailCodeStage("code");
 		setWrappedScene("credentials");
+		writePendingEmailLoginCodeDraft(loginEmail);
 		setFeedback({
 			kind: "success",
 			message: `Code sent to ${loginEmail}.`,
@@ -189,6 +208,7 @@ export function LoginForm(props: LoginFormProps) {
 	}
 
 	async function handleSocialSignIn(provider: "google" | "github") {
+		clearPendingEmailLoginCodeDraft();
 		setFeedback(null);
 		trackAuthenticationAction({
 			actionName: "sign_in",
@@ -239,6 +259,7 @@ export function LoginForm(props: LoginFormProps) {
 	}
 
 	function handleOpenWrappedEmail() {
+		clearPendingEmailLoginCodeDraft();
 		setFeedback(null);
 		setEmailCode("");
 		setEmailCodeStage("email");
@@ -266,6 +287,7 @@ export function LoginForm(props: LoginFormProps) {
 	}
 
 	function handleReturnToWrappedChoice() {
+		clearPendingEmailLoginCodeDraft();
 		setFeedback(null);
 		setEmailCode("");
 		setEmailCodeStage("email");
@@ -377,6 +399,7 @@ export function LoginForm(props: LoginFormProps) {
 									variant="ghost"
 									size="xs"
 									onClick={() => {
+										clearPendingEmailLoginCodeDraft();
 										setFeedback(null);
 										setEmailCode("");
 										setEmailCodeStage("email");
@@ -439,6 +462,7 @@ export function LoginForm(props: LoginFormProps) {
 						<button
 							type="button"
 							onClick={() => {
+								clearPendingEmailLoginCodeDraft();
 								trackAuthenticationAction({
 									actionName: "open_signup",
 									sourceComponent: "login_form",

--- a/apps/web/src/features/auth/email-code-auth.ts
+++ b/apps/web/src/features/auth/email-code-auth.ts
@@ -1,4 +1,6 @@
 export const EMAIL_CODE_LENGTH = 6;
+const LOGIN_CODE_DRAFT_STORAGE_KEY = "rudel:email-login-code-draft";
+const LOGIN_CODE_DRAFT_MAX_AGE_MS = 15 * 60 * 1000;
 
 export type EmailCodeStage = "email" | "code";
 
@@ -6,6 +8,10 @@ export type EmailAuthFeedback = {
 	kind: "error" | "success";
 	message: string;
 } | null;
+
+export interface PendingEmailLoginCodeDraft {
+	email: string;
+}
 
 export function normalizeAuthEmail(email: string) {
 	return email.trim();
@@ -21,4 +27,88 @@ export function sanitizeEmailCodeInput(value: string) {
 
 export function isValidEmailCode(code: string) {
 	return code.length === EMAIL_CODE_LENGTH;
+}
+
+export function readPendingEmailLoginCodeDraft(): PendingEmailLoginCodeDraft | null {
+	if (typeof window === "undefined") {
+		return null;
+	}
+
+	const rawDraft = window.sessionStorage.getItem(LOGIN_CODE_DRAFT_STORAGE_KEY);
+	if (!rawDraft) {
+		return null;
+	}
+
+	try {
+		const parsed: unknown = JSON.parse(rawDraft);
+		if (!isStoredPendingEmailLoginCodeDraft(parsed)) {
+			clearPendingEmailLoginCodeDraft();
+			return null;
+		}
+
+		if (Date.now() - parsed.updatedAt > LOGIN_CODE_DRAFT_MAX_AGE_MS) {
+			clearPendingEmailLoginCodeDraft();
+			return null;
+		}
+
+		return { email: parsed.email };
+	} catch {
+		clearPendingEmailLoginCodeDraft();
+		return null;
+	}
+}
+
+export function writePendingEmailLoginCodeDraft(email: string) {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	const loginEmail = normalizeAuthEmail(email);
+	if (!isValidAuthEmail(loginEmail)) {
+		clearPendingEmailLoginCodeDraft();
+		return;
+	}
+
+	try {
+		window.sessionStorage.setItem(
+			LOGIN_CODE_DRAFT_STORAGE_KEY,
+			JSON.stringify({
+				email: loginEmail,
+				updatedAt: Date.now(),
+			}),
+		);
+	} catch {
+		// Best effort only: the controlled inputs still retain state in memory.
+	}
+}
+
+export function clearPendingEmailLoginCodeDraft() {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	try {
+		window.sessionStorage.removeItem(LOGIN_CODE_DRAFT_STORAGE_KEY);
+	} catch {
+		// Ignore blocked storage.
+	}
+}
+
+export function hasPendingEmailLoginCodeDraft() {
+	return readPendingEmailLoginCodeDraft() !== null;
+}
+
+function isStoredPendingEmailLoginCodeDraft(
+	value: unknown,
+): value is PendingEmailLoginCodeDraft & { updatedAt: number } {
+	return (
+		isRecord(value) &&
+		typeof value.email === "string" &&
+		isValidAuthEmail(value.email) &&
+		typeof value.updatedAt === "number"
+	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
## Summary
- persist pending email-login code state in sessionStorage for 15 minutes
- restore the login code step after remounts or tab reloads
- start guest auth on login when a login-code draft is pending
- add focused coverage for remount persistence and guest auth defaulting

## Test plan
- [x] bunx --no-install biome check apps/web/src/features/auth/email-code-auth.ts apps/web/src/features/auth/LoginForm.tsx apps/web/src/features/auth/GuestApp.tsx apps/web/src/features/auth/AuthStateRefresh.test.tsx apps/web/src/features/auth/GuestApp.test.tsx
- [x] bun run --cwd apps/web test src/features/auth/AuthStateRefresh.test.tsx src/features/auth/GuestApp.test.tsx
- [x] bun run --cwd apps/web check-types
- [x] bun run verify