### PR TITLE
fix(cli): stop persisting git remote credentials

### DIFF
--- a/apps/cli/src/__tests__/local-state-security.test.ts
+++ b/apps/cli/src/__tests__/local-state-security.test.ts
@@ -1,0 +1,211 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+	chmod,
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { normalizeRemoteUrl } from "../lib/git-info.js";
+
+const REPO_ROOT = resolve(import.meta.dir, "../../../..");
+const FAKE_TOKEN = "fake_pat_RUD204";
+const PROJECT_CONFIG_SCRIPT = `
+import { getProjectOrgId, setProjectOrgId } from "./apps/cli/src/lib/project-config.ts";
+
+const action = process.argv[1];
+const projectDir = process.argv[2];
+if (action === "set") {
+	await setProjectOrgId(projectDir, "org-123");
+} else {
+	process.stdout.write((await getProjectOrgId(projectDir)) ?? "");
+}
+`;
+const LOCAL_STATE_SCRIPT = `
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { recordFailedUpload } from "./apps/cli/src/lib/failed-uploads.ts";
+import { cacheRemotes } from "./apps/cli/src/lib/remote-cache.ts";
+import { disposeLogging, setupHookLogging } from "./apps/cli/src/logging.ts";
+
+const configDir = process.env.RUDEL_CONFIG_DIR;
+if (!configDir) throw new Error("RUDEL_CONFIG_DIR is required");
+
+const logDir = join(configDir, "logs");
+const failedUploadsPath = join(configDir, "failed-uploads.json");
+const remoteCachePath = join(configDir, "remote-cache.json");
+const logPath = join(logDir, "hook-upload.log");
+
+await mkdir(logDir, { recursive: true });
+await Promise.all([
+	writeFile(failedUploadsPath, JSON.stringify({ failures: [] })),
+	writeFile(remoteCachePath, "{}"),
+	writeFile(logPath, "existing log\\n"),
+]);
+await Promise.all([
+	chmod(configDir, 0o755),
+	chmod(logDir, 0o755),
+	chmod(failedUploadsPath, 0o644),
+	chmod(remoteCachePath, 0o644),
+	chmod(logPath, 0o644),
+]);
+
+await recordFailedUpload({
+	sessionId: "session-123",
+	transcriptPath: "/private/transcript.jsonl",
+	projectPath: "/private/project",
+	error: "upload failed",
+});
+await cacheRemotes({ encodedProject: "github.com/acme/widget" });
+await setupHookLogging();
+await disposeLogging();
+`;
+
+const tempRoot = await mkdtemp(join(tmpdir(), "rudel-local-state-security-"));
+
+afterAll(async () => {
+	await rm(tempRoot, { recursive: true, force: true });
+});
+
+describe("git remote sanitization", () => {
+	test.each([
+		[
+			`https://oauth2:${FAKE_TOKEN}@github.com/acme/widget.git`,
+			"github.com/acme/widget",
+		],
+		[
+			"ssh://git:fake-password@git.example.com/acme/widget.git",
+			"git.example.com/acme/widget",
+		],
+		[
+			"https://git.example.com:8443/acme/widget.git",
+			"git.example.com/8443/acme/widget",
+		],
+		["git@github.com:acme/widget.git", "github.com/acme/widget"],
+	])("normalizes %s without credentials", (remote, expected) => {
+		expect(normalizeRemoteUrl(remote)).toBe(expected);
+	});
+
+	test("persists the sanitized key and resolves it across remote formats", async () => {
+		const fixtureRoot = join(tempRoot, "project");
+		const configDir = join(fixtureRoot, "config");
+		const projectDir = join(fixtureRoot, "repo");
+		const projectsPath = join(configDir, "projects.json");
+		await Promise.all([
+			mkdir(configDir, { recursive: true }),
+			mkdir(projectDir, { recursive: true }),
+		]);
+		await writeFile(projectsPath, JSON.stringify({ projects: {} }));
+		await Promise.all([
+			chmod(configDir, 0o755),
+			chmod(projectsPath, 0o644),
+			runCommand(["git", "-C", projectDir, "init", "-q"]),
+		]);
+		await runCommand([
+			"git",
+			"-C",
+			projectDir,
+			"remote",
+			"add",
+			"origin",
+			`https://oauth2:${FAKE_TOKEN}@github.com/acme/widget.git`,
+		]);
+
+		const setResult = await runProjectConfig("set", projectDir, configDir);
+		expect(setResult.exitCode).toBe(0);
+		const config = await readFile(projectsPath, "utf8");
+		expect(config).not.toContain(FAKE_TOKEN);
+		expect(config).toContain('"github.com/acme/widget"');
+		expect(await permissions(configDir)).toBe(0o700);
+		expect(await permissions(projectsPath)).toBe(0o600);
+
+		await runCommand([
+			"git",
+			"-C",
+			projectDir,
+			"remote",
+			"set-url",
+			"origin",
+			"git@github.com:acme/widget.git",
+		]);
+		const getResult = await runProjectConfig("get", projectDir, configDir);
+		expect(getResult.exitCode).toBe(0);
+		expect(getResult.stdout).toBe("org-123");
+	});
+});
+
+test("repairs private local-state permissions", async () => {
+	const home = join(tempRoot, "local-state");
+	const configDir = join(home, ".rudel");
+	const result = await runBunScript(LOCAL_STATE_SCRIPT, {
+		HOME: home,
+		RUDEL_CONFIG_DIR: configDir,
+	});
+
+	expect(result.exitCode).toBe(0);
+	expect(result.stderr).toBe("");
+	expect(await permissions(configDir)).toBe(0o700);
+	expect(await permissions(join(configDir, "logs"))).toBe(0o700);
+	expect(await permissions(join(configDir, "failed-uploads.json"))).toBe(0o600);
+	expect(await permissions(join(configDir, "remote-cache.json"))).toBe(0o600);
+	expect(await permissions(join(configDir, "logs", "hook-upload.log"))).toBe(
+		0o600,
+	);
+});
+
+interface ProcessResult {
+	exitCode: number;
+	stderr: string;
+	stdout: string;
+}
+
+async function runProjectConfig(
+	action: "get" | "set",
+	projectDir: string,
+	configDir: string,
+): Promise<ProcessResult> {
+	return runBunScript(PROJECT_CONFIG_SCRIPT, { RUDEL_CONFIG_DIR: configDir }, [
+		action,
+		projectDir,
+	]);
+}
+
+async function runBunScript(
+	script: string,
+	env: Record<string, string>,
+	args: readonly string[] = [],
+): Promise<ProcessResult> {
+	return runProcess([process.execPath, "-e", script, ...args], env);
+}
+
+async function runCommand(command: readonly string[]): Promise<ProcessResult> {
+	const result = await runProcess(command);
+	expect(result.exitCode).toBe(0);
+	return result;
+}
+
+async function runProcess(
+	command: readonly string[],
+	env: Record<string, string> = {},
+): Promise<ProcessResult> {
+	const processHandle = Bun.spawn(command, {
+		cwd: REPO_ROOT,
+		env: { ...process.env, ...env },
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+	const [exitCode, stderr, stdout] = await Promise.all([
+		processHandle.exited,
+		new Response(processHandle.stderr).text(),
+		new Response(processHandle.stdout).text(),
+	]);
+	return { exitCode, stderr, stdout };
+}
+
+async function permissions(path: string): Promise<number> {
+	return (await stat(path)).mode & 0o777;
+}

--- a/apps/cli/src/lib/failed-uploads.ts
+++ b/apps/cli/src/lib/failed-uploads.ts
@@ -1,16 +1,18 @@
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { type Source, SourceSchema } from "@rudel/api-routes";
+import {
+	ensurePrivateFile,
+	getRudelConfigDir,
+	writePrivateFile,
+} from "./local-state.js";
 
 // Resolved per call, not at module load: RUDEL_CONFIG_DIR must work the same
 // way it does for credentials.ts, including when set after import (Bun
 // snapshots homedir() at process start, so a load-time constant would pin the
 // real home directory for the life of the process).
 function getFailedUploadsPath(): string {
-	const configDir = process.env.RUDEL_CONFIG_DIR ?? join(homedir(), ".rudel");
-	return join(configDir, "failed-uploads.json");
+	return join(getRudelConfigDir(), "failed-uploads.json");
 }
 
 export interface FailedUpload {
@@ -38,6 +40,7 @@ export async function loadFailedUploads(): Promise<FailedUpload[]> {
 	try {
 		const path = getFailedUploadsPath();
 		if (!existsSync(path)) return [];
+		await ensurePrivateFile(path, getRudelConfigDir());
 		const data = JSON.parse(readFileSync(path, "utf-8")) as FailedUploadsData;
 		return data.failures.map((f) => ({
 			...f,
@@ -51,9 +54,12 @@ export async function loadFailedUploads(): Promise<FailedUpload[]> {
 async function saveFailedUploads(failures: FailedUpload[]): Promise<void> {
 	try {
 		const path = getFailedUploadsPath();
-		await mkdir(dirname(path), { recursive: true });
 		const data: FailedUploadsData = { failures };
-		await writeFile(path, JSON.stringify(data, null, 2));
+		await writePrivateFile(
+			path,
+			JSON.stringify(data, null, 2),
+			getRudelConfigDir(),
+		);
 	} catch {
 		// Best-effort — don't break the upload flow
 	}

--- a/apps/cli/src/lib/git-info.ts
+++ b/apps/cli/src/lib/git-info.ts
@@ -14,7 +14,8 @@ export interface GitInfo {
  * Normalize a git remote URL to a canonical form: "github.com/owner/repo"
  */
 export function normalizeRemoteUrl(url: string): string {
-	return url
+	const sanitizedUrl = url.replace(/^([a-z][a-z\d+.-]*:\/\/)[^/]+@/i, "$1");
+	return sanitizedUrl
 		.replace(/^(https?:\/\/|git@|ssh:\/\/)/, "")
 		.replace(/:/, "/")
 		.replace(/\.git$/, "");

--- a/apps/cli/src/lib/local-state.ts
+++ b/apps/cli/src/lib/local-state.ts
@@ -1,0 +1,37 @@
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+
+export function getRudelConfigDir(): string {
+	return process.env.RUDEL_CONFIG_DIR ?? join(homedir(), ".rudel");
+}
+
+export async function ensurePrivateFile(
+	filePath: string,
+	configDir: string,
+): Promise<void> {
+	await secureDirectory(configDir);
+	const fileDirectory = dirname(filePath);
+	if (fileDirectory !== configDir) {
+		await secureDirectory(fileDirectory);
+	}
+	await writeFile(filePath, "", { flag: "a", mode: PRIVATE_FILE_MODE });
+	await chmod(filePath, PRIVATE_FILE_MODE);
+}
+
+export async function writePrivateFile(
+	filePath: string,
+	content: string,
+	configDir: string,
+): Promise<void> {
+	await ensurePrivateFile(filePath, configDir);
+	await writeFile(filePath, content, "utf8");
+}
+
+async function secureDirectory(path: string): Promise<void> {
+	await mkdir(path, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
+	await chmod(path, PRIVATE_DIRECTORY_MODE);
+}

--- a/apps/cli/src/lib/project-config.ts
+++ b/apps/cli/src/lib/project-config.ts
@@ -1,7 +1,14 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { exec } from "./exec.js";
+import { normalizeRemoteUrl } from "./git-info.js";
 
 interface ProjectEntry {
 	organizationId: string;
@@ -22,18 +29,19 @@ function getProjectsConfigPath(): string {
 function loadProjectsConfig(): ProjectsConfig {
 	const path = getProjectsConfigPath();
 	if (!existsSync(path)) return { projects: {} };
+	chmodSync(getConfigDir(), 0o700);
+	chmodSync(path, 0o600);
 	const content = readFileSync(path, "utf-8");
 	return JSON.parse(content) as ProjectsConfig;
 }
 
 function saveProjectsConfig(config: ProjectsConfig): void {
 	const dir = getConfigDir();
-	if (!existsSync(dir)) {
-		mkdirSync(dir, { recursive: true, mode: 0o700 });
-	}
-	writeFileSync(getProjectsConfigPath(), JSON.stringify(config, null, 2), {
-		mode: 0o600,
-	});
+	mkdirSync(dir, { recursive: true, mode: 0o700 });
+	chmodSync(dir, 0o700);
+	const path = getProjectsConfigPath();
+	writeFileSync(path, JSON.stringify(config, null, 2), { mode: 0o600 });
+	chmodSync(path, 0o600);
 }
 
 async function getProjectKey(cwd: string): Promise<string> {
@@ -48,11 +56,9 @@ async function getProjectKey(cwd: string): Promise<string> {
 		]);
 		if (result.exitCode === 0) {
 			const url = result.stdout.trim();
-			// Normalize: strip .git suffix and protocol
-			return url
-				.replace(/^(https?:\/\/|git@|ssh:\/\/)/, "")
-				.replace(/:/, "/")
-				.replace(/\.git$/, "");
+			if (url.length > 0) {
+				return normalizeRemoteUrl(url);
+			}
 		}
 	} catch {
 		// Not a git repo or no remote

--- a/apps/cli/src/lib/remote-cache.ts
+++ b/apps/cli/src/lib/remote-cache.ts
@@ -1,16 +1,19 @@
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
-
-const CACHE_PATH = join(homedir(), ".rudel", "remote-cache.json");
+import { join } from "node:path";
+import {
+	ensurePrivateFile,
+	getRudelConfigDir,
+	writePrivateFile,
+} from "./local-state.js";
 
 type RemoteCacheData = Record<string, string>;
 
 export async function getRemoteCache(): Promise<RemoteCacheData> {
 	try {
-		if (!existsSync(CACHE_PATH)) return {};
-		return JSON.parse(readFileSync(CACHE_PATH, "utf-8")) as RemoteCacheData;
+		const path = getRemoteCachePath();
+		if (!existsSync(path)) return {};
+		await ensurePrivateFile(path, getRudelConfigDir());
+		return JSON.parse(readFileSync(path, "utf-8")) as RemoteCacheData;
 	} catch {
 		return {};
 	}
@@ -33,9 +36,16 @@ export function cacheRemote(
 
 export async function cacheRemotes(cache: RemoteCacheData): Promise<void> {
 	try {
-		await mkdir(dirname(CACHE_PATH), { recursive: true });
-		await writeFile(CACHE_PATH, JSON.stringify(cache));
+		await writePrivateFile(
+			getRemoteCachePath(),
+			JSON.stringify(cache),
+			getRudelConfigDir(),
+		);
 	} catch {
 		// Fire-and-forget — cache is best-effort
 	}
+}
+
+function getRemoteCachePath(): string {
+	return join(getRudelConfigDir(), "remote-cache.json");
 }

--- a/apps/cli/src/logging.ts
+++ b/apps/cli/src/logging.ts
@@ -1,18 +1,16 @@
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { getFileSink } from "@logtape/file";
 import { configure, dispose } from "@logtape/logtape";
-
-const LOG_DIR = join(homedir(), ".rudel", "logs");
-const LOG_FILE = join(LOG_DIR, "hook-upload.log");
+import { ensurePrivateFile, getRudelConfigDir } from "./lib/local-state.js";
 
 export async function setupHookLogging(): Promise<void> {
-	const { mkdir } = await import("node:fs/promises");
-	await mkdir(LOG_DIR, { recursive: true }).catch(() => {});
+	const configDir = getRudelConfigDir();
+	const logFile = join(configDir, "logs", "hook-upload.log");
+	await ensurePrivateFile(logFile, configDir);
 
 	await configure({
 		sinks: {
-			file: getFileSink(LOG_FILE),
+			file: getFileSink(logFile),
 		},
 		loggers: [
 			{


### PR DESCRIPTION
## Summary
- Strip Git URL userinfo before deriving project identities, preventing credentials from entering project config or normalized Git metadata.
- Secure sensitive CLI state with `0700` directories and `0600` files, including permission repair for existing state.
- Add regression coverage for HTTPS/SSH remotes and local-state permissions.

## Test plan
- [x] `bun run verify`
