### PR TITLE
ci: gate release automation on successful CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,32 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+  workflow_dispatch:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
   release-please:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main'
+      )
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: release
     steps:
       - name: Run Release Please
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,21 @@ This runs linting, type checking, tests, and builds across the entire monorepo. 
 - Include a description of what changed and why.
 - If your change affects the CLI, test it locally with `bun run --cwd apps/cli dev`.
 
+### Release Versioning
+
+The published `rudel` CLI follows [Semantic Versioning](https://semver.org/).
+Release Please derives the next version from the squash-merged PR title:
+
+- `fix:` increments the patch version for a backward-compatible bug fix.
+- `feat:` increments the minor version for backward-compatible functionality.
+- A `!` before the colon, such as `feat(cli)!:`, increments the major version
+  for an incompatible change.
+- Other PR types do not trigger a version bump unless they declare a breaking
+  change.
+
+Choose the type by compatibility impact, not by the size or importance of the
+change. Describe migration requirements for every breaking change in the PR.
+
 ## Project Structure
 
 ```

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,6 @@
 	"include-v-in-tag": false,
 	"tag-separator": "@",
 	"bootstrap-sha": "29e6a903b20c9eb7af342eed9e1cc87860bdcadf",
-	"bump-minor-pre-major": true,
-	"bump-patch-for-minor-pre-major": true,
 	"packages": {
 		"apps/cli": {
 			"release-type": "node",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
 	"include-v-in-tag": false,
 	"tag-separator": "@",
+	"bootstrap-sha": "29e6a903b20c9eb7af342eed9e1cc87860bdcadf",
 	"bump-minor-pre-major": true,
 	"bump-patch-for-minor-pre-major": true,
 	"packages": {


### PR DESCRIPTION
## Summary

- run Release Please only after a successful `CI` run on `main`, with an explicit manual-dispatch escape hatch
- isolate release credentials in the `release` environment
- use `RELEASE_PLEASE_TOKEN` so Release Please updates trigger normal pull-request CI
- bound the initial release history at the verified `0.1.14` publication merge
- use standard SemVer mapping: fixes are patch, compatible features are minor, and breaking changes are major

## Release baseline

- repository manifest: `0.1.14`
- CLI package version: `0.1.14`
- npm latest: `0.1.14`
- pending release PR: #312 proposes `0.1.15`
- `0.1.14` was published immediately after merge commit `29e6a903b20c9eb7af342eed9e1cc87860bdcadf`

The repository has no `rudel@0.1.14` Git tag or GitHub release. `bootstrap-sha` therefore records the real published baseline without creating retroactive release metadata. Release Please treats the value as an exclusive history boundary.

## Version policy

The previous pre-1.0 overrides made compatible features patch releases and
breaking changes minor releases. Removing those overrides restores the standard
Release Please and SemVer mapping, documented in `CONTRIBUTING.md`.

## Validation

- workflow YAML parses successfully
- Release Please configuration parses successfully
- `git diff --check`
- required GitHub checks will validate the branch

Full local `bun run verify` could not be provisioned in the isolated worktree because the environment's safe installer selected pnpm for this Bun workspace. No application or test code changes in this PR.

## Human gate

Do not merge until `RELEASE_PLEASE_TOKEN` exists in the `release` environment. It must be a fine-grained PAT limited to `evrendom/rudel` with:

- Contents: read/write
- Pull requests: read/write
- Issues: read/write

After merge, manually dispatch `Release` once and confirm that PR #312 is updated under the PAT identity and receives normal CI checks.

Linear: RUD-211
