### PR TITLE
ci: restore GitHub-hosted CI runners

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,7 +7,7 @@ runs:
       with:
         bun-version: 1.3.10
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v6
       name: Setup bun cache
       with:
         path: ~/.bun/install/cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   verify:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
   deploy:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: verify
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   lint-pr-title:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Enforce conventional commit format
         uses: amannn/action-semantic-pull-request@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Run Release Please
         id: release

--- a/packages/ch-schema/chx/meta/snapshot.json
+++ b/packages/ch-schema/chx/meta/snapshot.json
@@ -1,690 +1,659 @@
 {
-  "version": 1,
-  "generatedAt": "2026-05-18T23:34:37.446Z",
-  "definitions": [
-    {
-      "database": "rudel",
-      "name": "claude_sessions",
-      "engine": "ReplacingMergeTree(ingested_at)",
-      "columns": [
-        {
-          "name": "session_date",
-          "type": "DateTime64(3, 'UTC')",
-          "default": "fn:now64(3)"
-        },
-        {
-          "name": "last_interaction_date",
-          "type": "DateTime64(3, 'UTC')",
-          "default": "fn:now64(3)"
-        },
-        {
-          "name": "session_id",
-          "type": "String"
-        },
-        {
-          "name": "organization_id",
-          "type": "String"
-        },
-        {
-          "name": "project_path",
-          "type": "String"
-        },
-        {
-          "name": "git_remote",
-          "type": "String",
-          "default": "''"
-        },
-        {
-          "name": "package_name",
-          "type": "String",
-          "default": "''"
-        },
-        {
-          "name": "package_type",
-          "type": "String",
-          "default": "''"
-        },
-        {
-          "name": "content",
-          "type": "String"
-        },
-        {
-          "name": "ingested_at",
-          "type": "DateTime64(3, 'UTC')",
-          "default": "fn:now64(3)"
-        },
-        {
-          "name": "user_id",
-          "type": "String"
-        },
-        {
-          "name": "git_branch",
-          "type": "String",
-          "nullable": true
-        },
-        {
-          "name": "git_sha",
-          "type": "String",
-          "nullable": true
-        },
-        {
-          "name": "tag",
-          "type": "String",
-          "nullable": true
-        },
-        {
-          "name": "subagents",
-          "type": "Map(String, String)",
-          "default": "fn:map()"
-        }
-      ],
-      "primaryKey": [
-        "organization_id",
-        "session_date",
-        "session_id"
-      ],
-      "orderBy": [
-        "organization_id",
-        "session_date",
-        "session_id"
-      ],
-      "partitionBy": "toYYYYMM(toDate(session_date))",
-      "ttl": "toDate(session_date) + toIntervalDay(365)",
-      "settings": {
-        "index_granularity": "8192",
-        "storage_policy": "'s3'"
-      },
-      "kind": "table"
-    },
-    {
-      "database": "rudel",
-      "name": "codex_sessions",
-      "engine": "ReplacingMergeTree(ingested_at)",
-      "columns": [
-        {
-          "name": "session_date",
-          "type": "DateTime64(3, 'UTC')",
-          "default": "fn:now64(3)"
-        },
-        {
-          "name": "last_interaction_date",
-          "type": "DateTime64(3, 'UTC')",
-          "default": "fn:now64(3)"
-        },
-        {
-          "name": "session_id",
-          "type": "String"
-        },
-        {
-          "name": "organization_id",
-          "type": "String"
-        },
-        {
-          "name": "project_path",
-          "type": "String"
-        },
-        {
-          "name": "git_remote",
-          "type": "String",
-          "default": "''"
-        },
-        {
-          "name": "package_name",
-          "type": "String",
-          "default": "''"
-        },
-        {
-          "name": "package_type",
-          "type": "String",
-          "default": "''"
-        },
-        {
-          "name": "content",
-          "type": "String"
-        },
-        {
-          "name": "ingested_at",
-          "type": "DateTime64(3, 'UTC')",
-          "default": "fn:now64(3)"
-        },
-        {
-          "name": "user_id",
-          "type": "String"
-        },
-        {
-          "name": "git_branch",
-          "type": "String",
-          "nullable": true
-        },
-        {
-          "name": "git_sha",
-          "type": "String",
-          "nullable": true
-        },
-        {
-          "name": "tag",
-          "type": "String",
-          "nullable": true
-        }
-      ],
-      "primaryKey": [
-        "organization_id",
-        "session_date",
-        "session_id"
-      ],
-      "orderBy": [
-        "organization_id",
-        "session_date",
-        "session_id"
-      ],
-      "partitionBy": "toYYYYMM(toDate(session_date))",
-      "ttl": "toDate(session_date) + toIntervalDay(365)",
-      "settings": {
-        "index_granularity": "8192",
-        "storage_policy": "'s3'"
-      },
-      "kind": "table"
-    },
-    {
-      "database": "rudel",
-      "name": "session_analytics",
-      "engine": "ReplacingMergeTree(ingested_at)",
-      "columns": [
-        {
-          "name": "session_date",
-          "type": "DateTime64(3, 'UTC')",
-          "default": "fn:now64(3)"
-        },
-        {
-          "name": "last_interaction_date",
-          "type": "DateTime64(3, 'UTC')",
-          "default": "fn:now64(3)"
-        },
-        {
-          "name": "session_id",
-          "type": "String"
-        },
-        {
-          "name": "organization_id",
-          "type": "String"
-        },
-        {
-          "name": "project_path",
-          "type": "String"
-        },
-        {
-          "name": "git_remote",
-          "type": "String",
-          "default": "''"
-        },
-        {
-          "name": "package_name",
-          "type": "String",
-          "default": "''"
-        },
-        {
-          "name": "package_type",
-          "type": "String",
-          "default": "''"
-        },
-        {
-          "name": "content",
-          "type": "String"
-        },
-        {
-          "name": "subagents",
-          "type": "Map(String, String)",
-          "default": "fn:map()"
-        },
-        {
-          "name": "skills",
-          "type": "Array(String)",
-          "default": "fn:[]"
-        },
-        {
-          "name": "slash_commands",
-          "type": "Array(String)",
-          "default": "fn:[]"
-        },
-        {
-          "name": "subagent_types",
-          "type": "Array(String)",
-          "default": "fn:[]"
-        },
-        {
-          "name": "ingested_at",
-          "type": "DateTime64(3, 'UTC')",
-          "default": "fn:now64(3)"
-        },
-        {
-          "name": "user_id",
-          "type": "String"
-        },
-        {
-          "name": "git_branch",
-          "type": "String",
-          "nullable": true
-        },
-        {
-          "name": "git_sha",
-          "type": "String",
-          "nullable": true
-        },
-        {
-          "name": "input_tokens",
-          "type": "UInt64",
-          "default": "fn:0"
-        },
-        {
-          "name": "output_tokens",
-          "type": "UInt64",
-          "default": "fn:0"
-        },
-        {
-          "name": "cache_read_input_tokens",
-          "type": "UInt64",
-          "default": "fn:0"
-        },
-        {
-          "name": "cache_creation_input_tokens",
-          "type": "UInt64",
-          "default": "fn:0"
-        },
-        {
-          "name": "total_tokens",
-          "type": "UInt64",
-          "default": "fn:0"
-        },
-        {
-          "name": "tag",
-          "type": "String",
-          "nullable": true
-        },
-        {
-          "name": "source",
-          "type": "LowCardinality(String)",
-          "default": "'claude_code'"
-        },
-        {
-          "name": "total_interactions",
-          "type": "UInt32",
-          "default": "fn:0"
-        },
-        {
-          "name": "actual_duration_min",
-          "type": "UInt32",
-          "default": "fn:0"
-        },
-        {
-          "name": "avg_period_sec",
-          "type": "Float64",
-          "default": "fn:0"
-        },
-        {
-          "name": "median_period_sec",
-          "type": "Float64",
-          "default": "fn:0"
-        },
-        {
-          "name": "quick_responses",
-          "type": "UInt32",
-          "default": "fn:0"
-        },
-        {
-          "name": "normal_responses",
-          "type": "UInt32",
-          "default": "fn:0"
-        },
-        {
-          "name": "long_pauses",
-          "type": "UInt32",
-          "default": "fn:0"
-        },
-        {
-          "name": "error_count",
-          "type": "UInt32",
-          "default": "fn:0"
-        },
-        {
-          "name": "model_used",
-          "type": "String",
-          "default": "''"
-        },
-        {
-          "name": "has_commit",
-          "type": "UInt8",
-          "default": "fn:0"
-        },
-        {
-          "name": "session_archetype",
-          "type": "String",
-          "default": "'standard'"
-        },
-        {
-          "name": "success_score",
-          "type": "UInt8",
-          "default": "fn:0"
-        },
-        {
-          "name": "used_plan_mode",
-          "type": "UInt8",
-          "default": "fn:0"
-        },
-        {
-          "name": "inference_duration_sec",
-          "type": "UInt32",
-          "default": "fn:0"
-        },
-        {
-          "name": "human_duration_sec",
-          "type": "UInt32",
-          "default": "fn:0"
-        }
-      ],
-      "primaryKey": [
-        "organization_id",
-        "session_date",
-        "session_id"
-      ],
-      "orderBy": [
-        "organization_id",
-        "session_date",
-        "session_id"
-      ],
-      "partitionBy": "toYYYYMM(toDate(session_date))",
-      "settings": {
-        "index_granularity": "8192"
-      },
-      "indexes": [
-        {
-          "name": "idx_git_remote",
-          "expression": "git_remote",
-          "type": "set",
-          "typeArgs": "0",
-          "granularity": 4
-        },
-        {
-          "name": "idx_model_used",
-          "expression": "model_used",
-          "type": "set",
-          "typeArgs": "0",
-          "granularity": 4
-        },
-        {
-          "name": "idx_project_path",
-          "expression": "project_path",
-          "type": "set",
-          "typeArgs": "0",
-          "granularity": 4
-        },
-        {
-          "name": "idx_source",
-          "expression": "source",
-          "type": "set",
-          "typeArgs": "0",
-          "granularity": 4
-        },
-        {
-          "name": "idx_user_id",
-          "expression": "user_id",
-          "type": "set",
-          "typeArgs": "0",
-          "granularity": 4
-        }
-      ],
-      "kind": "table"
-    },
-    {
-      "database": "rudel",
-      "name": "wrapped_user_archetype_runs_v1",
-      "engine": "MergeTree()",
-      "columns": [
-        {
-          "name": "snapshot_id",
-          "type": "String"
-        },
-        {
-          "name": "snapshot_created_at",
-          "type": "DateTime64(3, 'UTC')"
-        },
-        {
-          "name": "pipeline_version",
-          "type": "LowCardinality(String)"
-        },
-        {
-          "name": "centroid_version",
-          "type": "LowCardinality(String)"
-        },
-        {
-          "name": "scope",
-          "type": "LowCardinality(String)"
-        },
-        {
-          "name": "user_scope_count",
-          "type": "UInt32"
-        },
-        {
-          "name": "trigger_reason",
-          "type": "LowCardinality(String)"
-        },
-        {
-          "name": "trigger_source",
-          "type": "LowCardinality(Nullable(String))"
-        },
-        {
-          "name": "trigger_session_id",
-          "type": "String",
-          "nullable": true
-        }
-      ],
-      "primaryKey": [],
-      "orderBy": [
-        "snapshot_created_at",
-        "snapshot_id"
-      ],
-      "kind": "table"
-    },
-    {
-      "database": "rudel",
-      "name": "wrapped_user_archetype_snapshots_v1",
-      "engine": "MergeTree()",
-      "columns": [
-        {
-          "name": "snapshot_id",
-          "type": "String"
-        },
-        {
-          "name": "snapshot_created_at",
-          "type": "DateTime64(3, 'UTC')"
-        },
-        {
-          "name": "pipeline_version",
-          "type": "LowCardinality(String)"
-        },
-        {
-          "name": "centroid_version",
-          "type": "LowCardinality(String)"
-        },
-        {
-          "name": "scope",
-          "type": "LowCardinality(String)"
-        },
-        {
-          "name": "organization_id",
-          "type": "String"
-        },
-        {
-          "name": "user_id",
-          "type": "String"
-        },
-        {
-          "name": "first_session_at",
-          "type": "DateTime64(3, 'UTC')"
-        },
-        {
-          "name": "last_session_at",
-          "type": "DateTime64(3, 'UTC')"
-        },
-        {
-          "name": "days_since_first_session",
-          "type": "UInt32"
-        },
-        {
-          "name": "total_sessions",
-          "type": "UInt32"
-        },
-        {
-          "name": "active_days",
-          "type": "UInt32"
-        },
-        {
-          "name": "claude_session_count",
-          "type": "UInt32"
-        },
-        {
-          "name": "codex_session_count",
-          "type": "UInt32"
-        },
-        {
-          "name": "total_tokens",
-          "type": "UInt64"
-        },
-        {
-          "name": "estimated_spend_usd",
-          "type": "Float64"
-        },
-        {
-          "name": "mean_session_min",
-          "type": "Float64"
-        },
-        {
-          "name": "longest_session_min",
-          "type": "UInt32"
-        },
-        {
-          "name": "commit_sessions",
-          "type": "UInt32"
-        },
-        {
-          "name": "distinct_repos",
-          "type": "UInt32",
-          "nullable": true
-        },
-        {
-          "name": "breadth_available",
-          "type": "UInt8"
-        },
-        {
-          "name": "range_entropy",
-          "type": "Float64"
-        },
-        {
-          "name": "consistency_raw",
-          "type": "Float64"
-        },
-        {
-          "name": "intensity_raw",
-          "type": "Float64"
-        },
-        {
-          "name": "session_shape_raw",
-          "type": "Float64"
-        },
-        {
-          "name": "cost_intensity_raw",
-          "type": "Float64"
-        },
-        {
-          "name": "output_raw",
-          "type": "Float64"
-        },
-        {
-          "name": "breadth_raw",
-          "type": "Float64",
-          "nullable": true
-        },
-        {
-          "name": "range_raw",
-          "type": "Float64"
-        },
-        {
-          "name": "consistency",
-          "type": "Float64"
-        },
-        {
-          "name": "intensity",
-          "type": "Float64"
-        },
-        {
-          "name": "session_shape",
-          "type": "Float64"
-        },
-        {
-          "name": "cost_intensity",
-          "type": "Float64"
-        },
-        {
-          "name": "output",
-          "type": "Float64"
-        },
-        {
-          "name": "breadth",
-          "type": "Float64",
-          "nullable": true
-        },
-        {
-          "name": "range",
-          "type": "Float64"
-        },
-        {
-          "name": "archetype_id",
-          "type": "UInt8"
-        },
-        {
-          "name": "archetype_key",
-          "type": "LowCardinality(String)"
-        },
-        {
-          "name": "archetype_name",
-          "type": "String"
-        },
-        {
-          "name": "archetype_distance",
-          "type": "Float64"
-        },
-        {
-          "name": "archetype_distance_ratio_to_max",
-          "type": "Float64"
-        }
-      ],
-      "primaryKey": [],
-      "orderBy": [
-        "snapshot_id",
-        "organization_id",
-        "user_id"
-      ],
-      "partitionBy": "toYYYYMM(toDate(snapshot_created_at))",
-      "kind": "table"
-    },
-    {
-      "database": "rudel",
-      "name": "codex_session_analytics_mv",
-      "to": {
-        "database": "rudel",
-        "name": "session_analytics"
-      },
-      "as": "SELECT * EXCEPT (_dedupe_rank) FROM ( WITH arrayFilter( x -> x != '', splitByChar('\\n', cs.content) ) AS _all_lines, arrayFilter(x -> JSONHas(x, 'timestamp'), _all_lines) AS _ts_lines, arrayMap( x -> parseDateTime64BestEffort(JSONExtractString(x, 'timestamp')), _ts_lines ) AS _timestamps, if(length(_timestamps) > 1, arrayMap(i -> dateDiff('second', _timestamps[i], _timestamps[i+1]), range(1, length(_timestamps))), [] ) AS _prompt_periods_sec, if(length(_timestamps) > 1, arrayMap(i -> if(i < length(_timestamps), dateDiff('second', _timestamps[i], _timestamps[i+1]), 0), range(1, length(_timestamps))), [] ) AS _inference_gaps, arrayFilter( x -> JSONExtractString(x, 'type') = 'response_item' OR JSONExtractString(x, 'type') = 'event_msg', _all_lines ) AS _interaction_lines, arrayFilter( x -> JSONExtractString(x, 'type') = 'response_item' AND JSONExtractString(JSONExtractRaw(x, 'payload'), 'type') = 'function_call_output', _all_lines ) AS _tool_output_lines, arrayFilter( x -> JSONExtractString(x, 'type') = 'event_msg' AND JSONExtractString(JSONExtractRaw(x, 'payload'), 'type') = 'token_count' AND JSONExtractRaw(JSONExtractRaw(x, 'payload'), 'info') IS NOT NULL AND JSONExtractRaw(JSONExtractRaw(x, 'payload'), 'info') != 'null', _all_lines ) AS _token_count_lines, if(length(_token_count_lines) > 0, JSONExtractRaw(JSONExtractRaw(JSONExtractRaw(arrayElement(_token_count_lines, -1), 'payload'), 'info'), 'total_token_usage'), '{}' ) AS _final_usage, toUInt64OrZero(JSONExtractRaw(_final_usage, 'input_tokens')) AS _input_tokens, toUInt64OrZero(JSONExtractRaw(_final_usage, 'output_tokens')) AS _output_tokens, toUInt64OrZero(JSONExtractRaw(_final_usage, 'cached_input_tokens')) AS _cache_read_input_tokens, arrayMin(_timestamps) AS _session_date, arrayMax(_timestamps) AS _last_interaction_date, dateDiff('minute', _session_date, _last_interaction_date) AS _duration_min, arrayFilter(x -> JSONExtractString(x, 'type') = 'session_meta', _all_lines) AS _meta_lines, JSONExtractString( JSONExtractRaw(arrayElement(_meta_lines, 1), 'payload'), 'model_provider' ) AS _model_provider, arrayFilter( x -> JSONExtractString(x, 'type') = 'turn_context', _all_lines ) AS _turn_context_lines, if(length(_turn_context_lines) > 0, JSONExtractString(JSONExtractRaw(arrayElement(_turn_context_lines, 1), 'payload'), 'model'), '' ) AS _model_from_turn_context, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '\"name\":\"exec_command\"[^}]*skills/([a-zA-Z0-9_-]+)/SKILL'))) AS _skills SELECT * EXCEPT (session_date, last_interaction_date), _session_date as session_date, _last_interaction_date as last_interaction_date, 'codex' as source, _input_tokens as input_tokens, _output_tokens as output_tokens, _cache_read_input_tokens as cache_read_input_tokens, toUInt64(0) as cache_creation_input_tokens, _input_tokens + _output_tokens as total_tokens, _skills as skills, [] :: Array(String) as slash_commands, [] :: Array(String) as subagent_types, map() as subagents, toUInt32(length(_interaction_lines)) as total_interactions, toUInt32(_duration_min) as actual_duration_min, if(length(_prompt_periods_sec) > 0, round(arrayAvg(_prompt_periods_sec), 2), 0) as avg_period_sec, if( length(_prompt_periods_sec) > 0, toFloat64(arrayElement( arraySort(_prompt_periods_sec), toUInt64(ceil(length(_prompt_periods_sec) / 2)) )), 0 ) as median_period_sec, toUInt32(arrayCount(x -> x < 5, _prompt_periods_sec)) as quick_responses, toUInt32(arrayCount(x -> x >= 5 AND x <= 60, _prompt_periods_sec)) as normal_responses, toUInt32(arrayCount(x -> x > 300, _prompt_periods_sec)) as long_pauses, toUInt32( length(extractAll(cs.content, '\\\\\\\\\"exit_code\\\\\\\\\":[1-9][0-9]*')) + arrayCount( x -> x ILIKE '%Error:%' OR x ILIKE '%Exception:%', _tool_output_lines ) ) as error_count, multiIf( _model_from_turn_context != '', _model_from_turn_context, _model_provider != '', _model_provider, 'unknown' ) as model_used, toUInt8(if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 1, 0)) as has_commit, toUInt8(0) as used_plan_mode, toUInt32(arraySum(_inference_gaps)) as inference_duration_sec, toUInt32(0) as human_duration_sec, CASE WHEN _duration_min <= 10 AND (_input_tokens + _output_tokens) < 500000 AND _output_tokens > 1000 THEN 'quick_win' WHEN _duration_min > 30 AND _output_tokens > 50000 AND cs.git_sha IS NOT NULL AND cs.git_sha != '' THEN 'deep_work' WHEN (_input_tokens + _output_tokens) > 1000000 AND (_output_tokens / nullif(_input_tokens, 0)) < 0.3 AND _duration_min > 20 THEN 'struggle' WHEN length(_skills) >= 3 AND (cs.git_sha IS NULL OR cs.git_sha = '') AND (_input_tokens + _output_tokens) > 200000 THEN 'exploration' WHEN _duration_min < 3 AND _output_tokens < 500 THEN 'abandoned' ELSE 'standard' END as session_archetype, toUInt8(round( 50 + (if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 20, 0)) + (if((_output_tokens / nullif(_input_tokens, 0)) > 0.5, 15, 0)) + (least(toUInt32(length(_skills)), 3) * 5) - (if((_input_tokens + _output_tokens) > 1500000 AND (cs.git_sha IS NULL OR cs.git_sha = ''), 20, 0)) - (if(_duration_min < 2 AND _output_tokens < 200, 30, 0)) - (least(toUInt32( length(extractAll(cs.content, '\\\\\\\\\"exit_code\\\\\\\\\":[1-9][0-9]*')) + arrayCount( x -> JSONExtractString(JSONExtractRaw(x, 'payload'), 'output') ILIKE '%Error:%' OR JSONExtractString(JSONExtractRaw(x, 'payload'), 'output') ILIKE '%Exception:%', _tool_output_lines ) ), 10) * 2) )) as success_score, ROW_NUMBER() OVER (PARTITION BY cs.session_id ORDER BY cs.ingested_at DESC) AS _dedupe_rank FROM rudel.codex_sessions AS cs WHERE length(_timestamps) > 0 ) WHERE _dedupe_rank = 1",
-      "kind": "materialized_view"
-    },
-    {
-      "database": "rudel",
-      "name": "session_analytics_mv",
-      "to": {
-        "database": "rudel",
-        "name": "session_analytics"
-      },
-      "as": "SELECT * EXCEPT (_dedupe_rank) FROM ( WITH arrayFilter( x -> JSONExtractString(x, 'type') IN ('user', 'assistant'), splitByChar('\\n', cs.content) ) AS _interaction_lines, arrayFilter(x -> JSONHas(x, 'timestamp'), _interaction_lines) AS _ts_lines, arrayMap( x -> parseDateTime64BestEffort(JSONExtractString(x, 'timestamp')), _ts_lines ) AS _timestamps, arrayMap( x -> JSONExtractString(x, 'type'), _ts_lines ) AS _msg_types, if(length(_timestamps) > 1, arrayMap(i -> dateDiff('second', _timestamps[i], _timestamps[i+1]), range(1, length(_timestamps))), [] ) AS _prompt_periods_sec, if(length(_timestamps) > 1, arrayMap(i -> if(_msg_types[i] = 'user' AND _msg_types[i+1] = 'assistant', dateDiff('second', _timestamps[i], _timestamps[i+1]), 0), range(1, length(_timestamps))), [] ) AS _inference_gaps, if(length(_timestamps) > 1, arrayMap(i -> if(_msg_types[i] = 'assistant' AND _msg_types[i+1] = 'user', dateDiff('second', _timestamps[i], _timestamps[i+1]), 0), range(1, length(_timestamps))), [] ) AS _human_gaps, arrayFilter( x -> JSONExtractString(x, 'type') = 'assistant' AND JSONHas(x, 'message'), splitByChar('\\n', cs.content) ) AS _assistant_lines, arrayMap( x -> JSONExtractString(JSONExtractRaw(x, 'message'), 'id'), _assistant_lines ) AS _assistant_ids, arrayFilter( (x, i) -> i = length(_assistant_ids) OR _assistant_ids[i] != _assistant_ids[i + 1], _assistant_lines, arrayEnumerate(_assistant_lines) ) AS _deduped_assistant_lines, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'input_tokens')) + toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_read_input_tokens')) + toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_creation_input_tokens')), _deduped_assistant_lines)) AS _input_tokens, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'output_tokens')), _deduped_assistant_lines)) AS _output_tokens, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_read_input_tokens')), _deduped_assistant_lines)) AS _cache_read, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_creation_input_tokens')), _deduped_assistant_lines)) AS _cache_creation, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '\"name\":\"Skill\"[^}]*\"skill\":\"([^\"]+)\"'))) AS _skills, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '\"name\":\"Task\"[^}]*\"subagent_type\":\"([^\"]+)\"'))) AS _subagent_types, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '<command-name>/([^<]+)</command-name>'))) AS _slash_commands, arrayMin(_timestamps) AS _session_date, arrayMax(_timestamps) AS _last_interaction_date, dateDiff('minute', _session_date, _last_interaction_date) AS _duration_min SELECT * EXCEPT (session_date, last_interaction_date), _session_date as session_date, _last_interaction_date as last_interaction_date, 'claude_code' as source, _input_tokens as input_tokens, _output_tokens as output_tokens, _cache_read as cache_read_input_tokens, _cache_creation as cache_creation_input_tokens, _input_tokens + _output_tokens as total_tokens, _skills as skills, _slash_commands as slash_commands, _subagent_types as subagent_types, toUInt32(length(_timestamps)) as total_interactions, toUInt32(_duration_min) as actual_duration_min, if(length(_prompt_periods_sec) > 0, round(arrayAvg(_prompt_periods_sec), 2), 0) as avg_period_sec, if( length(_prompt_periods_sec) > 0, toFloat64(arrayElement( arraySort(_prompt_periods_sec), toUInt64(ceil(length(_prompt_periods_sec) / 2)) )), 0 ) as median_period_sec, toUInt32(arrayCount(x -> x < 5, _prompt_periods_sec)) as quick_responses, toUInt32(arrayCount(x -> x >= 5 AND x <= 60, _prompt_periods_sec)) as normal_responses, toUInt32(arrayCount(x -> x > 300, _prompt_periods_sec)) as long_pauses, toUInt32( length(extractAll(cs.content, '\"isApiErrorMessage\":true')) + length(extractAll(cs.content, '\"is_error\":true')) ) as error_count, JSONExtractString( JSONExtractRaw( arrayElement( arrayFilter( x -> JSONExtractString(x, 'type') = 'assistant', splitByChar('\\n', cs.content) ), -1 ), 'message' ), 'model' ) as model_used, toUInt8(if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 1, 0)) as has_commit, toUInt8(if(position(cs.content, '\"name\":\"EnterPlanMode\"') > 0, 1, 0)) as used_plan_mode, toUInt32(arraySum(_inference_gaps)) as inference_duration_sec, toUInt32(arraySum(_human_gaps)) as human_duration_sec, CASE WHEN _duration_min <= 10 AND (_input_tokens + _output_tokens) < 500000 AND _output_tokens > 1000 THEN 'quick_win' WHEN _duration_min > 30 AND _output_tokens > 50000 AND cs.git_sha IS NOT NULL AND cs.git_sha != '' THEN 'deep_work' WHEN (_input_tokens + _output_tokens) > 1000000 AND (_output_tokens / nullif(_input_tokens, 0)) < 0.3 AND _duration_min > 20 THEN 'struggle' WHEN length(_skills) >= 3 AND (cs.git_sha IS NULL OR cs.git_sha = '') AND (_input_tokens + _output_tokens) > 200000 THEN 'exploration' WHEN _duration_min < 3 AND _output_tokens < 500 THEN 'abandoned' ELSE 'standard' END as session_archetype, toUInt8(round( 50 + (if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 20, 0)) + (if((_output_tokens / nullif(_input_tokens, 0)) > 0.5, 15, 0)) + (least(toUInt32(length(_skills)), 3) * 5) - (if((_input_tokens + _output_tokens) > 1500000 AND (cs.git_sha IS NULL OR cs.git_sha = ''), 20, 0)) - (if(_duration_min < 2 AND _output_tokens < 200, 30, 0)) - (least(toUInt32( length(extractAll(cs.content, '\"isApiErrorMessage\":true')) + length(extractAll(cs.content, '\"is_error\":true')) ), 10) * 2) )) as success_score, ROW_NUMBER() OVER (PARTITION BY cs.session_id ORDER BY cs.ingested_at DESC) AS _dedupe_rank FROM rudel.claude_sessions AS cs WHERE length(_timestamps) > 0 ) WHERE _dedupe_rank = 1",
-      "kind": "materialized_view"
-    }
-  ]
+	"version": 1,
+	"generatedAt": "2026-05-18T23:34:37.446Z",
+	"definitions": [
+		{
+			"database": "rudel",
+			"name": "claude_sessions",
+			"engine": "ReplacingMergeTree(ingested_at)",
+			"columns": [
+				{
+					"name": "session_date",
+					"type": "DateTime64(3, 'UTC')",
+					"default": "fn:now64(3)"
+				},
+				{
+					"name": "last_interaction_date",
+					"type": "DateTime64(3, 'UTC')",
+					"default": "fn:now64(3)"
+				},
+				{
+					"name": "session_id",
+					"type": "String"
+				},
+				{
+					"name": "organization_id",
+					"type": "String"
+				},
+				{
+					"name": "project_path",
+					"type": "String"
+				},
+				{
+					"name": "git_remote",
+					"type": "String",
+					"default": "''"
+				},
+				{
+					"name": "package_name",
+					"type": "String",
+					"default": "''"
+				},
+				{
+					"name": "package_type",
+					"type": "String",
+					"default": "''"
+				},
+				{
+					"name": "content",
+					"type": "String"
+				},
+				{
+					"name": "ingested_at",
+					"type": "DateTime64(3, 'UTC')",
+					"default": "fn:now64(3)"
+				},
+				{
+					"name": "user_id",
+					"type": "String"
+				},
+				{
+					"name": "git_branch",
+					"type": "String",
+					"nullable": true
+				},
+				{
+					"name": "git_sha",
+					"type": "String",
+					"nullable": true
+				},
+				{
+					"name": "tag",
+					"type": "String",
+					"nullable": true
+				},
+				{
+					"name": "subagents",
+					"type": "Map(String, String)",
+					"default": "fn:map()"
+				}
+			],
+			"primaryKey": ["organization_id", "session_date", "session_id"],
+			"orderBy": ["organization_id", "session_date", "session_id"],
+			"partitionBy": "toYYYYMM(toDate(session_date))",
+			"ttl": "toDate(session_date) + toIntervalDay(365)",
+			"settings": {
+				"index_granularity": "8192",
+				"storage_policy": "'s3'"
+			},
+			"kind": "table"
+		},
+		{
+			"database": "rudel",
+			"name": "codex_sessions",
+			"engine": "ReplacingMergeTree(ingested_at)",
+			"columns": [
+				{
+					"name": "session_date",
+					"type": "DateTime64(3, 'UTC')",
+					"default": "fn:now64(3)"
+				},
+				{
+					"name": "last_interaction_date",
+					"type": "DateTime64(3, 'UTC')",
+					"default": "fn:now64(3)"
+				},
+				{
+					"name": "session_id",
+					"type": "String"
+				},
+				{
+					"name": "organization_id",
+					"type": "String"
+				},
+				{
+					"name": "project_path",
+					"type": "String"
+				},
+				{
+					"name": "git_remote",
+					"type": "String",
+					"default": "''"
+				},
+				{
+					"name": "package_name",
+					"type": "String",
+					"default": "''"
+				},
+				{
+					"name": "package_type",
+					"type": "String",
+					"default": "''"
+				},
+				{
+					"name": "content",
+					"type": "String"
+				},
+				{
+					"name": "ingested_at",
+					"type": "DateTime64(3, 'UTC')",
+					"default": "fn:now64(3)"
+				},
+				{
+					"name": "user_id",
+					"type": "String"
+				},
+				{
+					"name": "git_branch",
+					"type": "String",
+					"nullable": true
+				},
+				{
+					"name": "git_sha",
+					"type": "String",
+					"nullable": true
+				},
+				{
+					"name": "tag",
+					"type": "String",
+					"nullable": true
+				}
+			],
+			"primaryKey": ["organization_id", "session_date", "session_id"],
+			"orderBy": ["organization_id", "session_date", "session_id"],
+			"partitionBy": "toYYYYMM(toDate(session_date))",
+			"ttl": "toDate(session_date) + toIntervalDay(365)",
+			"settings": {
+				"index_granularity": "8192",
+				"storage_policy": "'s3'"
+			},
+			"kind": "table"
+		},
+		{
+			"database": "rudel",
+			"name": "session_analytics",
+			"engine": "ReplacingMergeTree(ingested_at)",
+			"columns": [
+				{
+					"name": "session_date",
+					"type": "DateTime64(3, 'UTC')",
+					"default": "fn:now64(3)"
+				},
+				{
+					"name": "last_interaction_date",
+					"type": "DateTime64(3, 'UTC')",
+					"default": "fn:now64(3)"
+				},
+				{
+					"name": "session_id",
+					"type": "String"
+				},
+				{
+					"name": "organization_id",
+					"type": "String"
+				},
+				{
+					"name": "project_path",
+					"type": "String"
+				},
+				{
+					"name": "git_remote",
+					"type": "String",
+					"default": "''"
+				},
+				{
+					"name": "package_name",
+					"type": "String",
+					"default": "''"
+				},
+				{
+					"name": "package_type",
+					"type": "String",
+					"default": "''"
+				},
+				{
+					"name": "content",
+					"type": "String"
+				},
+				{
+					"name": "subagents",
+					"type": "Map(String, String)",
+					"default": "fn:map()"
+				},
+				{
+					"name": "skills",
+					"type": "Array(String)",
+					"default": "fn:[]"
+				},
+				{
+					"name": "slash_commands",
+					"type": "Array(String)",
+					"default": "fn:[]"
+				},
+				{
+					"name": "subagent_types",
+					"type": "Array(String)",
+					"default": "fn:[]"
+				},
+				{
+					"name": "ingested_at",
+					"type": "DateTime64(3, 'UTC')",
+					"default": "fn:now64(3)"
+				},
+				{
+					"name": "user_id",
+					"type": "String"
+				},
+				{
+					"name": "git_branch",
+					"type": "String",
+					"nullable": true
+				},
+				{
+					"name": "git_sha",
+					"type": "String",
+					"nullable": true
+				},
+				{
+					"name": "input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "output_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "cache_read_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "cache_creation_input_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "total_tokens",
+					"type": "UInt64",
+					"default": "fn:0"
+				},
+				{
+					"name": "tag",
+					"type": "String",
+					"nullable": true
+				},
+				{
+					"name": "source",
+					"type": "LowCardinality(String)",
+					"default": "'claude_code'"
+				},
+				{
+					"name": "total_interactions",
+					"type": "UInt32",
+					"default": "fn:0"
+				},
+				{
+					"name": "actual_duration_min",
+					"type": "UInt32",
+					"default": "fn:0"
+				},
+				{
+					"name": "avg_period_sec",
+					"type": "Float64",
+					"default": "fn:0"
+				},
+				{
+					"name": "median_period_sec",
+					"type": "Float64",
+					"default": "fn:0"
+				},
+				{
+					"name": "quick_responses",
+					"type": "UInt32",
+					"default": "fn:0"
+				},
+				{
+					"name": "normal_responses",
+					"type": "UInt32",
+					"default": "fn:0"
+				},
+				{
+					"name": "long_pauses",
+					"type": "UInt32",
+					"default": "fn:0"
+				},
+				{
+					"name": "error_count",
+					"type": "UInt32",
+					"default": "fn:0"
+				},
+				{
+					"name": "model_used",
+					"type": "String",
+					"default": "''"
+				},
+				{
+					"name": "has_commit",
+					"type": "UInt8",
+					"default": "fn:0"
+				},
+				{
+					"name": "session_archetype",
+					"type": "String",
+					"default": "'standard'"
+				},
+				{
+					"name": "success_score",
+					"type": "UInt8",
+					"default": "fn:0"
+				},
+				{
+					"name": "used_plan_mode",
+					"type": "UInt8",
+					"default": "fn:0"
+				},
+				{
+					"name": "inference_duration_sec",
+					"type": "UInt32",
+					"default": "fn:0"
+				},
+				{
+					"name": "human_duration_sec",
+					"type": "UInt32",
+					"default": "fn:0"
+				}
+			],
+			"primaryKey": ["organization_id", "session_date", "session_id"],
+			"orderBy": ["organization_id", "session_date", "session_id"],
+			"partitionBy": "toYYYYMM(toDate(session_date))",
+			"settings": {
+				"index_granularity": "8192"
+			},
+			"indexes": [
+				{
+					"name": "idx_git_remote",
+					"expression": "git_remote",
+					"type": "set",
+					"typeArgs": "0",
+					"granularity": 4
+				},
+				{
+					"name": "idx_model_used",
+					"expression": "model_used",
+					"type": "set",
+					"typeArgs": "0",
+					"granularity": 4
+				},
+				{
+					"name": "idx_project_path",
+					"expression": "project_path",
+					"type": "set",
+					"typeArgs": "0",
+					"granularity": 4
+				},
+				{
+					"name": "idx_source",
+					"expression": "source",
+					"type": "set",
+					"typeArgs": "0",
+					"granularity": 4
+				},
+				{
+					"name": "idx_user_id",
+					"expression": "user_id",
+					"type": "set",
+					"typeArgs": "0",
+					"granularity": 4
+				}
+			],
+			"kind": "table"
+		},
+		{
+			"database": "rudel",
+			"name": "wrapped_user_archetype_runs_v1",
+			"engine": "MergeTree()",
+			"columns": [
+				{
+					"name": "snapshot_id",
+					"type": "String"
+				},
+				{
+					"name": "snapshot_created_at",
+					"type": "DateTime64(3, 'UTC')"
+				},
+				{
+					"name": "pipeline_version",
+					"type": "LowCardinality(String)"
+				},
+				{
+					"name": "centroid_version",
+					"type": "LowCardinality(String)"
+				},
+				{
+					"name": "scope",
+					"type": "LowCardinality(String)"
+				},
+				{
+					"name": "user_scope_count",
+					"type": "UInt32"
+				},
+				{
+					"name": "trigger_reason",
+					"type": "LowCardinality(String)"
+				},
+				{
+					"name": "trigger_source",
+					"type": "LowCardinality(Nullable(String))"
+				},
+				{
+					"name": "trigger_session_id",
+					"type": "String",
+					"nullable": true
+				}
+			],
+			"primaryKey": [],
+			"orderBy": ["snapshot_created_at", "snapshot_id"],
+			"kind": "table"
+		},
+		{
+			"database": "rudel",
+			"name": "wrapped_user_archetype_snapshots_v1",
+			"engine": "MergeTree()",
+			"columns": [
+				{
+					"name": "snapshot_id",
+					"type": "String"
+				},
+				{
+					"name": "snapshot_created_at",
+					"type": "DateTime64(3, 'UTC')"
+				},
+				{
+					"name": "pipeline_version",
+					"type": "LowCardinality(String)"
+				},
+				{
+					"name": "centroid_version",
+					"type": "LowCardinality(String)"
+				},
+				{
+					"name": "scope",
+					"type": "LowCardinality(String)"
+				},
+				{
+					"name": "organization_id",
+					"type": "String"
+				},
+				{
+					"name": "user_id",
+					"type": "String"
+				},
+				{
+					"name": "first_session_at",
+					"type": "DateTime64(3, 'UTC')"
+				},
+				{
+					"name": "last_session_at",
+					"type": "DateTime64(3, 'UTC')"
+				},
+				{
+					"name": "days_since_first_session",
+					"type": "UInt32"
+				},
+				{
+					"name": "total_sessions",
+					"type": "UInt32"
+				},
+				{
+					"name": "active_days",
+					"type": "UInt32"
+				},
+				{
+					"name": "claude_session_count",
+					"type": "UInt32"
+				},
+				{
+					"name": "codex_session_count",
+					"type": "UInt32"
+				},
+				{
+					"name": "total_tokens",
+					"type": "UInt64"
+				},
+				{
+					"name": "estimated_spend_usd",
+					"type": "Float64"
+				},
+				{
+					"name": "mean_session_min",
+					"type": "Float64"
+				},
+				{
+					"name": "longest_session_min",
+					"type": "UInt32"
+				},
+				{
+					"name": "commit_sessions",
+					"type": "UInt32"
+				},
+				{
+					"name": "distinct_repos",
+					"type": "UInt32",
+					"nullable": true
+				},
+				{
+					"name": "breadth_available",
+					"type": "UInt8"
+				},
+				{
+					"name": "range_entropy",
+					"type": "Float64"
+				},
+				{
+					"name": "consistency_raw",
+					"type": "Float64"
+				},
+				{
+					"name": "intensity_raw",
+					"type": "Float64"
+				},
+				{
+					"name": "session_shape_raw",
+					"type": "Float64"
+				},
+				{
+					"name": "cost_intensity_raw",
+					"type": "Float64"
+				},
+				{
+					"name": "output_raw",
+					"type": "Float64"
+				},
+				{
+					"name": "breadth_raw",
+					"type": "Float64",
+					"nullable": true
+				},
+				{
+					"name": "range_raw",
+					"type": "Float64"
+				},
+				{
+					"name": "consistency",
+					"type": "Float64"
+				},
+				{
+					"name": "intensity",
+					"type": "Float64"
+				},
+				{
+					"name": "session_shape",
+					"type": "Float64"
+				},
+				{
+					"name": "cost_intensity",
+					"type": "Float64"
+				},
+				{
+					"name": "output",
+					"type": "Float64"
+				},
+				{
+					"name": "breadth",
+					"type": "Float64",
+					"nullable": true
+				},
+				{
+					"name": "range",
+					"type": "Float64"
+				},
+				{
+					"name": "archetype_id",
+					"type": "UInt8"
+				},
+				{
+					"name": "archetype_key",
+					"type": "LowCardinality(String)"
+				},
+				{
+					"name": "archetype_name",
+					"type": "String"
+				},
+				{
+					"name": "archetype_distance",
+					"type": "Float64"
+				},
+				{
+					"name": "archetype_distance_ratio_to_max",
+					"type": "Float64"
+				}
+			],
+			"primaryKey": [],
+			"orderBy": ["snapshot_id", "organization_id", "user_id"],
+			"partitionBy": "toYYYYMM(toDate(snapshot_created_at))",
+			"kind": "table"
+		},
+		{
+			"database": "rudel",
+			"name": "codex_session_analytics_mv",
+			"to": {
+				"database": "rudel",
+				"name": "session_analytics"
+			},
+			"as": "SELECT * EXCEPT (_dedupe_rank) FROM ( WITH arrayFilter( x -> x != '', splitByChar('\\n', cs.content) ) AS _all_lines, arrayFilter(x -> JSONHas(x, 'timestamp'), _all_lines) AS _ts_lines, arrayMap( x -> parseDateTime64BestEffort(JSONExtractString(x, 'timestamp')), _ts_lines ) AS _timestamps, if(length(_timestamps) > 1, arrayMap(i -> dateDiff('second', _timestamps[i], _timestamps[i+1]), range(1, length(_timestamps))), [] ) AS _prompt_periods_sec, if(length(_timestamps) > 1, arrayMap(i -> if(i < length(_timestamps), dateDiff('second', _timestamps[i], _timestamps[i+1]), 0), range(1, length(_timestamps))), [] ) AS _inference_gaps, arrayFilter( x -> JSONExtractString(x, 'type') = 'response_item' OR JSONExtractString(x, 'type') = 'event_msg', _all_lines ) AS _interaction_lines, arrayFilter( x -> JSONExtractString(x, 'type') = 'response_item' AND JSONExtractString(JSONExtractRaw(x, 'payload'), 'type') = 'function_call_output', _all_lines ) AS _tool_output_lines, arrayFilter( x -> JSONExtractString(x, 'type') = 'event_msg' AND JSONExtractString(JSONExtractRaw(x, 'payload'), 'type') = 'token_count' AND JSONExtractRaw(JSONExtractRaw(x, 'payload'), 'info') IS NOT NULL AND JSONExtractRaw(JSONExtractRaw(x, 'payload'), 'info') != 'null', _all_lines ) AS _token_count_lines, if(length(_token_count_lines) > 0, JSONExtractRaw(JSONExtractRaw(JSONExtractRaw(arrayElement(_token_count_lines, -1), 'payload'), 'info'), 'total_token_usage'), '{}' ) AS _final_usage, toUInt64OrZero(JSONExtractRaw(_final_usage, 'input_tokens')) AS _input_tokens, toUInt64OrZero(JSONExtractRaw(_final_usage, 'output_tokens')) AS _output_tokens, toUInt64OrZero(JSONExtractRaw(_final_usage, 'cached_input_tokens')) AS _cache_read_input_tokens, arrayMin(_timestamps) AS _session_date, arrayMax(_timestamps) AS _last_interaction_date, dateDiff('minute', _session_date, _last_interaction_date) AS _duration_min, arrayFilter(x -> JSONExtractString(x, 'type') = 'session_meta', _all_lines) AS _meta_lines, JSONExtractString( JSONExtractRaw(arrayElement(_meta_lines, 1), 'payload'), 'model_provider' ) AS _model_provider, arrayFilter( x -> JSONExtractString(x, 'type') = 'turn_context', _all_lines ) AS _turn_context_lines, if(length(_turn_context_lines) > 0, JSONExtractString(JSONExtractRaw(arrayElement(_turn_context_lines, 1), 'payload'), 'model'), '' ) AS _model_from_turn_context, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '\"name\":\"exec_command\"[^}]*skills/([a-zA-Z0-9_-]+)/SKILL'))) AS _skills SELECT * EXCEPT (session_date, last_interaction_date), _session_date as session_date, _last_interaction_date as last_interaction_date, 'codex' as source, _input_tokens as input_tokens, _output_tokens as output_tokens, _cache_read_input_tokens as cache_read_input_tokens, toUInt64(0) as cache_creation_input_tokens, _input_tokens + _output_tokens as total_tokens, _skills as skills, [] :: Array(String) as slash_commands, [] :: Array(String) as subagent_types, map() as subagents, toUInt32(length(_interaction_lines)) as total_interactions, toUInt32(_duration_min) as actual_duration_min, if(length(_prompt_periods_sec) > 0, round(arrayAvg(_prompt_periods_sec), 2), 0) as avg_period_sec, if( length(_prompt_periods_sec) > 0, toFloat64(arrayElement( arraySort(_prompt_periods_sec), toUInt64(ceil(length(_prompt_periods_sec) / 2)) )), 0 ) as median_period_sec, toUInt32(arrayCount(x -> x < 5, _prompt_periods_sec)) as quick_responses, toUInt32(arrayCount(x -> x >= 5 AND x <= 60, _prompt_periods_sec)) as normal_responses, toUInt32(arrayCount(x -> x > 300, _prompt_periods_sec)) as long_pauses, toUInt32( length(extractAll(cs.content, '\\\\\\\\\"exit_code\\\\\\\\\":[1-9][0-9]*')) + arrayCount( x -> x ILIKE '%Error:%' OR x ILIKE '%Exception:%', _tool_output_lines ) ) as error_count, multiIf( _model_from_turn_context != '', _model_from_turn_context, _model_provider != '', _model_provider, 'unknown' ) as model_used, toUInt8(if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 1, 0)) as has_commit, toUInt8(0) as used_plan_mode, toUInt32(arraySum(_inference_gaps)) as inference_duration_sec, toUInt32(0) as human_duration_sec, CASE WHEN _duration_min <= 10 AND (_input_tokens + _output_tokens) < 500000 AND _output_tokens > 1000 THEN 'quick_win' WHEN _duration_min > 30 AND _output_tokens > 50000 AND cs.git_sha IS NOT NULL AND cs.git_sha != '' THEN 'deep_work' WHEN (_input_tokens + _output_tokens) > 1000000 AND (_output_tokens / nullif(_input_tokens, 0)) < 0.3 AND _duration_min > 20 THEN 'struggle' WHEN length(_skills) >= 3 AND (cs.git_sha IS NULL OR cs.git_sha = '') AND (_input_tokens + _output_tokens) > 200000 THEN 'exploration' WHEN _duration_min < 3 AND _output_tokens < 500 THEN 'abandoned' ELSE 'standard' END as session_archetype, toUInt8(round( 50 + (if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 20, 0)) + (if((_output_tokens / nullif(_input_tokens, 0)) > 0.5, 15, 0)) + (least(toUInt32(length(_skills)), 3) * 5) - (if((_input_tokens + _output_tokens) > 1500000 AND (cs.git_sha IS NULL OR cs.git_sha = ''), 20, 0)) - (if(_duration_min < 2 AND _output_tokens < 200, 30, 0)) - (least(toUInt32( length(extractAll(cs.content, '\\\\\\\\\"exit_code\\\\\\\\\":[1-9][0-9]*')) + arrayCount( x -> JSONExtractString(JSONExtractRaw(x, 'payload'), 'output') ILIKE '%Error:%' OR JSONExtractString(JSONExtractRaw(x, 'payload'), 'output') ILIKE '%Exception:%', _tool_output_lines ) ), 10) * 2) )) as success_score, ROW_NUMBER() OVER (PARTITION BY cs.session_id ORDER BY cs.ingested_at DESC) AS _dedupe_rank FROM rudel.codex_sessions AS cs WHERE length(_timestamps) > 0 ) WHERE _dedupe_rank = 1",
+			"kind": "materialized_view"
+		},
+		{
+			"database": "rudel",
+			"name": "session_analytics_mv",
+			"to": {
+				"database": "rudel",
+				"name": "session_analytics"
+			},
+			"as": "SELECT * EXCEPT (_dedupe_rank) FROM ( WITH arrayFilter( x -> JSONExtractString(x, 'type') IN ('user', 'assistant'), splitByChar('\\n', cs.content) ) AS _interaction_lines, arrayFilter(x -> JSONHas(x, 'timestamp'), _interaction_lines) AS _ts_lines, arrayMap( x -> parseDateTime64BestEffort(JSONExtractString(x, 'timestamp')), _ts_lines ) AS _timestamps, arrayMap( x -> JSONExtractString(x, 'type'), _ts_lines ) AS _msg_types, if(length(_timestamps) > 1, arrayMap(i -> dateDiff('second', _timestamps[i], _timestamps[i+1]), range(1, length(_timestamps))), [] ) AS _prompt_periods_sec, if(length(_timestamps) > 1, arrayMap(i -> if(_msg_types[i] = 'user' AND _msg_types[i+1] = 'assistant', dateDiff('second', _timestamps[i], _timestamps[i+1]), 0), range(1, length(_timestamps))), [] ) AS _inference_gaps, if(length(_timestamps) > 1, arrayMap(i -> if(_msg_types[i] = 'assistant' AND _msg_types[i+1] = 'user', dateDiff('second', _timestamps[i], _timestamps[i+1]), 0), range(1, length(_timestamps))), [] ) AS _human_gaps, arrayFilter( x -> JSONExtractString(x, 'type') = 'assistant' AND JSONHas(x, 'message'), splitByChar('\\n', cs.content) ) AS _assistant_lines, arrayMap( x -> JSONExtractString(JSONExtractRaw(x, 'message'), 'id'), _assistant_lines ) AS _assistant_ids, arrayFilter( (x, i) -> i = length(_assistant_ids) OR _assistant_ids[i] != _assistant_ids[i + 1], _assistant_lines, arrayEnumerate(_assistant_lines) ) AS _deduped_assistant_lines, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'input_tokens')) + toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_read_input_tokens')) + toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_creation_input_tokens')), _deduped_assistant_lines)) AS _input_tokens, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'output_tokens')), _deduped_assistant_lines)) AS _output_tokens, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_read_input_tokens')), _deduped_assistant_lines)) AS _cache_read, arraySum(arrayMap(x -> toUInt64OrZero(JSONExtractRaw(JSONExtractRaw(x, 'message'), 'usage', 'cache_creation_input_tokens')), _deduped_assistant_lines)) AS _cache_creation, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '\"name\":\"Skill\"[^}]*\"skill\":\"([^\"]+)\"'))) AS _skills, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '\"name\":\"Task\"[^}]*\"subagent_type\":\"([^\"]+)\"'))) AS _subagent_types, arrayDistinct(arrayFilter(x -> x != '', extractAll(cs.content, '<command-name>/([^<]+)</command-name>'))) AS _slash_commands, arrayMin(_timestamps) AS _session_date, arrayMax(_timestamps) AS _last_interaction_date, dateDiff('minute', _session_date, _last_interaction_date) AS _duration_min SELECT * EXCEPT (session_date, last_interaction_date), _session_date as session_date, _last_interaction_date as last_interaction_date, 'claude_code' as source, _input_tokens as input_tokens, _output_tokens as output_tokens, _cache_read as cache_read_input_tokens, _cache_creation as cache_creation_input_tokens, _input_tokens + _output_tokens as total_tokens, _skills as skills, _slash_commands as slash_commands, _subagent_types as subagent_types, toUInt32(length(_timestamps)) as total_interactions, toUInt32(_duration_min) as actual_duration_min, if(length(_prompt_periods_sec) > 0, round(arrayAvg(_prompt_periods_sec), 2), 0) as avg_period_sec, if( length(_prompt_periods_sec) > 0, toFloat64(arrayElement( arraySort(_prompt_periods_sec), toUInt64(ceil(length(_prompt_periods_sec) / 2)) )), 0 ) as median_period_sec, toUInt32(arrayCount(x -> x < 5, _prompt_periods_sec)) as quick_responses, toUInt32(arrayCount(x -> x >= 5 AND x <= 60, _prompt_periods_sec)) as normal_responses, toUInt32(arrayCount(x -> x > 300, _prompt_periods_sec)) as long_pauses, toUInt32( length(extractAll(cs.content, '\"isApiErrorMessage\":true')) + length(extractAll(cs.content, '\"is_error\":true')) ) as error_count, JSONExtractString( JSONExtractRaw( arrayElement( arrayFilter( x -> JSONExtractString(x, 'type') = 'assistant', splitByChar('\\n', cs.content) ), -1 ), 'message' ), 'model' ) as model_used, toUInt8(if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 1, 0)) as has_commit, toUInt8(if(position(cs.content, '\"name\":\"EnterPlanMode\"') > 0, 1, 0)) as used_plan_mode, toUInt32(arraySum(_inference_gaps)) as inference_duration_sec, toUInt32(arraySum(_human_gaps)) as human_duration_sec, CASE WHEN _duration_min <= 10 AND (_input_tokens + _output_tokens) < 500000 AND _output_tokens > 1000 THEN 'quick_win' WHEN _duration_min > 30 AND _output_tokens > 50000 AND cs.git_sha IS NOT NULL AND cs.git_sha != '' THEN 'deep_work' WHEN (_input_tokens + _output_tokens) > 1000000 AND (_output_tokens / nullif(_input_tokens, 0)) < 0.3 AND _duration_min > 20 THEN 'struggle' WHEN length(_skills) >= 3 AND (cs.git_sha IS NULL OR cs.git_sha = '') AND (_input_tokens + _output_tokens) > 200000 THEN 'exploration' WHEN _duration_min < 3 AND _output_tokens < 500 THEN 'abandoned' ELSE 'standard' END as session_archetype, toUInt8(round( 50 + (if(cs.git_sha IS NOT NULL AND cs.git_sha != '', 20, 0)) + (if((_output_tokens / nullif(_input_tokens, 0)) > 0.5, 15, 0)) + (least(toUInt32(length(_skills)), 3) * 5) - (if((_input_tokens + _output_tokens) > 1500000 AND (cs.git_sha IS NULL OR cs.git_sha = ''), 20, 0)) - (if(_duration_min < 2 AND _output_tokens < 200, 30, 0)) - (least(toUInt32( length(extractAll(cs.content, '\"isApiErrorMessage\":true')) + length(extractAll(cs.content, '\"is_error\":true')) ), 10) * 2) )) as success_score, ROW_NUMBER() OVER (PARTITION BY cs.session_id ORDER BY cs.ingested_at DESC) AS _dedupe_rank FROM rudel.claude_sessions AS cs WHERE length(_timestamps) > 0 ) WHERE _dedupe_rank = 1",
+			"kind": "materialized_view"
+		}
+	]
 }


### PR DESCRIPTION
## Summary
- replace the four unavailable Blacksmith runners with `ubuntu-24.04`
- upgrade the shared Bun cache action from v3 to v6
- mechanically format the ClickHouse snapshot so the existing repository verification can pass
- cancel the two workflow runs left queued by the repository transfer

## Root cause
Blacksmith runners are available only to organization-owned repositories. After the move to the personal `evrendom` account, every GitHub Actions job remained queued.

## Validation
- `bun run verify`
- snapshot content compared as normalized JSON with no semantic changes
- confirmed no `blacksmith` or `actions/cache@v3` references remain

Linear: RUD-205