### PR TITLE
ci: gate and serialize production deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.sha }}
@@ -97,9 +97,13 @@ jobs:
 
   deploy:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    needs: verify
+    needs: [verify, integration]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    environment: production
+    concurrency:
+      group: production-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- require both `verify` and `integration` before production deploys can start
- attach deploys to the `production` GitHub environment
- serialize production deploys without canceling an active deployment
- read `TURBO_TEAM` from a repository variable instead of a secret

## Live GitHub configuration

- created the `production` environment with no manual approval gate
- restricted that environment to the `main` branch
- environment-scoped deploy secrets and the `TURBO_TEAM` repository variable are still required before merge

## Validation

- [x] workflow YAML parses successfully
- [x] `git diff --check`
- [x] database-free `bun run verify` (12/12 tasks)
- [x] GitHub PR checks
- [ ] green post-merge deploy using environment-scoped credentials

## Human gate before merge

Do not merge until the eight deployment values are present in the `production` environment and `TURBO_TEAM` exists as a repository variable. The repository-level copies remain in place until a green environment-scoped deploy proves the migration.

Linear: RUD-209
