### PR TITLE
ci: advance CLI release bootstrap cutoff

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
 	"include-v-in-tag": false,
 	"tag-separator": "@",
-	"bootstrap-sha": "29e6a903b20c9eb7af342eed9e1cc87860bdcadf",
+	"bootstrap-sha": "ffb9d74e625d34b6a0d8099330c0e54f6a1b6208",
 	"packages": {
 		"apps/cli": {
 			"release-type": "node",


### PR DESCRIPTION
## Summary

- move Release Please's one-time bootstrap cutoff to the completed CI recovery
- exclude transferred pre-recovery history whose GitHub file metadata is incomplete
- keep npm and the release manifest at the actual latest CLI version, `0.1.14`

## Why

The RUD-211 proof run correctly used the PAT and reduced PR #312 from 45
historical changelog lines to one entry. The remaining entry is
`perf: fix load times` from commit `57dfa68`, an empty child commit of old PR
#342. That PR changed web code, not `apps/cli`, but GitHub reports no files for
the child commit after the repository transfer, so Release Please cannot assign
it to the correct package path and applies it to the CLI.

There are no release-triggering CLI commits between the published `0.1.14`
merge and the CI recovery cutoff. The only commits touching `apps/cli` in that
range are CI/test-file classification and repository-link maintenance.

`bootstrap-sha` is an exclusive, one-time history boundary. Future `fix:`,
`feat:`, and breaking CLI changes after this cutoff retain the standard SemVer
behavior documented in `CONTRIBUTING.md`.

## Validation

- `release-please-config.json` parses successfully
- `git diff --check`
- compared `apps/cli` history and diff from the `0.1.14` publication merge
- required GitHub checks will validate the branch

Linear: RUD-211
