### PR TITLE
fix: make YC cleanup migration idempotent

### DIFF
--- a/packages/sql-schema/db/migrations/0012_yc_review_sessions.sql
+++ b/packages/sql-schema/db/migrations/0012_yc_review_sessions.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "session" ADD COLUMN "yc_review" boolean DEFAULT false NOT NULL;
+ALTER TABLE "session" ADD COLUMN IF NOT EXISTS "yc_review" boolean DEFAULT false NOT NULL;


### PR DESCRIPTION
## Summary
- Make the legacy YC migration safe when the column already exists.
- Let the existing cleanup and later migrations continue.

## Test plan
- [x] Ran the Drizzle migration in disposable PostgreSQL databases with and without the existing column.
- [x] Ran `bun run verify` (12/12 tasks passed).