### PR TITLE
fix: validate post-auth redirect destinations

### DIFF
--- a/apps/web/src/features/auth/AuthStateRefresh.test.tsx
+++ b/apps/web/src/features/auth/AuthStateRefresh.test.tsx
@@ -11,6 +11,7 @@ import {
 	getPendingSignupRedirect,
 	getSocialLoginRedirectOptions,
 	getSocialSignupRedirectOptions,
+	getValidRedirect,
 	isGetStartedPath,
 	primePendingSignupRedirect,
 } from "./auth-route-utils";
@@ -175,6 +176,18 @@ describe("auth state refresh", () => {
 		expect(
 			getEmailLoginSuccessDestination("/", "?redirect=%2Fdashboard%2Fsessions"),
 		).toBe("/dashboard/sessions");
+	});
+
+	it.each([
+		["a scheme-relative URL", "?redirect=%2F%2Fattacker.example"],
+		["a raw backslash", "?redirect=%2F%5Cattacker.example"],
+		["an encoded backslash", "?redirect=%2F%255Cattacker.example"],
+		["an encoded slash", "?redirect=%2F%252Fattacker.example"],
+		["a raw control character", "?redirect=%2F%00attacker.example"],
+		["an encoded control character", "?redirect=%2F%250Aattacker.example"],
+	])("rejects %s as a post-auth redirect", (_label, search) => {
+		expect(getValidRedirect(search)).toBeNull();
+		expect(getEmailLoginSuccessDestination("/", search)).toBe("/");
 	});
 
 	it("preserves direct wrapped destinations for email login", () => {

--- a/apps/web/src/features/auth/auth-route-utils.ts
+++ b/apps/web/src/features/auth/auth-route-utils.ts
@@ -4,10 +4,24 @@ import type { authClient } from "@/lib/auth-client";
 export type AppSession = ReturnType<typeof authClient.useSession>["data"];
 const PENDING_SIGNUP_REDIRECT_PARAM = "signup_redirect";
 const RELATIVE_URL_BASE = "https://rudel.local";
+const RELATIVE_URL_ORIGIN = new URL(RELATIVE_URL_BASE).origin;
+const REDIRECT_ENCODED_AMBIGUOUS_CHARACTER_PATTERN =
+	/%(?:2f|5c|[01][0-9a-f]|7f)/i;
 type WrappedAuthRedirectFlow =
 	| "card-profile"
 	| "desktop-ready"
 	| "sessions-landed";
+
+function containsControlCharacter(value: string): boolean {
+	for (const character of value) {
+		const characterCode = character.charCodeAt(0);
+		if (characterCode <= 31 || characterCode === 127) {
+			return true;
+		}
+	}
+
+	return false;
+}
 
 function normalizeValidRelativeRedirect(
 	redirect: string | null,
@@ -17,6 +31,23 @@ function normalizeValidRelativeRedirect(
 	}
 
 	if (!redirect.startsWith("/") || redirect.startsWith("//")) {
+		return null;
+	}
+
+	if (
+		redirect.includes("\\") ||
+		containsControlCharacter(redirect) ||
+		REDIRECT_ENCODED_AMBIGUOUS_CHARACTER_PATTERN.test(redirect)
+	) {
+		return null;
+	}
+
+	try {
+		const resolvedRedirect = new URL(redirect, RELATIVE_URL_BASE);
+		if (resolvedRedirect.origin !== RELATIVE_URL_ORIGIN) {
+			return null;
+		}
+	} catch {
 		return null;
 	}
 


### PR DESCRIPTION
## Summary

- Validate post-auth destinations against a local base URL.
- Reject ambiguous redirect input before navigation.
- Add regression tests for invalid destination forms.

## Test plan

- [x] `bun run verify`
