### PR TITLE
fix: preserve default email auth codes

### DIFF
--- a/apps/web/src/features/auth/AuthStateRefresh.test.tsx
+++ b/apps/web/src/features/auth/AuthStateRefresh.test.tsx
@@ -14,7 +14,10 @@ import {
 	isGetStartedPath,
 	primePendingSignupRedirect,
 } from "./auth-route-utils";
-import { readPendingEmailLoginCodeDraft } from "./email-code-auth";
+import {
+	readPendingEmailLoginCodeDraft,
+	readPendingEmailSignupCodeDraft,
+} from "./email-code-auth";
 import { LoginForm } from "./LoginForm";
 import { SignupForm } from "./SignupForm";
 
@@ -75,6 +78,7 @@ describe("auth state refresh", () => {
 		mockNavigateToDestination.mockReset();
 		mockRefreshAuthClientState.mockReset();
 		mockTrackAuthenticationAction.mockReset();
+		window.localStorage.clear();
 		window.sessionStorage.clear();
 	});
 
@@ -352,6 +356,56 @@ describe("auth state refresh", () => {
 		expect(mockNavigateToDestination).not.toHaveBeenCalled();
 	});
 
+	it("restores a pending default email sign up code after remounting", async () => {
+		mockSendVerificationOtp.mockResolvedValue({ error: null });
+		mockSignInEmailOtp.mockResolvedValue({ error: null });
+
+		const user = userEvent.setup();
+		const view = render(<SignupForm onSwitchToLogin={vi.fn()} />);
+
+		await user.click(
+			screen.getByRole("button", { name: "Create account with Email" }),
+		);
+		await user.type(screen.getByLabelText("Email"), "ada.lovelace@example.com");
+		await user.click(screen.getByRole("button", { name: "Send code" }));
+
+		await waitFor(() => {
+			expect(mockSendVerificationOtp).toHaveBeenCalledWith({
+				email: "ada.lovelace@example.com",
+				type: "sign-in",
+			});
+		});
+
+		expect(readPendingEmailSignupCodeDraft()).toEqual({
+			email: "ada.lovelace@example.com",
+			mode: "signup",
+		});
+
+		window.sessionStorage.clear();
+		view.unmount();
+		render(<SignupForm onSwitchToLogin={vi.fn()} />);
+
+		expect(screen.getByLabelText("Email")).toHaveValue(
+			"ada.lovelace@example.com",
+		);
+		expect(screen.getByLabelText("Email code")).toHaveValue("");
+		expect(
+			screen.getByRole("button", { name: "Verify code" }),
+		).toBeInTheDocument();
+
+		await user.type(screen.getByLabelText("Email code"), "123456");
+		await user.click(screen.getByRole("button", { name: "Verify code" }));
+
+		await waitFor(() => {
+			expect(mockSignInEmailOtp).toHaveBeenCalledWith({
+				name: "Ada Lovelace",
+				email: "ada.lovelace@example.com",
+				otp: "123456",
+			});
+		});
+		expect(readPendingEmailSignupCodeDraft()).toBeNull();
+	});
+
 	it("uses separate existing-user and new-user destinations for homepage social sign up", async () => {
 		mockSignInSocial.mockResolvedValue({ error: null });
 
@@ -454,6 +508,7 @@ describe("auth state refresh", () => {
 			});
 		});
 
+		window.sessionStorage.clear();
 		view.unmount();
 		render(<LoginForm onSwitchToSignup={vi.fn()} />);
 

