### PR TITLE
fix: refuse the ClickHouse default superuser on remote endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,13 @@ BETTER_AUTH_SECRET=
 # a reverse proxy on port 443 (https://...).
 CLICKHOUSE_URL=http://localhost:8123
 
-# ClickHouse credentials. The API accepts both CLICKHOUSE_USERNAME and
-# CLICKHOUSE_USER (prefers CLICKHOUSE_USERNAME). Local Docker default password
-# is "clickhouse".
+# ClickHouse credentials. CLICKHOUSE_USERNAME is canonical; CLICKHOUSE_USER is
+# accepted as a legacy fallback, and setting both to different values is an
+# error. Local Docker default password is "clickhouse".
+#
+# "default" is the ClickHouse superuser, so it is only assumed for a local
+# endpoint. Pointing CLICKHOUSE_URL at a remote host without a username is an
+# error rather than a silent fall back to `default`.
 CLICKHOUSE_USERNAME=default
 CLICKHOUSE_PASSWORD=
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -25,7 +25,7 @@ This guide walks through deploying Rudel using **ObsessionDB** (ClickHouse), **N
 ```bash
 # From the repo root — set the env vars that chkit reads
 CLICKHOUSE_URL=https://your-instance.obsessiondb.com \
-CLICKHOUSE_USER=your-username \
+CLICKHOUSE_USERNAME=your-username \
 CLICKHOUSE_PASSWORD=your-password \
 CLICKHOUSE_DB=default \
   bun --bun --cwd packages/ch-schema chkit migrate --apply
@@ -33,7 +33,7 @@ CLICKHOUSE_DB=default \
 
 The migration creates the `rudel` database, the `claude_sessions` and `session_analytics` tables, and a materialized view that computes analytics on insert. The cloud migration uses `SharedReplacingMergeTree` for `claude_sessions`.
 
-> **Note**: `CLICKHOUSE_DB` must be set to `default` for the migration because the `rudel` database doesn't exist yet — the migration creates it. `CLICKHOUSE_USER` (not `CLICKHOUSE_USERNAME`) is the env var name that the migration tool expects.
+> **Note**: `CLICKHOUSE_DB` must be set to `default` for the migration because the `rudel` database doesn't exist yet — the migration creates it. Use `CLICKHOUSE_USERNAME` throughout; `CLICKHOUSE_USER` is still accepted as a fallback.
 
 ## 2. Provision Postgres (Neon)
 
@@ -59,7 +59,7 @@ This creates the auth tables (users, sessions, accounts, verification tokens) us
 fly launch --name your-app-name --no-deploy
 ```
 
