### PR TITLE
fix: enable clickhouse analyzer for inserts

### DIFF
--- a/apps/api/src/__tests__/clickhouse.test.ts
+++ b/apps/api/src/__tests__/clickhouse.test.ts
@@ -5,6 +5,7 @@ import {
 	addOptionalStringEqFilter,
 	addOptionalStringInFilter,
 	buildAbsoluteDateFilter,
+	buildClickHouseInsertQuery,
 	buildDateFilter,
 	getSafeClickHouseTable,
 } from "../clickhouse.js";
@@ -67,6 +68,22 @@ describe("clickhouse helpers", () => {
 		expect(() => getSafeClickHouseTable("rudel.unknown_table")).toThrow(
 			"Unsupported ClickHouse table",
 		);
+	});
+
+	test("enables the analyzer for inserts that fan out through materialized views", () => {
+		const query = buildClickHouseInsertQuery("rudel.claude_sessions", [
+			{
+				session_id: "session-1",
+				content: "line1\nline2",
+			},
+		]);
+
+		expect(
+			query.startsWith(
+				"INSERT INTO rudel.claude_sessions SETTINGS async_insert=0, allow_experimental_analyzer=1 FORMAT JSONEachRow ",
+			),
+		).toBe(true);
+		expect(query).toContain('"session_id":"session-1"');
 	});
 });
 

--- a/apps/api/src/clickhouse.ts
+++ b/apps/api/src/clickhouse.ts
@@ -9,6 +9,11 @@ const ALLOWED_CLICKHOUSE_TABLES = new Set([
 	"rudel.session_analytics",
 ]);
 
+const INSERT_SETTINGS = [
+	"async_insert=0",
+	"allow_experimental_analyzer=1",
+].join(", ");
+
 export interface ClickHouseStatement {
 	query: string;
 	query_params?: Record<string, unknown>;
@@ -26,6 +31,15 @@ export function getSafeClickHouseTable(table: string): string {
 		throw new Error(`Unsupported ClickHouse table: ${table}`);
 	}
 	return table;
+}
+
+export function buildClickHouseInsertQuery(
+	table: string,
+	values: object[],
+): string {
+	const safeTable = getSafeClickHouseTable(table);
+	const rows = values.map((r) => JSON.stringify(r)).join("\n");
+	return `INSERT INTO ${safeTable} SETTINGS ${INSERT_SETTINGS} FORMAT JSONEachRow ${rows}`;
 }
 
 export function createClickHouseExecutor(config: {
@@ -61,12 +75,10 @@ export function createClickHouseExecutor(config: {
 			return result.json();
 		},
 		async insert(params) {
-			const table = getSafeClickHouseTable(params.table);
 			// Use command() with FORMAT JSONEachRow instead of client.insert()
 			// because ClickHouse Cloud's @clickhouse/client insert() silently drops data.
-			const rows = params.values.map((r) => JSON.stringify(r)).join("\n");
 			await client.command({
-				query: `INSERT INTO ${table} SETTINGS async_insert=0 FORMAT JSONEachRow ${rows}`,
+				query: buildClickHouseInsertQuery(params.table, params.values),
 			});
 		},
 	};


### PR DESCRIPTION
## Summary
- add `allow_experimental_analyzer=1` to shared ClickHouse JSONEachRow inserts while preserving `async_insert=0`
- extract the insert query builder so the analyzer setting is covered by a focused regression test

## Test plan
- [x] `bun test apps/api/src/__tests__/ingest.test.ts apps/api/src/__tests__/clickhouse.test.ts`
- [x] `bun node_modules/.bin/biome check apps/api/src/clickhouse.ts apps/api/src/__tests__/clickhouse.test.ts`
- [x] `bun run verify`