### PR TITLE
fix(api): protect session count refresh

### DIFF
--- a/apps/api/src/__tests__/org-session.service.test.ts
+++ b/apps/api/src/__tests__/org-session.service.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { ClickHouseStatement } from "../clickhouse.js";
-import { getOrgSessionCount } from "../services/org-session.service.js";
+import {
+	createOrgSessionCountCache,
+	getOrgSessionCount,
+} from "../services/org-session.service.js";
 
 const queryCalls: ClickHouseStatement[] = [];
 let rawTableCounts = new Map<string, string>();
@@ -62,5 +65,78 @@ describe("getOrgSessionCount", () => {
 		expect(queryCalls[1]?.query).toContain("FROM rudel.codex_sessions");
 		expect(queryCalls[0]?.query).not.toContain("user_id = {userId:String}");
 		expect(queryCalls[1]?.query).not.toContain("user_id = {userId:String}");
+	});
+});
+
+describe("createOrgSessionCountCache", () => {
+	test("coalesces simultaneous reads for the same count", async () => {
+		const load = mock(() => Promise.resolve(96));
+		const getCachedCount = createOrgSessionCountCache({
+			load,
+			ttlMs: 2_000,
+		});
+
+		const counts = await Promise.all([
+			getCachedCount("org-1", "user-1"),
+			getCachedCount("org-1", "user-1"),
+			getCachedCount("org-1", "user-1"),
+		]);
+
+		expect(counts).toEqual([96, 96, 96]);
+		expect(load).toHaveBeenCalledTimes(1);
+	});
+
+	test("refreshes the count after the short cache window", async () => {
+		let now = 1_000;
+		let currentCount = 40;
+		const load = mock(() => Promise.resolve(currentCount));
+		const getCachedCount = createOrgSessionCountCache({
+			load,
+			now: () => now,
+			ttlMs: 2_000,
+		});
+
+		expect(await getCachedCount("org-1")).toBe(40);
+		currentCount = 41;
+		now += 1_999;
+		expect(await getCachedCount("org-1")).toBe(40);
+		now += 2;
+		expect(await getCachedCount("org-1")).toBe(41);
+		expect(load).toHaveBeenCalledTimes(2);
+	});
+
+	test("keeps organization-wide and user-specific counts separate", async () => {
+		let nextCount = 1;
+		const load = mock(() => Promise.resolve(nextCount++));
+		const getCachedCount = createOrgSessionCountCache({
+			load,
+			ttlMs: 2_000,
+		});
+
+		expect(await getCachedCount("org-1")).toBe(1);
+		expect(await getCachedCount("org-1", "user-1")).toBe(2);
+		expect(await getCachedCount("org-2")).toBe(3);
+		expect(load).toHaveBeenCalledTimes(3);
+	});
+
+	test("retries after a count read fails", async () => {
+		let shouldFail = true;
+		const load = mock(() => {
+			if (shouldFail) {
+				return Promise.reject(new Error("Temporary count failure"));
+			}
+			return Promise.resolve(12);
+		});
+		const getCachedCount = createOrgSessionCountCache({
+			load,
+			ttlMs: 2_000,
+		});
+
+		await expect(getCachedCount("org-1")).rejects.toThrow(
+			"Temporary count failure",
+		);
+		shouldFail = false;
+		await expect(getCachedCount("org-1")).resolves.toBe(12);
+		expect(load).toHaveBeenCalledTimes(2);
 	});
 });

