### PR TITLE
refactor: simplify team roster and session detail UI data

### DIFF
--- a/apps/web/src/features/sessions/components/SessionDetailView.tsx
+++ b/apps/web/src/features/sessions/components/SessionDetailView.tsx
@@ -6,23 +6,16 @@ import { InfoTooltip } from "@/components/ui/InfoTooltip";
 import { useTrackProductPageView } from "@/features/analytics/tracking/useTrackProductPageView";
 import { DashboardModelBadges } from "@/features/dashboard/components/DashboardModelBadges";
 import { useUserMap } from "@/features/workspace/hooks/useUserMap";
-import { calculateCost, formatUsername } from "@/lib/format";
 import { orpc } from "@/lib/orpc";
 import { formatRelativeTime } from "@/lib/time-utils";
+import { buildSessionDetailViewModel } from "./session-detail-view-model";
 import {
-	createSessionMetadataBadges,
-	getConversationSummary,
 	isForbiddenError,
 	SessionDetailErrorBoundary,
 	SessionDetailHoverTooltip,
 	SessionDetailMetric,
 	SessionTranscriptSummaryTab,
 	sessionArchetypeStyles,
-	toContentString,
-	toNumber,
-	toOptionalString,
-	toStringArray,
-	toSubagentMap,
 } from "./session-detail-view-parts";
 
 type SessionDetailViewProps = {
@@ -175,53 +168,29 @@ export function SessionDetailView({
 		);
 	}
 
-	const safeSessionId = session.session_id || "unknown-session";
-	const safeSessionDate = toOptionalString(session.session_date) ?? "";
-	const safeUserId = toOptionalString(session.user_id) ?? "unknown-user";
-	const safeUserDisplayName =
-		safeUserId === "unknown-user"
-			? "User"
-			: formatUsername(safeUserId, userMap);
-	const safeInputTokens = toNumber(session.input_tokens);
-	const safeOutputTokens = toNumber(session.output_tokens);
-	const safeDurationMin =
-		session.duration_min === undefined
-			? undefined
-			: toNumber(session.duration_min);
-	const safeTotalInteractions =
-		session.total_interactions === undefined
-			? undefined
-			: toNumber(session.total_interactions);
-	const safeSuccessScore =
-		session.success_score === undefined
-			? undefined
-			: toNumber(session.success_score);
-	const safeSkills = toStringArray(session.skills);
-	const safeSlashCommands = toStringArray(session.slash_commands);
-	const safeSubagents = toSubagentMap(session.subagents);
-	const safeRepository = toOptionalString(session.repository);
-	const safeGitBranch = toOptionalString(session.git_branch);
-	const safeGitSha = toOptionalString(session.git_sha);
-	const safeModelUsed = toOptionalString(session.model_used) ?? undefined;
-	const safeSessionArchetype =
-		toOptionalString(session.session_archetype) ?? undefined;
-	const safeContent = toContentString(session.content);
-	const metadataBadges = createSessionMetadataBadges({
-		gitBranch: safeGitBranch,
-		repository: safeRepository,
-	});
-	const conversationSummary = getConversationSummary(safeContent);
-	const subagentNames = Object.keys(safeSubagents);
+	const {
+		conversationSummary,
+		costLabel,
+		metadataBadges,
+		safeContent,
+		safeDurationMin,
+		safeGitSha,
+		safeModelUsed,
+		safeSessionArchetype,
+		safeSessionDate,
+		safeSessionId,
+		safeSkills,
+		safeSlashCommands,
+		safeSuccessScore,
+		safeTotalInteractions,
+		safeUserDisplayName,
+		subagentNames,
+		tokenUsageLabel,
+	} = buildSessionDetailViewModel(session, userMap);
 	const sessionArchetypeStyle = safeSessionArchetype
 		? (sessionArchetypeStyles[safeSessionArchetype] ??
 			sessionArchetypeStyles.standard)
 		: null;
-	const tokenUsageLabel = `${safeInputTokens.toLocaleString()} / ${safeOutputTokens.toLocaleString()}`;
-	const costLabel = `$${calculateCost(
-		safeInputTokens,
-		safeOutputTokens,
-		safeModelUsed,
-	).toFixed(4)}`;
 	return (
 		<SessionDetailErrorBoundary>
 			<div className="dashboardy-page flex h-full min-h-0 flex-col bg-[color:var(--dashboardy-surface)] text-[color:var(--dashboardy-heading)]">

--- a/apps/web/src/features/sessions/components/session-detail-view-model.test.ts
+++ b/apps/web/src/features/sessions/components/session-detail-view-model.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionDetailViewModel } from "./session-detail-view-model";
+
+const userEntry = JSON.stringify({
+	type: "user",
+	uuid: "entry-user",
+	timestamp: "2026-05-12T10:00:00.000Z",
+	sessionId: "session-1",
+	message: {
+		role: "user",
+		content: "please help",
+	},
+});
+
+const assistantEntry = JSON.stringify({
+	type: "assistant",
+	uuid: "entry-assistant",
+	timestamp: "2026-05-12T10:01:00.000Z",
+	sessionId: "session-1",
+	message: {
+		role: "assistant",
+		content: [{ type: "text", text: "done" }],
+	},
+});
+
+describe("buildSessionDetailViewModel", () => {
+	it("normalizes session detail values without changing display labels", () => {
+		const model = buildSessionDetailViewModel(
+			{
+				content: `${userEntry}\n${assistantEntry}`,
+				duration_min: "42",
+				git_branch: "main",
+				git_sha: "abcdef123456",
+				input_tokens: "1200",
+				model_used: "claude-sonnet-4-5",
+				output_tokens: 3400,
+				repository: "rudel",
+				session_archetype: "deep_work",
+				session_date: "2026-05-12",
+				session_id: "session-123456",
+				skills: ["refactor", 12, "tests"],
+				slash_commands: ["plan", null, "review"],
+				subagents: {
+					explorer: "read code",
+					ignored: 42,
+					worker: "patched code",
+				},
+				success_score: "88.5",
+				total_interactions: "7",
+				user_id: "user-1",
+			},
+			{ "user-1": "Ada Lovelace" },
+		);
+
+		expect(model.safeSessionId).toBe("session-123456");
+		expect(model.safeSessionDate).toBe("2026-05-12");
+		expect(model.safeUserDisplayName).toBe("Ada Lovelace");
+		expect(model.safeDurationMin).toBe(42);
+		expect(model.safeTotalInteractions).toBe(7);
+		expect(model.safeSuccessScore).toBe(88.5);
+		expect(model.safeSkills).toEqual(["refactor", "tests"]);
+		expect(model.safeSlashCommands).toEqual(["plan", "review"]);
+		expect(model.subagentNames).toEqual(["explorer", "worker"]);
+		expect(model.tokenUsageLabel).toBe("1,200 / 3,400");
+		expect(model.costLabel).toMatch(/^\$\d+\.\d{4}$/);
+		expect(model.safeSessionArchetype).toBe("deep_work");
+		expect(model.conversationSummary).toEqual({
+			assistantMessages: 1,
+			systemMessages: 0,
+			totalMessages: 2,
+			userMessages: 1,
+		});
+		expect(model.metadataBadges.map((badge) => badge.label)).toEqual([
+			"rudel",
+			"main",
+		]);
+	});
+
+	it("uses stable fallbacks for missing or malformed session detail fields", () => {
+		const model = buildSessionDetailViewModel(
+			{
+				content: { unsupported: true },
+				duration_min: Number.NaN,
+				input_tokens: "invalid",
+				output_tokens: null,
+				session_id: "",
+				subagents: [
+					["reviewer", "checked"],
+					["ignored", 100],
+				],
+				total_interactions: undefined,
+				user_id: "",
+			},
+			{},
+		);
+
+		expect(model.safeSessionId).toBe("unknown-session");
+		expect(model.safeSessionDate).toBe("");
+		expect(model.safeUserDisplayName).toBe("User");
+		expect(model.safeDurationMin).toBe(0);
+		expect(model.safeTotalInteractions).toBeUndefined();
+		expect(model.safeSkills).toEqual([]);
+		expect(model.safeSlashCommands).toEqual([]);
+		expect(model.subagentNames).toEqual(["reviewer"]);
+		expect(model.tokenUsageLabel).toBe("0 / 0");
+		expect(model.costLabel).toBe("$0.0000");
+		expect(model.conversationSummary).toBeNull();
+		expect(model.metadataBadges).toEqual([]);
+		expect(model.safeContent).toBe('{\n  "unsupported": true\n}');
+	});
+});

--- a/apps/web/src/features/sessions/components/session-detail-view-model.ts
+++ b/apps/web/src/features/sessions/components/session-detail-view-model.ts
@@ -1,0 +1,103 @@
+import { calculateCost, formatUsername } from "@/lib/format";
+import {
+	createSessionMetadataBadges,
+	getConversationSummary,
+	toContentString,
+	toNumber,
+	toOptionalString,
+	toStringArray,
+	toSubagentMap,
+} from "./session-detail-view-parts";
+
+export interface SessionDetailViewModelSource {
+	content?: unknown;
+	duration_min?: unknown;
+	git_branch?: unknown;
+	git_sha?: unknown;
+	input_tokens?: unknown;
+	model_used?: unknown;
+	output_tokens?: unknown;
+	repository?: unknown;
+	session_archetype?: unknown;
+	session_date?: unknown;
+	session_id?: unknown;
+	skills?: unknown;
+	slash_commands?: unknown;
+	subagents?: unknown;
+	success_score?: unknown;
+	total_interactions?: unknown;
+	user_id?: unknown;
+}
+
+export function buildSessionDetailViewModel(
+	session: SessionDetailViewModelSource,
+	userMap: Record<string, string>,
+) {
+	const safeSessionId =
+		toOptionalString(session.session_id) ?? "unknown-session";
+	const safeSessionDate = toOptionalString(session.session_date) ?? "";
+	const safeUserId = toOptionalString(session.user_id) ?? "unknown-user";
+	const safeUserDisplayName =
+		safeUserId === "unknown-user"
+			? "User"
+			: formatUsername(safeUserId, userMap);
+	const safeInputTokens = toNumber(session.input_tokens);
+	const safeOutputTokens = toNumber(session.output_tokens);
+	const safeDurationMin =
+		session.duration_min === undefined
+			? undefined
+			: toNumber(session.duration_min);
+	const safeTotalInteractions =
+		session.total_interactions === undefined
+			? undefined
+			: toNumber(session.total_interactions);
+	const safeSuccessScore =
+		session.success_score === undefined
+			? undefined
+			: toNumber(session.success_score);
+	const safeSkills = toStringArray(session.skills);
+	const safeSlashCommands = toStringArray(session.slash_commands);
+	const safeSubagents = toSubagentMap(session.subagents);
+	const safeRepository = toOptionalString(session.repository);
+	const safeGitBranch = toOptionalString(session.git_branch);
+	const safeGitSha = toOptionalString(session.git_sha);
+	const safeModelUsed = toOptionalString(session.model_used) ?? undefined;
+	const safeSessionArchetype =
+		toOptionalString(session.session_archetype) ?? undefined;
+	const safeContent = toContentString(session.content);
+	const metadataBadges = createSessionMetadataBadges({
+		gitBranch: safeGitBranch,
+		repository: safeRepository,
+	});
+	const conversationSummary = getConversationSummary(safeContent);
+	const subagentNames = Object.keys(safeSubagents);
+	const tokenUsageLabel = `${safeInputTokens.toLocaleString()} / ${safeOutputTokens.toLocaleString()}`;
+	const costLabel = `$${calculateCost(
+		safeInputTokens,
+		safeOutputTokens,
+		safeModelUsed,
+	).toFixed(4)}`;
+
+	return {
+		conversationSummary,
+		costLabel,
+		metadataBadges,
+		safeContent,
+		safeDurationMin,
+		safeGitSha,
+		safeInputTokens,
+		safeModelUsed,
+		safeOutputTokens,
+		safeSessionArchetype,
+		safeSessionDate,
+		safeSessionId,
+		safeSkills,
+		safeSlashCommands,
+		safeSubagents,
+		safeSuccessScore,
+		safeTotalInteractions,
+		safeUserDisplayName,
+		subagentNames,
+		tokenUsageLabel,
+	};
+}

--- a/apps/web/src/features/team/use-team-page-data.ts
+++ b/apps/web/src/features/team/use-team-page-data.ts
@@ -10,6 +10,10 @@ import {
 import { useDateRange } from "@/features/analytics/date-range/useDateRange";
 import { useAnalyticsQuery } from "@/features/analytics/queries/useAnalyticsQuery";
 import type { TeamRosterMemberSource } from "@/features/team/data/team-roster-data";
+import {
+	type FullOrganization,
+	useFullOrganization,
+} from "@/features/workspace/hooks/useFullOrganization";
 import { useOrganization } from "@/features/workspace/organization/useOrganization";
 import { MAX_ANALYTICS_DAYS } from "@/lib/analytics-date-range";
 import { authClient } from "@/lib/auth-client";
@@ -158,6 +162,18 @@ function buildTeamMemberRows(
 		);
 }
 
+function buildTeamRosterMembers(
+	members: FullOrganization["members"] | undefined,
+) {
+	return (members ?? []).map((member) => ({
+		displayName: member.user.name,
+		email: member.user.email,
+		imageUrl: member.user.image,
+		role: member.role,
+		userId: member.userId,
+	}));
+}
+
 export function useTeamPageData() {
 	const { data: session, isPending: isSessionPending } =
 		authClient.useSession();
@@ -174,39 +190,15 @@ export function useTeamPageData() {
 	const canInviteTeamMembers =
 		activeOrganizationId !== null && workspaceMeta?.isOrgAdmin === true;
 	const {
-		data: members = [],
+		data: fullOrganization,
 		isLoading: isOrganizationPending,
 		isError: isOrganizationError,
-		refetch: refetchMembers,
-	} = useQuery<readonly TeamRosterMemberSource[]>({
-		queryKey: ["team-page-members", activeOrganizationId],
-		queryFn: async () => {
-			const response = await authClient.organization.getFullOrganization({
-				query: { organizationId: activeOrganizationId ?? "" },
-			});
-			const fullOrganization =
-				(response.data as {
-					members?: Array<{
-						userId: string;
-						role: string;
-						user: {
-							image: string | null;
-							name: string;
-							email: string;
-						};
-					}>;
-				} | null) ?? null;
-
-			return (fullOrganization?.members ?? []).map((member) => ({
-				displayName: member.user.name,
-				email: member.user.email,
-				imageUrl: member.user.image,
-				role: member.role,
-				userId: member.userId,
-			}));
-		},
-		enabled: activeOrganizationId !== null,
-	});
+		invalidate: invalidateFullOrganization,
+	} = useFullOrganization(activeOrganizationId ?? undefined);
+	const members = useMemo<readonly TeamRosterMemberSource[]>(
+		() => buildTeamRosterMembers(fullOrganization?.members),
+		[fullOrganization?.members],
+	);
 	const teamInviteLinkQuery = useQuery({
 		...(canInviteTeamMembers
 			? orpc.teamInviteLink.get.queryOptions({
@@ -297,7 +289,7 @@ export function useTeamPageData() {
 			await Promise.all([
 				teamCardsQuery.refetch(),
 				developersQuery.refetch(),
-				refetchMembers(),
+				activeOrganizationId ? invalidateFullOrganization() : null,
 				canInviteTeamMembers ? teamInviteLinkQuery.refetch() : null,
 			]);
 		},

--- a/apps/web/src/features/workspace/hooks/useFullOrganization.ts
+++ b/apps/web/src/features/workspace/hooks/useFullOrganization.ts
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { authClient } from "@/lib/auth-client";
 
-interface FullOrg {
+export interface FullOrganization {
 	id: string;
 	name: string;
 	slug: string;
@@ -31,13 +31,13 @@ export function useFullOrganization(orgId: string | undefined) {
 			const res = await authClient.organization.getFullOrganization({
 				query: { organizationId: orgId as string },
 			});
-			return (res.data as unknown as FullOrg) ?? null;
+			return (res.data as unknown as FullOrganization) ?? null;
 		},
 		enabled: !!orgId,
 	});
 
 	const invalidate = useCallback(() => {
-		queryClient.invalidateQueries({ queryKey });
+		return queryClient.invalidateQueries({ queryKey });
 	}, [queryClient, queryKey]);
 
 	return { data: data ?? null, isLoading, isError, invalidate };

--- a/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
+++ b/apps/web/src/features/wrapped/WrappedAuthFlow.tsx
@@ -613,7 +613,7 @@ export function WrappedAuthFlow(props: WrappedAuthFlowProps) {
 				/>
 			}
 			titleClassName="rudel-wrapped-entry-stage__headline--auth"
-			useReferenceTopChrome={mode !== null}
+			useAlignedTopChrome={mode !== null}
 		/>
 	);
 }

--- a/apps/web/src/features/wrapped/WrappedCardProfileStep.tsx
+++ b/apps/web/src/features/wrapped/WrappedCardProfileStep.tsx
@@ -307,7 +307,7 @@ export function WrappedCardProfileStep(props: WrappedCardProfileStepProps) {
 			stageClassName="rudel-wrapped-entry-stage--auth rudel-wrapped-entry-stage--auth-profile"
 			title={WRAPPED_CARD_PROFILE_TITLE}
 			titleClassName="rudel-wrapped-entry-stage__headline--auth-intro"
-			useReferenceTopChrome
+			useAlignedTopChrome
 		/>
 	);
 }

--- a/apps/web/src/features/wrapped/WrappedPublicCardScreen.tsx
+++ b/apps/web/src/features/wrapped/WrappedPublicCardScreen.tsx
@@ -56,7 +56,7 @@ export function WrappedPublicCardScreen(props: WrappedPublicCardScreenProps) {
 
 	return (
 		<main className="rudel-wrapped-route rudel-wrapped-route--onboarding rudel-wrapped-route--step-card rudel-wrapped-route--public-card">
-			<div className="rudel-wrapped-shell rudel-wrapped-shell--reference-top-chrome relative z-[1] mx-auto flex w-full flex-1 flex-col text-foreground">
+			<div className="rudel-wrapped-shell rudel-wrapped-shell--aligned-top-chrome relative z-[1] mx-auto flex w-full flex-1 flex-col text-foreground">
 				<div
 					className={cn(
 						"rudel-wrapped-shell__frame",

--- a/apps/web/src/features/wrapped/onboarding/shell.tsx
+++ b/apps/web/src/features/wrapped/onboarding/shell.tsx
@@ -420,7 +420,7 @@ export function WrappedTeamCardOnboarding(
 					) : null}
 					<motion.div
 						layout
-						className="rudel-wrapped-shell rudel-wrapped-shell--reference-top-chrome relative z-[1] mx-auto flex w-full flex-1 flex-col text-foreground"
+						className="rudel-wrapped-shell rudel-wrapped-shell--aligned-top-chrome relative z-[1] mx-auto flex w-full flex-1 flex-col text-foreground"
 					>
 						<motion.div layout className="rudel-wrapped-shell__frame">
 							<WrappedOnboardingHeader

--- a/apps/web/src/features/wrapped/route-stage-shell.tsx
+++ b/apps/web/src/features/wrapped/route-stage-shell.tsx
@@ -35,7 +35,7 @@ interface WrappedRouteStageShellProps {
 	stage: ReactNode;
 	title?: ReactNode;
 	titleClassName?: string;
-	useReferenceTopChrome?: boolean;
+	useAlignedTopChrome?: boolean;
 }
 
 const WRAPPED_SETUP_ENTRANCE_EASE = [0.22, 1, 0.36, 1] as const;
@@ -104,7 +104,7 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 		status,
 		title,
 		titleClassName,
-		useReferenceTopChrome = false,
+		useAlignedTopChrome = false,
 	} = props;
 	const navigate = useNavigate();
 	const shouldReduceMotion = useReducedMotion();
@@ -112,12 +112,11 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 	const progressView = progressStepId
 		? getWrappedOnboardingProgressView(progressStepId)
 		: null;
-	const shouldUseReferenceTopChrome =
-		useReferenceTopChrome || progressView !== null;
+	const shouldUseAlignedTopChrome =
+		useAlignedTopChrome || progressView !== null;
 	const hasFooter = Boolean(footer) || Boolean(footerDebugControls);
 	const shouldAnimateSetupEntrance = entrancePreset === "setup";
-	const hasSupportButton =
-		!hideTopChromeControls && shouldUseReferenceTopChrome;
+	const hasSupportButton = !hideTopChromeControls && shouldUseAlignedTopChrome;
 	const hasTextStatus =
 		typeof status === "string" || typeof status === "number";
 	const hasDefaultLeadingControl =
@@ -127,7 +126,7 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 	const hasTopTrayContent =
 		hasDefaultLeadingControl ||
 		hasCustomLeadingControl ||
-		shouldUseReferenceTopChrome ||
+		shouldUseAlignedTopChrome ||
 		progressView !== null ||
 		status !== undefined;
 	const animatedCopy =
@@ -198,8 +197,8 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 			<div
 				className={cn(
 					"rudel-wrapped-shell relative z-[1] mx-auto flex w-full flex-1 flex-col text-foreground",
-					shouldUseReferenceTopChrome
-						? "rudel-wrapped-shell--reference-top-chrome"
+					shouldUseAlignedTopChrome
+						? "rudel-wrapped-shell--aligned-top-chrome"
 						: null,
 				)}
 			>
@@ -234,13 +233,13 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 										type="button"
 										aria-label={backLabel}
 										className={cn(
-											shouldUseReferenceTopChrome
+											shouldUseAlignedTopChrome
 												? "rudel-wrapped-top-tray__edge-control"
 												: "rudel-wrapped-back-button rounded-full transition-colors",
 										)}
 										onClick={handleBack}
 									>
-										{shouldUseReferenceTopChrome ? (
+										{shouldUseAlignedTopChrome ? (
 											<ChevronLeft className="rudel-wrapped-top-tray__edge-icon rudel-wrapped-top-tray__edge-icon--back" />
 										) : (
 											<X className="size-4" />
@@ -278,7 +277,7 @@ export function WrappedRouteStageShell(props: WrappedRouteStageShellProps) {
 										aria-hidden="true"
 										className="rudel-wrapped-top-tray__utility-placeholder"
 									/>
-								) : shouldUseReferenceTopChrome ? (
+								) : shouldUseAlignedTopChrome ? (
 									<WrappedSupportChatwootButton />
 								) : (
 									<span

--- a/apps/web/src/features/wrapped/wrapped.css
+++ b/apps/web/src/features/wrapped/wrapped.css
@@ -119,12 +119,12 @@ body.rudel-wrapped-body .woot-widget-bubble {
 	overscroll-behavior: none;
 }
 
-.rudel-wrapped-shell--reference-top-chrome {
+.rudel-wrapped-shell--aligned-top-chrome {
 	--wrapped-shell-top-inset: 24px;
-	--wrapped-reference-top-chrome-edge-inset: calc(27px - ((44px - 23px) / 2));
+	--wrapped-aligned-top-chrome-edge-inset: calc(27px - ((44px - 23px) / 2));
 }
 
-.rudel-wrapped-route--step-card .rudel-wrapped-shell--reference-top-chrome {
+.rudel-wrapped-route--step-card .rudel-wrapped-shell--aligned-top-chrome {
 	--wrapped-shell-bottom-inset: 20px;
 	--wrapped-shell-stage-gap: 0.85rem;
 }
@@ -170,12 +170,12 @@ body.rudel-wrapped-body .woot-widget-bubble {
 	overflow: visible;
 }
 
-.rudel-wrapped-shell--reference-top-chrome .rudel-wrapped-top-tray__row {
+.rudel-wrapped-shell--aligned-top-chrome .rudel-wrapped-top-tray__row {
 	margin-inline: calc(
 		-1 *
 		(
 			var(--wrapped-shell-inline-inset) -
-			var(--wrapped-reference-top-chrome-edge-inset)
+			var(--wrapped-aligned-top-chrome-edge-inset)
 		)
 	);
 }
@@ -7551,7 +7551,7 @@ body.rudel-wrapped-body[data-wrapped-bottom-occluded="true"]
 }
 
 @media (max-height: 61.25rem) {
-	.rudel-wrapped-route--public-card .rudel-wrapped-shell--reference-top-chrome {
+	.rudel-wrapped-route--public-card .rudel-wrapped-shell--aligned-top-chrome {
 		--wrapped-shell-top-inset: 16px;
 		--wrapped-shell-bottom-inset: 14px;
 		--wrapped-shell-stage-gap: 0.55rem;
@@ -9083,7 +9083,7 @@ body.rudel-wrapped-body[data-wrapped-bottom-occluded="true"]
 		--wrapped-shell-bottom-inset: 40px;
 	}
 
-	.rudel-wrapped-shell--reference-top-chrome {
+	.rudel-wrapped-shell--aligned-top-chrome {
 		--wrapped-shell-top-inset: 24px;
 	}
 
@@ -9295,11 +9295,11 @@ body.rudel-wrapped-body[data-wrapped-bottom-occluded="true"]
 		--wrapped-shell-stage-gap: 0.8rem;
 	}
 
-	.rudel-wrapped-shell--reference-top-chrome {
+	.rudel-wrapped-shell--aligned-top-chrome {
 		--wrapped-shell-top-inset: 24px;
 	}
 
-	.rudel-wrapped-route--step-card .rudel-wrapped-shell--reference-top-chrome {
+	.rudel-wrapped-route--step-card .rudel-wrapped-shell--aligned-top-chrome {
 		--wrapped-shell-bottom-inset: 14px;
 		--wrapped-shell-stage-gap: 0.65rem;
 	}
@@ -9590,7 +9590,7 @@ body.rudel-wrapped-body[data-wrapped-bottom-occluded="true"]
 		line-height: 1.3;
 	}
 
-	.rudel-wrapped-route--public-card .rudel-wrapped-shell--reference-top-chrome {
+	.rudel-wrapped-route--public-card .rudel-wrapped-shell--aligned-top-chrome {
 		--wrapped-shell-top-inset: 12px;
 		--wrapped-shell-bottom-inset: 10px;
 		--wrapped-shell-stage-gap: 0.45rem;


### PR DESCRIPTION
## Summary
- route team roster loading through the shared full-organization hook instead of a separate team-only query
- extract session detail normalization/label building into a pure view-model helper with focused tests
- rename wrapped top-chrome alignment selectors/prop to describe their current layout role

## Notes
- no table/chart interaction changes
- no query limits, API contracts, DB schema, or transcript fetch behavior changes

## Test plan
- bun run lint:wrapped:hig
- bun run --cwd apps/web check-types
- bun run --cwd apps/web test -- src/features/team/TeamPage.test.tsx src/features/team/TeamPageManualRefreshSmoke.test.tsx src/features/dashboard/DashboardPage.test.tsx src/features/sessions/components/session-detail-view-model.test.ts
- bun run verify