### PR TITLE
docs: encode integration-first testing strategy in testing-bun skill

### DIFF
--- a/.claude/skills/testing-bun/SKILL.md
+++ b/.claude/skills/testing-bun/SKILL.md
@@ -12,6 +12,11 @@ allowed-tools: [Read, Edit, Grep, Glob, Bash]
 - Do not introduce Vitest or Jest in this repo
 - For local e2e/integration runs that need env vars, use Doppler (`bun run test:env`)
 
+## Test Strategy
+- **Default to API integration tests against real infrastructure** (real Postgres, real ClickHouse). Call a real endpoint, let data flow through the API into the DB, then verify by calling another endpoint. This is "e2e" from the API perspective only — frontend is out of scope here.
+- **Never mock services, DB clients, or external APIs.** If a test would need a mock, write the integration test instead.
+- **Unit tests are reserved for pure logical utilities** (parsers, formatters, pure functions). A service that "needs" a unit test is a smell — prefer the integration path above.
+
 ## Critical Rules
 
 ### 1. No Try/Catch in Positive Tests


### PR DESCRIPTION
## Summary
- Adds a new **Test Strategy** section to `.claude/skills/testing-bun/SKILL.md` between Framework and Critical Rules
- Encodes three rules previously left implicit: default to API-level integration tests against real Postgres/ClickHouse; never mock services, DB clients, or external APIs; unit tests are reserved for pure logical utilities
- "E2E" in this repo means API-in to API-out — frontend is explicitly out of scope for this skill

## Test plan
- [ ] No code change; SKILL.md only. Verify renders cleanly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)