--- a/apps/api/src/__tests__/rate-limit.test.ts
+++ b/apps/api/src/__tests__/rate-limit.test.ts
@@ -4,6 +4,7 @@ import {
 	checkAnalyticsRateLimit,
 	checkHookIngestRateLimit,
 	checkManualIngestRateLimit,
+	checkOrganizationSessionCountRateLimit,
 } from "../rate-limit.js";
 
 describe("IngestSessionInputSchema metadata field limits", () => {
@@ -111,6 +112,44 @@ describe("checkAnalyticsRateLimit", () => {
 		}
 		// userA is exhausted, userB should still work
 		expect(() => checkAnalyticsRateLimit(userB)).not.toThrow();
+	});
+});
+
+describe("checkOrganizationSessionCountRateLimit", () => {
+	test("allows five one-second pollers for one minute", () => {
+		const userId = `test-session-count-polling-${Date.now()}`;
+		const organizationId = "org-polling";
+
+		expect(() => {
+			for (let i = 0; i < 300; i++) {
+				checkOrganizationSessionCountRateLimit(userId, organizationId);
+			}
+		}).not.toThrow();
+	});
+
+	test("blocks sustained traffic above the refresh limit", () => {
+		const userId = `test-session-count-over-${Date.now()}`;
+		const organizationId = "org-over";
+
+		for (let i = 0; i < 300; i++) {
+			checkOrganizationSessionCountRateLimit(userId, organizationId);
+		}
+
+		expect(() =>
+			checkOrganizationSessionCountRateLimit(userId, organizationId),
+		).toThrow("Session count refresh is temporarily limited");
+	});
+
+	test("keeps organization limits independent", () => {
+		const userId = `test-session-count-orgs-${Date.now()}`;
+
+		for (let i = 0; i < 300; i++) {
+			checkOrganizationSessionCountRateLimit(userId, "org-at-limit");
+		}
+
+		expect(() =>
+			checkOrganizationSessionCountRateLimit(userId, "org-fresh"),
+		).not.toThrow();
 	});
 });
 

--- a/apps/api/src/rate-limit.ts
+++ b/apps/api/src/rate-limit.ts
@@ -10,6 +10,7 @@ interface SlidingWindowEntry {
 }
 
 const analyticsWindows = new Map<string, SlidingWindowEntry>();
+const organizationSessionCountWindows = new Map<string, SlidingWindowEntry>();
 const wrappedShareCreateWindows = new Map<string, SlidingWindowEntry>();
 const wrappedShareLookupWindows = new Map<string, SlidingWindowEntry>();
 const wrappedResumeCreateWindows = new Map<string, SlidingWindowEntry>();
@@ -20,6 +21,8 @@ const ANALYTICS_MAX_REQUESTS = Number(
 );
 const ANALYTICS_WINDOW_MS =
 	Number(process.env.RATE_LIMIT_ANALYTICS_WINDOW ?? 60) * 1000;
+const ORGANIZATION_SESSION_COUNT_MAX_REQUESTS = 300;
+const ORGANIZATION_SESSION_COUNT_WINDOW_MS = 60_000;
 const WRAPPED_SHARE_CREATE_MAX_REQUESTS = Number(
 	process.env.RATE_LIMIT_WRAPPED_SHARE_CREATE_MAX ?? 12,
 );
@@ -71,6 +74,21 @@ export function checkAnalyticsRateLimit(userId: string): void {
 	}
 
 	entry.timestamps.push(now);
