### PR TITLE
fix(web): exclude wrapped preview from production

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -30,11 +30,13 @@ const WrappedRouteGate = lazy(() =>
 	})),
 );
 
-const WrappedDevPage = lazy(() =>
-	import("@/features/wrapped/WrappedDevPage").then((module) => ({
-		default: module.WrappedDevPage,
-	})),
-);
+const WrappedDevPage = import.meta.env.DEV
+	? lazy(() =>
+			import("@/features/wrapped/WrappedDevPage").then((module) => ({
+				default: module.WrappedDevPage,
+			})),
+		)
+	: null;
 
 const WrappedDesktopResumePage = lazy(() =>
 	import("@/features/get-started/WrappedDesktopResumePage").then((module) => ({
@@ -117,7 +119,7 @@ function App() {
 			<>
 				<ProductAnalyticsSessionSync session={session} />
 				<Suspense fallback={<FullscreenRouteLoadingScreen />}>
-					{import.meta.env.DEV ? (
+					{WrappedDevPage ? (
 						<WrappedDevPage />
 					) : (
 						<Navigate replace to={appRoutes.wrappedTeamCard()} />


### PR DESCRIPTION
## Summary
- Gate the wrapped dev page import behind the Vite development flag so production builds omit the lazy chunk and its internal preview data.
- Preserve the existing development preview and production redirect behavior without additional scanners or fixture changes.

## Test plan
- [x] `bun run verify`
- [x] Confirm the production build emits no WrappedDevPage asset or unique wrapped-dev metadata.

Closes #182.