### PR TITLE
test: preserve clickhouse mock exports

### DIFF
--- a/apps/api/src/services/wrapped-archetype-rebuild.service.test.ts
+++ b/apps/api/src/services/wrapped-archetype-rebuild.service.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { ClickHouseStatement } from "../clickhouse.js";
 
+const clickhouseModule = await import("../clickhouse.js");
+
 const executeCalls: ClickHouseStatement[] = [];
 const execute = mock((statement: ClickHouseStatement) => {
 	executeCalls.push(statement);
@@ -8,6 +10,7 @@ const execute = mock((statement: ClickHouseStatement) => {
 });
 
 mock.module("../clickhouse.js", () => ({
+	...clickhouseModule,
 	getClickhouse: () => ({
 		execute,
 		insert: mock(() => Promise.resolve()),


### PR DESCRIPTION
## Summary
- preserve real ClickHouse module exports when mocking `getClickhouse` in the wrapped archetype rebuild test
- prevent Bun test-order/mock leakage from breaking API tests that import ClickHouse helper exports

## Test plan
- [x] bunx --no-install biome check apps/api/src/services/wrapped-archetype-rebuild.service.test.ts
- [x] bun test src/__tests__/clickhouse.test.ts src/__tests__/org-session.service.test.ts src/services/wrapped.service.test.ts src/services/wrapped-archetype-rebuild.service.test.ts
- [x] bun test (from apps/api)
- [x] bun run verify