+}
+
+export function checkOrganizationSessionCountRateLimit(
+	userId: string,
+	organizationId: string,
+): void {
+	checkSlidingWindowRateLimit({
+		entityId: JSON.stringify([userId, organizationId]),
+		errorMessage:
+			"Session count refresh is temporarily limited. Please wait a moment and try again.",
+		maxRequests: ORGANIZATION_SESSION_COUNT_MAX_REQUESTS,
+		map: organizationSessionCountWindows,
+		operationName: "organization session count refresh",
+		windowMs: ORGANIZATION_SESSION_COUNT_WINDOW_MS,
+	});
 }
 
 // Saturday share abuse protection stays intentionally small and auditable.

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -27,10 +27,11 @@ import {
 import {
 	checkHookIngestRateLimit,
 	checkManualIngestRateLimit,
+	checkOrganizationSessionCountRateLimit,
 } from "./rate-limit.js";
 import {
 	deleteOrgSessions,
-	getOrgSessionCount,
+	getCachedOrgSessionCount,
 	hasOrgUploadsInLastDays,
 } from "./services/org-session.service.js";
 
@@ -233,6 +234,17 @@ const revokeCliToken = os.cli.revokeToken
 const getOrganizationSessionCount = os.getOrganizationSessionCount
 	.use(authMiddleware)
 	.handler(async ({ input, context }) => {
+		if (input.userId && input.userId !== context.user.id) {
+			throw new ORPCError("FORBIDDEN", {
+				message: "Cannot read another user's raw session count",
+			});
+		}
+
+		checkOrganizationSessionCountRateLimit(
+			context.user.id,
+			input.organizationId,
+		);
+
 		const membership = await sqlClient<Array<{ id: string }>>`
 			SELECT id
 			FROM member
@@ -247,13 +259,10 @@ const getOrganizationSessionCount = os.getOrganizationSessionCount
 			});
 		}
 
-		if (input.userId && input.userId !== context.user.id) {
-			throw new ORPCError("FORBIDDEN", {
-				message: "Cannot read another user's raw session count",
-			});
-		}
-
-		const count = await getOrgSessionCount(input.organizationId, input.userId);
+		const count = await getCachedOrgSessionCount(
+			input.organizationId,
+			input.userId,
+		);
 		return { count };
 	});
 

--- a/apps/api/src/services/org-session.service.ts
+++ b/apps/api/src/services/org-session.service.ts
@@ -16,6 +16,58 @@ interface GetOrgSessionCountOptions {
 	rawTableNames?: readonly string[];
 }
 
+interface OrgSessionCountCacheEntry {
+	expiresAt: number;
+	pendingCount: Promise<number>;
+}
+
+interface OrgSessionCountCacheOptions {
+	load: (organizationId: string, userId?: string) => Promise<number>;
+	now?: () => number;
+	ttlMs?: number;
+}
+
+const ORG_SESSION_COUNT_CACHE_TTL_MS = 2_000;
+
+export function createOrgSessionCountCache(
+	options: OrgSessionCountCacheOptions,
+): (organizationId: string, userId?: string) => Promise<number> {
+	const entries = new Map<string, OrgSessionCountCacheEntry>();
+	const now = options.now ?? Date.now;
+	const ttlMs = options.ttlMs ?? ORG_SESSION_COUNT_CACHE_TTL_MS;
+
+	return (organizationId: string, userId?: string) => {
+		const currentTime = now();
+		const cacheKey = JSON.stringify([organizationId, userId ?? null]);
+		const cachedEntry = entries.get(cacheKey);
+
+		if (cachedEntry && cachedEntry.expiresAt > currentTime) {
+			return cachedEntry.pendingCount;
+		}
+
+		for (const [key, entry] of entries) {
+			if (entry.expiresAt <= currentTime) {
+				entries.delete(key);
+			}
+		}
+
+		const pendingCount = options.load(organizationId, userId);
+		const entry = {
+			expiresAt: currentTime + ttlMs,
+			pendingCount,
+		};
+		entries.set(cacheKey, entry);
+
+		void pendingCount.catch(() => {
+			if (entries.get(cacheKey) === entry) {
+				entries.delete(cacheKey);
+			}
+		});
+
+		return pendingCount;
+	};
+}
+
 export async function getOrgSessionCount(
 	orgId: string,
 	userId?: string,
@@ -52,6 +104,10 @@ export async function getOrgSessionCount(
 	);
 	return results.reduce((sum, rows) => sum + Number(rows[0]?.count ?? 0), 0);
 }
+
+export const getCachedOrgSessionCount = createOrgSessionCountCache({
+	load: getOrgSessionCount,
+});
 
 export async function hasOrgUploadsInLastDays(
 	orgId: string,


### PR DESCRIPTION
## Summary
- Add a scoped refresh guard for session count requests.
- Reuse short-lived results and combine concurrent reads.
- Add tests for normal polling, bounded traffic, cache scope, expiry, and retry.

## Test plan
- [x] `bun run verify`