--- a/apps/web/src/features/auth/GuestApp.test.tsx
+++ b/apps/web/src/features/auth/GuestApp.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { writePendingEmailLoginCodeDraft } from "./email-code-auth";
+import {
+	writePendingEmailLoginCodeDraft,
+	writePendingEmailSignupCodeDraft,
+} from "./email-code-auth";
 import { GuestApp } from "./GuestApp";
 
 vi.mock("./LoginForm", () => ({
@@ -13,6 +16,7 @@ vi.mock("./SignupForm", () => ({
 
 describe("GuestApp", () => {
 	beforeEach(() => {
+		window.localStorage.clear();
 		window.sessionStorage.clear();
 	});
 
@@ -30,5 +34,14 @@ describe("GuestApp", () => {
 
 		expect(screen.getByText("Login form")).toBeInTheDocument();
 		expect(screen.queryByText("Signup form")).not.toBeInTheDocument();
+	});
+
+	it("keeps signup first when an email signup code is pending", () => {
+		writePendingEmailSignupCodeDraft("ada@example.com");
+
+		render(<GuestApp />);
+
+		expect(screen.getByText("Signup form")).toBeInTheDocument();
+		expect(screen.queryByText("Login form")).not.toBeInTheDocument();
 	});
 });

--- a/apps/web/src/features/auth/GuestApp.tsx
+++ b/apps/web/src/features/auth/GuestApp.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { hasPendingEmailLoginCodeDraft } from "@/features/auth/email-code-auth";
+import { readPendingEmailCodeDraft } from "@/features/auth/email-code-auth";
 import { LoginForm } from "@/features/auth/LoginForm";
 import { SignupForm } from "@/features/auth/SignupForm";
 
@@ -15,8 +15,8 @@ interface GuestAppProps {
 
 export function GuestApp(props: GuestAppProps = {}) {
 	const { description, eyebrow, showLogo = true, title } = props;
-	const [page, setPage] = useState<Page>(() =>
-		hasPendingEmailLoginCodeDraft() ? "login" : "signup",
+	const [page, setPage] = useState<Page>(
+		() => readPendingEmailCodeDraft()?.mode ?? "signup",
 	);
 
 	return (

--- a/apps/web/src/features/auth/SignupForm.tsx
+++ b/apps/web/src/features/auth/SignupForm.tsx
@@ -19,12 +19,15 @@ import {
 	primePendingSignupRedirect,
 } from "./auth-route-utils";
 import {
+	clearPendingEmailCodeDraft,
 	type EmailAuthFeedback,
 	type EmailCodeStage,
 	isValidAuthEmail,
 	isValidEmailCode,
 	normalizeAuthEmail,
+	readPendingEmailSignupCodeDraft,
 	sanitizeEmailCodeInput,
+	writePendingEmailSignupCodeDraft,
 } from "./email-code-auth";
 import {
 	recordOAuthRedirectResult,
@@ -82,13 +85,27 @@ export function SignupForm(props: SignupFormProps) {
 		onSwitchToLogin,
 		variant = "default",
 	} = props;
-	const [email, setEmail] = useState("");
+	const [initialSignupDraft] = useState(readPendingEmailSignupCodeDraft);
+	const [email, setEmail] = useState(() => initialSignupDraft?.email ?? "");
 	const [emailCode, setEmailCode] = useState("");
-	const [emailCodeStage, setEmailCodeStage] = useState<EmailCodeStage>("email");
-	const [feedback, setFeedback] = useState<EmailAuthFeedback>(null);
+	const [emailCodeStage, setEmailCodeStage] = useState<EmailCodeStage>(() =>
+		initialSignupDraft ? "code" : "email",
+	);
+	const [feedback, setFeedback] = useState<EmailAuthFeedback>(() =>
+		initialSignupDraft
+			? {
+					kind: "success",
+					message: `Code sent to ${initialSignupDraft.email}.`,
+				}
+			: null,
+	);
 	const [loading, setLoading] = useState(false);
-	const [showEmailForm, setShowEmailForm] = useState(false);
-	const [wrappedScene, setWrappedScene] = useState<WrappedAuthScene>("choice");
+	const [showEmailForm, setShowEmailForm] = useState(
+		() => initialSignupDraft !== null,
+	);
+	const [wrappedScene, setWrappedScene] = useState<WrappedAuthScene>(() =>
+		initialSignupDraft ? "credentials" : "choice",
+	);
 	const { trackAuthenticationAction } = useAnalyticsTracking({
 		pageName: "signup",
 	});
@@ -170,6 +187,7 @@ export function SignupForm(props: SignupFormProps) {
 			return;
 		}
 
+		clearPendingEmailCodeDraft();
 		refreshAuthClientState();
 		navigateToDestination(successDestination);
 	}
@@ -228,6 +246,7 @@ export function SignupForm(props: SignupFormProps) {
 		setEmailCode("");
 		setEmailCodeStage("code");
 		setWrappedScene("credentials");
+		writePendingEmailSignupCodeDraft(signupEmail);
 		setFeedback({
 			kind: "success",
 			message: `Code sent to ${signupEmail}.`,
@@ -235,6 +254,7 @@ export function SignupForm(props: SignupFormProps) {
 	}
 
 	async function handleSocialSignIn(provider: "google" | "github") {
+		clearPendingEmailCodeDraft();
 		setFeedback(null);
 		const { callbackURL, newUserCallbackURL } =
 			getSocialSignupRedirectOptions();
@@ -291,6 +311,7 @@ export function SignupForm(props: SignupFormProps) {
 	}
 
 	function handleOpenWrappedEmail() {
+		clearPendingEmailCodeDraft();
 		setFeedback(null);
 		setEmailCode("");
 		setEmailCodeStage("email");
@@ -318,6 +339,7 @@ export function SignupForm(props: SignupFormProps) {
 	}
 
 	function handleReturnToWrappedChoice() {
+		clearPendingEmailCodeDraft();
 		setFeedback(null);
 		setEmailCode("");
 		setEmailCodeStage("email");
@@ -428,6 +450,7 @@ export function SignupForm(props: SignupFormProps) {
 									variant="ghost"
 									size="xs"
 									onClick={() => {
+										clearPendingEmailCodeDraft();
 										setFeedback(null);
 										setEmailCode("");
 										setEmailCodeStage("email");
@@ -490,6 +513,7 @@ export function SignupForm(props: SignupFormProps) {
 						<button
 							type="button"
 							onClick={() => {
+								clearPendingEmailCodeDraft();
 								trackAuthenticationAction({
 									actionName: "open_login",
 									sourceComponent: "signup_form",

--- a/apps/web/src/features/auth/email-code-auth.ts
+++ b/apps/web/src/features/auth/email-code-auth.ts
@@ -3,6 +3,7 @@ const LOGIN_CODE_DRAFT_STORAGE_KEY = "rudel:email-login-code-draft";
 const LOGIN_CODE_DRAFT_MAX_AGE_MS = 15 * 60 * 1000;
 
 export type EmailCodeStage = "email" | "code";
+export type EmailCodeAuthMode = "login" | "signup";
 
 export type EmailAuthFeedback = {
 	kind: "error" | "success";
@@ -11,7 +12,21 @@ export type EmailAuthFeedback = {
 
 export interface PendingEmailLoginCodeDraft {
 	email: string;
+	mode: "login";
 }
+
+export interface PendingEmailSignupCodeDraft {
+	email: string;
+	mode: "signup";
+}
+
+export type PendingEmailCodeDraft =
+	| PendingEmailLoginCodeDraft
+	| PendingEmailSignupCodeDraft;
+
+type StoredPendingEmailCodeDraft = PendingEmailCodeDraft & {
+	updatedAt: number;
+};
 
 export function normalizeAuthEmail(email: string) {
 	return email.trim();
@@ -29,84 +44,208 @@ export function isValidEmailCode(code: string) {
 	return code.length === EMAIL_CODE_LENGTH;
 }
 
-export function readPendingEmailLoginCodeDraft(): PendingEmailLoginCodeDraft | null {
+export function readPendingEmailCodeDraft(): PendingEmailCodeDraft | null {
 	if (typeof window === "undefined") {
 		return null;
 	}
 
-	const rawDraft = window.sessionStorage.getItem(LOGIN_CODE_DRAFT_STORAGE_KEY);
-	if (!rawDraft) {
+	let latestDraft: StoredPendingEmailCodeDraft | null = null;
+
+	for (const storage of getDraftStorageAreas()) {
+		const draft = readStoredPendingEmailCodeDraft(storage);
+		if (!draft) {
+			continue;
+		}
+
+		if (!latestDraft || draft.updatedAt > latestDraft.updatedAt) {
+			latestDraft = draft;
+		}
+	}
+
+	if (!latestDraft) {
 		return null;
 	}
 
-	try {
-		const parsed: unknown = JSON.parse(rawDraft);
-		if (!isStoredPendingEmailLoginCodeDraft(parsed)) {
-			clearPendingEmailLoginCodeDraft();
-			return null;
-		}
-
-		if (Date.now() - parsed.updatedAt > LOGIN_CODE_DRAFT_MAX_AGE_MS) {
-			clearPendingEmailLoginCodeDraft();
-			return null;
-		}
-
-		return { email: parsed.email };
-	} catch {
-		clearPendingEmailLoginCodeDraft();
-		return null;
-	}
+	return {
+		email: latestDraft.email,
+		mode: latestDraft.mode,
+	};
 }
 
-export function writePendingEmailLoginCodeDraft(email: string) {
+export function readPendingEmailLoginCodeDraft(): PendingEmailLoginCodeDraft | null {
+	const draft = readPendingEmailCodeDraft();
+	if (draft?.mode !== "login") {
+		return null;
+	}
+
+	return draft;
+}
+
+export function readPendingEmailSignupCodeDraft(): PendingEmailSignupCodeDraft | null {
+	const draft = readPendingEmailCodeDraft();
+	if (draft?.mode !== "signup") {
+		return null;
+	}
+
+	return draft;
+}
+
+export function writePendingEmailCodeDraft(
+	mode: EmailCodeAuthMode,
+	email: string,
+) {
 	if (typeof window === "undefined") {
 		return;
 	}
 
 	const loginEmail = normalizeAuthEmail(email);
 	if (!isValidAuthEmail(loginEmail)) {
-		clearPendingEmailLoginCodeDraft();
+		clearPendingEmailCodeDraft();
 		return;
 	}
 
+	const draft: StoredPendingEmailCodeDraft = {
+		email: loginEmail,
+		mode,
+		updatedAt: Date.now(),
+	};
+	const serializedDraft = JSON.stringify(draft);
+
+	for (const storage of getDraftStorageAreas()) {
+		writeStoredPendingEmailCodeDraft(storage, serializedDraft);
+	}
+}
+
+export function writePendingEmailLoginCodeDraft(email: string) {
+	writePendingEmailCodeDraft("login", email);
+}
+
+export function writePendingEmailSignupCodeDraft(email: string) {
+	writePendingEmailCodeDraft("signup", email);
+}
+
+export function clearPendingEmailCodeDraft() {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	for (const storage of getDraftStorageAreas()) {
+		removeStoredPendingEmailCodeDraft(storage);
+	}
+}
+
+export function clearPendingEmailLoginCodeDraft() {
+	clearPendingEmailCodeDraft();
+}
+
+function getDraftStorageAreas(): Storage[] {
+	if (typeof window === "undefined") {
+		return [];
+	}
+
+	return [
+		getDraftStorageArea("localStorage"),
+		getDraftStorageArea("sessionStorage"),
+	].filter((storageArea) => storageArea !== null);
+}
+
+function getDraftStorageArea(
+	storageName: "localStorage" | "sessionStorage",
+): Storage | null {
 	try {
-		window.sessionStorage.setItem(
-			LOGIN_CODE_DRAFT_STORAGE_KEY,
-			JSON.stringify({
-				email: loginEmail,
-				updatedAt: Date.now(),
-			}),
-		);
+		return storageName === "localStorage"
+			? window.localStorage
+			: window.sessionStorage;
+	} catch {
+		return null;
+	}
+}
+
+function readStoredPendingEmailCodeDraft(
+	storage: Storage,
+): StoredPendingEmailCodeDraft | null {
+	try {
+		const rawDraft = storage.getItem(LOGIN_CODE_DRAFT_STORAGE_KEY);
+		if (!rawDraft) {
+			return null;
+		}
+
+		const parsed: unknown = JSON.parse(rawDraft);
+		const draft = parseStoredPendingEmailCodeDraft(parsed);
+		if (!draft) {
+			removeStoredPendingEmailCodeDraft(storage);
+			return null;
+		}
+
+		if (Date.now() - draft.updatedAt > LOGIN_CODE_DRAFT_MAX_AGE_MS) {
+			removeStoredPendingEmailCodeDraft(storage);
+			return null;
+		}
+
+		return draft;
+	} catch {
+		removeStoredPendingEmailCodeDraft(storage);
+		return null;
+	}
+}
+
+function writeStoredPendingEmailCodeDraft(
+	storage: Storage,
+	serializedDraft: string,
+) {
+	try {
+		storage.setItem(LOGIN_CODE_DRAFT_STORAGE_KEY, serializedDraft);
 	} catch {
 		// Best effort only: the controlled inputs still retain state in memory.
 	}
 }
 
-export function clearPendingEmailLoginCodeDraft() {
-	if (typeof window === "undefined") {
-		return;
-	}
-
+function removeStoredPendingEmailCodeDraft(storage: Storage) {
 	try {
-		window.sessionStorage.removeItem(LOGIN_CODE_DRAFT_STORAGE_KEY);
+		storage.removeItem(LOGIN_CODE_DRAFT_STORAGE_KEY);
 	} catch {
 		// Ignore blocked storage.
 	}
 }
 
-export function hasPendingEmailLoginCodeDraft() {
-	return readPendingEmailLoginCodeDraft() !== null;
+function parseStoredPendingEmailCodeDraft(
+	value: unknown,
+): StoredPendingEmailCodeDraft | null {
+	if (!isRecord(value)) {
+		return null;
+	}
+
+	const mode = getStoredPendingEmailCodeMode(value);
+
+	if (
+		typeof value.email !== "string" ||
+		!isValidAuthEmail(value.email) ||
+		mode === null ||
+		typeof value.updatedAt !== "number" ||
+		!Number.isFinite(value.updatedAt)
+	) {
+		return null;
+	}
+
+	return {
+		email: value.email,
+		mode,
+		updatedAt: value.updatedAt,
+	};
 }
 
-function isStoredPendingEmailLoginCodeDraft(
-	value: unknown,
-): value is PendingEmailLoginCodeDraft & { updatedAt: number } {
-	return (
-		isRecord(value) &&
-		typeof value.email === "string" &&
-		isValidAuthEmail(value.email) &&
-		typeof value.updatedAt === "number"
-	);
+function getStoredPendingEmailCodeMode(
+	value: Record<string, unknown>,
+): EmailCodeAuthMode | null {
+	if (value.mode === "login" || value.mode === "signup") {
+		return value.mode;
+	}
+
+	if (!("mode" in value)) {
+		return "login";
+	}
+
+	return null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary
- persist pending email OTP drafts for both default signup and login flows
- restore the right default auth screen and code-entry state after remounts/reloads
- keep legacy login drafts readable and clear pending OTP drafts on success or auth-path changes

## Test plan
- [x] bunx --no-install biome check apps/web/src/features/auth/email-code-auth.ts apps/web/src/features/auth/LoginForm.tsx apps/web/src/features/auth/SignupForm.tsx apps/web/src/features/auth/GuestApp.tsx apps/web/src/features/auth/AuthStateRefresh.test.tsx apps/web/src/features/auth/GuestApp.test.tsx
- [x] bun run --cwd apps/web test src/features/auth/AuthStateRefresh.test.tsx src/features/auth/GuestApp.test.tsx
- [x] bun run --cwd apps/web check-types
- [x] bun run verify