-4. Set secrets (the API reads `CLICKHOUSE_USERNAME`, not `CLICKHOUSE_USER`):
+4. Set secrets:
 
 ```bash
 fly secrets set \

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -33,7 +33,9 @@ CLICKHOUSE_DB=default \
 
 The migration creates the `rudel` database, the `claude_sessions` and `session_analytics` tables, and a materialized view that computes analytics on insert. The cloud migration uses `SharedReplacingMergeTree` for `claude_sessions`.
 
-> **Note**: `CLICKHOUSE_DB` must be set to `default` for the migration because the `rudel` database doesn't exist yet — the migration creates it. Use `CLICKHOUSE_USERNAME` throughout; `CLICKHOUSE_USER` is still accepted as a fallback.
+> **Note**: `CLICKHOUSE_DB` must be set to `default` for the migration because the `rudel` database doesn't exist yet — the migration creates it. Use `CLICKHOUSE_USERNAME` throughout; `CLICKHOUSE_USER` is accepted as a legacy fallback, and setting both to different values is an error.
+>
+> `CLICKHOUSE_USERNAME` is **required** for a hosted endpoint. The migration tool assumes the `default` superuser only when the URL is local (`localhost`/loopback), so a missing username against a remote host fails loudly instead of quietly connecting as `default`.
 
 ## 2. Provision Postgres (Neon)
 

--- a/packages/ch-schema/clickhouse.config.ts
+++ b/packages/ch-schema/clickhouse.config.ts
@@ -3,6 +3,9 @@ import { backfill } from "@chkit/plugin-backfill";
 import { codegen } from "@chkit/plugin-codegen";
 import { obsessiondb } from "@chkit/plugin-obsessiondb";
 import { pull } from "@chkit/plugin-pull";
+import { resolveClickHouseUsername } from "./src/clickhouse-connection.js";
+
+const clickhouseUrl = process.env.CLICKHOUSE_URL ?? "http://localhost:8123";
 
 export default defineConfig({
 	schema: "./src/db/schema/**/*.ts",
@@ -20,14 +23,11 @@ export default defineConfig({
 		}),
 	],
 	clickhouse: {
-		url: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
-		// Prefer CLICKHOUSE_USERNAME to match apps/api and .env.example; keep
-		// CLICKHOUSE_USER as a fallback. The "default" fallback is load-bearing:
-		// scripts/dev-local.sh sets no username for the local Docker container.
-		username:
-			process.env.CLICKHOUSE_USERNAME ??
-			process.env.CLICKHOUSE_USER ??
-			"default",
+		url: clickhouseUrl,
+		// Prefers CLICKHOUSE_USERNAME to match apps/api and .env.example, and
+		// assumes the `default` superuser only for a local endpoint. Throws rather
+		// than falling back to `default` against a remote one.
+		username: resolveClickHouseUsername(process.env, clickhouseUrl),
 		password: process.env.CLICKHOUSE_PASSWORD ?? "",
 		database: process.env.CLICKHOUSE_DB ?? "default",
 	},

--- a/packages/ch-schema/clickhouse.config.ts
+++ b/packages/ch-schema/clickhouse.config.ts
@@ -21,7 +21,13 @@ export default defineConfig({
 	],
 	clickhouse: {
 		url: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
-		username: process.env.CLICKHOUSE_USER ?? "default",
+		// Prefer CLICKHOUSE_USERNAME to match apps/api and .env.example; keep
+		// CLICKHOUSE_USER as a fallback. The "default" fallback is load-bearing:
+		// scripts/dev-local.sh sets no username for the local Docker container.
+		username:
+			process.env.CLICKHOUSE_USERNAME ??
+			process.env.CLICKHOUSE_USER ??
+			"default",
 		password: process.env.CLICKHOUSE_PASSWORD ?? "",
 		database: process.env.CLICKHOUSE_DB ?? "default",
 	},

--- a/packages/ch-schema/src/__tests__/clickhouse-connection.test.ts
+++ b/packages/ch-schema/src/__tests__/clickhouse-connection.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import {
+	isLocalClickHouseEndpoint,
+	resolveClickHouseUsername,
+} from "../clickhouse-connection.js";
+
+const LOCAL = "http://localhost:8123";
+const REMOTE = "https://instance.obsessiondb.com";
+
+describe("isLocalClickHouseEndpoint", () => {
+	it("accepts loopback hosts and .localhost subdomains", () => {
+		expect(isLocalClickHouseEndpoint(LOCAL)).toBe(true);
+		expect(isLocalClickHouseEndpoint("http://127.0.0.1:8123")).toBe(true);
+		expect(isLocalClickHouseEndpoint("http://[::1]:8123")).toBe(true);
+		expect(isLocalClickHouseEndpoint("http://ch.localhost:8123")).toBe(true);
+		expect(isLocalClickHouseEndpoint("http://host.docker.internal:8123")).toBe(
+			true,
+		);
+	});
+
+	it("treats remote, private-range, unset and malformed URLs as non-local", () => {
+		expect(isLocalClickHouseEndpoint(REMOTE)).toBe(false);
+		// A private address can be a production cluster; never assume local.
+		expect(isLocalClickHouseEndpoint("http://10.0.0.5:8123")).toBe(false);
+		expect(isLocalClickHouseEndpoint("http://192.168.1.20:8123")).toBe(false);
+		expect(isLocalClickHouseEndpoint(undefined)).toBe(false);
+		expect(isLocalClickHouseEndpoint("not-a-url")).toBe(false);
+	});
+});
+
+describe("resolveClickHouseUsername", () => {
+	it("prefers CLICKHOUSE_USERNAME over the legacy CLICKHOUSE_USER", () => {
+		const username = resolveClickHouseUsername(
+			{
+				CLICKHOUSE_USERNAME: "rudel_migrator",
+				CLICKHOUSE_USER: "rudel_migrator",
+			},
+			REMOTE,
+		);
+		expect(username).toBe("rudel_migrator");
+	});
+
+	it("accepts the legacy variable alone", () => {
+		expect(
+			resolveClickHouseUsername({ CLICKHOUSE_USER: "legacy_user" }, REMOTE),
+		).toBe("legacy_user");
+	});
+
+	it("assumes default only for a local endpoint", () => {
+		expect(resolveClickHouseUsername({}, LOCAL)).toBe("default");
+	});
+
+	it("refuses to assume default against a remote endpoint", () => {
+		expect(() => resolveClickHouseUsername({}, REMOTE)).toThrow(
+			/required for a non-local ClickHouse endpoint/,
+		);
+	});
+
+	it("treats blank and whitespace-only values as missing", () => {
+		expect(
+			resolveClickHouseUsername(
+				{ CLICKHOUSE_USERNAME: "", CLICKHOUSE_USER: "   " },
+				LOCAL,
+			),
+		).toBe("default");
+		expect(() =>
+			resolveClickHouseUsername({ CLICKHOUSE_USERNAME: "   " }, REMOTE),
+		).toThrow(/required for a non-local ClickHouse endpoint/);
+	});
+
+	it("trims surrounding whitespace off a real value", () => {
+		expect(
+			resolveClickHouseUsername(
+				{ CLICKHOUSE_USERNAME: "  app_reader  " },
+				REMOTE,
+			),
+		).toBe("app_reader");
+	});
+
+	it("rejects conflicting canonical and legacy values", () => {
+		expect(() =>
+			resolveClickHouseUsername(
+				{ CLICKHOUSE_USERNAME: "migrator", CLICKHOUSE_USER: "default" },
+				REMOTE,
+			),
+		).toThrow(/ambiguous/);
+	});
+
+	it("fails closed on a malformed URL rather than assuming local", () => {
+		expect(() => resolveClickHouseUsername({}, "not-a-url")).toThrow(
+			/required for a non-local ClickHouse endpoint/,
+		);
+	});
+});

--- a/packages/ch-schema/src/clickhouse-connection.ts
+++ b/packages/ch-schema/src/clickhouse-connection.ts
@@ -1,0 +1,82 @@
+/**
+ * Credential resolution for the chkit ClickHouse connection.
+ *
+ * Kept free of `@chkit/core` imports so it can be unit-tested without pulling
+ * in `@clickhouse/client` (see CLAUDE.md on the barrel-import failure).
+ */
+
+/**
+ * Hosts we treat as a developer's own machine. Private ranges (10.x,
+ * 172.16-31.x, 192.168.x) are deliberately excluded — those can be a production
+ * cluster on a private network, and guessing wrong there is the failure this
+ * module exists to prevent.
+ */
+const LOCAL_HOSTNAMES = new Set([
+	"localhost",
+	"127.0.0.1",
+	"0.0.0.0",
+	"::1",
+	"[::1]",
+	"host.docker.internal",
+]);
+
+/** Treats an unparseable URL as remote, so a malformed value fails closed. */
+export function isLocalClickHouseEndpoint(url: string | undefined): boolean {
+	if (!url) return false;
+	let hostname: string;
+	try {
+		hostname = new URL(url).hostname.toLowerCase();
+	} catch {
+		return false;
+	}
+	return LOCAL_HOSTNAMES.has(hostname) || hostname.endsWith(".localhost");
+}
+
+function readTrimmed(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Resolves the username chkit authenticates with.
+ *
+ * `default` is the ClickHouse superuser, so it is only ever assumed for a local
+ * endpoint — scripts/dev-local.sh sets no username for the Docker container.
+ * Against a remote endpoint a missing username is an error, never a silent
+ * fall back to `default`.
+ *
+ * @throws if a remote endpoint has no username, or if the canonical and legacy
+ * variables disagree (ambiguous identity is exactly how migrations silently ran
+ * as `default`).
+ */
+export interface ClickHouseUsernameEnv {
+	CLICKHOUSE_USERNAME?: string | undefined;
+	CLICKHOUSE_USER?: string | undefined;
+}
+
+export function resolveClickHouseUsername(
+	env: ClickHouseUsernameEnv,
+	url: string | undefined,
+): string {
+	const canonical = readTrimmed(env.CLICKHOUSE_USERNAME);
+	const legacy = readTrimmed(env.CLICKHOUSE_USER);
+
+	if (canonical && legacy && canonical !== legacy) {
+		throw new Error(
+			"CLICKHOUSE_USERNAME and CLICKHOUSE_USER are both set to different " +
+				"values, so the identity to connect as is ambiguous. Unset " +
+				"CLICKHOUSE_USER and keep CLICKHOUSE_USERNAME.",
+		);
+	}
+
+	const username = canonical ?? legacy;
+	if (username) return username;
+
+	if (isLocalClickHouseEndpoint(url)) return "default";
+
+	throw new Error(
+		"CLICKHOUSE_USERNAME is required for a non-local ClickHouse endpoint. " +
+			"Refusing to fall back to the `default` superuser. Set " +
+			"CLICKHOUSE_USERNAME to a least-privilege identity.",
+	);
+}


### PR DESCRIPTION
## Why merge this

**Measured production first** (`SELECT currentUser(), version()` on 2026-07-25): production connects as **`default`**, and Doppler `prd` has `CLICKHOUSE_USERNAME` explicitly set to the literal string `default`. `CLICKHOUSE_USER` does not exist in that config.

That means this PR is a **no-op in production**: chkit resolved `"default"` before (via the absent `CLICKHOUSE_USER` falling back) and resolves `"default"` after (via `CLICKHOUSE_USERNAME`). Same identity. `ch:migrate:prd` behaves identically.

So the honest case for merging is *not* "this stops us using the superuser" — it doesn't. It's these three:

**1. A real bug for self-hosters.** `.env.example` sets only `CLICKHOUSE_USERNAME` and documents it as canonical, while `docs/self-hosting.md` instructed readers to use `CLICKHOUSE_USER`. So an external self-hoster who correctly set `CLICKHOUSE_USERNAME=their_user` had their migrations silently run as `default` regardless. For them this was never a no-op. Both docs are fixed here.

**2. It is the guardrail RUD-224 needs, and it's worth more before that work than after.** RUD-224 creates separate app/migration/readonly identities and rotates. Today, if a rotation leaves `CLICKHOUSE_USERNAME` empty or unset, chkit silently reverts to the `default` superuser — i.e. it silently undoes the exact thing RUD-224 is doing. After this PR it throws instead. Merging first means a botched rotation fails loudly.

**3. One variable name across the codebase**, so the split that caused this cannot quietly return.

Cost of merging: zero. Prod behaviour unchanged, CI green, 10 unit tests.

## What changed

### `fix: unify ClickHouse username env var across chkit and the API`

`packages/ch-schema/clickhouse.config.ts` read only `CLICKHOUSE_USER`. Every other consumer reads `CLICKHOUSE_USERNAME` — `apps/api/src/clickhouse.ts:86`, `rebuild-wrapped-user-archetypes.ts:59`, all four `turbo.json` passthrough lists, and `.env.example`. The `chcli` scripts even map it explicitly (`CLICKHOUSE_USER=$CLICKHOUSE_USERNAME`), which only makes sense because the secrets manager supplies the canonical name.

Also corrects `docs/self-hosting.md`, which told self-hosters to use `CLICKHOUSE_USER` *because* of this bug.

### `fix: refuse the ClickHouse default superuser on remote endpoints`

Adds `packages/ch-schema/src/clickhouse-connection.ts`:

- `default` is assumed **only** for a local endpoint (`localhost`, loopback, `::1`, `*.localhost`, `host.docker.internal`) — `scripts/dev-local.sh` sets no username, so that path must keep working
- a remote endpoint with **no** username throws rather than falling back
- blank and whitespace-only values count as missing
- `CLICKHOUSE_USERNAME` and `CLICKHOUSE_USER` set to *different* values throws — ambiguous identity is how the original split hid
- private ranges (`10.x`, `172.16-31.x`, `192.168.x`) are deliberately **not** local; those can be a production cluster
- an unparseable `CLICKHOUSE_URL` is treated as remote, so malformed config fails closed

Note this does **not** throw when a username is explicitly set to `default` — which is why production is unaffected. It only refuses the *implicit* fallback.

The module imports nothing from `@chkit/core`, so it is unit-testable without loading `@clickhouse/client` (see `CLAUDE.md` on the barrel-import failure).

## Residual risk / follow-up

**Production still connects as the `default` superuser after this merges.** Not just for migrations — `apps/api/src/clickhouse.ts` reads the same variable, so the API does too. There is no app/migration/readonly separation at all. That is entirely **RUD-224**, and this PR does not reduce privilege.

**Two call sites keep the same remote fail-open**, assigned to RUD-224:

| Location | Current code |
|---|---|
| `apps/api/src/clickhouse.ts:85-89` | `CLICKHOUSE_USERNAME \|\| CLICKHOUSE_USER \|\| "default"` |
| `packages/ch-schema/scripts/rebuild-wrapped-user-archetypes.ts:59` | `CLICKHOUSE_USERNAME ?? "default"` |

Wiring them to this resolver needs a lightweight package entry point (e.g. `"./connection"` alongside `"./generated"`) so `apps/api` avoids the `@chkit/core` barrel — plus a decision, since adopting the resolver makes the API fail closed on ambiguous config, a behaviour change on a running service.

Deliberately not done: requiring a password for remote connections. Not all deployments use password auth.

Refs RUD-223. Blocks RUD-224.

## Test plan

- [x] `bun run verify` — 12/12 tasks
- [x] 10 unit tests in `packages/ch-schema/src/__tests__/clickhouse-connection.test.ts`
- [x] Verified through the real config across seven env shapes:

| Scenario | Result |
|---|---|
| local URL, no username (`dev:local`) | `default` |
| no `CLICKHOUSE_URL` at all | `default` |
| remote + username | resolves to it |
| remote, **no** username | throws |
| remote + blank username | throws |
| conflicting `USERNAME`/`USER` | throws |
| private-range host, no username | throws |

- [x] Confirmed against production: `CLICKHOUSE_USERNAME=default` is explicitly set, so the resolver returns `default` and migrations are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
