### PR TITLE
fix(api): fail closed on invalid auth secrets

### DIFF
--- a/apps/api/src/__tests__/env.test.ts
+++ b/apps/api/src/__tests__/env.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readRequiredSecretEnv } from "../lib/env.js";
+
+const TEST_SECRET_ENV_NAME = "RUDEL_TEST_REQUIRED_SECRET";
+
+describe("readRequiredSecretEnv", () => {
+	afterEach(() => {
+		delete process.env[TEST_SECRET_ENV_NAME];
+	});
+
+	test("accepts and trims a secret at the minimum length", () => {
+		const secret = "a".repeat(32);
+		process.env[TEST_SECRET_ENV_NAME] = ` ${secret} `;
+
+		expect(readRequiredSecretEnv(TEST_SECRET_ENV_NAME, 32)).toBe(secret);
+	});
+
+	test("fails closed when the secret is absent, empty, or too short", () => {
+		for (const invalidValue of [undefined, "", "   ", "a".repeat(31)]) {
+			if (invalidValue === undefined) {
+				delete process.env[TEST_SECRET_ENV_NAME];
+			} else {
+				process.env[TEST_SECRET_ENV_NAME] = invalidValue;
+			}
+
+			expect(() => readRequiredSecretEnv(TEST_SECRET_ENV_NAME, 32)).toThrow(
+				`${TEST_SECRET_ENV_NAME} must be set to at least 32 characters`,
+			);
+		}
+	});
+});

--- a/apps/api/src/__tests__/org-deletion-security.test.ts
+++ b/apps/api/src/__tests__/org-deletion-security.test.ts
@@ -7,7 +7,7 @@ describe("organization deletion security", () => {
 		const auth = createAuth(mockDb, {
 			appURL: "http://localhost:4010",
 			frontendURL: "http://localhost:4011",
-			secret: "test-secret",
+			secret: "test-secret-that-is-at-least-32-chars",
 		});
 
 		// The organization plugin should have disableOrganizationDeletion set.

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -78,7 +78,7 @@ function toTrackedOrganizationRole(
 export interface AuthConfig {
 	appURL: string;
 	frontendURL: string;
-	secret?: string;
+	secret: string;
 	resend?: ResendConfig;
 	socialProviders?: Record<string, { clientId: string; clientSecret: string }>;
 	trustedOrigins?: string[];

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -10,7 +10,7 @@ import {
 	handleAvatarGetRequest,
 	handleAvatarUploadRequest,
 } from "./handlers/avatar-http.js";
-import { readPositiveSafeIntegerEnv } from "./lib/env.js";
+import { readBetterAuthSecret, readPositiveSafeIntegerEnv } from "./lib/env.js";
 import { shutdownApiProductAnalytics } from "./lib/product-analytics.js";
 import { setupLogging } from "./logging.js";
 import type { ApiKeyAuthFailure } from "./middleware.js";
@@ -30,6 +30,7 @@ await setupLogging();
 
 const logger = getLogger(["rudel", "api", "http"]);
 type AuthUser = AuthSession["user"];
+const betterAuthSecret = readBetterAuthSecret();
 const port = process.env.PORT ?? "4010";
 const DEFAULT_DEV_API_ORIGIN = `http://localhost:${port}`;
 const DEFAULT_DEV_ORIGIN = "http://localhost:4011";
@@ -105,7 +106,7 @@ for (const warning of getResendConfigWarnings(resend)) {
 const auth = createAuth(db, {
 	appURL,
 	frontendURL: preferredFrontendOrigin,
-	secret: process.env.BETTER_AUTH_SECRET,
+	secret: betterAuthSecret,
 	resend,
 	socialProviders,
 	trustedOrigins,

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -1,3 +1,12 @@
+const MINIMUM_AUTH_SECRET_LENGTH = 32;
+
+export function readBetterAuthSecret(): string {
+	return readRequiredSecretEnv(
+		"BETTER_AUTH_SECRET",
+		MINIMUM_AUTH_SECRET_LENGTH,
+	);
+}
+
 export function readPositiveSafeIntegerEnv(
 	name: string,
 	defaultValue: number,
@@ -13,4 +22,18 @@ export function readPositiveSafeIntegerEnv(
 	}
 
 	return parsedValue;
+}
+
+export function readRequiredSecretEnv(
+	name: string,
+	minimumLength: number,
+): string {
+	const value = process.env[name]?.trim();
+	if (!value || value.length < minimumLength) {
+		throw new Error(
+			`${name} must be set to at least ${minimumLength} characters`,
+		);
+	}
+
+	return value;
 }

--- a/apps/api/src/services/team-invite-link.service.ts
+++ b/apps/api/src/services/team-invite-link.service.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import { sqlClient } from "../db.js";
+import { readBetterAuthSecret } from "../lib/env.js";
 
 export type TeamInviteAcceptResult =
 	| {
@@ -19,7 +20,6 @@ export interface TeamInviteLink {
 }
 
 const TEAM_INVITE_TOKEN_VERSION = "v1";
-const LOCAL_TEAM_INVITE_SECRET = "rudel-local-team-invite-secret";
 
 export async function getTeamInviteLink(input: {
 	organizationId: string;
@@ -114,7 +114,7 @@ function signTeamInvitePayload(payload: string) {
 }
 
 function getTeamInviteSecret() {
-	return process.env.BETTER_AUTH_SECRET ?? LOCAL_TEAM_INVITE_SECRET;
+	return readBetterAuthSecret();
 }
 
 function safeEqual(left: string, right: string) {


### PR DESCRIPTION
## Summary

- require a non-empty `BETTER_AUTH_SECRET` of at least 32 characters before the API starts
- use the validated secret for Better Auth and team-invite HMAC signing, removing the public local fallback
- make the auth secret required in API configuration and cover absent, blank, short, and valid values

Fixes RUD-175.

## Test plan

- [x] `bun run verify`
- [x] confirm missing and short secrets abort API startup

🤖 Generated with [Codex](https://openai.com/codex/)
