### PR TITLE
docs: correct stale ClickHouse version claims in the archetype pipeline doc

### DIFF
--- a/docs/archetype-clickhouse-pipeline.md
+++ b/docs/archetype-clickhouse-pipeline.md
@@ -46,7 +46,6 @@ At the current production size, a full rebuild is cheap enough to prefer correct
 
 Observed in production on April 19, 2026:
 
-- ClickHouse version: `25.12.1.1`
 - Raw tables:
   - `rudel.claude_sessions` -> `SharedMergeTree`
   - `rudel.codex_sessions` -> `SharedReplacingMergeTree(ingested_at)` with 365-day TTL
@@ -113,11 +112,11 @@ ClickHouse documents `ReplacingMergeTree` deduplication as asynchronous. Correct
 
 That makes `session_analytics` a fine intermediate store, but a bad direct source for Wrapped reads.
 
-### 5. Current ClickHouse version is before the async-insert-plus-MV dedupe fix
+### 5. Async inserts need a measured verification pass, not a version upgrade
 
-ClickHouse 26.1 added reliable deduplication for asynchronous inserts with dependent materialized views.
+ClickHouse 26.1 added reliable deduplication for asynchronous inserts with dependent materialized views. The cluster has since been upgraded past that release, so the **version** constraint that originally forced `async_insert=0` no longer applies.
 
-Production is `25.12.1.1`, so the current decision to keep `async_insert=0` is correct for this pipeline. Do not switch this archetype flow to async inserts until the cluster is upgraded and the end-to-end behavior is verified.
+The setting is still `async_insert=0`, and it should stay that way until someone measures this pipeline specifically. Async inserts help frequent small client inserts; they do not help bulk `INSERT ... SELECT`. So the remaining question is whether they help *this* flow at all, which is an empirical one — not something the version number answers.
 
 ### 6. There is prod/schema drift already
 
@@ -405,7 +404,7 @@ Useful checks:
 - Do not use `project_path` in breadth.
 - Do not rely on `ReplacingMergeTree` merges for product correctness.
 - Do not use `FINAL` in Wrapped request paths as the steady-state design.
-- Do not turn on async inserts for this pipeline before a ClickHouse upgrade past the 26.1 materialized-view dedupe fix and a dedicated verification pass.
+- Do not turn on async inserts for this pipeline on the strength of the ClickHouse version alone. The version constraint (the 26.1 materialized-view dedupe fix) has been lifted; a dedicated verification pass on this pipeline has not happened.
 - Do not hardcode centroid values in multiple places. Keep one versioned centroid table.
 
 ## When to Revisit This Design


### PR DESCRIPTION
## Summary

Measured production on 2026-07-25: `SELECT version()` returns **a release past 26.1**. `docs/archetype-clickhouse-pipeline.md` recorded a pre-26.1 release from an April 19 observation, which made three statements **actively wrong**, not merely stale:

- Section 5 was titled *"Current ClickHouse version is before the async-insert-plus-MV dedupe fix"*. The cluster is now past 26.1, so the title asserted the opposite of the truth.
- *"Production is a pre-26.1 release, so the current decision to keep `async_insert=0` is correct… Do not switch until the cluster is upgraded"* — that gate is satisfied, so a reader would conclude async inserts are still version-blocked when they are not.
- The guardrail list at the bottom repeated the same claim.

## Deliberately did NOT write a release past 26.1 into the doc

This is a public repo, and publishing the exact current production version is precisely what the F-002 confidentiality work removes. Swapping one precise version for a newer precise version moves backwards.

The version-dependent claims are now version-agnostic instead, so they cannot go stale again *and* nothing about the deployment is disclosed. The remaining `26.1` references describe a ClickHouse **capability** — which release added async-insert dedupe for dependent MVs — not a deployment, so they stay.

The exact measured version is recorded in the tracker (RUD-222/223/224/227), which is where production specifics belong.

## Consequence

The operational caution is preserved and sharpened: async inserts help frequent small client inserts, not bulk `INSERT ... SELECT`, so whether they help this pipeline is an empirical question the version number does not answer. The setting stays `async_insert=0` until someone measures it.

This also unblocks the async-insert experiment that was previously gated on "until the cluster is upgraded" — the gate is lifted, the measurement still has to happen.

Refs RUD-227.

## Test plan

- [x] `bun run lint` — no new diagnostics (11 pre-existing warnings unchanged)
- [x] `git grep -nE '25\.12|26\.3\.[0-9]'` over tracked docs → empty; no exact production version remains anywhere
- [ ] Reviewer: confirm the async-insert guidance still reads as "do not enable without measuring"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

