### PR TITLE
fix: make database scripts environment-driven + add ch skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,9 +8,7 @@
 			"Bash(bun test:*)",
 			"Bash(where:*)",
 			"Bash(npm root:*)",
-			"Bash(CLICKHOUSE_DB=default doppler run:*)",
 			"Bash(chcli:*)",
-			"Bash(doppler whoami:*)",
 			"Bash(sqlite3:*)"
 		],
 		"deny": ["Read(./.entire/metadata/**)"]

--- a/.claude/skills/api-testing/SKILL.md
+++ b/.claude/skills/api-testing/SKILL.md
@@ -4,7 +4,7 @@ description: Test the local Rudel API with authenticated requests. Use when the 
 metadata:
   author: rudel
   version: "1.1"
-compatibility: Requires curl, jq, and a running local API server (bun run dev:local or bun run --cwd apps/api dev:env).
+compatibility: Requires curl, jq, and a running local API server (bun run dev:local or bun run --cwd apps/api dev).
 allowed-tools: Bash(curl:*) Bash(source:*) Bash(mkdir:*) Read
 ---
 
@@ -203,7 +203,7 @@ For today's date, read `.context/api-logs-$(date +%Y-%m-%d).txt`. The log file c
 - **Input validation failed / BAD_REQUEST**: Check that input is wrapped in `{"json": {...}}`. Endpoints with parameters require this wrapper.
 - **MISSING_OR_NULL_ORIGIN on auth endpoints**: Add `-H "Origin: http://localhost:4010"` to better-auth API calls (`/api/auth/*`).
 - **BAD_REQUEST on analytics endpoints**: No active organization set. Run step 2 to set the active org.
-- **Connection refused**: API server not running. Start it with `bun run dev:local` or `bun run --cwd apps/api dev:env`.
+- **Connection refused**: API server not running. Start it with `bun run dev:local` or `bun run --cwd apps/api dev`.
 - **Unexpected 500 or unclear error**: Read the API log file at `.context/api-logs-$(date +%Y-%m-%d).txt` for the server-side stack trace.
 
 ## Best Practices

--- a/.claude/skills/clickhouse-architecture-advisor/AGENTS.md
+++ b/.claude/skills/clickhouse-architecture-advisor/AGENTS.md
@@ -1,0 +1,86 @@
+# ClickHouse Architecture Advisor
+
+**Version 0.1.0**  
+ClickHouse Inc  
+April 2026  
+ClickHouse 24.1+
+
+## Abstract
+
+This skill complements `clickhouse-best-practices` by adding a workload-aware architecture layer for ClickHouse. It is optimized for advisory, workshop, and system design workflows where a user needs more than a rule check. It provides decision frameworks for ingestion strategy, time-series partitioning, enrichment paths, late-arriving data, and real-time pre-aggregation.
+
+## Core principle
+
+Official documentation is the source of truth. Every recommendation must be labeled as:
+
+- `official`
+- `derived`
+- `field`
+
+## Decision areas
+
+### 1. Ingestion strategy
+Use when deciding between:
+- direct inserts
+- async inserts
+- Kafka engine + MV
+- upstream buffering
+
+### 2. Time-series partitioning
+Use when deciding:
+- whether to partition
+- partition granularity
+- how retention and TTL affect design
+- how to avoid excessive partition counts
+
+### 3. Enrichment path selection
+Use when deciding between:
+- runtime JOINs
+- dictionaries
+- denormalization
+- materialized enrichment
+
+### 4. Late-arriving data and mutable state
+Use when reasoning about:
+- immutable append-only events
+- latest-state queries
+- replacing or collapsing semantics
+- whether frequent mutations should be avoided
+
+### 5. Real-time pre-aggregation
+Use when deciding:
+- raw-only design
+- incremental materialized views
+- refreshable MVs
+- rollup tables
+
+## Output standard
+
+A valid architecture response should include:
+- workload summary
+- key decisions
+- recommendations with provenance labels
+- suggested target architecture
+- example DDL or SQL
+- validation approach
+
+## Required recommendation schema
+
+See `schemas/recommendation_schema.yaml`.
+
+## Rule index
+
+1. `decision-ingestion-strategy`
+2. `decision-partitioning-timeseries`
+3. `decision-join-enrichment`
+4. `decision-late-arriving-upserts`
+5. `decision-real-time-preaggregation`
+
+## Implementation notes
+
+This skill is intentionally narrow:
+- it does not replace low-level rule enforcement
+- it does not make commercial recommendations
+- it does not claim field heuristics are official policy
+
+Its purpose is to translate documented ClickHouse capabilities into workload-specific architecture decisions.

--- a/.claude/skills/clickhouse-architecture-advisor/README.md
+++ b/.claude/skills/clickhouse-architecture-advisor/README.md
@@ -1,0 +1,65 @@
+# ClickHouse Architecture Advisor
+
+Agent skill providing workload-aware architecture guidance for ClickHouse.
+
+This skill is intended to complement `clickhouse-best-practices`, not replace it.
+
+## What it adds
+
+The existing best-practices skill is rule-first and documentation-first. This skill adds:
+
+- workload classification
+- decision frameworks
+- architecture tradeoff guidance
+- broader system design suggestions
+- explicit separation of doc-backed guidance from field heuristics
+
+## Recommendation categories
+
+Every recommendation must be labeled as exactly one of:
+
+- `official` — directly backed by official ClickHouse documentation
+- `derived` — reasoned from official documentation and core ClickHouse behavior
+- `field` — practice-based guidance from field experience, explicitly flagged as non-authoritative
+
+## When this skill should activate
+
+Use this skill when the user is:
+- designing a real-time architecture
+- choosing between ingestion patterns
+- deciding whether to use joins, dictionaries, denormalization, or MVs
+- planning for late-arriving data or upserts
+- reasoning about time-series modeling
+- building a POC or workshop design
+- asking for “what should the architecture look like?”
+
+## Relationship to `clickhouse-best-practices`
+
+Use `clickhouse-best-practices` for:
+- concrete schema and query rule checks
+- low-level design validation
+- docs-backed enforcement
+
+Use this skill for:
+- when / why / how decisioning
+- architecture shape
+- system-level tradeoffs
+- converting best practices into a target design
+
+## Included decision frameworks
+
+- ingestion strategy for throughput and latency
+- time-series partitioning and retention design
+- enrichment path selection: JOIN vs dictionary vs denormalization
+- late-arriving data and mutable-state patterns
+- real-time pre-aggregation with incremental MVs
+
+## Output contract
+
+Responses should typically include:
+1. workload summary
+2. key decisions
+3. recommendations with provenance labels
+4. suggested target architecture
+5. example DDL and query patterns
+6. caveats and validation steps

--- a/.claude/skills/clickhouse-architecture-advisor/SKILL.md
+++ b/.claude/skills/clickhouse-architecture-advisor/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: clickhouse-architecture-advisor
+description: MUST USE when designing ClickHouse architectures, selecting between ingestion or modeling patterns, or translating best practices into workload-specific system designs. Complements clickhouse-best-practices with decision frameworks and explicit provenance labels.
+license: Apache-2.0
+metadata:
+  author: ClickHouse Inc
+  version: "0.1.0"
+---
+
+# ClickHouse Architecture Advisor
+
+This skill adds workload-aware architecture decisioning on top of `clickhouse-best-practices`.
+
+> **Official docs remain the source of truth.**
+> This skill must always prefer official ClickHouse documentation when available.
+
+## Required behavior
+
+Before producing recommendations:
+
+1. Identify the workload shape
+   - observability
+   - security / SIEM
+   - product analytics
+   - IoT / telemetry
+   - market data / financial services
+   - mixed OLAP with point-lookups
+2. Read the relevant decision rule files in `rules/`
+3. Use `mappings/doc_links.yaml` to attach official documentation
+4. Classify every recommendation as:
+   - `official`
+   - `derived`
+   - `field`
+5. Never present field guidance as official guidance
+6. If a recommendation is uncertain, say so explicitly
+
+## Provenance rules
+
+### `official`
+Use this when the recommendation is directly backed by official docs.
+
+### `derived`
+Use this when the recommendation is not stated verbatim in docs but follows logically from documented ClickHouse behavior.
+
+### `field`
+Use this only for experience-based guidance that may be situational.
+When using `field`, include:
+- a disclaimer that the advice is heuristic
+- a relevant official doc if one partially applies
+- the reason the advice depends on workload context
+
+## Read these rule files by scenario
+
+### Real-time ingestion design
+1. `rules/decision-ingestion-strategy.md`
+2. `rules/decision-real-time-preaggregation.md`
+3. Relevant best-practices insert rules
+
+### Time-series and retention design
+1. `rules/decision-partitioning-timeseries.md`
+2. Relevant best-practices schema partition rules
+
+### Enrichment and dimension lookups
+1. `rules/decision-join-enrichment.md`
+2. Relevant best-practices query join rules
+
+### Mutable state / late-arriving events
+1. `rules/decision-late-arriving-upserts.md`
+2. Relevant best-practices mutation avoidance rules
+
+## Output format
+
+Structure responses like this:
+
+```markdown
+## Workload Summary
+- workload:
+- latency target:
+- data shape:
+- primary query patterns:
+- operational constraints:
+
+## Key Decisions
+- ...
+- ...
+
+## Recommendations
+
+### <Recommendation title>
+
+**What**
+...
+
+**Why**
+...
+
+**How**
+...
+
+**Category**
+official | derived | field
+
+**Confidence**
+high | medium | heuristic
+
+**Source**
+- doc link(s)
+
+**Validation**
+- concrete SQL, metric, or smoke test
+```
+
+## Architecture-specific guidance
+
+Prefer decision frameworks over generic advice. Good responses should:
+- explain tradeoffs
+- identify the likely operating bottleneck
+- separate immediate actions from structural redesign
+- provide target architecture patterns, not just isolated settings
+
+## Full reference
+
+See `AGENTS.md` for the compiled version and `examples/` for sample outputs.

--- a/.claude/skills/clickhouse-architecture-advisor/examples/README.md
+++ b/.claude/skills/clickhouse-architecture-advisor/examples/README.md
@@ -1,0 +1,17 @@
+# Example workload pack
+
+This folder demonstrates how the architecture advisor should respond for representative real-time and enterprise workloads.
+
+## Included
+
+- `observability-high-throughput.md`
+- `finserv-market-surveillance.md`
+- `siem-security-analytics.md`
+
+## Why examples matter
+
+The examples show how the skill should:
+- classify the workload
+- separate key architectural decisions from low-level rules
+- provide official documentation links
+- label derived and field guidance explicitly

--- a/.claude/skills/clickhouse-architecture-advisor/examples/finserv-market-surveillance.md
+++ b/.claude/skills/clickhouse-architecture-advisor/examples/finserv-market-surveillance.md
@@ -1,0 +1,118 @@
+# Example: Financial Services — Real-time market surveillance
+
+## Scenario
+
+- Workload: order and execution event stream
+- Ingest rate: 80M events/day
+- Query pattern:
+  - latest order state
+  - time-bounded compliance scans
+  - intraday anomaly and pattern detection
+- Freshness target: sub-second to low-single-digit seconds
+- Additional requirement: late-arriving corrections and cancels
+
+## Workload Summary
+
+This is not classic OLTP. It is a high-throughput analytical event pipeline with mutable business state derived from ordered events. The architecture should preserve append-only facts and compute latest-state views rather than forcing row-by-row transactional mutations.
+
+## Key Decisions
+
+1. Keep a raw append-only event table
+2. Model current state separately
+3. Avoid using ClickHouse like a row store
+4. Use pre-aggregation only for repeated surveillance views
+
+## Recommendations
+
+### 1. Raw event table plus latest-state projection
+
+**What**  
+Store all order lifecycle events immutably, then derive current order state.
+
+**Why**  
+This preserves auditability and handles late-arriving business events without relying on heavy mutations.
+
+**Category**  
+derived
+
+**Confidence**  
+medium
+
+**Source**
+- https://clickhouse.com/docs/en/guides/replacing-merge-tree
+
+### 2. Use ReplacingMergeTree for current-state table if version semantics are clean
+
+**What**  
+Maintain a latest-state table keyed by order identifier and version timestamp.
+
+**Why**  
+If corrections naturally replace prior state, ReplacingMergeTree is often the cleanest documented pattern.
+
+**Category**  
+official
+
+**Confidence**  
+high
+
+**Source**
+- https://clickhouse.com/docs/en/guides/replacing-merge-tree
+
+### 3. Use dictionaries for small reference data used in surveillance rules
+
+**What**  
+Use dictionaries for symbol metadata, venue mappings, or account-tier lookups if they are read constantly and update slowly.
+
+**Why**  
+Repeated runtime joins in hot surveillance logic are often more expensive than key-based dictionary lookup.
+
+**Category**  
+official
+
+**Confidence**  
+high
+
+**Source**
+- https://clickhouse.com/docs/en/sql-reference/dictionaries
+
+## Example raw events table
+
+```sql
+CREATE TABLE order_events
+(
+    event_time DateTime64(3),
+    trade_date Date,
+    order_id String,
+    account_id String,
+    symbol LowCardinality(String),
+    venue LowCardinality(String),
+    event_type LowCardinality(String),
+    qty UInt64,
+    px Decimal(18, 6),
+    version_ts DateTime64(3)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(trade_date)
+ORDER BY (trade_date, symbol, order_id, event_time);
+```
+
+## Example current-state table
+
+```sql
+CREATE TABLE order_state_latest
+(
+    order_id String,
+    symbol LowCardinality(String),
+    venue LowCardinality(String),
+    status LowCardinality(String),
+    qty UInt64,
+    px Decimal(18, 6),
+    version_ts DateTime64(3)
+)
+ENGINE = ReplacingMergeTree(version_ts)
+ORDER BY (order_id);
+```
+
+## Caveat
+
+This pattern is architectural, not transactional. If the requirement is strict OLTP locking semantics with many point updates per key, ClickHouse should not be the system of record for that path.

--- a/.claude/skills/clickhouse-architecture-advisor/examples/observability-high-throughput.md
+++ b/.claude/skills/clickhouse-architecture-advisor/examples/observability-high-throughput.md
@@ -1,0 +1,113 @@
+# Example: Observability — High-throughput event ingestion
+
+## Scenario
+
+- Workload: observability / logs
+- Ingest rate: 300K events/sec
+- Producer shape: many agents, uneven bursts
+- Query pattern: time-range scans, grouped aggregations, service-level dashboards
+- Freshness target: under 5 seconds
+
+## Workload Summary
+
+This is a high-ingest, append-friendly, time-series workload. The main architectural risks are:
+- excessive small parts
+- merge pressure
+- slow tail queries if rollups are not used for dashboards
+
+## Key Decisions
+
+1. Use a decoupled ingestion path
+2. Partition conservatively
+3. Preserve raw data while introducing focused rollups
+
+## Recommendations
+
+### 1. Kafka engine + materialized view for ingestion
+
+**What**  
+Use Kafka as the decoupling layer and load ClickHouse through Kafka engine tables and downstream MVs.
+
+**Why**  
+The producer fleet is bursty and distributed. This pattern improves replayability and isolates producers from storage behavior.
+
+**How**  
+- Kafka topic per stream family
+- Kafka engine source table
+- MV into MergeTree raw table
+
+**Category**  
+derived
+
+**Confidence**  
+medium
+
+**Source**
+- https://clickhouse.com/docs/engines/table-engines/integrations/kafka
+- https://clickhouse.com/docs/materialized-view/incremental-materialized-view
+
+### 2. Monthly partitions on event time
+
+**What**  
+Use `PARTITION BY toYYYYMM(event_time)` for the main raw table.
+
+**Why**  
+This workload is time-bounded and retention-based, but daily partitioning would likely create unnecessary operational overhead at scale.
+
+**Category**  
+derived
+
+**Confidence**  
+medium
+
+**Source**
+- https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/custom-partitioning-key
+
+### 3. Incremental MVs for hot service dashboards
+
+**What**  
+Create rollup tables for repeated service-health queries.
+
+**Why**  
+Dashboards and alerts should not repeatedly scan the raw log corpus.
+
+**Category**  
+official
+
+**Confidence**  
+high
+
+**Source**
+- https://clickhouse.com/docs/materialized-view/incremental-materialized-view
+
+## Example raw table
+
+```sql
+CREATE TABLE logs_raw
+(
+    event_time DateTime64(3),
+    service LowCardinality(String),
+    level LowCardinality(String),
+    host String,
+    message String,
+    attrs JSON
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(event_time)
+ORDER BY (service, event_time, host);
+```
+
+## Example rollup table
+
+```sql
+CREATE TABLE logs_rollup_1m
+(
+    bucket DateTime,
+    service LowCardinality(String),
+    level LowCardinality(String),
+    count_state AggregateFunction(count)
+)
+ENGINE = AggregatingMergeTree
+PARTITION BY toYYYYMM(bucket)
+ORDER BY (service, level, bucket);
+```

--- a/.claude/skills/clickhouse-architecture-advisor/examples/siem-security-analytics.md
+++ b/.claude/skills/clickhouse-architecture-advisor/examples/siem-security-analytics.md
@@ -1,0 +1,76 @@
+# Example: SIEM / security analytics
+
+## Scenario
+
+- Workload: endpoint, identity, cloud, and network telemetry
+- Query pattern:
+  - repeated detection logic
+  - time-bounded investigations
+  - lookup-heavy enrichments
+- Freshness target: near real-time
+
+## Workload Summary
+
+This workload is time-series heavy, multi-source, and often enrichment-bound. The two common failure modes are:
+- expensive runtime JOINs on slow-changing dimension data
+- micro-batched ingest that creates excessive parts
+
+## Key Decisions
+
+1. Use append-friendly event storage
+2. Replace repeated small-dimension JOINs where possible
+3. Protect hot detections with precomputation or lookup structures
+
+## Recommendations
+
+### 1. Enable async inserts for small-batch telemetry senders
+
+**What**  
+Use async inserts when many agents or producers write very small batches.
+
+**Why**  
+This reduces small-part pressure without rewriting every upstream sender.
+
+**Category**  
+official
+
+**Confidence**  
+high
+
+**Source**
+- https://clickhouse.com/docs/en/operations/settings/settings#async_insert
+- https://clickhouse.com/docs/optimize/asynchronous-inserts
+
+### 2. Use dictionaries for slow-changing asset and identity lookups
+
+**What**  
+Move repeated device-owner or asset-lookup enrichment out of runtime joins where appropriate.
+
+**Why**  
+Security detections often execute continuously; repeated joins on slow-changing dimensions waste CPU.
+
+**Category**  
+official
+
+**Confidence**  
+high
+
+**Source**
+- https://clickhouse.com/docs/en/sql-reference/dictionaries
+
+### 3. Use incremental MVs for repeated aggregated detection views
+
+**What**  
+Precompute common counts, rates, and rollups that power dashboards or recurring detections.
+
+**Why**  
+Not every threat-hunting query should hit the same raw telemetry tables repeatedly.
+
+**Category**  
+official
+
+**Confidence**  
+high
+
+**Source**
+- https://clickhouse.com/docs/materialized-view/incremental-materialized-view

--- a/.claude/skills/clickhouse-architecture-advisor/mappings/doc_links.yaml
+++ b/.claude/skills/clickhouse-architecture-advisor/mappings/doc_links.yaml
@@ -1,0 +1,32 @@
+async_inserts:
+  - https://clickhouse.com/docs/en/operations/settings/settings#async_insert
+  - https://clickhouse.com/docs/optimize/asynchronous-inserts
+
+partitioning:
+  - https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/custom-partitioning-key
+  - https://clickhouse.com/docs/partitions
+
+joins:
+  - https://clickhouse.com/docs/guides/joining-tables
+  - https://clickhouse.com/docs/best-practices/minimize-optimize-joins
+
+dictionaries:
+  - https://clickhouse.com/docs/en/sql-reference/dictionaries
+
+incremental_materialized_views:
+  - https://clickhouse.com/docs/materialized-view/incremental-materialized-view
+
+refreshable_materialized_views:
+  - https://clickhouse.com/docs/materialized-view/refreshable-materialized-view
+
+replacing_merge_tree:
+  - https://clickhouse.com/docs/en/guides/replacing-merge-tree
+
+collapsing_merge_tree:
+  - https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/collapsingmergetree
+
+query_optimization:
+  - https://clickhouse.com/docs/optimize/query-optimization
+
+time_series:
+  - https://clickhouse.com/docs/use-cases/time-series/basic-operations

--- a/.claude/skills/clickhouse-architecture-advisor/rules/decision-ingestion-strategy.md
+++ b/.claude/skills/clickhouse-architecture-advisor/rules/decision-ingestion-strategy.md
@@ -1,0 +1,70 @@
+---
+title: Choose an ingestion strategy based on throughput, latency, and producer shape
+impact: CRITICAL
+tags:
+  - ingestion
+  - kafka
+  - async_insert
+  - real-time
+---
+
+# Choose an ingestion strategy based on throughput, latency, and producer shape
+
+## Principle
+
+Do not recommend a single ingestion pattern for every workload. The right approach depends on:
+- events per second
+- rows per insert
+- acceptable buffering latency
+- whether producers can batch
+- whether decoupling is required
+
+## Decision framework
+
+| Condition | Recommended path | Category |
+|---|---|---|
+| Producers can batch to 10K-100K rows and latency tolerance is moderate | Direct inserts | official |
+| Producers send many small inserts and cannot batch effectively | Async inserts | official |
+| Producers are bursty, many independent writers exist, or decoupling is needed | Kafka engine + materialized view | derived |
+| Reliability, replay, and ingestion fan-out are primary concerns | Upstream queue or log broker before ClickHouse | field |
+
+## Guidance
+
+### Recommendation: direct batched inserts
+Use when the application can naturally batch inserts into healthy sizes.
+
+**Why**
+The existing best-practices guidance already favors appropriately sized insert batches.
+
+**Official sources**
+- `insert-batch-size`
+- https://clickhouse.com/docs/best-practices/selecting-an-insert-strategy
+
+### Recommendation: async inserts
+Use when producers emit many small writes and the application cannot easily batch.
+
+**Why**
+Async inserts let ClickHouse buffer small writes server-side to reduce part pressure.
+
+**Official sources**
+- https://clickhouse.com/docs/en/operations/settings/settings#async_insert
+- https://clickhouse.com/docs/optimize/asynchronous-inserts
+
+### Recommendation: Kafka engine + materialized view
+Use when a queue-based, decoupled ingest path is needed.
+
+**Why**
+This is typically the right design when multiple producers, burst handling, or replayability matter.
+
+**Category**
+derived
+
+**Sources**
+- https://clickhouse.com/docs/engines/table-engines/integrations/kafka
+- https://clickhouse.com/docs/materialized-view/incremental-materialized-view
+
+## Validation
+
+- Check average rows per insert
+- Check part creation rate
+- Check whether insert latency spikes correlate with small batch behavior

--- a/.claude/skills/clickhouse-architecture-advisor/rules/decision-join-enrichment.md
+++ b/.claude/skills/clickhouse-architecture-advisor/rules/decision-join-enrichment.md
@@ -1,0 +1,58 @@
+---
+title: "Choose the right enrichment path: JOIN, dictionary, denormalization, or precomputed enrichment"
+impact: CRITICAL
+tags:
+  - joins
+  - dictionaries
+  - denormalization
+  - enrichment
+---
+
+# Choose the right enrichment path: JOIN, dictionary, denormalization, or precomputed enrichment
+
+## Principle
+
+Not every dimension lookup should remain a runtime JOIN. The right design depends on dimension volatility, cardinality, and the cost profile of repeated enrichment.
+
+## Decision framework
+
+| Condition | Recommendation | Category |
+|---|---|---|
+| Small, slowly changing lookup table used in many queries | Dictionary | official |
+| Dimension is naturally embedded and storage duplication is acceptable | Denormalize | derived |
+| Join logic is complex and refreshed on a schedule | Refreshable MV | official |
+| Query is exploratory or infrequent and dimensions change often | Runtime JOIN | official |
+
+## Guidance
+
+### Recommendation: dictionaries for repeated low-latency lookups
+**Why**
+Dictionaries are often the best fit for repeated key-based enrichment when the lookup data is relatively static.
+
+**Official sources**
+- https://clickhouse.com/docs/en/sql-reference/dictionaries
+- `query-join-consider-alternatives`
+
+### Recommendation: denormalize when operationally simple
+**Why**
+If the dimension is stable and queried constantly, denormalization may outperform repeated joins.
+
+**Category**
+derived
+
+**Official context**
+- https://clickhouse.com/docs/best-practices/minimize-optimize-joins
+
+### Recommendation: use refreshable or incremental MVs for structured enrichment
+**Why**
+Precomputed enrichment is often better than expensive runtime joins for recurring production queries.
+
+**Official sources**
+- https://clickhouse.com/docs/materialized-view/incremental-materialized-view
+- https://clickhouse.com/docs/materialized-view/refreshable-materialized-view
+
+## Validation
+
+- Identify top CPU-consuming JOIN patterns
+- Compare runtime JOIN cost vs dictionary lookup or precomputed enrichment
+- Check dimension update frequency before choosing dictionary lifetime

--- a/.claude/skills/clickhouse-architecture-advisor/rules/decision-late-arriving-upserts.md
+++ b/.claude/skills/clickhouse-architecture-advisor/rules/decision-late-arriving-upserts.md
@@ -1,0 +1,59 @@
+---
+title: Handle late-arriving data and mutable state without defaulting to heavy mutations
+impact: CRITICAL
+tags:
+  - upserts
+  - late-arriving
+  - replacingmergetree
+  - collapsingmergetree
+  - mutable-state
+---
+
+# Handle late-arriving data and mutable state without defaulting to heavy mutations
+
+## Principle
+
+Frequent `ALTER TABLE UPDATE` and `ALTER TABLE DELETE` operations are usually the wrong first answer. Prefer append-friendly patterns and engines designed for state evolution.
+
+## Decision framework
+
+| Condition | Recommendation | Category |
+|---|---|---|
+| Immutable event log with latest-state queries | Raw append table + latest-state query or MV | derived |
+| Natural replacement semantics with version ordering | ReplacingMergeTree | official |
+| Explicit row-state transitions are modeled | CollapsingMergeTree or VersionedCollapsingMergeTree | official |
+| Small correction workload, infrequent and operationally bounded | Targeted mutation may be acceptable | field |
+
+## Guidance
+
+### Recommendation: prefer append + latest-state logic for event streams
+**Why**
+Many real-time systems do not need in-place updates if the application can compute current state from ordered events.
+
+**Category**
+derived
+
+**Official context**
+- https://clickhouse.com/docs/en/guides/replacing-merge-tree
+
+### Recommendation: use ReplacingMergeTree for replacement semantics
+**Why**
+ReplacingMergeTree is the standard documented pattern for row replacement based on version ordering.
+
+**Official sources**
+- https://clickhouse.com/docs/en/guides/replacing-merge-tree
+- `insert-mutation-avoid-update`
+
+### Recommendation: avoid defaulting to mutations
+**Why**
+Heavy mutation usage often becomes the bottleneck in otherwise append-friendly systems.
+
+**Official sources**
+- `insert-mutation-avoid-update`
+- `insert-mutation-avoid-delete`
+
+## Validation
+
+- Measure mutation volume per day
+- Check whether the workload is actually latest-state, not true OLTP
+- Confirm whether late-arriving records can be handled by version semantics

--- a/.claude/skills/clickhouse-architecture-advisor/rules/decision-partitioning-timeseries.md
+++ b/.claude/skills/clickhouse-architecture-advisor/rules/decision-partitioning-timeseries.md
@@ -1,0 +1,58 @@
+---
+title: Choose time-series partitioning for retention, pruning, and operational hygiene
+impact: HIGH
+tags:
+  - partitioning
+  - time-series
+  - retention
+  - ttl
+---
+
+# Choose time-series partitioning for retention, pruning, and operational hygiene
+
+## Principle
+
+Partitioning should primarily support lifecycle management and bounded pruning. It should not be used casually or at excessively fine granularity.
+
+## Decision framework
+
+| Workload condition | Recommendation | Category |
+|---|---|---|
+| Early-stage or modest data volume with unclear retention needs | Start without partitioning | official |
+| Time-bounded workload with month-scale retention windows | Monthly partitioning | derived |
+| Very short retention and strictly day-bounded queries | Daily partitioning only if partition count stays reasonable | derived |
+| High-scale time-series with TTL and bulk expiration needs | Partition by time unit aligned to retention operations | official |
+
+## Guidance
+
+### Recommendation: start without partitioning when unsure
+**Why**
+The best-practices skill already notes that teams often over-partition too early.
+
+**Official sources**
+- `schema-partition-start-without`
+- https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/custom-partitioning-key
+
+### Recommendation: monthly partitions for many real-time systems
+**Why**
+For observability, SIEM, telemetry, and many financial workloads, monthly partitions often balance lifecycle management with manageable partition counts.
+
+**Category**
+derived
+
+**Source**
+- https://clickhouse.com/docs/partitions
+
+### Recommendation: align partitioning with TTL boundaries
+**Why**
+If retention deletes are a primary operational concern, partitioning should make those drops efficient.
+
+**Official sources**
+- `schema-partition-lifecycle`
+- https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/custom-partitioning-key
+
+## Validation
+
+- Count active partitions
+- Verify common queries align to the partition key
+- Confirm retention actions operate at partition granularity where possible

--- a/.claude/skills/clickhouse-architecture-advisor/rules/decision-real-time-preaggregation.md
+++ b/.claude/skills/clickhouse-architecture-advisor/rules/decision-real-time-preaggregation.md
@@ -1,0 +1,58 @@
+---
+title: Choose raw-only vs incremental materialized views vs refreshable materialized views
+impact: HIGH
+tags:
+  - materialized_views
+  - preaggregation
+  - rollups
+  - real-time
+---
+
+# Choose raw-only vs incremental materialized views vs refreshable materialized views
+
+## Principle
+
+Real-time workloads should not be forced into either “everything raw” or “precompute everything.” The correct choice depends on freshness, query repetition, and transformation complexity.
+
+## Decision framework
+
+| Condition | Recommendation | Category |
+|---|---|---|
+| Queries are ad hoc and freshness matters most | Query raw tables | derived |
+| Repeated aggregation pattern over append-only data | Incremental MV | official |
+| Complex joins or scheduled batch recomputation | Refreshable MV | official |
+| Very hot dashboard or alerting path | Incremental rollup table plus raw table fallback | derived |
+
+## Guidance
+
+### Recommendation: incremental MVs for repeated real-time aggregation
+**Why**
+Incremental MVs are the documented best fit for continuously maintained rollups over insert streams.
+
+**Official sources**
+- https://clickhouse.com/docs/materialized-view/incremental-materialized-view
+- `query-mv-incremental`
+
+### Recommendation: refreshable MVs for heavier joins or scheduled transforms
+**Why**
+Refreshable MVs better fit complex transformations that do not need per-row trigger semantics.
+
+**Official sources**
+- https://clickhouse.com/docs/materialized-view/refreshable-materialized-view
+- `query-mv-refreshable`
+
+### Recommendation: dual-path design for hot dashboards
+**Why**
+A raw table preserves flexibility while a rollup path protects latency-sensitive workloads.
+
+**Category**
+derived
+
+**Official context**
+- https://clickhouse.com/docs/use-cases/time-series/basic-operations
+
+## Validation
+
+- Identify repeated dashboard queries
+- Compare raw scan cost against incremental aggregation maintenance
+- Confirm whether the source is append-only enough for incremental MV semantics

--- a/.claude/skills/clickhouse-architecture-advisor/schemas/recommendation_schema.yaml
+++ b/.claude/skills/clickhouse-architecture-advisor/schemas/recommendation_schema.yaml
@@ -1,0 +1,30 @@
+recommendation:
+  title: string
+  what: string
+  why: string
+  how: string
+  decision_context: string
+  category:
+    enum:
+      - official
+      - derived
+      - field
+  confidence:
+    enum:
+      - high
+      - medium
+      - heuristic
+  source_links:
+    type: array
+    items:
+      type: string
+  caveats:
+    type: array
+    items:
+      type: string
+  validation:
+    type: array
+    items:
+      type: string
+  example_sql:
+    type: string

--- a/.claude/skills/clickhouse-best-practices/AGENTS.md
+++ b/.claude/skills/clickhouse-best-practices/AGENTS.md
@@ -1,0 +1,1922 @@
+# ClickHouse Best Practices
+
+**Version 0.1.0**  
+ClickHouse Inc  
+January 2026
+ClickHouse 24.1+
+
+> **Note:**  
+> This document is mainly for agents and LLMs to follow when designing,  
+> optimizing, or maintaining ClickHouse databases. Humans may also find it  
+> useful, but guidance here is optimized for automation and consistency by  
+> AI-assisted workflows.
+
+---
+
+## Abstract
+
+Comprehensive best practices for ClickHouse database optimization. Covers schema design, query optimization, table engines, indexing strategies, materialized views, distributed operations, and operational best practices. Each rule includes detailed explanations, SQL examples comparing incorrect vs. correct implementations, and specific impact metrics to guide database design and query optimization.
+
+---
+
+## Table of Contents
+
+1. [Schema Design](#1-schema-design) — **CRITICAL**
+   - 1.1 [Avoid Nullable Unless Semantically Required](#11-avoid-nullable-unless-semantically-required)
+   - 1.2 [Consider Starting Without Partitioning](#12-consider-starting-without-partitioning)
+   - 1.3 [Filter on ORDER BY Columns in Queries](#13-filter-on-order-by-columns-in-queries)
+   - 1.4 [Keep Partition Cardinality Low (100-1,000 Values)](#14-keep-partition-cardinality-low-100-1000-values)
+   - 1.5 [Minimize Bit-Width for Numeric Types](#15-minimize-bit-width-for-numeric-types)
+   - 1.6 [Order Columns by Cardinality (Low to High)](#16-order-columns-by-cardinality-low-to-high)
+   - 1.7 [Plan PRIMARY KEY Before Table Creation](#17-plan-primary-key-before-table-creation)
+   - 1.8 [Prioritize Filter Columns in ORDER BY](#18-prioritize-filter-columns-in-order-by)
+   - 1.9 [Understand Partition Query Performance Trade-offs](#19-understand-partition-query-performance-trade-offs)
+   - 1.10 [Use Enum for Finite Value Sets](#110-use-enum-for-finite-value-sets)
+   - 1.11 [Use JSON Type for Dynamic Schemas](#111-use-json-type-for-dynamic-schemas)
+   - 1.12 [Use LowCardinality for Repeated Strings](#112-use-lowcardinality-for-repeated-strings)
+   - 1.13 [Use Native Types Instead of String](#113-use-native-types-instead-of-string)
+   - 1.14 [Use Partitioning for Data Lifecycle Management](#114-use-partitioning-for-data-lifecycle-management)
+2. [Query Optimization](#2-query-optimization) — **CRITICAL**
+   - 2.1 [Choose the Right JOIN Algorithm](#21-choose-the-right-join-algorithm)
+   - 2.2 [Consider Alternatives to JOINs](#22-consider-alternatives-to-joins)
+   - 2.3 [Filter Tables Before Joining](#23-filter-tables-before-joining)
+   - 2.4 [Optimize NULL Handling in Outer JOINs](#24-optimize-null-handling-in-outer-joins)
+   - 2.5 [Use ANY JOIN When Only One Match Needed](#25-use-any-join-when-only-one-match-needed)
+   - 2.6 [Use Data Skipping Indices for Non-ORDER BY Filters](#26-use-data-skipping-indices-for-non-order-by-filters)
+   - 2.7 [Use Incremental MVs for Real-Time Aggregations](#27-use-incremental-mvs-for-real-time-aggregations)
+   - 2.8 [Use Refreshable MVs for Complex Joins and Batch Workflows](#28-use-refreshable-mvs-for-complex-joins-and-batch-workflows)
+3. [Insert Strategy](#3-insert-strategy) — **CRITICAL**
+   - 3.1 [Avoid ALTER TABLE DELETE](#31-avoid-alter-table-delete)
+   - 3.2 [Avoid ALTER TABLE UPDATE](#32-avoid-alter-table-update)
+   - 3.3 [Avoid OPTIMIZE TABLE FINAL](#33-avoid-optimize-table-final)
+   - 3.4 [Batch Inserts Appropriately (10K-100K rows)](#34-batch-inserts-appropriately-10k-100k-rows)
+   - 3.5 [Use Async Inserts for High-Frequency Small Batches](#35-use-async-inserts-for-high-frequency-small-batches)
+   - 3.6 [Use Native Format for Best Insert Performance](#36-use-native-format-for-best-insert-performance)
+4. [Agent Integration](#4-agent-integration) — **CRITICAL**
+   - 4.1 [Apply Safety Limits to Agent-Generated Queries](#41-apply-safety-limits-to-agent-generated-queries)
+   - 4.2 [Connect AI Agents to ClickHouse](#42-connect-ai-agents-to-clickhouse)
+   - 4.3 [Discover Schema Before Querying](#43-discover-schema-before-querying)
+
+---
+
+## 1. Schema Design
+
+**Impact: CRITICAL**
+
+Proper schema design is foundational to ClickHouse performance. ORDER BY is immutable after table creation; wrong choices require full data migration. Includes primary key selection, data types, partitioning strategy, and JSON usage. Column types and ordering can impact query speed by orders of magnitude.
+
+### 1.1 Avoid Nullable Unless Semantically Required
+
+**Impact: HIGH (Nullable adds storage overhead; use DEFAULT values instead)**
+
+Nullable columns maintain a separate UInt8 column for tracking null values, increasing storage and degrading performance. Use DEFAULT values instead when feasible.
+
+**Incorrect: Nullable everywhere**
+
+```sql
+CREATE TABLE users (
+    id Nullable(UInt64),              -- IDs should never be null
+    name Nullable(String),            -- Empty string is fine
+    age Nullable(UInt8),              -- 0 is a valid default
+    login_count Nullable(UInt32)      -- 0 is a valid default
+)
+```
+
+**Correct: DEFAULT values, Nullable only when semantic**
+
+```sql
+CREATE TABLE users (
+    id UInt64,                                    -- Never null
+    name String DEFAULT '',                       -- Empty = unknown
+    age UInt8 DEFAULT 0,                          -- 0 = unknown
+    login_count UInt32 DEFAULT 0,                 -- 0 = never logged in
+    deleted_at Nullable(DateTime),                -- NULL = not deleted (semantic!)
+    parent_id Nullable(UInt64)                    -- NULL = no parent (semantic!)
+)
+```
+
+**When Nullable IS appropriate:**
+
+| Use Case | Why |
+
+|----------|-----|
+
+| `deleted_at` | NULL = "not deleted", timestamp = "deleted at X" |
+
+| `parent_id` | NULL = "no parent", value = "has parent" |
+
+| `discount_percent` | NULL = "no discount", 0 = "0% discount" |
+
+**Defaults instead of Nullable:**
+
+| Type | Default |
+
+|------|---------|
+
+| String | `''` (empty string) |
+
+| UInt*/Int* | `0` |
+
+| DateTime | `now()` or `toDateTime(0)` |
+
+| UUID | `generateUUIDv4()` |
+
+Reference: [https://clickhouse.com/docs/best-practices/select-data-types](https://clickhouse.com/docs/best-practices/select-data-types)
+
+### 1.2 Consider Starting Without Partitioning
+
+**Impact: MEDIUM (Add partitioning later when you have clear lifecycle requirements)**
+
+Start without partitioning and add it later only if:
+
+- You have clear data lifecycle requirements (retention, archiving)
+
+- Your access patterns clearly benefit from partition pruning
+
+- You understand the cardinality implications
+
+**Example: start simple**
+
+```sql
+-- Start simple, no partitioning
+CREATE TABLE events (
+    timestamp DateTime,
+    event_type LowCardinality(String),
+    user_id UInt64
+)
+ENGINE = MergeTree()
+ORDER BY (event_type, timestamp);
+
+-- Add partitioning later if needed for lifecycle management
+-- (requires table recreation or materialized view migration)
+```
+
+**When to add partitioning:**
+
+| Need | Add Partitioning? |
+
+|------|-------------------|
+
+| Time-based data retention | Yes |
+
+| Archive old data to cold storage | Yes |
+
+| Query performance on time ranges | Maybe (test first) |
+
+| No specific lifecycle needs | No |
+
+Reference: [https://clickhouse.com/docs/best-practices/choosing-a-partitioning-key](https://clickhouse.com/docs/best-practices/choosing-a-partitioning-key)
+
+### 1.3 Filter on ORDER BY Columns in Queries
+
+**Impact: CRITICAL (Skipping prefix columns prevents index usage)**
+
+Even with good schema design, queries must use ORDER BY columns to benefit. Skipping prefix columns or filtering on non-ORDER BY columns prevents index usage.
+
+**Incorrect: skips prefix or uses non-ORDER BY columns**
+
+```sql
+-- Given: ORDER BY (tenant_id, event_type, timestamp)
+
+-- Skips prefix columns - can't use index effectively
+SELECT * FROM events WHERE event_type = 'click';
+
+-- Filter on column not in ORDER BY - full table scan
+SELECT * FROM events WHERE user_agent LIKE '%Chrome%';
+```
+
+**Correct: uses ORDER BY prefix**
+
+```sql
+-- Given: ORDER BY (tenant_id, event_type, timestamp)
+
+-- Full prefix match - best performance
+SELECT * FROM events
+WHERE tenant_id = 123 AND event_type = 'click';
+
+-- Partial prefix - still uses index
+SELECT * FROM events WHERE tenant_id = 123;
+
+-- Range on later column after equality on earlier
+SELECT * FROM events
+WHERE tenant_id = 123 AND event_type = 'click' AND timestamp >= '2024-01-01';
+```
+
+**Index usage reference:**
+
+| Filter | Index Used? |
+
+|--------|-------------|
+
+| `WHERE tenant_id = 123` | Full |
+
+| `WHERE tenant_id = 123 AND event_type = 'click'` | Full |
+
+| `WHERE event_type = 'click'` | None (skipped prefix) |
+
+| `WHERE timestamp > '2024-01-01'` | None (skipped both) |
+
+Reference: [https://clickhouse.com/docs/best-practices/choosing-a-primary-key](https://clickhouse.com/docs/best-practices/choosing-a-primary-key)
+
+### 1.4 Keep Partition Cardinality Low (100-1,000 Values)
+
+**Impact: HIGH (Too many partitions cause part explosion and 'too many parts' errors)**
+
+Too many distinct partition values create excessive data parts, eventually triggering "too many parts" errors. ClickHouse enforces limits via `max_parts_in_total` and `parts_to_throw_insert` settings.
+
+**Incorrect: high cardinality partitioning**
+
+```sql
+-- High cardinality = too many partitions
+CREATE TABLE events (...)
+ENGINE = MergeTree()
+PARTITION BY user_id  -- Millions of partitions!
+ORDER BY (timestamp);
+
+-- Daily partitions can grow unbounded over years
+CREATE TABLE logs (...)
+ENGINE = MergeTree()
+PARTITION BY toDate(timestamp)  -- 3650 partitions over 10 years
+ORDER BY (service, timestamp);
+```
+
+**Correct: bounded cardinality**
+
+```sql
+-- Monthly partitions = 12 per year, bounded cardinality
+CREATE TABLE events (
+    timestamp DateTime,
+    event_type LowCardinality(String),
+    user_id UInt64
+)
+ENGINE = MergeTree()
+PARTITION BY toStartOfMonth(timestamp)
+ORDER BY (event_type, timestamp);
+```
+
+**Validation:**
+
+```sql
+-- Check partition count and health
+SELECT
+    partition,
+    count() as parts,
+    sum(rows) as rows,
+    formatReadableSize(sum(bytes_on_disk)) as size
+FROM system.parts
+WHERE table = 'events' AND active
+GROUP BY partition
+ORDER BY partition;
+
+-- Warning signs: hundreds or thousands of partitions
+```
+
+Reference: [https://clickhouse.com/docs/best-practices/choosing-a-partitioning-key](https://clickhouse.com/docs/best-practices/choosing-a-partitioning-key)
+
+### 1.5 Minimize Bit-Width for Numeric Types
+
+**Impact: HIGH (Smaller types reduce storage and improve cache efficiency)**
+
+Select the smallest numeric type that accommodates your data range. Prefer unsigned types when negative values aren't needed.
+
+**Incorrect: oversized types**
+
+```sql
+CREATE TABLE metrics (
+    status_code Int64,        -- HTTP codes are 100-599
+    age Int64,                -- Human age fits in UInt8
+    year Int64,               -- Years fit in UInt16
+    item_count Int64          -- Often small numbers
+)
+```
+
+**Correct: right-sized types**
+
+```sql
+CREATE TABLE metrics (
+    status_code UInt16,       -- 0-65,535 (HTTP codes fit easily)
+    age UInt8,                -- 0-255 (sufficient for age)
+    year UInt16,              -- 0-65,535 (sufficient for years)
+    item_count UInt32         -- 0-4 billion (adjust based on actual max)
+)
+```
+
+**Numeric Type Reference:**
+
+| Type | Range | Bytes |
+
+|------|-------|-------|
+
+| UInt8 | 0 to 255 | 1 |
+
+| UInt16 | 0 to 65,535 | 2 |
+
+| UInt32 | 0 to 4.3 billion | 4 |
+
+| UInt64 | 0 to 18 quintillion | 8 |
+
+| Int8 | -128 to 127 | 1 |
+
+| Int16 | -32,768 to 32,767 | 2 |
+
+| Int32 | -2.1 billion to 2.1 billion | 4 |
+
+| Int64 | -9 quintillion to 9 quintillion | 8 |
+
+Reference: [https://clickhouse.com/docs/best-practices/select-data-types](https://clickhouse.com/docs/best-practices/select-data-types)
+
+### 1.6 Order Columns by Cardinality (Low to High)
+
+**Impact: CRITICAL (Enables granule skipping; high-cardinality first prevents index pruning)**
+
+Since the sparse primary index operates on data blocks (granules) rather than individual rows, low-cardinality leading columns create more useful index entries that can skip entire blocks. Place lower-cardinality columns before higher-cardinality ones in the ordering key.
+
+**Incorrect: high cardinality first**
+
+```sql
+-- UUID first means no pruning benefit
+CREATE TABLE events (...)
+ENGINE = MergeTree()
+ORDER BY (event_id, event_type, timestamp);
+-- Every granule has different event_id values, index can't skip anything
+```
+
+**Correct: low cardinality first**
+
+```sql
+-- Low cardinality first enables pruning
+CREATE TABLE events (...)
+ENGINE = MergeTree()
+ORDER BY (event_type, event_date, event_id);
+-- Index can skip entire event_type groups
+```
+
+**Column Order Guidelines:**
+
+| Position | Cardinality | Examples |
+
+|----------|-------------|----------|
+
+| 1st | Low (few distinct values) | event_type, status, country |
+
+| 2nd | Date (coarse granularity) | toDate(timestamp) |
+
+| 3rd+ | Medium-High | user_id, session_id |
+
+| Last | High (if needed) | event_id, uuid |
+
+**Tip:** Use `toDate(timestamp)` instead of raw `DateTime` columns when day-level filtering suffices - this reduces index size from 32-bit to 16-bit representations.
+
+Reference: [https://clickhouse.com/docs/best-practices/choosing-a-primary-key](https://clickhouse.com/docs/best-practices/choosing-a-primary-key)
+
+### 1.7 Plan PRIMARY KEY Before Table Creation
+
+**Impact: CRITICAL (ORDER BY is immutable; wrong choice requires full data migration)**
+
+ClickHouse's ORDER BY clause defines physical data ordering and the sparse index. Unlike other databases, **ORDER BY cannot be modified after table creation**. A wrong choice requires creating a new table and migrating all data.
+
+**Incorrect: arbitrary ORDER BY without query analysis**
+
+```sql
+-- Creating table without analyzing query patterns
+CREATE TABLE events (
+    event_id UUID,
+    user_id UInt64,
+    timestamp DateTime
+)
+ENGINE = MergeTree()
+ORDER BY (event_id);  -- Chosen arbitrarily
+
+-- Later: "Most queries filter by user_id!"
+-- Cannot fix with: ALTER TABLE events MODIFY ORDER BY (user_id, timestamp)
+-- ERROR: Cannot modify ORDER BY
+```
+
+**Correct: query-driven ORDER BY selection**
+
+```sql
+-- Step 1: Document query patterns BEFORE creating table
+/*
+Query Analysis:
+- 60% of queries: WHERE user_id = ? AND timestamp BETWEEN ? AND ?
+- 25% of queries: WHERE event_type = ? AND timestamp > ?
+- 15% of queries: WHERE event_id = ?
+
+Conclusion: user_id and event_type are primary filters
+*/
+
+-- Step 2: Create table with correct ORDER BY
+CREATE TABLE events (
+    event_id UUID DEFAULT generateUUIDv4(),
+    user_id UInt64,
+    event_type LowCardinality(String),
+    timestamp DateTime,
+    event_date Date DEFAULT toDate(timestamp)
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(event_date)
+ORDER BY (user_id, event_date, event_id);
+```
+
+**Pre-creation checklist:**
+
+- [ ] Listed top 5-10 query patterns
+
+- [ ] Identified columns in WHERE clauses with frequency
+
+- [ ] Prioritized columns that exclude large numbers of rows
+
+- [ ] Ordered columns by cardinality (low first, high last)
+
+- [ ] Limited to 4-5 key columns (typically sufficient)
+
+Reference: [https://clickhouse.com/docs/best-practices/choosing-a-primary-key](https://clickhouse.com/docs/best-practices/choosing-a-primary-key)
+
+### 1.8 Prioritize Filter Columns in ORDER BY
+
+**Impact: CRITICAL (Columns not in ORDER BY cause full table scans)**
+
+Prioritize columns frequently used in query filters (WHERE clause), especially those that exclude large numbers of rows. Queries filtering on columns not in ORDER BY result in full table scans.
+
+**Incorrect: ORDER BY doesn't match query patterns**
+
+```sql
+-- If most queries filter by tenant_id:
+CREATE TABLE events (...)
+ENGINE = MergeTree()
+ORDER BY (event_id);  -- Queries by tenant_id will full-scan!
+```
+
+**Correct: ORDER BY matches filter patterns**
+
+```sql
+-- ORDER BY matches query filter patterns
+CREATE TABLE events (...)
+ENGINE = MergeTree()
+ORDER BY (tenant_id, event_date, event_id);
+
+-- Query now uses primary index:
+SELECT * FROM events WHERE tenant_id = 123 AND event_date >= '2024-01-01';
+```
+
+**Validation:**
+
+```sql
+-- Verify index usage
+EXPLAIN indexes = 1
+SELECT * FROM events WHERE tenant_id = 123;
+-- Look for "PrimaryKey" with Key Condition
+```
+
+Reference: [https://clickhouse.com/docs/best-practices/choosing-a-primary-key](https://clickhouse.com/docs/best-practices/choosing-a-primary-key)
+
+### 1.9 Understand Partition Query Performance Trade-offs
+
+**Impact: MEDIUM (Partition pruning helps some queries; spanning many partitions hurts others)**
+
+Partitioning can help or hurt query performance:
+
+- **Potential improvement**: Queries filtering by partition key may benefit from partition pruning
+
+- **Potential degradation**: Queries spanning many partitions increase total parts scanned
+
+ClickHouse automatically builds **MinMax indexes** on partition columns. Data merges occur **within partitions only**, not across them.
+
+**Incorrect: query scans all partitions**
+
+```sql
+-- Query must scan all partitions
+SELECT count(*) FROM events
+WHERE event_type = 'click';  -- No partition pruning
+```
+
+**Correct: query prunes to single partition**
+
+```sql
+-- Query prunes to single partition
+SELECT count(*) FROM events
+WHERE timestamp >= '2024-01-01' AND timestamp < '2024-02-01'
+  AND event_type = 'click';
+```
+
+Reference: [https://clickhouse.com/docs/best-practices/choosing-a-partitioning-key](https://clickhouse.com/docs/best-practices/choosing-a-partitioning-key)
+
+### 1.10 Use Enum for Finite Value Sets
+
+**Impact: MEDIUM (Insert-time validation and natural ordering; 1-2 bytes storage)**
+
+Enum types provide validation at insert time and enable queries that exploit natural ordering. Use Enum8 (up to 256 values) or Enum16 (up to 65,536 values).
+
+**Incorrect: String without validation**
+
+```sql
+CREATE TABLE orders (
+    status String    -- No validation, typos like "shiped" allowed
+)
+
+-- Ordering requires CASE statements
+SELECT * FROM orders ORDER BY
+    CASE status
+        WHEN 'pending' THEN 1
+        WHEN 'processing' THEN 2
+        WHEN 'shipped' THEN 3
+    END;
+```
+
+**Correct: Enum with validation and ordering**
+
+```sql
+CREATE TABLE orders (
+    status Enum8('pending' = 1, 'processing' = 2, 'shipped' = 3, 'delivered' = 4)
+)
+
+-- Insert validation: invalid values rejected
+INSERT INTO orders VALUES ('shiped');  -- ERROR: Unknown element 'shiped'
+
+-- Natural ordering works automatically
+SELECT * FROM orders ORDER BY status;  -- Orders by enum value (1, 2, 3, 4)
+
+-- Comparisons use natural order
+SELECT * FROM orders WHERE status > 'processing';  -- shipped and delivered
+```
+
+**Enum Guidelines:**
+
+| Scenario | Use |
+
+|----------|-----|
+
+| Fixed set of values known at schema time | Enum8/Enum16 |
+
+| Values may change frequently | LowCardinality(String) |
+
+| Need insert-time validation | Enum |
+
+| Need natural ordering in queries | Enum |
+
+| < 256 distinct values | Enum8 (1 byte) |
+
+| 256-65,536 distinct values | Enum16 (2 bytes) |
+
+Reference: [https://clickhouse.com/docs/best-practices/select-data-types](https://clickhouse.com/docs/best-practices/select-data-types)
+
+### 1.11 Use JSON Type for Dynamic Schemas
+
+**Impact: MEDIUM (Field-level querying for semi-structured data; use typed columns for known schemas)**
+
+ClickHouse's JSON type splits JSON objects into separate sub-columns, enabling field-level query optimization. Use it for truly dynamic data, not everything.
+
+**Incorrect: schema bloat or opaque String**
+
+```sql
+-- BAD: Hundreds of nullable columns for event properties
+CREATE TABLE events (
+    event_id UUID,
+    prop_page_url Nullable(String),
+    prop_button_id Nullable(String),
+    -- ... 100 more nullable columns
+)
+
+-- BAD: JSON as String when you need field queries
+CREATE TABLE events (
+    event_id UUID,
+    properties String  -- No field-level optimization
+)
+```
+
+**Correct: JSON for dynamic, typed for known**
+
+```sql
+-- Use JSON type for dynamic properties
+CREATE TABLE events (
+    event_id UUID DEFAULT generateUUIDv4(),
+    event_type LowCardinality(String),
+    timestamp DateTime DEFAULT now(),
+    properties JSON  -- Flexible schema with type inference
+)
+ENGINE = MergeTree()
+ORDER BY (event_type, timestamp);
+
+-- Query JSON paths directly
+SELECT
+    event_type,
+    properties.url as page_url,
+    properties.amount as purchase_amount
+FROM events
+WHERE event_type = 'page_view' AND properties.url = '/home';
+```
+
+**When to use JSON:**
+
+```sql
+CREATE TABLE events (
+    properties JSON(
+        url String,
+        amount Float64,
+        product_id UInt64
+    )
+)
+```
+
+| Scenario | Use JSON? |
+
+|----------|-----------|
+
+| Data structure varies unpredictably | Yes |
+
+| Field types/schemas change over time | Yes |
+
+| Need field-level querying | Yes |
+
+| Fixed, known schema | No (use typed columns) |
+
+| JSON as opaque blob (no field queries) | No (use String) |
+
+**Optimization: specify types for known paths:**
+
+Reference: [https://clickhouse.com/docs/best-practices/use-json-where-appropriate](https://clickhouse.com/docs/best-practices/use-json-where-appropriate)
+
+### 1.12 Use LowCardinality for Repeated Strings
+
+**Impact: HIGH (Dictionary encoding for <10K unique values; significant storage reduction)**
+
+String columns with repeated values store each value repeatedly. LowCardinality uses dictionary encoding for significant storage reduction.
+
+**Incorrect: plain String for repeated values**
+
+```sql
+CREATE TABLE events (
+    country String,       -- "United States" stored 500M times
+    browser String,       -- "Chrome" stored 300M times
+    event_type String     -- "page_view" stored 800M times
+)
+```
+
+**Correct: LowCardinality for low unique counts**
+
+```sql
+CREATE TABLE events (
+    country LowCardinality(String),      -- ~200 unique values
+    browser LowCardinality(String),      -- ~50 unique values
+    event_type LowCardinality(String)    -- ~100 unique values
+)
+```
+
+**When to use LowCardinality:**
+
+```sql
+-- Check cardinality before deciding
+SELECT uniq(column_name) FROM table_name;
+```
+
+| Unique Values | Recommendation |
+
+|---------------|----------------|
+
+| < 10,000 | Use LowCardinality |
+
+| > 10,000 | Use regular String |
+
+**LowCardinality vs FixedString:**
+
+```sql
+-- FixedString: Only for truly fixed-length data
+country_code FixedString(2),    -- "US", "DE", "JP" - always 2 chars
+
+-- LowCardinality: For variable-length low-cardinality strings
+country_name LowCardinality(String),  -- "United States", "Germany"
+```
+
+Reserve `FixedString` for strictly fixed-length data (e.g., 2-char country codes). For most low-cardinality text, `LowCardinality(String)` outperforms `FixedString`.
+
+Reference: [https://clickhouse.com/docs/best-practices/select-data-types](https://clickhouse.com/docs/best-practices/select-data-types)
+
+### 1.13 Use Native Types Instead of String
+
+**Impact: CRITICAL (2-10x storage reduction; enables compression and correct semantics)**
+
+Using String for all data wastes storage, prevents compression optimization, and makes comparisons slower. ClickHouse's column-oriented architecture benefits directly from optimal type selection.
+
+**Incorrect: String for everything**
+
+```sql
+CREATE TABLE events (
+    event_id String,        -- "550e8400-e29b-41d4-a716-446655440000" = 36 bytes
+    user_id String,         -- "12345" = 5 bytes (no numeric operations)
+    created_at String,      -- "2024-01-15 10:30:00" = 19 bytes
+    count String,           -- "42" - can't do math!
+    is_active String        -- "true" = 4 bytes
+)
+```
+
+**Correct: native types**
+
+```sql
+CREATE TABLE events (
+    event_id UUID DEFAULT generateUUIDv4(),     -- 16 bytes (vs 36)
+    user_id UInt64,                              -- 8 bytes, numeric ops
+    created_at DateTime DEFAULT now(),           -- 4 bytes (vs 19)
+    count UInt32 DEFAULT 0,                      -- 4 bytes, math works
+    is_active Bool DEFAULT true                  -- 1 byte (vs 4)
+)
+```
+
+**Type Selection Quick Reference:**
+
+| Data | Use | Avoid |
+
+|------|-----|-------|
+
+| Sequential IDs | UInt32/UInt64 | String |
+
+| UUIDs | UUID | String |
+
+| Status/Category | Enum8 or LowCardinality(String) | String |
+
+| Timestamps | DateTime | DateTime64, String |
+
+| Dates only | Date or Date32 | DateTime, String |
+
+| Counts | UInt8/16/32 (smallest that fits) | Int64, String |
+
+| Money | Decimal(P,S) or Int64 (cents) | Float64, String |
+
+| Booleans | Bool or UInt8 | String |
+
+Reference: [https://clickhouse.com/docs/best-practices/select-data-types](https://clickhouse.com/docs/best-practices/select-data-types)
+
+### 1.14 Use Partitioning for Data Lifecycle Management
+
+**Impact: HIGH (DROP PARTITION is instant; DELETE is expensive row-by-row scan)**
+
+Partitioning is **primarily a data management technique, not a query optimization tool**. It excels at:
+
+- **Dropping data**: Remove entire partitions as single metadata operations
+
+- **TTL retention**: Implement time-based retention policies efficiently
+
+- **Tiered storage**: Move old partitions to cold storage
+
+- **Archiving**: Move partitions between tables
+
+**Incorrect: no time alignment for lifecycle**
+
+```sql
+-- Cannot efficiently drop old data by time
+CREATE TABLE events (...)
+ENGINE = MergeTree()
+PARTITION BY event_type  -- No time alignment
+ORDER BY (timestamp);
+
+-- Slow: must scan and delete row by row
+DELETE FROM events WHERE timestamp < '2023-01-01';
+```
+
+**Correct: time-based for lifecycle**
+
+```sql
+CREATE TABLE events (
+    timestamp DateTime,
+    event_type LowCardinality(String)
+)
+ENGINE = MergeTree()
+PARTITION BY toStartOfMonth(timestamp)
+ORDER BY (event_type, timestamp)
+TTL timestamp + INTERVAL 1 YEAR DELETE;  -- Drops whole partitions
+
+-- Fast: metadata-only operation
+ALTER TABLE events DROP PARTITION '202301';
+
+-- Archive to cold storage
+ALTER TABLE events_archive ATTACH PARTITION '202301' FROM events;
+```
+
+Reference: [https://clickhouse.com/docs/best-practices/choosing-a-partitioning-key](https://clickhouse.com/docs/best-practices/choosing-a-partitioning-key)
+
+---
+
+## 2. Query Optimization
+
+**Impact: CRITICAL**
+
+Query patterns dramatically affect performance. JOIN algorithms, filtering strategies, skipping indices, and materialized views can reduce query time from minutes to milliseconds. Pre-computed aggregations read thousands of rows instead of billions.
+
+### 2.1 Choose the Right JOIN Algorithm
+
+**Impact: CRITICAL (Wrong algorithm causes OOM; right algorithm handles large tables efficiently)**
+
+ClickHouse's default hash join loads the RIGHT table entirely into memory. Choose the right algorithm based on table sizes and constraints.
+
+**Algorithm selection:**
+
+| Algorithm | Best For | Trade-off |
+
+|-----------|----------|-----------|
+
+| `parallel_hash` | Small-to-medium in-memory tables | Default since 24.11; fast, concurrent |
+
+| `hash` | General purpose, all join types | Single-threaded hash table build |
+
+| `direct` | Dictionary lookups (INNER/LEFT only) | Fastest; no hash table construction |
+
+| `full_sorting_merge` | Tables already sorted on join key | Skips sort if pre-ordered; low memory |
+
+| `partial_merge` | Large tables, memory-constrained | Minimized memory; slower execution |
+
+| `grace_hash` | Large datasets, tunable memory | Flexible; disk-spilling capability |
+
+| `auto` | Adaptive algorithm selection | Tries hash first, falls back on memory pressure |
+
+**Example usage:**
+
+```sql
+-- Let ClickHouse choose automatically
+SET join_algorithm = 'auto';
+
+-- For large-to-large joins where memory is constrained
+SET join_algorithm = 'partial_merge';
+SELECT * FROM large_a JOIN large_b ON large_b.id = large_a.id;
+
+-- When joining by primary key columns, sort-merge skips sorting step
+SET join_algorithm = 'full_sorting_merge';
+SELECT * FROM table_a a JOIN table_b b ON b.pk_col = a.pk_col;
+```
+
+**Note:** ClickHouse 24.12+ automatically positions smaller tables on the right side. For earlier versions, manually ensure the smaller table is on the RIGHT.
+
+Reference: [https://clickhouse.com/docs/best-practices/minimize-optimize-joins](https://clickhouse.com/docs/best-practices/minimize-optimize-joins)
+
+### 2.2 Consider Alternatives to JOINs
+
+**Impact: CRITICAL (Dictionaries and denormalization shift work from query time to insert time)**
+
+Repeated JOINs to dimension tables add overhead. Dictionaries or denormalization shift computational work from query time to insert/pre-processing time.
+
+**Incorrect: JOIN on every query**
+
+```sql
+-- JOIN on every query
+SELECT o.order_id, c.name, c.email
+FROM orders o
+JOIN customers c ON c.id = o.customer_id
+WHERE o.created_at > '2024-01-01';
+```
+
+**Correct - Dictionary Lookup:**
+
+```sql
+-- Create dictionary
+CREATE DICTIONARY customer_dict (
+    id UInt64,
+    name String,
+    email String
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'customers'))
+LAYOUT(HASHED())
+LIFETIME(MIN 300 MAX 360);
+
+-- Use dictGet instead of JOIN (uses direct join algorithm - fastest)
+SELECT
+    order_id,
+    dictGet('customer_dict', 'name', customer_id) as customer_name,
+    dictGet('customer_dict', 'email', customer_id) as customer_email
+FROM orders
+WHERE created_at > '2024-01-01';
+```
+
+**Correct - Denormalization:**
+
+```sql
+-- Denormalized table with materialized view
+CREATE MATERIALIZED VIEW orders_enriched_mv TO orders_enriched AS
+SELECT
+    o.order_id, o.customer_id,
+    c.name as customer_name,
+    c.email as customer_email,
+    o.total, o.created_at
+FROM orders o
+JOIN customers c ON c.id = o.customer_id;
+```
+
+**Approach comparison:**
+
+| Approach | Use Case | Performance |
+
+|----------|----------|-------------|
+
+| Dictionary | Frequent lookups to small dimension | Fastest (in-memory) |
+
+| Denormalization | Analytics always need enriched data | Fast (no join at query) |
+
+| IN subquery | Existence filtering | Often faster than JOIN |
+
+| JOIN | Infrequent or complex joins | Acceptable |
+
+**Critical dictionary caveat:** Dictionaries silently deduplicate duplicate keys, retaining only the final value. Only use when source has unique keys.
+
+Reference: [https://clickhouse.com/docs/best-practices/minimize-optimize-joins](https://clickhouse.com/docs/best-practices/minimize-optimize-joins)
+
+### 2.3 Filter Tables Before Joining
+
+**Impact: CRITICAL (Joining full tables then filtering wastes resources)**
+
+Joining full tables then filtering wastes resources. Add filtering in `WHERE` or `JOIN ON` clauses. If automatic pushdown fails, restructure as a subquery.
+
+**Incorrect: join then filter**
+
+```sql
+-- Joins entire tables, then filters
+SELECT o.order_id, c.name, o.total
+FROM orders o
+JOIN customers c ON c.id = o.customer_id
+WHERE o.created_at > '2024-01-01' AND c.country = 'US';
+```
+
+**Correct: filter in subqueries before joining**
+
+```sql
+-- Filter in subqueries before joining
+SELECT o.order_id, c.name, o.total
+FROM (
+    SELECT order_id, customer_id, total
+    FROM orders
+    WHERE created_at > '2024-01-01'
+) o
+JOIN (
+    SELECT id, name
+    FROM customers
+    WHERE country = 'US'
+) c ON c.id = o.customer_id;
+```
+
+**Even better - aggregate before joining:**
+
+```sql
+SELECT c.country, o.total_revenue
+FROM (
+    SELECT customer_id, sum(total) as total_revenue
+    FROM orders
+    WHERE created_at > '2024-01-01'
+    GROUP BY customer_id
+) o
+JOIN customers c ON c.id = o.customer_id;
+```
+
+Reference: [https://clickhouse.com/docs/best-practices/minimize-optimize-joins](https://clickhouse.com/docs/best-practices/minimize-optimize-joins)
+
+### 2.4 Optimize NULL Handling in Outer JOINs
+
+**Impact: MEDIUM (Default values instead of NULL reduces memory overhead)**
+
+Set `join_use_nulls = 0` to use default column values instead of NULL markers, reducing memory overhead compared to Nullable wrappers.
+
+**Example:**
+
+```sql
+-- Use default values instead of NULLs for non-matching rows
+SET join_use_nulls = 0;
+
+SELECT o.order_id, c.name
+FROM orders o
+LEFT JOIN customers c ON c.id = o.customer_id;
+-- Non-matching rows get '' for name instead of NULL
+```
+
+**When to use:**
+
+| Setting | Behavior | Use Case |
+
+|---------|----------|----------|
+
+| `join_use_nulls = 0` (default) | Default values (empty string, 0) for non-matches | When you can handle default values |
+
+| `join_use_nulls = 1` | NULL for non-matches | When you need to distinguish "no match" from "matched with default" |
+
+Reference: [https://clickhouse.com/docs/best-practices/minimize-optimize-joins](https://clickhouse.com/docs/best-practices/minimize-optimize-joins)
+
+### 2.5 Use ANY JOIN When Only One Match Needed
+
+**Impact: HIGH (Returns first match only; less memory and faster execution)**
+
+Use `ANY` JOINs when you only need a single match rather than all matches. They consume less memory and execute faster.
+
+**Incorrect: returns all matches**
+
+```sql
+-- Returns all matching rows, uses more memory
+SELECT o.order_id, c.name
+FROM orders o
+LEFT JOIN customers c ON c.id = o.customer_id;
+```
+
+**Correct: returns first match only**
+
+```sql
+-- Returns only first match per row, faster and less memory
+SELECT o.order_id, c.name
+FROM orders o
+LEFT ANY JOIN customers c ON c.id = o.customer_id;
+```
+
+**ANY JOIN types:**
+
+| Type | Behavior |
+
+|------|----------|
+
+| `LEFT ANY JOIN` | At most one match from right table |
+
+| `INNER ANY JOIN` | At most one match, only matching rows |
+
+| `RIGHT ANY JOIN` | At most one match from left table |
+
+Reference: [https://clickhouse.com/docs/best-practices/minimize-optimize-joins](https://clickhouse.com/docs/best-practices/minimize-optimize-joins)
+
+### 2.6 Use Data Skipping Indices for Non-ORDER BY Filters
+
+**Impact: HIGH (Up to 60x faster queries by skipping irrelevant granules)**
+
+Queries filtering on columns not in ORDER BY cannot use the primary index and result in full scans. Data skipping indices store metadata about blocks and skip granules that definitely don't match.
+
+**Important:** Skip indices should be considered **after** optimizing data types, primary key selection, and materialized views.
+
+**When to use:**
+
+- High overall cardinality but low cardinality within blocks
+
+- Rare values critical for search (error codes, specific IDs)
+
+- Column correlates with primary key
+
+**When NOT to use:**
+
+- As a first optimization step
+
+- Matching values scattered across many blocks
+
+- Without testing on real data
+
+**Incorrect: filtering on non-ORDER BY column**
+
+```sql
+CREATE TABLE events (
+    event_type LowCardinality(String),
+    timestamp DateTime,
+    user_id UInt64    -- Not in ORDER BY
+)
+ENGINE = MergeTree()
+ORDER BY (event_type, toDate(timestamp));
+
+-- Query filters on user_id - scans all matching event_type
+SELECT * FROM events
+WHERE event_type = 'click' AND user_id = 12345;
+```
+
+**Correct: add skipping index**
+
+```sql
+CREATE TABLE events (
+    event_type LowCardinality(String),
+    timestamp DateTime,
+    user_id UInt64,
+    INDEX idx_user_id user_id TYPE bloom_filter GRANULARITY 4
+)
+ENGINE = MergeTree()
+ORDER BY (event_type, toDate(timestamp));
+
+-- Or add to existing table
+ALTER TABLE events ADD INDEX idx_user_id user_id TYPE bloom_filter GRANULARITY 4;
+ALTER TABLE events MATERIALIZE INDEX idx_user_id;
+```
+
+**Index types:**
+
+| Type | Best For | Example Filter |
+
+|------|----------|----------------|
+
+| `bloom_filter` | Equality on high-cardinality | `WHERE user_id = 123` |
+
+| `set(N)` | Low cardinality (N unique values) | `WHERE status IN ('a','b')` |
+
+| `minmax` | Range queries | `WHERE amount > 1000` |
+
+| `ngrambf_v1` | Text search | `WHERE text LIKE '%term%'` |
+
+| `tokenbf_v1` | Token search | `WHERE hasToken(text, 'word')` |
+
+**Validation:**
+
+```sql
+EXPLAIN indexes = 1
+SELECT * FROM events WHERE user_id = 12345;
+-- Look for "Skip" in output showing granules skipped
+```
+
+Reference: [https://clickhouse.com/docs/best-practices/use-data-skipping-indices-where-appropriate](https://clickhouse.com/docs/best-practices/use-data-skipping-indices-where-appropriate)
+
+### 2.7 Use Incremental MVs for Real-Time Aggregations
+
+**Impact: HIGH (Read thousands of rows instead of billions; minimal cluster overhead)**
+
+Incremental MVs automatically apply the view's query to new data blocks at insert time. Results are written to a target table and partial results merge over time.
+
+**Incorrect: full aggregation on every query**
+
+```sql
+-- Full aggregation on every dashboard load
+SELECT
+    event_type,
+    toStartOfHour(timestamp) as hour,
+    count() as events,
+    uniq(user_id) as unique_users
+FROM events
+WHERE timestamp >= now() - INTERVAL 7 DAY
+GROUP BY event_type, hour;
+-- Scans 7 days of data every time (billions of rows)
+```
+
+**Correct: incremental MV with pre-aggregation**
+
+```sql
+-- Create target table for aggregated data
+CREATE TABLE events_hourly (
+    event_type LowCardinality(String),
+    hour DateTime,
+    events AggregateFunction(count),
+    unique_users AggregateFunction(uniq, UInt64)
+)
+ENGINE = AggregatingMergeTree()
+ORDER BY (event_type, hour);
+
+-- Create materialized view to populate incrementally
+CREATE MATERIALIZED VIEW events_hourly_mv TO events_hourly AS
+SELECT
+    event_type,
+    toStartOfHour(timestamp) as hour,
+    countState() as events,
+    uniqState(user_id) as unique_users
+FROM events
+GROUP BY event_type, hour;
+
+-- Query the pre-aggregated data
+SELECT
+    event_type, hour,
+    countMerge(events) as events,
+    uniqMerge(unique_users) as unique_users
+FROM events_hourly
+WHERE hour >= now() - INTERVAL 7 DAY
+GROUP BY event_type, hour;
+-- Reads thousands of rows instead of billions
+```
+
+**Key points:**
+
+- Use `-State` functions in MV, `-Merge` functions in query
+
+- Incremental - existing data not automatically included (backfill separately)
+
+- Minimal cluster overhead at insert time
+
+Reference: [https://clickhouse.com/docs/best-practices/use-materialized-views](https://clickhouse.com/docs/best-practices/use-materialized-views)
+
+### 2.8 Use Refreshable MVs for Complex Joins and Batch Workflows
+
+**Impact: HIGH (Sub-millisecond queries with periodic refresh; ideal for complex joins)**
+
+Refreshable MVs execute queries periodically on a schedule. The full query re-executes and overwrites (or appends to) the target table.
+
+**Best for:**
+
+- Sub-millisecond latency where minor staleness is acceptable
+
+- Caching "top N" results or lookup tables
+
+- Complex multi-table joins requiring denormalization
+
+- Batch workflows and DAG dependencies
+
+**Incorrect: expensive join on every request**
+
+```sql
+-- Complex join executed on every request
+SELECT
+    o.order_id, o.total,
+    c.name as customer_name,
+    p.name as product_name
+FROM orders o
+JOIN customers c ON o.customer_id = c.id
+JOIN products p ON o.product_id = p.id
+WHERE o.created_at >= now() - INTERVAL 1 DAY;
+```
+
+**Correct: refreshable MV**
+
+```sql
+-- Create refreshable MV that runs every 5 minutes
+CREATE MATERIALIZED VIEW orders_denormalized
+REFRESH EVERY 5 MINUTE
+ENGINE = MergeTree()
+ORDER BY (created_at, order_id)
+AS SELECT
+    o.order_id, o.created_at, o.total,
+    c.name as customer_name, c.segment,
+    p.name as product_name
+FROM orders o
+JOIN customers c ON o.customer_id = c.id
+JOIN products p ON o.product_id = p.id
+WHERE o.created_at >= now() - INTERVAL 1 DAY;
+
+-- Query the pre-joined data (sub-millisecond)
+SELECT * FROM orders_denormalized WHERE segment = 'enterprise';
+```
+
+**APPEND vs REPLACE modes:**
+
+| Mode | Behavior | Use Case |
+
+|------|----------|----------|
+
+| `REPLACE` (default) | Overwrites previous contents | Current state, lookup tables |
+
+| `APPEND` | Adds new rows to existing data | Periodic snapshots, historical accumulation |
+
+**Critical warning:** Query should run quickly compared to refresh interval. Don't schedule every 10 seconds if the query takes 10+ seconds.
+
+Reference: [https://clickhouse.com/docs/best-practices/use-materialized-views](https://clickhouse.com/docs/best-practices/use-materialized-views)
+
+---
+
+## 3. Insert Strategy
+
+**Impact: CRITICAL**
+
+Each INSERT creates a data part. Single-row inserts overwhelm the merge process. Proper batching (10K-100K rows), async inserts for high-frequency writes, mutation avoidance, and letting background merges work are essential for stable cluster performance.
+
+### 3.1 Avoid ALTER TABLE DELETE
+
+**Impact: CRITICAL (Use lightweight DELETE, CollapsingMergeTree, or DROP PARTITION instead)**
+
+`ALTER TABLE DELETE` is a mutation that rewrites entire data parts. Use alternatives like lightweight DELETE, CollapsingMergeTree, or DROP PARTITION.
+
+**Incorrect: mutation delete**
+
+```sql
+-- Mutation delete for cleanup
+ALTER TABLE orders DELETE WHERE status = 'cancelled';
+
+-- Time-based cleanup via mutation (very expensive)
+ALTER TABLE sessions DELETE WHERE created_at < now() - INTERVAL 7 DAY;
+```
+
+**Correct - CollapsingMergeTree:**
+
+```sql
+CREATE TABLE orders (
+    order_id UInt64,
+    customer_id UInt64,
+    total Decimal(10,2),
+    sign Int8  -- 1 = active, -1 = deleted
+)
+ENGINE = CollapsingMergeTree(sign)
+ORDER BY order_id;
+
+-- Insert order
+INSERT INTO orders VALUES (123, 456, 99.99, 1);
+
+-- "Delete" by inserting with sign = -1
+INSERT INTO orders VALUES (123, 456, 99.99, -1);
+
+-- Query collapses +1 and -1 pairs
+SELECT order_id, sum(total * sign) as total
+FROM orders GROUP BY order_id HAVING sum(sign) > 0;
+```
+
+**Correct - Lightweight Deletes (23.3+):**
+
+```sql
+-- Marks rows, doesn't rewrite immediately
+DELETE FROM orders WHERE status = 'cancelled';
+-- Physical deletion happens during normal merges
+```
+
+**Correct - DROP PARTITION for Bulk Deletion:**
+
+```sql
+-- Instant deletion of old data
+ALTER TABLE events DROP PARTITION '202301';
+
+-- Much faster than:
+ALTER TABLE events DELETE WHERE toYYYYMM(timestamp) = 202301;
+```
+
+**Delete strategy comparison:**
+
+| Method | Speed | When to Use |
+
+|--------|-------|-------------|
+
+| ALTER DELETE | Slow | Rare corrections only |
+
+| CollapsingMergeTree | Fast | Frequent soft deletes |
+
+| Lightweight DELETE | Medium | Occasional deletes |
+
+| DROP PARTITION | Instant | Bulk deletion by partition |
+
+Reference: [https://clickhouse.com/docs/best-practices/avoid-mutations](https://clickhouse.com/docs/best-practices/avoid-mutations)
+
+### 3.2 Avoid ALTER TABLE UPDATE
+
+**Impact: CRITICAL (Mutations rewrite entire parts; use ReplacingMergeTree instead)**
+
+`ALTER TABLE UPDATE` is a mutation - an asynchronous background process that rewrites entire data parts affected by the change. This is extremely expensive for frequent or large-scale operations.
+
+**Why mutations are problematic:**
+
+- **Write amplification:** Rewrite complete parts even for minor changes
+
+- **Disk I/O spike:** Degrades overall cluster performance
+
+- **No rollback:** Cannot be rolled back after submission
+
+- **Inconsistent reads:** SELECT may read mix of mutated and unmutated parts
+
+**Incorrect: mutation for updates**
+
+```sql
+-- Rewrites potentially huge amounts of data
+ALTER TABLE users UPDATE status = 'inactive'
+WHERE last_login < now() - INTERVAL 90 DAY;
+
+-- Frequent row updates via mutation
+ALTER TABLE inventory UPDATE quantity = quantity - 1
+WHERE product_id = 123;
+-- If product exists across 100 parts, rewrites ALL 100 parts
+```
+
+**Correct: ReplacingMergeTree**
+
+```sql
+-- Table design for updates
+CREATE TABLE users (
+    user_id UInt64,
+    name String,
+    status LowCardinality(String),
+    updated_at DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY user_id;
+
+-- "Update" by inserting new version
+INSERT INTO users (user_id, name, status)
+VALUES (123, 'John', 'inactive');
+
+-- Query with FINAL to get latest version
+SELECT * FROM users FINAL WHERE user_id = 123;
+
+-- Or use aggregation
+SELECT user_id, argMax(status, updated_at) as status
+FROM users GROUP BY user_id;
+```
+
+Reference: [https://clickhouse.com/docs/best-practices/avoid-mutations](https://clickhouse.com/docs/best-practices/avoid-mutations)
+
+### 3.3 Avoid OPTIMIZE TABLE FINAL
+
+**Impact: HIGH (Forces expensive merge of all parts; let background merges work)**
+
+`OPTIMIZE TABLE ... FINAL` forces immediate merge of all parts into one part per partition. This is resource-intensive and rarely necessary. ClickHouse already performs smart background merges.
+
+**Note:** `OPTIMIZE FINAL` is not the same as `FINAL`. The `FINAL` modifier in SELECT queries may be necessary for deduplicated results in ReplacingMergeTree and is generally fine to use.
+
+**Incorrect: OPTIMIZE FINAL after inserts**
+
+```sql
+-- Running OPTIMIZE FINAL after every batch insert
+INSERT INTO events SELECT * FROM staging_events;
+OPTIMIZE TABLE events FINAL;  -- Expensive and unnecessary!
+
+-- Scheduled OPTIMIZE FINAL jobs
+-- Cron: 0 * * * * clickhouse-client -q "OPTIMIZE TABLE events FINAL"
+```
+
+**Correct: let background merges work**
+
+```sql
+-- Let background merges handle optimization
+INSERT INTO events SELECT * FROM staging_events;
+-- Done! ClickHouse merges automatically
+
+-- For ReplacingMergeTree deduplication, use FINAL in queries
+SELECT * FROM events FINAL WHERE user_id = 123;
+-- Instead of running OPTIMIZE FINAL to deduplicate
+```
+
+**Problems with OPTIMIZE FINAL:**
+
+- Rewrites entire partition regardless of need
+
+- Ignores the ~150 GB part size safeguard
+
+- Can cause memory pressure or OOM errors
+
+- Lengthy execution time for large datasets
+
+**When OPTIMIZE FINAL may be acceptable:**
+
+- Finalizing data before table freezing
+
+- Preparing data for export operations
+
+- One-time operations, not regular workflows
+
+**Better alternatives:**
+
+| Need | Alternative |
+
+|------|-------------|
+
+| Deduplicate ReplacingMergeTree | Use `FINAL` modifier in SELECT |
+
+| Reduce part count | Rely on background merges |
+
+Reference: [https://clickhouse.com/docs/best-practices/avoid-optimize-final](https://clickhouse.com/docs/best-practices/avoid-optimize-final)
+
+### 3.4 Batch Inserts Appropriately (10K-100K rows)
+
+**Impact: CRITICAL (Each INSERT creates a part; single-row inserts overwhelm merge process)**
+
+Each INSERT creates a new data part. Single-row or small-batch inserts create thousands of tiny parts, overwhelming the merge process and causing cluster instability.
+
+**Incorrect: single-row or tiny batches**
+
+```python
+# Single-row inserts - creates 10,000 parts!
+for event in events:
+    client.execute("INSERT INTO events VALUES", [event])
+
+# Tiny batches - still too many parts
+for batch in chunks(events, 100):  # 100 rows per INSERT
+    client.execute("INSERT INTO events VALUES", batch)
+```
+
+**Correct: proper batch size**
+
+```python
+# Ideal batch size: 10,000-100,000 rows
+BATCH_SIZE = 10_000
+for batch in chunks(events, BATCH_SIZE):
+    client.execute("INSERT INTO events VALUES", batch)
+```
+
+**Recommended batch sizes:**
+
+| Threshold | Value |
+
+|-----------|-------|
+
+| Minimum | 1,000 rows |
+
+| Ideal range | 10,000-100,000 rows |
+
+| Insert rate (sync) | ~1 insert per second |
+
+**Validation:**
+
+```sql
+-- Monitor part count (>3000 per partition blocks inserts)
+SELECT table, count() as parts, sum(rows) as total_rows
+FROM system.parts
+WHERE active AND database = 'default'
+GROUP BY table
+ORDER BY parts DESC;
+```
+
+Reference: [https://clickhouse.com/docs/best-practices/selecting-an-insert-strategy](https://clickhouse.com/docs/best-practices/selecting-an-insert-strategy)
+
+### 3.5 Use Async Inserts for High-Frequency Small Batches
+
+**Impact: HIGH (Server-side buffering when client batching isn't practical)**
+
+When client-side batching isn't practical, async inserts buffer server-side and create larger parts automatically.
+
+**Incorrect: small batches without async**
+
+```python
+# Small batches without async_insert - creates too many parts
+for batch in chunks(events, 100):
+    client.execute("INSERT INTO events VALUES", batch)
+```
+
+**Correct: enable async inserts**
+
+```sql
+-- Configure server-side for specific users
+ALTER USER my_app_user SETTINGS
+    async_insert = 1,
+    wait_for_async_insert = 1,
+    async_insert_max_data_size = 10000000,  -- Flush at 10MB
+    async_insert_busy_timeout_ms = 1000;    -- Flush after 1s
+```
+
+**Flush conditions: whichever occurs first**
+
+- Buffer reaches `async_insert_max_data_size`
+
+- Time threshold `async_insert_busy_timeout_ms` elapses
+
+- Maximum insert queries accumulate
+
+**Return modes:**
+
+| Setting | Behavior | Use Case |
+
+|---------|----------|----------|
+
+| `wait_for_async_insert=1` | Waits for flush, confirms durability | **Recommended** |
+
+| `wait_for_async_insert=0` | Fire-and-forget, unaware of errors | **Risky** - only if you accept data loss |
+
+Reference: [https://clickhouse.com/docs/best-practices/selecting-an-insert-strategy](https://clickhouse.com/docs/best-practices/selecting-an-insert-strategy)
+
+### 3.6 Use Native Format for Best Insert Performance
+
+**Impact: MEDIUM (Native format is most efficient; JSONEachRow is expensive to parse)**
+
+Data format affects insert performance. Native format is column-oriented with minimal parsing overhead.
+
+**Performance Ranking: fastest to slowest**
+
+| Format | Notes |
+
+|--------|-------|
+
+| **Native** | Most efficient. Column-oriented, minimal parsing. Recommended. |
+
+| **RowBinary** | Efficient row-based alternative |
+
+| **JSONEachRow** | Easier to use but expensive to parse |
+
+**Example:**
+
+```python
+# Use Native format for best performance
+client.execute("INSERT INTO events VALUES", data, settings={'input_format': 'Native'})
+```
+
+Reference: [https://clickhouse.com/docs/best-practices/selecting-an-insert-strategy](https://clickhouse.com/docs/best-practices/selecting-an-insert-strategy)
+
+---
+
+## 4. Agent Integration
+
+**Impact: CRITICAL**
+
+AI agents working with ClickHouse need deliberate connection setup, schema discovery, and safe query execution. Agents that skip discovery write queries that ignore the sort key and scan full tables; agents without safety limits run unbounded queries that exhaust compute budgets. Covers MCP/CLI/HTTP connectivity and credential handling, the schema discovery workflow (databases → tables → columns → sort keys → skip indexes → sample → EXPLAIN), and query safety defaults (LIMIT, `max_execution_time`, `EXPLAIN ESTIMATE`).
+
+### 4.1 Apply Safety Limits to Agent-Generated Queries
+
+**Impact: CRITICAL (Unbounded agent queries can scan billions of rows and saturate cluster resources)**
+
+Every agent-generated query must have explicit safety limits. A single unbounded query can scan billions of rows, consume all memory, or run for minutes.
+
+**Non-negotiable rules:**
+
+- ALWAYS use `LIMIT` to cap returned rows (default `LIMIT 1000`)
+
+- ALWAYS bound scan size with `max_rows_to_read` or `max_bytes_to_read` — `LIMIT` alone does not prevent a full scan
+
+- ALWAYS set `max_execution_time` (default 30)
+
+- NEVER run `SELECT *` on large tables without `LIMIT` and scan caps
+
+- NEVER query without filtering on sort key or partition key columns
+
+**Incorrect:**
+
+```sql
+SELECT * FROM events WHERE user_id = '123'
+```
+
+**Correct:**
+
+```sql
+SELECT *
+FROM events
+WHERE event_date >= today() - 7 AND user_id = '123'
+LIMIT 100
+SETTINGS max_execution_time = 30,
+         max_rows_to_read = 1000000000,
+         timeout_before_checking_execution_speed = 0
+```
+
+**Recommended per-query settings:**
+
+| Setting | Recommended | Effect |
+
+|---------|-------------|--------|
+
+| `max_rows_to_read` | 1e9 | Caps rows scanned before materialization — the real guardrail |
+
+| `max_bytes_to_read` | 1e11 | Caps bytes scanned |
+
+| `max_execution_time` | 30 | Interrupts query when projected execution time exceeds N seconds (see `timeout_before_checking_execution_speed`) |
+
+| `timeout_before_checking_execution_speed` | 0 | Makes `max_execution_time` behave as a wall-clock limit (default `10` gives queries 10s of grace before timeouts kick in) |
+
+| `max_estimated_execution_time` | 60 | Rejects queries whose projected runtime exceeds N seconds — kills expensive queries before they start |
+
+| `max_result_rows` | 10000 | Caps output rows |
+
+| `result_overflow_mode` | `'break'` | Returns partial result of ≥ `max_result_rows`, rounded up to the next block boundary (it does not truncate exactly) |
+
+Limits are checked at block boundaries, so actual scans and runtime can overshoot slightly.
+
+**Cloud vs self-hosted defaults that matter:**
+
+| Setting | Self-hosted default | Cloud default |
+
+|---------|---------------------|---------------|
+
+| `max_memory_usage` | `0` (unlimited) | Depends on replica RAM — not unlimited |
+
+| `max_bytes_before_external_group_by` | `0` (no spill) | Half the memory per replica — spills automatically |
+
+| `max_bytes_before_external_sort` | `0` (no spill) | Half the memory per replica — spills automatically |
+
+| `max_rows_to_read` / `max_bytes_to_read` | `0` (unlimited) | `0` (unlimited) — must be set explicitly on both |
+
+| `max_execution_time` | `0` (unlimited) | `0` (unlimited) — must be set explicitly on both |
+
+On self-hosted, GROUP BY and ORDER BY have no automatic memory ceiling — set the `max_bytes_before_external_*` settings explicitly or enforce via profile. On Cloud, GROUP BY / ORDER BY spill to disk automatically and per-query memory is bounded, but scan and execution-time caps are still your job.
+
+**When things go wrong:**
+
+- **Timeout** (`TIMEOUT_EXCEEDED`): Narrow the time range, add sort key filters, run `EXPLAIN ESTIMATE` to check scan size before retrying. Consider `max_estimated_execution_time` to reject expensive queries up front.
+
+- **Memory error** (`MEMORY_LIMIT_EXCEEDED`): Reduce actual memory use — narrow filters, add `LIMIT`, lower GROUP BY cardinality, enable `max_bytes_before_external_group_by` (already on by default in Cloud, off on self-hosted), or split into smaller time windows. Raising `max_memory_usage` only helps if you're authorized and the ceiling is genuinely the problem; *lowering* it makes the error happen sooner, not later.
+
+- **Too many parts** (`TOO_MANY_PARTS`): Back off inserts — merges are behind. Wait and retry.
+
+**Role-level hardening (belt-and-suspenders):**
+
+Per-query `SETTINGS` only applies if the agent remembers to emit it. For production, the primary mechanism should be a [settings profile](https://clickhouse.com/docs/operations/settings/settings-profiles) plus [`readonly=2`](https://clickhouse.com/docs/operations/settings/constraints-on-settings#read-only) on the agent's role, so limits apply even when the agent forgets. Per-query settings are then defense in depth, not the fence.
+
+Per-query limits also don't stop abuse via many small queries — use [quotas](https://clickhouse.com/docs/operations/quotas) to bound requests or scanned bytes per interval.
+
+**Progressive exploration pattern:**
+
+```sql
+-- 1. Count first (cheap)
+SELECT count() FROM events WHERE event_date = today();
+
+-- 2. Small sample (if count is reasonable)
+SELECT * FROM events WHERE event_date = today() LIMIT 10;
+
+-- 3. Full query with LIMIT and scan caps
+SELECT user_id, count() as events
+FROM events
+WHERE event_date = today()
+GROUP BY user_id
+ORDER BY events DESC
+LIMIT 100
+SETTINGS max_execution_time = 30,
+         max_rows_to_read = 1000000000,
+         timeout_before_checking_execution_speed = 0;
+```
+
+Start narrow, widen only if needed:
+
+Reference: [https://clickhouse.com/docs/operations/settings/query-complexity](https://clickhouse.com/docs/operations/settings/query-complexity), [https://clickhouse.com/docs/operations/settings/query-level](https://clickhouse.com/docs/operations/settings/query-level)
+
+### 4.2 Connect AI Agents to ClickHouse
+
+**Impact: HIGH (Proper connection setup eliminates credential-prompting friction and enables structured access)**
+
+Two connection methods, each with a clear use case. Pick one based on your environment.
+
+**Incorrect: prompting for credentials every time**
+
+```python
+# Agent asks the user for host, port, user, password on every session
+# Credentials are hardcoded in the prompt or conversation
+response = client.query("SELECT 1",
+    host="???", user="???", password="???")  # fragile, unsecured
+```
+
+**Correct: MCP or CLI with pre-configured credentials**
+
+```bash
+# MCP: credentials configured once via env vars or OAuth
+claude mcp add --transport http clickhouse-cloud https://mcp.clickhouse.cloud/mcp
+
+# CLI: credentials in a named profile or env vars
+clickhouse client --host abc123.clickhouse.cloud --port 9440 --secure \
+  --user default --password "$CLICKHOUSE_PASSWORD" --format JSON \
+  --query "SELECT 1"
+```
+
+Best for schema discovery, iterative analysis, and multi-step conversations.
+
+**ClickHouse Cloud — zero-install hosted MCP:**
+
+```bash
+claude mcp add --transport http clickhouse-cloud https://mcp.clickhouse.cloud/mcp
+```
+
+Uses OAuth. Read-only. No env vars needed.
+
+**Self-hosted MCP (any ClickHouse deployment):**
+
+```bash
+pip install mcp-clickhouse
+```
+
+| Variable | Example | Notes |
+
+|----------|---------|-------|
+
+| `CLICKHOUSE_HOST` | `abc123.clickhouse.cloud` | Hostname |
+
+| `CLICKHOUSE_USER` | `default` | Database user |
+
+| `CLICKHOUSE_PASSWORD` | `your-password` | Database password |
+
+| `CLICKHOUSE_SECURE` | `true` | Always `true` for Cloud |
+
+Enable writes: `export CLICKHOUSE_ALLOW_WRITE_ACCESS=true`
+
+**Limitations:**
+
+```bash
+curl -s "https://abc123.clickhouse.cloud:8443/" \
+  -H "X-ClickHouse-User: default" \
+  -H "X-ClickHouse-Key: your-password" \
+  --data-binary "SELECT name, engine FROM system.tables WHERE database = 'default' FORMAT JSON"
+```
+
+- MCP has ~200-500ms overhead per call. For large result sets or batch operations, use CLI.
+
+- MCP's `list_tables` may not surface column `COMMENT` annotations — query `system.columns` directly for full schema context (see `agent-discovery-schema`).
+
+**ClickHouse Cloud note:** Services can be idle/sleeping. The first query after inactivity may take 10-20 seconds while the service wakes up. A timeout or `503` on first connection is expected — retry once before treating it as an error.
+
+Best for scripting, automation, and queries returning >10K rows. Zero per-call overhead.
+
+If you have credentials but can't install `clickhouse-client` (lambda, sandbox, web-based agent), use the HTTP interface directly:
+
+Port `8443` is HTTPS. Pass query settings as URL params: `?max_execution_time=30&max_result_rows=10000`.
+
+1. Go to [console.clickhouse.cloud](https://console.clickhouse.cloud)
+
+2. Click your service → **Connect** in the left sidebar
+
+3. The dialog shows hostname, port, user, and a pre-built CLI command
+
+4. **Reset password** if needed from the same dialog
+
+For self-managed: check `config.xml` or ask your administrator.
+
+Always specify a format. The default (TabSeparated without headers) is unparseable by agents.
+
+| Format | Tokens (1K rows) | Best For |
+
+|--------|------------------|----------|
+
+| `JSON` | ~20K | Single queries — includes column types, row count, statistics |
+
+| `JSONCompact` | ~10K | Same metadata as JSON but rows as arrays — good for wide tables |
+
+| `JSONEachRow` | ~15K | Streaming large results, piping through `jq` |
+
+| `TabSeparatedWithNames` | ~4K | Minimal tokens, simple tabular data |
+
+Use `JSON` as the default for agent work. Switch to `TabSeparatedWithNames` when result sets are large and context window budget matters.
+
+Reference: [https://github.com/ClickHouse/mcp-clickhouse](https://github.com/ClickHouse/mcp-clickhouse), [https://clickhouse.com/docs/interfaces/cli](https://clickhouse.com/docs/interfaces/cli), [https://clickhouse.com/docs/interfaces/formats](https://clickhouse.com/docs/interfaces/formats)
+
+### 4.3 Discover Schema Before Querying
+
+**Impact: CRITICAL (Skipping schema discovery leads to full scans, wrong columns, and wasted compute)**
+
+ALWAYS start by understanding the schema. Never assume table or column names. Agents that skip schema discovery write queries that scan unnecessary data, use wrong column names, or miss the sort key — all of which burn compute and return bad results.
+
+**Step 1: List databases**
+
+**Step 2: List tables with size context**
+
+This tells you which tables are large (and therefore expensive to scan carelessly) and what engine each uses.
+
+**Step 3: Get columns, types, and comments**
+
+**Column comments are critical.** If table creators have added `COMMENT` annotations to columns, they are invaluable for understanding semantics (e.g., distinguishing `user_id_hash` from `user_id`). MCP's `list_tables` tool returns column names and types but may not surface comments — always query `system.columns` directly when you need full context.
+
+**Step 4: Understand the sort key**
+
+This is the most important step for writing efficient queries. Filtering on sort key columns allows ClickHouse to skip entire data granules. Filtering on non-key columns forces a full scan.
+
+**Step 5: Check for skipping indexes**
+
+Skipping indexes (`bloom_filter`, `minmax`, `set`, `tokenbf_v1`) tell you which non-sort-key columns already have optimized filter paths. If an index exists on a column, filtering on it is efficient even though it's not in the sort key. Missing this step means you won't know which "non-key" filters are actually fast.
+
+**Step 6: Sample data**
+
+A small sample reveals actual data patterns — date ranges, enum values, null frequency — that inform how to write correct `WHERE` clauses.
+
+**Step 7: Verify query plan before execution**
+
+Before running a potentially expensive query, use `EXPLAIN` to verify it will use indexes efficiently:
+
+Look for:
+
+- **Keys** section showing your sort key columns are being used for filtering
+
+- **Parts** and **Granules** counts — if these are not significantly reduced from the total, your filters aren't pruning effectively
+
+- **Skip** entries showing data skipping index usage
+
+For a quick cost estimate without running the query:
+
+This returns estimated rows and bytes to be read — if the numbers look unreasonably large, refine your filters before executing.
+
+**Example full discovery workflow:**
+
+```sql
+-- 1. What databases exist?
+SELECT name FROM system.databases
+WHERE name NOT IN ('system', 'information_schema', 'INFORMATION_SCHEMA');
+
+-- 2. What's in the target database?
+SELECT name, engine, total_rows,
+       formatReadableSize(total_bytes) as size
+FROM system.tables
+WHERE database = 'analytics'
+ORDER BY total_bytes DESC;
+
+-- 3. What columns does the main table have? (comments reveal semantics)
+SELECT name, type, comment
+FROM system.columns
+WHERE database = 'analytics' AND table = 'events'
+ORDER BY position;
+
+-- 4. What's the sort key? (determines efficient filter columns)
+SELECT sorting_key, primary_key, partition_key
+FROM system.tables
+WHERE database = 'analytics' AND table = 'events';
+
+-- 5. What skipping indexes exist? (optimized non-key filters)
+SELECT name, type_full, expr, granularity
+FROM system.data_skipping_indices
+WHERE database = 'analytics' AND table = 'events';
+
+-- 6. What does the data look like?
+SELECT * FROM analytics.events LIMIT 5;
+
+-- 7. Verify the query plan before running
+EXPLAIN indexes = 1
+SELECT event_type, count()
+FROM analytics.events
+WHERE event_date >= '2024-01-01'
+  AND user_id = 'abc123'
+GROUP BY event_type;
+
+-- 8. NOW execute the query with confidence:
+SELECT event_type, count()
+FROM analytics.events
+WHERE event_date >= '2024-01-01'  -- partition key filter
+  AND user_id = 'abc123'          -- sort key filter
+GROUP BY event_type
+ORDER BY count() DESC
+LIMIT 100;
+```
+
+**Why each step matters:**
+
+| Step | Skipping It Causes |
+
+|------|-------------------|
+
+| List databases | Querying wrong or nonexistent database |
+
+| List tables | Missing the right table, querying the wrong one |
+
+| Get columns + comments | Wrong column names, misunderstood semantics |
+
+| Check sort key | Full table scans instead of index-pruned reads |
+
+| Check skip indexes | Missing optimized filter paths on non-key columns |
+
+| Sample data | Wrong assumptions about date ranges, nulls, enums |
+
+| Verify EXPLAIN | Expensive queries that could have been caught before execution |
+
+Reference: [https://clickhouse.com/docs/operations/system-tables](https://clickhouse.com/docs/operations/system-tables)
+
+---
+
+## References
+
+1. [https://clickhouse.com/docs](https://clickhouse.com/docs)
+2. [https://github.com/ClickHouse/ClickHouse](https://github.com/ClickHouse/ClickHouse)

--- a/.claude/skills/clickhouse-best-practices/README.md
+++ b/.claude/skills/clickhouse-best-practices/README.md
@@ -1,0 +1,56 @@
+# ClickHouse Best Practices
+
+Agent skill providing comprehensive ClickHouse guidance for schema design, query optimization, and data ingestion.
+
+## Installation
+
+```bash
+npx skills add ClickHouse/clickhouse-agent-skills
+```
+
+## What's Included
+
+**31 atomic rules** organized by prefix:
+
+| Prefix | Count | Coverage |
+|--------|-------|----------|
+| `schema-pk-*` | 4 | PRIMARY KEY selection, cardinality ordering |
+| `schema-types-*` | 5 | Data types, LowCardinality, Nullable |
+| `schema-partition-*` | 4 | Partitioning strategy, lifecycle management |
+| `schema-json-*` | 1 | JSON type usage |
+| `query-join-*` | 5 | JOIN algorithms, filtering, alternatives |
+| `query-index-*` | 1 | Data skipping indices |
+| `query-mv-*` | 2 | Incremental and refreshable MVs |
+| `insert-batch-*` | 1 | Batch sizing (10K-100K rows) |
+| `insert-async-*` | 2 | Async inserts, data formats |
+| `insert-mutation-*` | 2 | Mutation avoidance |
+| `insert-optimize-*` | 1 | OPTIMIZE FINAL avoidance |
+| `agent-connect-*` | 1 | MCP + CLI connectivity, credentials, output formats |
+| `agent-discovery-*` | 1 | 7-step schema discovery workflow |
+| `agent-query-*` | 1 | Query safety limits, progressive exploration |
+
+## Trigger Phrases
+
+This skill activates when you:
+- "Create a table for..."
+- "Optimize this query..."
+- "Design a schema for..."
+- "Why is this query slow?"
+- "How should I insert data into..."
+- "Should I use UPDATE or..."
+- "Connect Claude to ClickHouse..."
+- "Set up MCP for ClickHouse..."
+- "Query ClickHouse from an agent..."
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `SKILL.md` | Quick reference and decision frameworks |
+| `AGENTS.md` | Complete rule reference (auto-generated) |
+| `rules/*.md` | Individual rule definitions |
+
+## Related Documentation
+
+All rules link to official ClickHouse documentation:
+- [ClickHouse Best Practices](https://clickhouse.com/docs/best-practices)

--- a/.claude/skills/clickhouse-best-practices/SKILL.md
+++ b/.claude/skills/clickhouse-best-practices/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: clickhouse-best-practices
+description: MUST USE when reviewing ClickHouse schemas, queries, or configurations. Contains 31 rules that MUST be checked before providing recommendations. Always read relevant rule files and cite specific rules in responses.
+license: Apache-2.0
+metadata:
+  author: ClickHouse Inc
+  version: "0.4.0"
+---
+
+# ClickHouse Best Practices
+
+Comprehensive guidance for ClickHouse covering schema design, query optimization, data ingestion, and AI agent connectivity. Contains 31 rules across 4 main categories (schema, query, insert, agent), prioritized by impact.
+
+> **Official docs:** [ClickHouse Best Practices](https://clickhouse.com/docs/best-practices)
+
+## IMPORTANT: How to Apply This Skill
+
+**Before answering ClickHouse questions, follow this priority order:**
+
+1. **Check for applicable rules** in the `rules/` directory
+2. **If rules exist:** Apply them and cite them in your response using "Per `rule-name`..."
+3. **If no rule exists:** Use the LLM's ClickHouse knowledge or search documentation
+4. **If uncertain:** Use web search for current best practices
+5. **Always cite your source:** rule name, "general ClickHouse guidance", or URL
+
+**Why rules take priority:** ClickHouse has specific behaviors (columnar storage, sparse indexes, merge tree mechanics) where general database intuition can be misleading. The rules encode validated, ClickHouse-specific guidance.
+
+---
+
+## Agent Connectivity & Query Workflow
+
+Before querying ClickHouse, agents must establish a connection and follow the discovery workflow:
+
+1. `rules/agent-connect-mcp.md` - Connection setup (MCP + CLI), credential discovery, output format selection
+2. `rules/agent-discovery-schema.md` - **CRITICAL**: 7-step schema discovery workflow
+3. `rules/agent-query-safety.md` - **CRITICAL**: LIMIT, timeouts, progressive exploration
+
+**Every agent session should follow this sequence:**
+
+1. **Connect** — establish connection via MCP or CLI (see `agent-connect-mcp`)
+2. **Discover** — databases → tables → columns + comments → sort keys → skip indexes → sample → EXPLAIN
+3. **Plan** — use sort key and skip index knowledge to write efficient WHERE clauses
+4. **Execute** — run queries with LIMIT and timeouts
+5. **Recover** — on timeout/memory errors, narrow filters and retry (see `agent-query-safety`)
+
+### Subagent architecture notes
+
+If your system dispatches ClickHouse tasks to specialized subagents:
+- **Schema discovery + query execution**: any model — the steps are procedural
+- **EXPLAIN analysis + query optimization**: benefits from mid-tier reasoning
+- **Schema design review against all 28 rules**: benefits from mid-tier reasoning
+
+---
+
+## Review Procedures
+
+### For Schema Reviews (CREATE TABLE, ALTER TABLE)
+
+**Read these rule files in order:**
+
+1. `rules/schema-pk-plan-before-creation.md` - ORDER BY is immutable
+2. `rules/schema-pk-cardinality-order.md` - Column ordering in keys
+3. `rules/schema-pk-prioritize-filters.md` - Filter column inclusion
+4. `rules/schema-types-native-types.md` - Proper type selection
+5. `rules/schema-types-minimize-bitwidth.md` - Numeric type sizing
+6. `rules/schema-types-lowcardinality.md` - LowCardinality usage
+7. `rules/schema-types-avoid-nullable.md` - Nullable vs DEFAULT
+8. `rules/schema-partition-low-cardinality.md` - Partition count limits
+9. `rules/schema-partition-lifecycle.md` - Partitioning purpose
+
+**Check for:**
+- [ ] PRIMARY KEY / ORDER BY column order (low-to-high cardinality)
+- [ ] Data types match actual data ranges
+- [ ] LowCardinality applied to appropriate string columns
+- [ ] Partition key cardinality bounded (100-1,000 values)
+- [ ] ReplacingMergeTree has version column if used
+
+### For Query Reviews (SELECT, JOIN, aggregations)
+
+**Read these rule files:**
+
+1. `rules/query-join-choose-algorithm.md` - Algorithm selection
+2. `rules/query-join-filter-before.md` - Pre-join filtering
+3. `rules/query-join-use-any.md` - ANY vs regular JOIN
+4. `rules/query-index-skipping-indices.md` - Secondary index usage
+5. `rules/schema-pk-filter-on-orderby.md` - Filter alignment with ORDER BY
+
+**Check for:**
+- [ ] Filters use ORDER BY prefix columns
+- [ ] JOINs filter tables before joining (not after)
+- [ ] Correct JOIN algorithm for table sizes
+- [ ] Skipping indices for non-ORDER BY filter columns
+
+### For Insert Strategy Reviews (data ingestion, updates, deletes)
+
+**Read these rule files:**
+
+1. `rules/insert-batch-size.md` - Batch sizing requirements
+2. `rules/insert-mutation-avoid-update.md` - UPDATE alternatives
+3. `rules/insert-mutation-avoid-delete.md` - DELETE alternatives
+4. `rules/insert-async-small-batches.md` - Async insert usage
+5. `rules/insert-optimize-avoid-final.md` - OPTIMIZE TABLE risks
+
+**Check for:**
+- [ ] Batch size 10K-100K rows per INSERT
+- [ ] No ALTER TABLE UPDATE for frequent changes
+- [ ] ReplacingMergeTree or CollapsingMergeTree for update patterns
+- [ ] Async inserts enabled for high-frequency small batches
+
+---
+
+## Output Format
+
+Structure your response as follows:
+
+```
+## Rules Checked
+- `rule-name-1` - Compliant / Violation found
+- `rule-name-2` - Compliant / Violation found
+...
+
+## Findings
+
+### Violations
+- **`rule-name`**: Description of the issue
+  - Current: [what the code does]
+  - Required: [what it should do]
+  - Fix: [specific correction]
+
+### Compliant
+- `rule-name`: Brief note on why it's correct
+
+## Recommendations
+[Prioritized list of changes, citing rules]
+```
+
+---
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix | Rule Count |
+|----------|----------|--------|--------|------------|
+| 1 | Primary Key Selection | CRITICAL | `schema-pk-` | 4 |
+| 2 | Data Type Selection | CRITICAL | `schema-types-` | 5 |
+| 3 | JOIN Optimization | CRITICAL | `query-join-` | 5 |
+| 4 | Insert Batching | CRITICAL | `insert-batch-` | 1 |
+| 5 | Mutation Avoidance | CRITICAL | `insert-mutation-` | 2 |
+| 6 | Partitioning Strategy | HIGH | `schema-partition-` | 4 |
+| 7 | Skipping Indices | HIGH | `query-index-` | 1 |
+| 8 | Materialized Views | HIGH | `query-mv-` | 2 |
+| 9 | Async Inserts | HIGH | `insert-async-` | 2 |
+| 10 | OPTIMIZE Avoidance | HIGH | `insert-optimize-` | 1 |
+| 11 | JSON Usage | MEDIUM | `schema-json-` | 1 |
+| 12 | Agent Schema Discovery | CRITICAL | `agent-discovery-` | 1 |
+| 13 | Agent Query Safety | CRITICAL | `agent-query-` | 1 |
+| 14 | Agent Connectivity + Formats | HIGH | `agent-connect-` | 1 |
+
+---
+
+## Quick Reference
+
+### Schema Design - Primary Key (CRITICAL)
+
+- `schema-pk-plan-before-creation` - Plan ORDER BY before table creation (immutable)
+- `schema-pk-cardinality-order` - Order columns low-to-high cardinality
+- `schema-pk-prioritize-filters` - Include frequently filtered columns
+- `schema-pk-filter-on-orderby` - Query filters must use ORDER BY prefix
+
+### Schema Design - Data Types (CRITICAL)
+
+- `schema-types-native-types` - Use native types, not String for everything
+- `schema-types-minimize-bitwidth` - Use smallest numeric type that fits
+- `schema-types-lowcardinality` - LowCardinality for <10K unique strings
+- `schema-types-enum` - Enum for finite value sets with validation
+- `schema-types-avoid-nullable` - Avoid Nullable; use DEFAULT instead
+
+### Schema Design - Partitioning (HIGH)
+
+- `schema-partition-low-cardinality` - Keep partition count 100-1,000
+- `schema-partition-lifecycle` - Use partitioning for data lifecycle, not queries
+- `schema-partition-query-tradeoffs` - Understand partition pruning trade-offs
+- `schema-partition-start-without` - Consider starting without partitioning
+
+### Schema Design - JSON (MEDIUM)
+
+- `schema-json-when-to-use` - JSON for dynamic schemas; typed columns for known
+
+### Query Optimization - JOINs (CRITICAL)
+
+- `query-join-choose-algorithm` - Select algorithm based on table sizes
+- `query-join-use-any` - ANY JOIN when only one match needed
+- `query-join-filter-before` - Filter tables before joining
+- `query-join-consider-alternatives` - Dictionaries/denormalization vs JOIN
+- `query-join-null-handling` - join_use_nulls=0 for default values
+
+### Query Optimization - Indices (HIGH)
+
+- `query-index-skipping-indices` - Skipping indices for non-ORDER BY filters
+
+### Query Optimization - Materialized Views (HIGH)
+
+- `query-mv-incremental` - Incremental MVs for real-time aggregations
+- `query-mv-refreshable` - Refreshable MVs for complex joins
+
+### Insert Strategy - Batching (CRITICAL)
+
+- `insert-batch-size` - Batch 10K-100K rows per INSERT
+
+### Insert Strategy - Async (HIGH)
+
+- `insert-async-small-batches` - Async inserts for high-frequency small batches
+- `insert-format-native` - Native format for best performance
+
+### Insert Strategy - Mutations (CRITICAL)
+
+- `insert-mutation-avoid-update` - ReplacingMergeTree instead of ALTER UPDATE
+- `insert-mutation-avoid-delete` - Lightweight DELETE or DROP PARTITION
+
+### Insert Strategy - Optimization (HIGH)
+
+- `insert-optimize-avoid-final` - Let background merges work
+
+### Agent Integration - Discovery (CRITICAL)
+
+- `agent-discovery-schema` - Always discover schema before querying
+
+### Agent Integration - Safety (CRITICAL)
+
+- `agent-query-safety` - LIMIT, timeouts, progressive exploration
+
+### Agent Integration - Connectivity + Formats (HIGH)
+
+- `agent-connect-mcp` - MCP + CLI setup, credential discovery, output format selection
+
+---
+
+## When to Apply
+
+This skill activates when you encounter:
+
+- AI agent connecting to ClickHouse (MCP, CLI, HTTP)
+- Agent workflow design for ClickHouse
+- Schema discovery or exploration requests
+
+- `CREATE TABLE` statements
+- `ALTER TABLE` modifications
+- `ORDER BY` or `PRIMARY KEY` discussions
+- Data type selection questions
+- Slow query troubleshooting
+- JOIN optimization requests
+- Data ingestion pipeline design
+- Update/delete strategy questions
+- ReplacingMergeTree or other specialized engine usage
+- Partitioning strategy decisions
+
+---
+
+## Rule File Structure
+
+Each rule file in `rules/` contains:
+
+- **YAML frontmatter**: title, impact level, tags
+- **Brief explanation**: Why this rule matters
+- **Incorrect example**: Anti-pattern with explanation
+- **Correct example**: Best practice with explanation
+- **Additional context**: Trade-offs, when to apply, references
+
+---
+
+## Full Compiled Document
+
+For the complete guide with all rules expanded inline: `AGENTS.md`
+
+Use `AGENTS.md` when you need to check multiple rules quickly without reading individual files.

--- a/.claude/skills/clickhouse-best-practices/rules/_sections.md
+++ b/.claude/skills/clickhouse-best-practices/rules/_sections.md
@@ -1,0 +1,30 @@
+# Sections
+
+This file defines all sections, their ordering, impact levels, and descriptions.
+The section ID (in parentheses) is the filename prefix used to group rules.
+
+---
+
+## 1. Schema Design (schema)
+
+**Impact:** CRITICAL
+
+**Description:** Proper schema design is foundational to ClickHouse performance. ORDER BY is immutable after table creation; wrong choices require full data migration. Includes primary key selection, data types, partitioning strategy, and JSON usage. Column types and ordering can impact query speed by orders of magnitude.
+
+## 2. Query Optimization (query)
+
+**Impact:** CRITICAL
+
+**Description:** Query patterns dramatically affect performance. JOIN algorithms, filtering strategies, skipping indices, and materialized views can reduce query time from minutes to milliseconds. Pre-computed aggregations read thousands of rows instead of billions.
+
+## 3. Insert Strategy (insert)
+
+**Impact:** CRITICAL
+
+**Description:** Each INSERT creates a data part. Single-row inserts overwhelm the merge process. Proper batching (10K-100K rows), async inserts for high-frequency writes, mutation avoidance, and letting background merges work are essential for stable cluster performance.
+
+## 4. Agent Integration (agent)
+
+**Impact:** CRITICAL
+
+**Description:** AI agents working with ClickHouse need deliberate connection setup, schema discovery, and safe query execution. Agents that skip discovery write queries that ignore the sort key and scan full tables; agents without safety limits run unbounded queries that exhaust compute budgets. Covers MCP/CLI/HTTP connectivity and credential handling, the schema discovery workflow (databases → tables → columns → sort keys → skip indexes → sample → EXPLAIN), and query safety defaults (LIMIT, `max_execution_time`, `EXPLAIN ESTIMATE`).

--- a/.claude/skills/clickhouse-best-practices/rules/_template.md
+++ b/.claude/skills/clickhouse-best-practices/rules/_template.md
@@ -1,0 +1,28 @@
+---
+title: Rule Title Here
+impact: CRITICAL | HIGH | MEDIUM | LOW
+impactDescription: "Quantified improvement (e.g., 10x faster queries)"
+tags: [tag1, tag2]
+---
+
+## Rule Title Here
+
+**Impact: CRITICAL** (optional description)
+
+Brief explanation of the rule and why it matters. This should be clear and concise, explaining the performance implications.
+
+**Incorrect (description of what's wrong):**
+
+```sql
+-- Bad: description
+SELECT * FROM table;
+```
+
+**Correct (description of what's right):**
+
+```sql
+-- Good: description
+SELECT * FROM table;
+```
+
+Reference: [Official Docs](https://clickhouse.com/docs/best-practices/...)

--- a/.claude/skills/clickhouse-best-practices/rules/agent-connect-mcp.md
+++ b/.claude/skills/clickhouse-best-practices/rules/agent-connect-mcp.md
@@ -1,0 +1,116 @@
+---
+title: Connect AI Agents to ClickHouse
+impact: HIGH
+impactDescription: "Proper connection setup eliminates credential-prompting friction and enables structured access"
+tags: [agent, mcp, cli, connectivity, setup]
+---
+
+## Connect AI Agents to ClickHouse
+
+**Impact: HIGH**
+
+Two connection methods, each with a clear use case. Pick one based on your environment.
+
+**Incorrect (prompting for credentials every time):**
+
+```python
+# Agent asks the user for host, port, user, password on every session
+# Credentials are hardcoded in the prompt or conversation
+response = client.query("SELECT 1",
+    host="???", user="???", password="???")  # fragile, unsecured
+```
+
+**Correct (MCP or CLI with pre-configured credentials):**
+
+```bash
+# MCP: credentials configured once via env vars or OAuth
+claude mcp add --transport http clickhouse-cloud https://mcp.clickhouse.cloud/mcp
+
+# CLI: credentials in a named profile or env vars
+clickhouse client --host abc123.clickhouse.cloud --port 9440 --secure \
+  --user default --password "$CLICKHOUSE_PASSWORD" --format JSON \
+  --query "SELECT 1"
+```
+
+### Option A: MCP Server (interactive agent workflows)
+
+Best for schema discovery, iterative analysis, and multi-step conversations.
+
+**ClickHouse Cloud — zero-install hosted MCP:**
+
+```bash
+claude mcp add --transport http clickhouse-cloud https://mcp.clickhouse.cloud/mcp
+```
+
+Uses OAuth. Read-only. No env vars needed.
+
+**Self-hosted MCP (any ClickHouse deployment):**
+
+```bash
+pip install mcp-clickhouse
+```
+
+| Variable | Example | Notes |
+|----------|---------|-------|
+| `CLICKHOUSE_HOST` | `abc123.clickhouse.cloud` | Hostname |
+| `CLICKHOUSE_USER` | `default` | Database user |
+| `CLICKHOUSE_PASSWORD` | `your-password` | Database password |
+| `CLICKHOUSE_SECURE` | `true` | Always `true` for Cloud |
+
+Enable writes: `export CLICKHOUSE_ALLOW_WRITE_ACCESS=true`
+
+**Limitations:**
+- MCP has ~200-500ms overhead per call. For large result sets or batch operations, use CLI.
+- MCP's `list_tables` may not surface column `COMMENT` annotations — query `system.columns` directly for full schema context (see `agent-discovery-schema`).
+
+**ClickHouse Cloud note:** Services can be idle/sleeping. The first query after inactivity may take 10-20 seconds while the service wakes up. A timeout or `503` on first connection is expected — retry once before treating it as an error.
+
+### Option B: clickhouse-client (batch operations, large results)
+
+Best for scripting, automation, and queries returning >10K rows. Zero per-call overhead.
+
+```bash
+clickhouse client \
+  --host abc123.clickhouse.cloud --port 9440 --secure \
+  --user default --password 'your-password' \
+  --format JSON \
+  --max_execution_time 30 \
+  --query "SELECT * FROM events LIMIT 100" 2>&1
+```
+
+### Option C: HTTP interface (fallback when CLI is unavailable)
+
+If you have credentials but can't install `clickhouse-client` (lambda, sandbox, web-based agent), use the HTTP interface directly:
+
+```bash
+curl -s "https://abc123.clickhouse.cloud:8443/" \
+  -H "X-ClickHouse-User: default" \
+  -H "X-ClickHouse-Key: your-password" \
+  --data-binary "SELECT name, engine FROM system.tables WHERE database = 'default' FORMAT JSON"
+```
+
+Port `8443` is HTTPS. Pass query settings as URL params: `?max_execution_time=30&max_result_rows=10000`.
+
+### Where to find connection credentials (ClickHouse Cloud)
+
+1. Go to [console.clickhouse.cloud](https://console.clickhouse.cloud)
+2. Click your service → **Connect** in the left sidebar
+3. The dialog shows hostname, port, user, and a pre-built CLI command
+4. **Reset password** if needed from the same dialog
+
+For self-managed: check `config.xml` or ask your administrator.
+
+### Output format selection
+
+Always specify a format. The default (TabSeparated without headers) is unparseable by agents.
+
+| Format | Tokens (1K rows) | Best For |
+|--------|------------------|----------|
+| `JSON` | ~20K | Single queries — includes column types, row count, statistics |
+| `JSONCompact` | ~10K | Same metadata as JSON but rows as arrays — good for wide tables |
+| `JSONEachRow` | ~15K | Streaming large results, piping through `jq` |
+| `TabSeparatedWithNames` | ~4K | Minimal tokens, simple tabular data |
+
+Use `JSON` as the default for agent work. Switch to `TabSeparatedWithNames` when result sets are large and context window budget matters.
+
+Reference: [ClickHouse MCP Server](https://github.com/ClickHouse/mcp-clickhouse) · [clickhouse-client](https://clickhouse.com/docs/interfaces/cli) · [Output Formats](https://clickhouse.com/docs/interfaces/formats)

--- a/.claude/skills/clickhouse-best-practices/rules/agent-discovery-schema.md
+++ b/.claude/skills/clickhouse-best-practices/rules/agent-discovery-schema.md
@@ -1,0 +1,168 @@
+---
+title: Discover Schema Before Querying
+impact: CRITICAL
+impactDescription: "Skipping schema discovery leads to full scans, wrong columns, and wasted compute"
+tags: [agent, schema, discovery, workflow]
+---
+
+## Discover Schema Before Querying
+
+**Impact: CRITICAL**
+
+ALWAYS start by understanding the schema. Never assume table or column names. Agents that skip schema discovery write queries that scan unnecessary data, use wrong column names, or miss the sort key — all of which burn compute and return bad results. The below queries are examples of how you access the schema for tables. Step 1 is a literal query. The rest are exemplars.
+
+**Step 1: List databases**
+
+```sql
+SELECT name
+FROM system.databases
+WHERE name NOT IN ('system', 'information_schema', 'INFORMATION_SCHEMA')
+ORDER BY name;
+```
+
+**Step 2: List tables with size context**
+
+```sql
+SELECT database, name, engine, total_rows,
+       formatReadableSize(total_bytes) as size
+FROM system.tables
+WHERE database = 'analytics'
+ORDER BY total_bytes DESC;
+```
+
+This tells you which tables are large (and therefore expensive to scan carelessly) and what engine each uses.
+
+**Step 3: Get columns, types, and comments**
+
+```sql
+SELECT name, type, comment
+FROM system.columns
+WHERE database = 'analytics' AND table = 'events'
+ORDER BY position;
+```
+
+**Column comments are critical.** If table creators have added `COMMENT` annotations to columns, they are invaluable for understanding semantics (e.g., distinguishing `user_id_hash` from `user_id`). MCP's `list_tables` tool returns column names and types but may not surface comments — always query `system.columns` directly when you need full context.
+
+**Step 4: Understand the sort key**
+
+```sql
+SELECT sorting_key, primary_key, partition_key
+FROM system.tables
+WHERE database = 'analytics' AND table = 'events';
+```
+
+This is the most important step for writing efficient queries. Filtering on sort key columns allows ClickHouse to skip entire data granules. Filtering on non-key columns forces a full scan.
+
+**Step 5: Check for skipping indexes**
+
+```sql
+SELECT name, type_full, expr, granularity
+FROM system.data_skipping_indices
+WHERE database = 'analytics' AND table = 'events';
+```
+
+Skipping indexes (`bloom_filter`, `minmax`, `set`, `tokenbf_v1`) tell you which non-sort-key columns already have optimized filter paths. If an index exists on a column, filtering on it is efficient even though it's not in the sort key. Missing this step means you won't know which "non-key" filters are actually fast.
+
+**Step 6: Sample data**
+
+```sql
+SELECT *
+FROM analytics.events
+LIMIT 5;
+```
+
+A small sample reveals actual data patterns — date ranges, enum values, null frequency — that inform how to write correct `WHERE` clauses.
+
+**Step 7: Verify query plan before execution**
+
+Before running a potentially expensive query, use `EXPLAIN` to verify it will use indexes efficiently:
+
+```sql
+-- Check which indexes and projections will be used
+EXPLAIN indexes = 1
+SELECT event_type, count()
+FROM analytics.events
+WHERE event_date >= '2024-01-01'
+  AND user_id = 'abc123'
+GROUP BY event_type;
+```
+
+Look for:
+- **Keys** section showing your sort key columns are being used for filtering
+- **Parts** and **Granules** counts — if these are not significantly reduced from the total, your filters aren't pruning effectively
+- **Skip** entries showing data skipping index usage
+
+For a quick cost estimate without running the query:
+
+```sql
+EXPLAIN ESTIMATE
+SELECT * FROM analytics.events
+WHERE event_date >= '2024-01-01' AND user_id = 'abc123';
+```
+
+This returns estimated rows and bytes to be read — if the numbers look unreasonably large, refine your filters before executing.
+
+**Example full discovery workflow:**
+
+```sql
+-- 1. What databases exist?
+SELECT name FROM system.databases
+WHERE name NOT IN ('system', 'information_schema', 'INFORMATION_SCHEMA');
+
+-- 2. What's in the target database?
+SELECT name, engine, total_rows,
+       formatReadableSize(total_bytes) as size
+FROM system.tables
+WHERE database = 'analytics'
+ORDER BY total_bytes DESC;
+
+-- 3. What columns does the main table have? (comments reveal semantics)
+SELECT name, type, comment
+FROM system.columns
+WHERE database = 'analytics' AND table = 'events'
+ORDER BY position;
+
+-- 4. What's the sort key? (determines efficient filter columns)
+SELECT sorting_key, primary_key, partition_key
+FROM system.tables
+WHERE database = 'analytics' AND table = 'events';
+
+-- 5. What skipping indexes exist? (optimized non-key filters)
+SELECT name, type_full, expr, granularity
+FROM system.data_skipping_indices
+WHERE database = 'analytics' AND table = 'events';
+
+-- 6. What does the data look like?
+SELECT * FROM analytics.events LIMIT 5;
+
+-- 7. Verify the query plan before running
+EXPLAIN indexes = 1
+SELECT event_type, count()
+FROM analytics.events
+WHERE event_date >= '2024-01-01'
+  AND user_id = 'abc123'
+GROUP BY event_type;
+
+-- 8. NOW execute the query with confidence:
+SELECT event_type, count()
+FROM analytics.events
+WHERE event_date >= '2024-01-01'  -- partition key filter
+  AND user_id = 'abc123'          -- sort key filter
+GROUP BY event_type
+ORDER BY count() DESC
+LIMIT 100;
+```
+
+**Why each step matters:**
+
+| Step | Skipping It Causes |
+|------|-------------------|
+| List databases | Querying wrong or nonexistent database |
+| List tables | Missing the right table, querying the wrong one |
+| Get columns + comments | Wrong column names, misunderstood semantics |
+| Check sort key | Full table scans instead of index-pruned reads |
+| Check skip indexes | Missing optimized filter paths on non-key columns |
+| Sample data | Wrong assumptions about date ranges, nulls, enums |
+| Verify EXPLAIN | Expensive queries that could have been caught before execution |
+
+Reference: [System Tables](https://clickhouse.com/docs/operations/system-tables)

--- a/.claude/skills/clickhouse-best-practices/rules/agent-query-safety.md
+++ b/.claude/skills/clickhouse-best-practices/rules/agent-query-safety.md
@@ -1,0 +1,101 @@
+---
+title: Apply Safety Limits to Agent-Generated Queries
+impact: CRITICAL
+impactDescription: "Unbounded agent queries can scan billions of rows and saturate cluster resources"
+tags: [agent, safety, limits, timeout]
+---
+
+## Apply Safety Limits to Agent-Generated Queries
+
+**Impact: CRITICAL**
+
+Every agent-generated query must have explicit safety limits. A single unbounded query can scan billions of rows, consume all memory, or run for minutes.
+
+**Non-negotiable rules:**
+
+- ALWAYS use `LIMIT` to cap returned rows (default `LIMIT 1000`)
+- ALWAYS bound scan size with `max_rows_to_read` or `max_bytes_to_read` — `LIMIT` alone does not prevent a full scan
+- ALWAYS set `max_execution_time` (default 30)
+- NEVER run `SELECT *` on large tables without `LIMIT` and scan caps
+- NEVER query without filtering on sort key or partition key columns
+
+**Incorrect:**
+
+```sql
+SELECT * FROM events WHERE user_id = '123'
+```
+
+**Correct:**
+
+```sql
+SELECT *
+FROM events
+WHERE event_date >= today() - 7 AND user_id = '123'
+LIMIT 100
+SETTINGS max_execution_time = 30,
+         max_rows_to_read = 1000000000,
+         timeout_before_checking_execution_speed = 0
+```
+
+**Recommended per-query settings:**
+
+| Setting | Recommended | Effect |
+|---------|-------------|--------|
+| `max_rows_to_read` | 1e9 | Caps rows scanned before materialization — the real guardrail |
+| `max_bytes_to_read` | 1e11 | Caps bytes scanned |
+| `max_execution_time` | 30 | Interrupts query when projected execution time exceeds N seconds (see `timeout_before_checking_execution_speed`) |
+| `timeout_before_checking_execution_speed` | 0 | Makes `max_execution_time` behave as a wall-clock limit (default `10` gives queries 10s of grace before timeouts kick in) |
+| `max_estimated_execution_time` | 60 | Rejects queries whose projected runtime exceeds N seconds — kills expensive queries before they start |
+| `max_result_rows` | 10000 | Caps output rows |
+| `result_overflow_mode` | `'break'` | Returns partial result of ≥ `max_result_rows`, rounded up to the next block boundary (it does not truncate exactly) |
+
+Limits are checked at block boundaries, so actual scans and runtime can overshoot slightly.
+
+**Cloud vs self-hosted defaults that matter:**
+
+| Setting | Self-hosted default | Cloud default |
+|---------|---------------------|---------------|
+| `max_memory_usage` | `0` (unlimited) | Depends on replica RAM — not unlimited |
+| `max_bytes_before_external_group_by` | `0` (no spill) | Half the memory per replica — spills automatically |
+| `max_bytes_before_external_sort` | `0` (no spill) | Half the memory per replica — spills automatically |
+| `max_rows_to_read` / `max_bytes_to_read` | `0` (unlimited) | `0` (unlimited) — must be set explicitly on both |
+| `max_execution_time` | `0` (unlimited) | `0` (unlimited) — must be set explicitly on both |
+
+On self-hosted, GROUP BY and ORDER BY have no automatic memory ceiling — set the `max_bytes_before_external_*` settings explicitly or enforce via profile. On Cloud, GROUP BY / ORDER BY spill to disk automatically and per-query memory is bounded, but scan and execution-time caps are still your job.
+
+**When things go wrong:**
+
+- **Timeout** (`TIMEOUT_EXCEEDED`): Narrow the time range, add sort key filters, run `EXPLAIN ESTIMATE` to check scan size before retrying. Consider `max_estimated_execution_time` to reject expensive queries up front.
+- **Memory error** (`MEMORY_LIMIT_EXCEEDED`): Reduce actual memory use — narrow filters, add `LIMIT`, lower GROUP BY cardinality, enable `max_bytes_before_external_group_by` (already on by default in Cloud, off on self-hosted), or split into smaller time windows. Raising `max_memory_usage` only helps if you're authorized and the ceiling is genuinely the problem; *lowering* it makes the error happen sooner, not later.
+- **Too many parts** (`TOO_MANY_PARTS`): Back off inserts — merges are behind. Wait and retry.
+
+**Role-level hardening (belt-and-suspenders):**
+
+Per-query `SETTINGS` only applies if the agent remembers to emit it. For production, the primary mechanism should be a [settings profile](https://clickhouse.com/docs/operations/settings/settings-profiles) plus [`readonly=2`](https://clickhouse.com/docs/operations/settings/constraints-on-settings#read-only) on the agent's role, so limits apply even when the agent forgets. Per-query settings are then defense in depth, not the fence.
+
+Per-query limits also don't stop abuse via many small queries — use [quotas](https://clickhouse.com/docs/operations/quotas) to bound requests or scanned bytes per interval.
+
+**Progressive exploration pattern:**
+
+Start narrow, widen only if needed:
+
+```sql
+-- 1. Count first (cheap)
+SELECT count() FROM events WHERE event_date = today();
+
+-- 2. Small sample (if count is reasonable)
+SELECT * FROM events WHERE event_date = today() LIMIT 10;
+
+-- 3. Full query with LIMIT and scan caps
+SELECT user_id, count() as events
+FROM events
+WHERE event_date = today()
+GROUP BY user_id
+ORDER BY events DESC
+LIMIT 100
+SETTINGS max_execution_time = 30,
+         max_rows_to_read = 1000000000,
+         timeout_before_checking_execution_speed = 0;
+```
+
+Reference: [Query complexity restrictions](https://clickhouse.com/docs/operations/settings/query-complexity) · [Query-level settings](https://clickhouse.com/docs/operations/settings/query-level)

--- a/.claude/skills/clickhouse-best-practices/rules/insert-async-small-batches.md
+++ b/.claude/skills/clickhouse-best-practices/rules/insert-async-small-batches.md
@@ -1,0 +1,55 @@
+---
+title: Use Async Inserts for High-Frequency Small Batches
+impact: HIGH
+impactDescription: "Server-side buffering when client batching isn't practical"
+tags: [insert, async, buffering, small-batches]
+---
+
+## Use Async Inserts for High-Frequency Small Batches
+
+**Impact: HIGH**
+
+When client-side batching isn't practical, async inserts buffer server-side and create larger parts automatically.
+
+**Incorrect (small batches without async):**
+
+```python
+# Small batches without async_insert - creates too many parts
+for batch in chunks(events, 100):
+    client.execute("INSERT INTO events VALUES", batch)
+```
+
+**Correct (enable async inserts):**
+
+```python
+# Enable async_insert with safe defaults
+client.execute("SET async_insert = 1")
+client.execute("SET wait_for_async_insert = 1")  # Confirms durability
+
+for batch in chunks(events, 100):
+    client.execute("INSERT INTO events VALUES", batch)
+# Server buffers and creates larger parts automatically
+```
+
+```sql
+-- Configure server-side for specific users
+ALTER USER my_app_user SETTINGS
+    async_insert = 1,
+    wait_for_async_insert = 1,
+    async_insert_max_data_size = 10000000,  -- Flush at 10MB
+    async_insert_busy_timeout_ms = 1000;    -- Flush after 1s
+```
+
+**Flush conditions (whichever occurs first):**
+- Buffer reaches `async_insert_max_data_size`
+- Time threshold `async_insert_busy_timeout_ms` elapses
+- Maximum insert queries accumulate
+
+**Return modes:**
+
+| Setting | Behavior | Use Case |
+|---------|----------|----------|
+| `wait_for_async_insert=1` | Waits for flush, confirms durability | **Recommended** |
+| `wait_for_async_insert=0` | Fire-and-forget, unaware of errors | **Risky** - only if you accept data loss |
+
+Reference: [Selecting an Insert Strategy](https://clickhouse.com/docs/best-practices/selecting-an-insert-strategy)

--- a/.claude/skills/clickhouse-best-practices/rules/insert-batch-size.md
+++ b/.claude/skills/clickhouse-best-practices/rules/insert-batch-size.md
@@ -1,0 +1,54 @@
+---
+title: Batch Inserts Appropriately (10K-100K rows)
+impact: CRITICAL
+impactDescription: "Each INSERT creates a part; single-row inserts overwhelm merge process"
+tags: [insert, batching, parts, performance]
+---
+
+## Batch Inserts Appropriately (10K-100K rows)
+
+**Impact: CRITICAL**
+
+Each INSERT creates a new data part. Single-row or small-batch inserts create thousands of tiny parts, overwhelming the merge process and causing cluster instability.
+
+**Incorrect (single-row or tiny batches):**
+
+```python
+# Single-row inserts - creates 10,000 parts!
+for event in events:
+    client.execute("INSERT INTO events VALUES", [event])
+
+# Tiny batches - still too many parts
+for batch in chunks(events, 100):  # 100 rows per INSERT
+    client.execute("INSERT INTO events VALUES", batch)
+```
+
+**Correct (proper batch size):**
+
+```python
+# Ideal batch size: 10,000-100,000 rows
+BATCH_SIZE = 10_000
+for batch in chunks(events, BATCH_SIZE):
+    client.execute("INSERT INTO events VALUES", batch)
+```
+
+**Recommended batch sizes:**
+
+| Threshold | Value |
+|-----------|-------|
+| Minimum | 1,000 rows |
+| Ideal range | 10,000-100,000 rows |
+| Insert rate (sync) | ~1 insert per second |
+
+**Validation:**
+
+```sql
+-- Monitor part count (>3000 per partition blocks inserts)
+SELECT table, count() as parts, sum(rows) as total_rows
+FROM system.parts
+WHERE active AND database = 'default'
+GROUP BY table
+ORDER BY parts DESC;
+```
+
+Reference: [Selecting an Insert Strategy](https://clickhouse.com/docs/best-practices/selecting-an-insert-strategy)

--- a/.claude/skills/clickhouse-best-practices/rules/insert-format-native.md
+++ b/.claude/skills/clickhouse-best-practices/rules/insert-format-native.md
@@ -1,0 +1,29 @@
+---
+title: Use Native Format for Best Insert Performance
+impact: MEDIUM
+impactDescription: "Native format is most efficient; JSONEachRow is expensive to parse"
+tags: [insert, format, Native, performance]
+---
+
+## Use Native Format for Best Insert Performance
+
+**Impact: MEDIUM**
+
+Data format affects insert performance. Native format is column-oriented with minimal parsing overhead.
+
+**Performance Ranking (fastest to slowest):**
+
+| Format | Notes |
+|--------|-------|
+| **Native** | Most efficient. Column-oriented, minimal parsing. Recommended. |
+| **RowBinary** | Efficient row-based alternative |
+| **JSONEachRow** | Easier to use but expensive to parse |
+
+**Example:**
+
+```python
+# Use Native format for best performance
+client.execute("INSERT INTO events VALUES", data, settings={'input_format': 'Native'})
+```
+
+Reference: [Selecting an Insert Strategy](https://clickhouse.com/docs/best-practices/selecting-an-insert-strategy)

--- a/.claude/skills/clickhouse-best-practices/rules/insert-mutation-avoid-delete.md
+++ b/.claude/skills/clickhouse-best-practices/rules/insert-mutation-avoid-delete.md
@@ -1,0 +1,74 @@
+---
+title: Avoid ALTER TABLE DELETE
+impact: CRITICAL
+impactDescription: "Use lightweight DELETE, CollapsingMergeTree, or DROP PARTITION instead"
+tags: [insert, mutation, DELETE, CollapsingMergeTree]
+---
+
+## Avoid ALTER TABLE DELETE
+
+**Impact: CRITICAL**
+
+`ALTER TABLE DELETE` is a mutation that rewrites entire data parts. Use alternatives like lightweight DELETE, CollapsingMergeTree, or DROP PARTITION.
+
+**Incorrect (mutation delete):**
+
+```sql
+-- Mutation delete for cleanup
+ALTER TABLE orders DELETE WHERE status = 'cancelled';
+
+-- Time-based cleanup via mutation (very expensive)
+ALTER TABLE sessions DELETE WHERE created_at < now() - INTERVAL 7 DAY;
+```
+
+**Correct - CollapsingMergeTree:**
+
+```sql
+CREATE TABLE orders (
+    order_id UInt64,
+    customer_id UInt64,
+    total Decimal(10,2),
+    sign Int8  -- 1 = active, -1 = deleted
+)
+ENGINE = CollapsingMergeTree(sign)
+ORDER BY order_id;
+
+-- Insert order
+INSERT INTO orders VALUES (123, 456, 99.99, 1);
+
+-- "Delete" by inserting with sign = -1
+INSERT INTO orders VALUES (123, 456, 99.99, -1);
+
+-- Query collapses +1 and -1 pairs
+SELECT order_id, sum(total * sign) as total
+FROM orders GROUP BY order_id HAVING sum(sign) > 0;
+```
+
+**Correct - Lightweight Deletes (23.3+):**
+
+```sql
+-- Marks rows, doesn't rewrite immediately
+DELETE FROM orders WHERE status = 'cancelled';
+-- Physical deletion happens during normal merges
+```
+
+**Correct - DROP PARTITION for Bulk Deletion:**
+
+```sql
+-- Instant deletion of old data
+ALTER TABLE events DROP PARTITION '202301';
+
+-- Much faster than:
+ALTER TABLE events DELETE WHERE toYYYYMM(timestamp) = 202301;
+```
+
+**Delete strategy comparison:**
+
+| Method | Speed | When to Use |
+|--------|-------|-------------|
+| ALTER DELETE | Slow | Rare corrections only |
+| CollapsingMergeTree | Fast | Frequent soft deletes |
+| Lightweight DELETE | Medium | Occasional deletes |
+| DROP PARTITION | Instant | Bulk deletion by partition |
+
+Reference: [Avoid Mutations](https://clickhouse.com/docs/best-practices/avoid-mutations)

--- a/.claude/skills/clickhouse-best-practices/rules/insert-mutation-avoid-update.md
+++ b/.claude/skills/clickhouse-best-practices/rules/insert-mutation-avoid-update.md
@@ -1,0 +1,74 @@
+---
+title: Avoid ALTER TABLE UPDATE
+impact: CRITICAL
+impactDescription: "Use lightweight UPDATE or ReplacingMergeTree instead"
+tags: [insert, mutation, UPDATE, ReplacingMergeTree]
+---
+
+## Avoid ALTER TABLE UPDATE
+
+**Impact: CRITICAL**
+
+`ALTER TABLE UPDATE` is a mutation that rewrites entire data parts affected by the change. Use alternatives like lightweight UPDATE or ReplacingMergeTree.
+
+**Why mutations are problematic:**
+- **Write amplification:** Rewrite complete parts even for minor changes
+- **Disk I/O spike:** Degrades overall cluster performance
+- **No rollback:** Cannot be rolled back after submission
+- **Inconsistent reads:** SELECT may read mix of mutated and unmutated parts
+
+**Incorrect (mutation update):**
+
+```sql
+-- Rewrites potentially huge amounts of data
+ALTER TABLE users UPDATE status = 'inactive'
+WHERE last_login < now() - INTERVAL 90 DAY;
+
+-- Frequent row updates via mutation
+ALTER TABLE inventory UPDATE quantity = quantity - 1
+WHERE product_id = 123;
+-- If product exists across 100 parts, rewrites ALL 100 parts
+```
+
+**Correct - ReplacingMergeTree:**
+
+```sql
+CREATE TABLE users (
+    user_id UInt64,
+    name String,
+    status LowCardinality(String),
+    updated_at DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY user_id;
+
+-- "Update" by inserting new version
+INSERT INTO users (user_id, name, status)
+VALUES (123, 'John', 'inactive');
+
+-- Query with FINAL to get latest version
+SELECT * FROM users FINAL WHERE user_id = 123;
+
+-- Or use aggregation
+SELECT user_id, argMax(status, updated_at) as status
+FROM users GROUP BY user_id;
+```
+
+**Correct - Lightweight Updates (25.7+):**
+
+```sql
+-- Writes a patch, doesn't rewrite parts immediately
+UPDATE users SET status = 'inactive'
+WHERE last_login < now() - INTERVAL 90 DAY;
+-- Patches are applied during normal merges
+```
+
+**Update strategy comparison:**
+
+| Method | Speed | When to Use |
+|--------|-------|-------------|
+| ALTER UPDATE | Slow | Rare corrections only |
+| ReplacingMergeTree | Fast | Frequent updates |
+| Lightweight UPDATE | Medium | Occasional updates |
+
+Reference: [Avoid Mutations](https://clickhouse.com/docs/best-practices/avoid-mutations)

--- a/.claude/skills/clickhouse-best-practices/rules/insert-optimize-avoid-final.md
+++ b/.claude/skills/clickhouse-best-practices/rules/insert-optimize-avoid-final.md
@@ -1,0 +1,57 @@
+---
+title: Avoid OPTIMIZE TABLE FINAL
+impact: HIGH
+impactDescription: "Forces expensive merge of all parts; let background merges work"
+tags: [insert, OPTIMIZE, merge, performance]
+---
+
+## Avoid OPTIMIZE TABLE FINAL
+
+**Impact: HIGH**
+
+`OPTIMIZE TABLE ... FINAL` forces immediate merge of all parts into one part per partition. This is resource-intensive and rarely necessary. ClickHouse already performs smart background merges.
+
+**Note:** `OPTIMIZE FINAL` is not the same as `FINAL`. The `FINAL` modifier in SELECT queries may be necessary for deduplicated results in ReplacingMergeTree and is generally fine to use.
+
+**Incorrect (OPTIMIZE FINAL after inserts):**
+
+```sql
+-- Running OPTIMIZE FINAL after every batch insert
+INSERT INTO events SELECT * FROM staging_events;
+OPTIMIZE TABLE events FINAL;  -- Expensive and unnecessary!
+
+-- Scheduled OPTIMIZE FINAL jobs
+-- Cron: 0 * * * * clickhouse-client -q "OPTIMIZE TABLE events FINAL"
+```
+
+**Correct (let background merges work):**
+
+```sql
+-- Let background merges handle optimization
+INSERT INTO events SELECT * FROM staging_events;
+-- Done! ClickHouse merges automatically
+
+-- For ReplacingMergeTree deduplication, use FINAL in queries
+SELECT * FROM events FINAL WHERE user_id = 123;
+-- Instead of running OPTIMIZE FINAL to deduplicate
+```
+
+**Problems with OPTIMIZE FINAL:**
+- Rewrites entire partition regardless of need
+- Ignores the ~150 GB part size safeguard
+- Can cause memory pressure or OOM errors
+- Lengthy execution time for large datasets
+
+**When OPTIMIZE FINAL may be acceptable:**
+- Finalizing data before table freezing
+- Preparing data for export operations
+- One-time operations, not regular workflows
+
+**Better alternatives:**
+
+| Need | Alternative |
+|------|-------------|
+| Deduplicate ReplacingMergeTree | Use `FINAL` modifier in SELECT |
+| Reduce part count | Rely on background merges |
+
+Reference: [Avoid OPTIMIZE FINAL](https://clickhouse.com/docs/best-practices/avoid-optimize-final)

--- a/.claude/skills/clickhouse-best-practices/rules/query-index-skipping-indices.md
+++ b/.claude/skills/clickhouse-best-practices/rules/query-index-skipping-indices.md
@@ -1,0 +1,77 @@
+---
+title: Use Data Skipping Indices for Non-ORDER BY Filters
+impact: HIGH
+impactDescription: "Up to 60x faster queries by skipping irrelevant granules"
+tags: [query, index, skipping, bloom_filter]
+---
+
+## Use Data Skipping Indices for Non-ORDER BY Filters
+
+**Impact: HIGH**
+
+Queries filtering on columns not in ORDER BY cannot use the primary index and result in full scans. Data skipping indices store metadata about blocks and skip granules that definitely don't match.
+
+**Important:** Skip indices should be considered **after** optimizing data types, primary key selection, and materialized views.
+
+**When to use:**
+- High overall cardinality but low cardinality within blocks
+- Rare values critical for search (error codes, specific IDs)
+- Column correlates with primary key
+
+**When NOT to use:**
+- As a first optimization step
+- Matching values scattered across many blocks
+- Without testing on real data
+
+**Incorrect (filtering on non-ORDER BY column):**
+
+```sql
+CREATE TABLE events (
+    event_type LowCardinality(String),
+    timestamp DateTime,
+    user_id UInt64    -- Not in ORDER BY
+)
+ENGINE = MergeTree()
+ORDER BY (event_type, toDate(timestamp));
+
+-- Query filters on user_id - scans all matching event_type
+SELECT * FROM events
+WHERE event_type = 'click' AND user_id = 12345;
+```
+
+**Correct (add skipping index):**
+
+```sql
+CREATE TABLE events (
+    event_type LowCardinality(String),
+    timestamp DateTime,
+    user_id UInt64,
+    INDEX idx_user_id user_id TYPE bloom_filter GRANULARITY 4
+)
+ENGINE = MergeTree()
+ORDER BY (event_type, toDate(timestamp));
+
+-- Or add to existing table
+ALTER TABLE events ADD INDEX idx_user_id user_id TYPE bloom_filter GRANULARITY 4;
+ALTER TABLE events MATERIALIZE INDEX idx_user_id;
+```
+
+**Index types:**
+
+| Type | Best For | Example Filter |
+|------|----------|----------------|
+| `bloom_filter` | Equality on high-cardinality | `WHERE user_id = 123` |
+| `set(N)` | Low cardinality (N unique values) | `WHERE status IN ('a','b')` |
+| `minmax` | Range queries | `WHERE amount > 1000` |
+| `ngrambf_v1` | Text search | `WHERE text LIKE '%term%'` |
+| `tokenbf_v1` | Token search | `WHERE hasToken(text, 'word')` |
+
+**Validation:**
+
+```sql
+EXPLAIN indexes = 1
+SELECT * FROM events WHERE user_id = 12345;
+-- Look for "Skip" in output showing granules skipped
+```
+
+Reference: [Use Data Skipping Indices Where Appropriate](https://clickhouse.com/docs/best-practices/use-data-skipping-indices-where-appropriate)

--- a/.claude/skills/clickhouse-best-practices/rules/query-join-choose-algorithm.md
+++ b/.claude/skills/clickhouse-best-practices/rules/query-join-choose-algorithm.md
@@ -1,0 +1,43 @@
+---
+title: Choose the Right JOIN Algorithm
+impact: CRITICAL
+impactDescription: "Wrong algorithm causes OOM; right algorithm handles large tables efficiently"
+tags: [query, JOIN, algorithm, memory]
+---
+
+## Choose the Right JOIN Algorithm
+
+**Impact: CRITICAL**
+
+ClickHouse's default hash join loads the RIGHT table entirely into memory. Choose the right algorithm based on table sizes and constraints.
+
+**Algorithm selection:**
+
+| Algorithm | Best For | Trade-off |
+|-----------|----------|-----------|
+| `parallel_hash` | Small-to-medium in-memory tables | Default since 24.11; fast, concurrent |
+| `hash` | General purpose, all join types | Single-threaded hash table build |
+| `direct` | Dictionary lookups (INNER/LEFT only) | Fastest; no hash table construction |
+| `full_sorting_merge` | Tables already sorted on join key | Skips sort if pre-ordered; low memory |
+| `partial_merge` | Large tables, memory-constrained | Minimized memory; slower execution |
+| `grace_hash` | Large datasets, tunable memory | Flexible; disk-spilling capability |
+| `auto` | Adaptive algorithm selection | Tries hash first, falls back on memory pressure |
+
+**Example usage:**
+
+```sql
+-- Let ClickHouse choose automatically
+SET join_algorithm = 'auto';
+
+-- For large-to-large joins where memory is constrained
+SET join_algorithm = 'partial_merge';
+SELECT * FROM large_a JOIN large_b ON large_b.id = large_a.id;
+
+-- When joining by primary key columns, sort-merge skips sorting step
+SET join_algorithm = 'full_sorting_merge';
+SELECT * FROM table_a a JOIN table_b b ON b.pk_col = a.pk_col;
+```
+
+**Note:** ClickHouse 24.12+ automatically positions smaller tables on the right side. For earlier versions, manually ensure the smaller table is on the RIGHT.
+
+Reference: [Minimize and Optimize JOINs](https://clickhouse.com/docs/best-practices/minimize-optimize-joins)

--- a/.claude/skills/clickhouse-best-practices/rules/query-join-consider-alternatives.md
+++ b/.claude/skills/clickhouse-best-practices/rules/query-join-consider-alternatives.md
@@ -1,0 +1,72 @@
+---
+title: Consider Alternatives to JOINs
+impact: CRITICAL
+impactDescription: "Dictionaries and denormalization shift work from query time to insert time"
+tags: [query, JOIN, dictionary, denormalization]
+---
+
+## Consider Alternatives to JOINs
+
+**Impact: CRITICAL**
+
+Repeated JOINs to dimension tables add overhead. Dictionaries or denormalization shift computational work from query time to insert/pre-processing time.
+
+**Incorrect (JOIN on every query):**
+
+```sql
+-- JOIN on every query
+SELECT o.order_id, c.name, c.email
+FROM orders o
+JOIN customers c ON c.id = o.customer_id
+WHERE o.created_at > '2024-01-01';
+```
+
+**Correct - Dictionary Lookup:**
+
+```sql
+-- Create dictionary
+CREATE DICTIONARY customer_dict (
+    id UInt64,
+    name String,
+    email String
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'customers'))
+LAYOUT(HASHED())
+LIFETIME(MIN 300 MAX 360);
+
+-- Use dictGet instead of JOIN (uses direct join algorithm - fastest)
+SELECT
+    order_id,
+    dictGet('customer_dict', 'name', customer_id) as customer_name,
+    dictGet('customer_dict', 'email', customer_id) as customer_email
+FROM orders
+WHERE created_at > '2024-01-01';
+```
+
+**Correct - Denormalization:**
+
+```sql
+-- Denormalized table with materialized view
+CREATE MATERIALIZED VIEW orders_enriched_mv TO orders_enriched AS
+SELECT
+    o.order_id, o.customer_id,
+    c.name as customer_name,
+    c.email as customer_email,
+    o.total, o.created_at
+FROM orders o
+JOIN customers c ON c.id = o.customer_id;
+```
+
+**Approach comparison:**
+
+| Approach | Use Case | Performance |
+|----------|----------|-------------|
+| Dictionary | Frequent lookups to small dimension | Fastest (in-memory) |
+| Denormalization | Analytics always need enriched data | Fast (no join at query) |
+| IN subquery | Existence filtering | Often faster than JOIN |
+| JOIN | Infrequent or complex joins | Acceptable |
+
+**Critical dictionary caveat:** Dictionaries silently deduplicate duplicate keys, retaining only the final value. Only use when source has unique keys.
+
+Reference: [Minimize and Optimize JOINs](https://clickhouse.com/docs/best-practices/minimize-optimize-joins)

--- a/.claude/skills/clickhouse-best-practices/rules/query-join-filter-before.md
+++ b/.claude/skills/clickhouse-best-practices/rules/query-join-filter-before.md
@@ -1,0 +1,54 @@
+---
+title: Filter Tables Before Joining
+impact: CRITICAL
+impactDescription: "Joining full tables then filtering wastes resources"
+tags: [query, JOIN, filtering, subquery]
+---
+
+## Filter Tables Before Joining
+
+**Impact: CRITICAL**
+
+Joining full tables then filtering wastes resources. Add filtering in `WHERE` or `JOIN ON` clauses. If automatic pushdown fails, restructure as a subquery.
+
+**Incorrect (join then filter):**
+
+```sql
+-- Joins entire tables, then filters
+SELECT o.order_id, c.name, o.total
+FROM orders o
+JOIN customers c ON c.id = o.customer_id
+WHERE o.created_at > '2024-01-01' AND c.country = 'US';
+```
+
+**Correct (filter in subqueries before joining):**
+
+```sql
+-- Filter in subqueries before joining
+SELECT o.order_id, c.name, o.total
+FROM (
+    SELECT order_id, customer_id, total
+    FROM orders
+    WHERE created_at > '2024-01-01'
+) o
+JOIN (
+    SELECT id, name
+    FROM customers
+    WHERE country = 'US'
+) c ON c.id = o.customer_id;
+```
+
+**Even better - aggregate before joining:**
+
+```sql
+SELECT c.country, o.total_revenue
+FROM (
+    SELECT customer_id, sum(total) as total_revenue
+    FROM orders
+    WHERE created_at > '2024-01-01'
+    GROUP BY customer_id
+) o
+JOIN customers c ON c.id = o.customer_id;
+```
+
+Reference: [Minimize and Optimize JOINs](https://clickhouse.com/docs/best-practices/minimize-optimize-joins)

--- a/.claude/skills/clickhouse-best-practices/rules/query-join-null-handling.md
+++ b/.claude/skills/clickhouse-best-practices/rules/query-join-null-handling.md
@@ -1,0 +1,33 @@
+---
+title: Optimize NULL Handling in Outer JOINs
+impact: MEDIUM
+impactDescription: "Default values instead of NULL reduces memory overhead"
+tags: [query, JOIN, NULL, memory]
+---
+
+## Optimize NULL Handling in Outer JOINs
+
+**Impact: MEDIUM**
+
+Set `join_use_nulls = 0` to use default column values instead of NULL markers, reducing memory overhead compared to Nullable wrappers.
+
+**Example:**
+
+```sql
+-- Use default values instead of NULLs for non-matching rows
+SET join_use_nulls = 0;
+
+SELECT o.order_id, c.name
+FROM orders o
+LEFT JOIN customers c ON c.id = o.customer_id;
+-- Non-matching rows get '' for name instead of NULL
+```
+
+**When to use:**
+
+| Setting | Behavior | Use Case |
+|---------|----------|----------|
+| `join_use_nulls = 0` (default) | Default values (empty string, 0) for non-matches | When you can handle default values |
+| `join_use_nulls = 1` | NULL for non-matches | When you need to distinguish "no match" from "matched with default" |
+
+Reference: [Minimize and Optimize JOINs](https://clickhouse.com/docs/best-practices/minimize-optimize-joins)

--- a/.claude/skills/clickhouse-best-practices/rules/query-join-use-any.md
+++ b/.claude/skills/clickhouse-best-practices/rules/query-join-use-any.md
@@ -1,0 +1,40 @@
+---
+title: Use ANY JOIN When Only One Match Needed
+impact: HIGH
+impactDescription: "Returns first match only; less memory and faster execution"
+tags: [query, JOIN, ANY, performance]
+---
+
+## Use ANY JOIN When Only One Match Needed
+
+**Impact: HIGH**
+
+Use `ANY` JOINs when you only need a single match rather than all matches. They consume less memory and execute faster.
+
+**Incorrect (returns all matches):**
+
+```sql
+-- Returns all matching rows, uses more memory
+SELECT o.order_id, c.name
+FROM orders o
+LEFT JOIN customers c ON c.id = o.customer_id;
+```
+
+**Correct (returns first match only):**
+
+```sql
+-- Returns only first match per row, faster and less memory
+SELECT o.order_id, c.name
+FROM orders o
+LEFT ANY JOIN customers c ON c.id = o.customer_id;
+```
+
+**ANY JOIN types:**
+
+| Type | Behavior |
+|------|----------|
+| `LEFT ANY JOIN` | At most one match from right table |
+| `INNER ANY JOIN` | At most one match, only matching rows |
+| `RIGHT ANY JOIN` | At most one match from left table |
+
+Reference: [Minimize and Optimize JOINs](https://clickhouse.com/docs/best-practices/minimize-optimize-joins)

--- a/.claude/skills/clickhouse-best-practices/rules/query-mv-incremental.md
+++ b/.claude/skills/clickhouse-best-practices/rules/query-mv-incremental.md
@@ -1,0 +1,68 @@
+---
+title: Use Incremental MVs for Real-Time Aggregations
+impact: HIGH
+impactDescription: "Read thousands of rows instead of billions; minimal cluster overhead"
+tags: [query, materialized-view, aggregation, real-time]
+---
+
+## Use Incremental MVs for Real-Time Aggregations
+
+**Impact: HIGH**
+
+Incremental MVs automatically apply the view's query to new data blocks at insert time. Results are written to a target table and partial results merge over time.
+
+**Incorrect (full aggregation on every query):**
+
+```sql
+-- Full aggregation on every dashboard load
+SELECT
+    event_type,
+    toStartOfHour(timestamp) as hour,
+    count() as events,
+    uniq(user_id) as unique_users
+FROM events
+WHERE timestamp >= now() - INTERVAL 7 DAY
+GROUP BY event_type, hour;
+-- Scans 7 days of data every time (billions of rows)
+```
+
+**Correct (incremental MV with pre-aggregation):**
+
+```sql
+-- Create target table for aggregated data
+CREATE TABLE events_hourly (
+    event_type LowCardinality(String),
+    hour DateTime,
+    events AggregateFunction(count),
+    unique_users AggregateFunction(uniq, UInt64)
+)
+ENGINE = AggregatingMergeTree()
+ORDER BY (event_type, hour);
+
+-- Create materialized view to populate incrementally
+CREATE MATERIALIZED VIEW events_hourly_mv TO events_hourly AS
+SELECT
+    event_type,
+    toStartOfHour(timestamp) as hour,
+    countState() as events,
+    uniqState(user_id) as unique_users
+FROM events
+GROUP BY event_type, hour;
+
+-- Query the pre-aggregated data
+SELECT
+    event_type, hour,
+    countMerge(events) as events,
+    uniqMerge(unique_users) as unique_users
+FROM events_hourly
+WHERE hour >= now() - INTERVAL 7 DAY
+GROUP BY event_type, hour;
+-- Reads thousands of rows instead of billions
+```
+
+**Key points:**
+- Use `-State` functions in MV, `-Merge` functions in query
+- Incremental - existing data not automatically included (backfill separately)
+- Minimal cluster overhead at insert time
+
+Reference: [Use Materialized Views](https://clickhouse.com/docs/best-practices/use-materialized-views)

--- a/.claude/skills/clickhouse-best-practices/rules/query-mv-refreshable.md
+++ b/.claude/skills/clickhouse-best-practices/rules/query-mv-refreshable.md
@@ -1,0 +1,64 @@
+---
+title: Use Refreshable MVs for Complex Joins and Batch Workflows
+impact: HIGH
+impactDescription: "Sub-millisecond queries with periodic refresh; ideal for complex joins"
+tags: [query, materialized-view, refresh, batch]
+---
+
+## Use Refreshable MVs for Complex Joins and Batch Workflows
+
+**Impact: HIGH**
+
+Refreshable MVs execute queries periodically on a schedule. The full query re-executes and overwrites (or appends to) the target table.
+
+**Best for:**
+- Sub-millisecond latency where minor staleness is acceptable
+- Caching "top N" results or lookup tables
+- Complex multi-table joins requiring denormalization
+- Batch workflows and DAG dependencies
+
+**Incorrect (expensive join on every request):**
+
+```sql
+-- Complex join executed on every request
+SELECT
+    o.order_id, o.total,
+    c.name as customer_name,
+    p.name as product_name
+FROM orders o
+JOIN customers c ON o.customer_id = c.id
+JOIN products p ON o.product_id = p.id
+WHERE o.created_at >= now() - INTERVAL 1 DAY;
+```
+
+**Correct (refreshable MV):**
+
+```sql
+-- Create refreshable MV that runs every 5 minutes
+CREATE MATERIALIZED VIEW orders_denormalized
+REFRESH EVERY 5 MINUTE
+ENGINE = MergeTree()
+ORDER BY (created_at, order_id)
+AS SELECT
+    o.order_id, o.created_at, o.total,
+    c.name as customer_name, c.segment,
+    p.name as product_name
+FROM orders o
+JOIN customers c ON o.customer_id = c.id
+JOIN products p ON o.product_id = p.id
+WHERE o.created_at >= now() - INTERVAL 1 DAY;
+
+-- Query the pre-joined data (sub-millisecond)
+SELECT * FROM orders_denormalized WHERE segment = 'enterprise';
+```
+
+**APPEND vs REPLACE modes:**
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| `REPLACE` (default) | Overwrites previous contents | Current state, lookup tables |
+| `APPEND` | Adds new rows to existing data | Periodic snapshots, historical accumulation |
+
+**Critical warning:** Query should run quickly compared to refresh interval. Don't schedule every 10 seconds if the query takes 10+ seconds.
+
+Reference: [Use Materialized Views](https://clickhouse.com/docs/best-practices/use-materialized-views)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-json-when-to-use.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-json-when-to-use.md
@@ -1,0 +1,76 @@
+---
+title: Use JSON Type for Dynamic Schemas
+impact: MEDIUM
+impactDescription: "Field-level querying for semi-structured data; use typed columns for known schemas"
+tags: [schema, JSON, semi-structured, flexibility]
+---
+
+## Use JSON Type for Dynamic Schemas
+
+**Impact: MEDIUM**
+
+ClickHouse's JSON type splits JSON objects into separate sub-columns, enabling field-level query optimization. Use it for truly dynamic data, not everything.
+
+**Incorrect (schema bloat or opaque String):**
+
+```sql
+-- BAD: Hundreds of nullable columns for event properties
+CREATE TABLE events (
+    event_id UUID,
+    prop_page_url Nullable(String),
+    prop_button_id Nullable(String),
+    -- ... 100 more nullable columns
+)
+
+-- BAD: JSON as String when you need field queries
+CREATE TABLE events (
+    event_id UUID,
+    properties String  -- No field-level optimization
+)
+```
+
+**Correct (JSON for dynamic, typed for known):**
+
+```sql
+-- Use JSON type for dynamic properties
+CREATE TABLE events (
+    event_id UUID DEFAULT generateUUIDv4(),
+    event_type LowCardinality(String),
+    timestamp DateTime DEFAULT now(),
+    properties JSON  -- Flexible schema with type inference
+)
+ENGINE = MergeTree()
+ORDER BY (event_type, timestamp);
+
+-- Query JSON paths directly
+SELECT
+    event_type,
+    properties.url as page_url,
+    properties.amount as purchase_amount
+FROM events
+WHERE event_type = 'page_view' AND properties.url = '/home';
+```
+
+**When to use JSON:**
+
+| Scenario | Use JSON? |
+|----------|-----------|
+| Data structure varies unpredictably | Yes |
+| Field types/schemas change over time | Yes |
+| Need field-level querying | Yes |
+| Fixed, known schema | No (use typed columns) |
+| JSON as opaque blob (no field queries) | No (use String) |
+
+**Optimization: specify types for known paths:**
+
+```sql
+CREATE TABLE events (
+    properties JSON(
+        url String,
+        amount Float64,
+        product_id UInt64
+    )
+)
+```
+
+Reference: [Use JSON Where Appropriate](https://clickhouse.com/docs/best-practices/use-json-where-appropriate)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-partition-lifecycle.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-partition-lifecycle.md
@@ -1,0 +1,50 @@
+---
+title: Use Partitioning for Data Lifecycle Management
+impact: HIGH
+impactDescription: "DROP PARTITION is instant; DELETE is expensive row-by-row scan"
+tags: [schema, partitioning, TTL, data-management]
+---
+
+## Use Partitioning for Data Lifecycle Management
+
+**Impact: HIGH**
+
+Partitioning is **primarily a data management technique, not a query optimization tool**. It excels at:
+- **Dropping data**: Remove entire partitions as single metadata operations
+- **TTL retention**: Implement time-based retention policies efficiently
+- **Tiered storage**: Move old partitions to cold storage
+- **Archiving**: Move partitions between tables
+
+**Incorrect (no time alignment for lifecycle):**
+
+```sql
+-- Cannot efficiently drop old data by time
+CREATE TABLE events (...)
+ENGINE = MergeTree()
+PARTITION BY event_type  -- No time alignment
+ORDER BY (timestamp);
+
+-- Slow: must scan and delete row by row
+DELETE FROM events WHERE timestamp < '2023-01-01';
+```
+
+**Correct (time-based for lifecycle):**
+
+```sql
+CREATE TABLE events (
+    timestamp DateTime,
+    event_type LowCardinality(String)
+)
+ENGINE = MergeTree()
+PARTITION BY toStartOfMonth(timestamp)
+ORDER BY (event_type, timestamp)
+TTL timestamp + INTERVAL 1 YEAR DELETE;  -- Drops whole partitions
+
+-- Fast: metadata-only operation
+ALTER TABLE events DROP PARTITION '202301';
+
+-- Archive to cold storage
+ALTER TABLE events_archive ATTACH PARTITION '202301' FROM events;
+```
+
+Reference: [Choosing a Partitioning Key](https://clickhouse.com/docs/best-practices/choosing-a-partitioning-key)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-partition-low-cardinality.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-partition-low-cardinality.md
@@ -1,0 +1,61 @@
+---
+title: Keep Partition Cardinality Low (100-1,000 Values)
+impact: HIGH
+impactDescription: "Too many partitions cause part explosion and 'too many parts' errors"
+tags: [schema, partitioning, parts]
+---
+
+## Keep Partition Cardinality Low (100-1,000 Values)
+
+**Impact: HIGH**
+
+Too many distinct partition values create excessive data parts, eventually triggering "too many parts" errors. ClickHouse enforces limits via `max_parts_in_total` and `parts_to_throw_insert` settings.
+
+**Incorrect (high cardinality partitioning):**
+
+```sql
+-- High cardinality = too many partitions
+CREATE TABLE events (...)
+ENGINE = MergeTree()
+PARTITION BY user_id  -- Millions of partitions!
+ORDER BY (timestamp);
+
+-- Daily partitions can grow unbounded over years
+CREATE TABLE logs (...)
+ENGINE = MergeTree()
+PARTITION BY toDate(timestamp)  -- 3650 partitions over 10 years
+ORDER BY (service, timestamp);
+```
+
+**Correct (bounded cardinality):**
+
+```sql
+-- Monthly partitions = 12 per year, bounded cardinality
+CREATE TABLE events (
+    timestamp DateTime,
+    event_type LowCardinality(String),
+    user_id UInt64
+)
+ENGINE = MergeTree()
+PARTITION BY toStartOfMonth(timestamp)
+ORDER BY (event_type, timestamp);
+```
+
+**Validation:**
+
+```sql
+-- Check partition count and health
+SELECT
+    partition,
+    count() as parts,
+    sum(rows) as rows,
+    formatReadableSize(sum(bytes_on_disk)) as size
+FROM system.parts
+WHERE table = 'events' AND active
+GROUP BY partition
+ORDER BY partition;
+
+-- Warning signs: hundreds or thousands of partitions
+```
+
+Reference: [Choosing a Partitioning Key](https://clickhouse.com/docs/best-practices/choosing-a-partitioning-key)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-partition-query-tradeoffs.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-partition-query-tradeoffs.md
@@ -1,0 +1,35 @@
+---
+title: Understand Partition Query Performance Trade-offs
+impact: MEDIUM
+impactDescription: "Partition pruning helps some queries; spanning many partitions hurts others"
+tags: [schema, partitioning, query, performance]
+---
+
+## Understand Partition Query Performance Trade-offs
+
+**Impact: MEDIUM**
+
+Partitioning can help or hurt query performance:
+- **Potential improvement**: Queries filtering by partition key may benefit from partition pruning
+- **Potential degradation**: Queries spanning many partitions increase total parts scanned
+
+ClickHouse automatically builds **MinMax indexes** on partition columns. Data merges occur **within partitions only**, not across them.
+
+**Incorrect (query scans all partitions):**
+
+```sql
+-- Query must scan all partitions
+SELECT count(*) FROM events
+WHERE event_type = 'click';  -- No partition pruning
+```
+
+**Correct (query prunes to single partition):**
+
+```sql
+-- Query prunes to single partition
+SELECT count(*) FROM events
+WHERE timestamp >= '2024-01-01' AND timestamp < '2024-02-01'
+  AND event_type = 'click';
+```
+
+Reference: [Choosing a Partitioning Key](https://clickhouse.com/docs/best-practices/choosing-a-partitioning-key)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-partition-start-without.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-partition-start-without.md
@@ -1,0 +1,42 @@
+---
+title: Consider Starting Without Partitioning
+impact: MEDIUM
+impactDescription: "Add partitioning later when you have clear lifecycle requirements"
+tags: [schema, partitioning, simplicity]
+---
+
+## Consider Starting Without Partitioning
+
+**Impact: MEDIUM**
+
+Start without partitioning and add it later only if:
+- You have clear data lifecycle requirements (retention, archiving)
+- Your access patterns clearly benefit from partition pruning
+- You understand the cardinality implications
+
+**Example (start simple):**
+
+```sql
+-- Start simple, no partitioning
+CREATE TABLE events (
+    timestamp DateTime,
+    event_type LowCardinality(String),
+    user_id UInt64
+)
+ENGINE = MergeTree()
+ORDER BY (event_type, timestamp);
+
+-- Add partitioning later if needed for lifecycle management
+-- (requires table recreation or materialized view migration)
+```
+
+**When to add partitioning:**
+
+| Need | Add Partitioning? |
+|------|-------------------|
+| Time-based data retention | Yes |
+| Archive old data to cold storage | Yes |
+| Query performance on time ranges | Maybe (test first) |
+| No specific lifecycle needs | No |
+
+Reference: [Choosing a Partitioning Key](https://clickhouse.com/docs/best-practices/choosing-a-partitioning-key)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-pk-cardinality-order.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-pk-cardinality-order.md
@@ -1,0 +1,45 @@
+---
+title: Order Columns by Cardinality (Low to High)
+impact: CRITICAL
+impactDescription: "Enables granule skipping; high-cardinality first prevents index pruning"
+tags: [schema, primary-key, cardinality, ORDER BY]
+---
+
+## Order Columns by Cardinality (Low to High)
+
+**Impact: CRITICAL**
+
+Since the sparse primary index operates on data blocks (granules) rather than individual rows, low-cardinality leading columns create more useful index entries that can skip entire blocks. Place lower-cardinality columns before higher-cardinality ones in the ordering key.
+
+**Incorrect (high cardinality first):**
+
+```sql
+-- UUID first means no pruning benefit
+CREATE TABLE events (...)
+ENGINE = MergeTree()
+ORDER BY (event_id, event_type, timestamp);
+-- Every granule has different event_id values, index can't skip anything
+```
+
+**Correct (low cardinality first):**
+
+```sql
+-- Low cardinality first enables pruning
+CREATE TABLE events (...)
+ENGINE = MergeTree()
+ORDER BY (event_type, event_date, event_id);
+-- Index can skip entire event_type groups
+```
+
+**Column Order Guidelines:**
+
+| Position | Cardinality | Examples |
+|----------|-------------|----------|
+| 1st | Low (few distinct values) | event_type, status, country |
+| 2nd | Date (coarse granularity) | toDate(timestamp) |
+| 3rd+ | Medium-High | user_id, session_id |
+| Last | High (if needed) | event_id, uuid |
+
+**Tip:** Use `toDate(timestamp)` instead of raw `DateTime` columns when day-level filtering suffices - this reduces index size from 32-bit to 16-bit representations.
+
+Reference: [Choosing a Primary Key](https://clickhouse.com/docs/best-practices/choosing-a-primary-key)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-pk-filter-on-orderby.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-pk-filter-on-orderby.md
@@ -1,0 +1,52 @@
+---
+title: Filter on ORDER BY Columns in Queries
+impact: CRITICAL
+impactDescription: "Skipping prefix columns prevents index usage"
+tags: [schema, primary-key, WHERE, query]
+---
+
+## Filter on ORDER BY Columns in Queries
+
+**Impact: CRITICAL**
+
+Even with good schema design, queries must use ORDER BY columns to benefit. Skipping prefix columns or filtering on non-ORDER BY columns prevents index usage.
+
+**Incorrect (skips prefix or uses non-ORDER BY columns):**
+
+```sql
+-- Given: ORDER BY (tenant_id, event_type, timestamp)
+
+-- Skips prefix columns - can't use index effectively
+SELECT * FROM events WHERE event_type = 'click';
+
+-- Filter on column not in ORDER BY - full table scan
+SELECT * FROM events WHERE user_agent LIKE '%Chrome%';
+```
+
+**Correct (uses ORDER BY prefix):**
+
+```sql
+-- Given: ORDER BY (tenant_id, event_type, timestamp)
+
+-- Full prefix match - best performance
+SELECT * FROM events
+WHERE tenant_id = 123 AND event_type = 'click';
+
+-- Partial prefix - still uses index
+SELECT * FROM events WHERE tenant_id = 123;
+
+-- Range on later column after equality on earlier
+SELECT * FROM events
+WHERE tenant_id = 123 AND event_type = 'click' AND timestamp >= '2024-01-01';
+```
+
+**Index usage reference:**
+
+| Filter | Index Used? |
+|--------|-------------|
+| `WHERE tenant_id = 123` | Full |
+| `WHERE tenant_id = 123 AND event_type = 'click'` | Full |
+| `WHERE event_type = 'click'` | None (skipped prefix) |
+| `WHERE timestamp > '2024-01-01'` | None (skipped both) |
+
+Reference: [Choosing a Primary Key](https://clickhouse.com/docs/best-practices/choosing-a-primary-key)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-pk-plan-before-creation.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-pk-plan-before-creation.md
@@ -1,0 +1,64 @@
+---
+title: Plan PRIMARY KEY Before Table Creation
+impact: CRITICAL
+impactDescription: "ORDER BY is immutable; wrong choice requires full data migration"
+tags: [schema, primary-key, ORDER BY]
+---
+
+## Plan PRIMARY KEY Before Table Creation
+
+**Impact: CRITICAL** (immutable after creation)
+
+ClickHouse's ORDER BY clause defines physical data ordering and the sparse index. Unlike other databases, **ORDER BY cannot be modified after table creation**. A wrong choice requires creating a new table and migrating all data.
+
+**Incorrect (arbitrary ORDER BY without query analysis):**
+
+```sql
+-- Creating table without analyzing query patterns
+CREATE TABLE events (
+    event_id UUID,
+    user_id UInt64,
+    timestamp DateTime
+)
+ENGINE = MergeTree()
+ORDER BY (event_id);  -- Chosen arbitrarily
+
+-- Later: "Most queries filter by user_id!"
+-- Cannot fix with: ALTER TABLE events MODIFY ORDER BY (user_id, timestamp)
+-- ERROR: Cannot modify ORDER BY
+```
+
+**Correct (query-driven ORDER BY selection):**
+
+```sql
+-- Step 1: Document query patterns BEFORE creating table
+/*
+Query Analysis:
+- 60% of queries: WHERE user_id = ? AND timestamp BETWEEN ? AND ?
+- 25% of queries: WHERE event_type = ? AND timestamp > ?
+- 15% of queries: WHERE event_id = ?
+
+Conclusion: user_id and event_type are primary filters
+*/
+
+-- Step 2: Create table with correct ORDER BY
+CREATE TABLE events (
+    event_id UUID DEFAULT generateUUIDv4(),
+    user_id UInt64,
+    event_type LowCardinality(String),
+    timestamp DateTime,
+    event_date Date DEFAULT toDate(timestamp)
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(event_date)
+ORDER BY (user_id, event_date, event_id);
+```
+
+**Pre-creation checklist:**
+- [ ] Listed top 5-10 query patterns
+- [ ] Identified columns in WHERE clauses with frequency
+- [ ] Prioritized columns that exclude large numbers of rows
+- [ ] Ordered columns by cardinality (low first, high last)
+- [ ] Limited to 4-5 key columns (typically sufficient)
+
+Reference: [Choosing a Primary Key](https://clickhouse.com/docs/best-practices/choosing-a-primary-key)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-pk-prioritize-filters.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-pk-prioritize-filters.md
@@ -1,0 +1,44 @@
+---
+title: Prioritize Filter Columns in ORDER BY
+impact: CRITICAL
+impactDescription: "Columns not in ORDER BY cause full table scans"
+tags: [schema, primary-key, WHERE, filtering]
+---
+
+## Prioritize Filter Columns in ORDER BY
+
+**Impact: CRITICAL**
+
+Prioritize columns frequently used in query filters (WHERE clause), especially those that exclude large numbers of rows. Queries filtering on columns not in ORDER BY result in full table scans.
+
+**Incorrect (ORDER BY doesn't match query patterns):**
+
+```sql
+-- If most queries filter by tenant_id:
+CREATE TABLE events (...)
+ENGINE = MergeTree()
+ORDER BY (event_id);  -- Queries by tenant_id will full-scan!
+```
+
+**Correct (ORDER BY matches filter patterns):**
+
+```sql
+-- ORDER BY matches query filter patterns
+CREATE TABLE events (...)
+ENGINE = MergeTree()
+ORDER BY (tenant_id, event_date, event_id);
+
+-- Query now uses primary index:
+SELECT * FROM events WHERE tenant_id = 123 AND event_date >= '2024-01-01';
+```
+
+**Validation:**
+
+```sql
+-- Verify index usage
+EXPLAIN indexes = 1
+SELECT * FROM events WHERE tenant_id = 123;
+-- Look for "PrimaryKey" with Key Condition
+```
+
+Reference: [Choosing a Primary Key](https://clickhouse.com/docs/best-practices/choosing-a-primary-key)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-types-avoid-nullable.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-types-avoid-nullable.md
@@ -1,0 +1,55 @@
+---
+title: Avoid Nullable Unless Semantically Required
+impact: HIGH
+impactDescription: "Nullable adds storage overhead; use DEFAULT values instead"
+tags: [schema, data-types, Nullable, DEFAULT]
+---
+
+## Avoid Nullable Unless Semantically Required
+
+**Impact: HIGH**
+
+Nullable columns maintain a separate UInt8 column for tracking null values, increasing storage and degrading performance. Use DEFAULT values instead when feasible.
+
+**Incorrect (Nullable everywhere):**
+
+```sql
+CREATE TABLE users (
+    id Nullable(UInt64),              -- IDs should never be null
+    name Nullable(String),            -- Empty string is fine
+    age Nullable(UInt8),              -- 0 is a valid default
+    login_count Nullable(UInt32)      -- 0 is a valid default
+)
+```
+
+**Correct (DEFAULT values, Nullable only when semantic):**
+
+```sql
+CREATE TABLE users (
+    id UInt64,                                    -- Never null
+    name String DEFAULT '',                       -- Empty = unknown
+    age UInt8 DEFAULT 0,                          -- 0 = unknown
+    login_count UInt32 DEFAULT 0,                 -- 0 = never logged in
+    deleted_at Nullable(DateTime),                -- NULL = not deleted (semantic!)
+    parent_id Nullable(UInt64)                    -- NULL = no parent (semantic!)
+)
+```
+
+**When Nullable IS appropriate:**
+
+| Use Case | Why |
+|----------|-----|
+| `deleted_at` | NULL = "not deleted", timestamp = "deleted at X" |
+| `parent_id` | NULL = "no parent", value = "has parent" |
+| `discount_percent` | NULL = "no discount", 0 = "0% discount" |
+
+**Defaults instead of Nullable:**
+
+| Type | Default |
+|------|---------|
+| String | `''` (empty string) |
+| UInt*/Int* | `0` |
+| DateTime | `now()` or `toDateTime(0)` |
+| UUID | `generateUUIDv4()` |
+
+Reference: [Select Data Types](https://clickhouse.com/docs/best-practices/select-data-types)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-types-enum.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-types-enum.md
@@ -1,0 +1,58 @@
+---
+title: Use Enum for Finite Value Sets
+impact: MEDIUM
+impactDescription: "Insert-time validation and natural ordering; 1-2 bytes storage"
+tags: [schema, data-types, Enum, validation]
+---
+
+## Use Enum for Finite Value Sets
+
+**Impact: MEDIUM**
+
+Enum types provide validation at insert time and enable queries that exploit natural ordering. Use Enum8 (up to 256 values) or Enum16 (up to 65,536 values).
+
+**Incorrect (String without validation):**
+
+```sql
+CREATE TABLE orders (
+    status String    -- No validation, typos like "shiped" allowed
+)
+
+-- Ordering requires CASE statements
+SELECT * FROM orders ORDER BY
+    CASE status
+        WHEN 'pending' THEN 1
+        WHEN 'processing' THEN 2
+        WHEN 'shipped' THEN 3
+    END;
+```
+
+**Correct (Enum with validation and ordering):**
+
+```sql
+CREATE TABLE orders (
+    status Enum8('pending' = 1, 'processing' = 2, 'shipped' = 3, 'delivered' = 4)
+)
+
+-- Insert validation: invalid values rejected
+INSERT INTO orders VALUES ('shiped');  -- ERROR: Unknown element 'shiped'
+
+-- Natural ordering works automatically
+SELECT * FROM orders ORDER BY status;  -- Orders by enum value (1, 2, 3, 4)
+
+-- Comparisons use natural order
+SELECT * FROM orders WHERE status > 'processing';  -- shipped and delivered
+```
+
+**Enum Guidelines:**
+
+| Scenario | Use |
+|----------|-----|
+| Fixed set of values known at schema time | Enum8/Enum16 |
+| Values may change frequently | LowCardinality(String) |
+| Need insert-time validation | Enum |
+| Need natural ordering in queries | Enum |
+| < 256 distinct values | Enum8 (1 byte) |
+| 256-65,536 distinct values | Enum16 (2 bytes) |
+
+Reference: [Select Data Types](https://clickhouse.com/docs/best-practices/select-data-types)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-types-lowcardinality.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-types-lowcardinality.md
@@ -1,0 +1,58 @@
+---
+title: Use LowCardinality for Repeated Strings
+impact: HIGH
+impactDescription: "Dictionary encoding for <10K unique values; significant storage reduction"
+tags: [schema, data-types, LowCardinality, storage]
+---
+
+## Use LowCardinality for Repeated Strings
+
+**Impact: HIGH**
+
+String columns with repeated values store each value repeatedly. LowCardinality uses dictionary encoding for significant storage reduction.
+
+**Incorrect (plain String for repeated values):**
+
+```sql
+CREATE TABLE events (
+    country String,       -- "United States" stored 500M times
+    browser String,       -- "Chrome" stored 300M times
+    event_type String     -- "page_view" stored 800M times
+)
+```
+
+**Correct (LowCardinality for low unique counts):**
+
+```sql
+CREATE TABLE events (
+    country LowCardinality(String),      -- ~200 unique values
+    browser LowCardinality(String),      -- ~50 unique values
+    event_type LowCardinality(String)    -- ~100 unique values
+)
+```
+
+**When to use LowCardinality:**
+
+| Unique Values | Recommendation |
+|---------------|----------------|
+| < 10,000 | Use LowCardinality |
+| > 10,000 | Use regular String |
+
+```sql
+-- Check cardinality before deciding
+SELECT uniq(column_name) FROM table_name;
+```
+
+**LowCardinality vs FixedString:**
+
+Reserve `FixedString` for strictly fixed-length data (e.g., 2-char country codes). For most low-cardinality text, `LowCardinality(String)` outperforms `FixedString`.
+
+```sql
+-- FixedString: Only for truly fixed-length data
+country_code FixedString(2),    -- "US", "DE", "JP" - always 2 chars
+
+-- LowCardinality: For variable-length low-cardinality strings
+country_name LowCardinality(String),  -- "United States", "Germany"
+```
+
+Reference: [Select Data Types](https://clickhouse.com/docs/best-practices/select-data-types)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-types-minimize-bitwidth.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-types-minimize-bitwidth.md
@@ -1,0 +1,49 @@
+---
+title: Minimize Bit-Width for Numeric Types
+impact: HIGH
+impactDescription: "Smaller types reduce storage and improve cache efficiency"
+tags: [schema, data-types, numeric, storage]
+---
+
+## Minimize Bit-Width for Numeric Types
+
+**Impact: HIGH**
+
+Select the smallest numeric type that accommodates your data range. Prefer unsigned types when negative values aren't needed.
+
+**Incorrect (oversized types):**
+
+```sql
+CREATE TABLE metrics (
+    status_code Int64,        -- HTTP codes are 100-599
+    age Int64,                -- Human age fits in UInt8
+    year Int64,               -- Years fit in UInt16
+    item_count Int64          -- Often small numbers
+)
+```
+
+**Correct (right-sized types):**
+
+```sql
+CREATE TABLE metrics (
+    status_code UInt16,       -- 0-65,535 (HTTP codes fit easily)
+    age UInt8,                -- 0-255 (sufficient for age)
+    year UInt16,              -- 0-65,535 (sufficient for years)
+    item_count UInt32         -- 0-4 billion (adjust based on actual max)
+)
+```
+
+**Numeric Type Reference:**
+
+| Type | Range | Bytes |
+|------|-------|-------|
+| UInt8 | 0 to 255 | 1 |
+| UInt16 | 0 to 65,535 | 2 |
+| UInt32 | 0 to 4.3 billion | 4 |
+| UInt64 | 0 to 18 quintillion | 8 |
+| Int8 | -128 to 127 | 1 |
+| Int16 | -32,768 to 32,767 | 2 |
+| Int32 | -2.1 billion to 2.1 billion | 4 |
+| Int64 | -9 quintillion to 9 quintillion | 8 |
+
+Reference: [Select Data Types](https://clickhouse.com/docs/best-practices/select-data-types)

--- a/.claude/skills/clickhouse-best-practices/rules/schema-types-native-types.md
+++ b/.claude/skills/clickhouse-best-practices/rules/schema-types-native-types.md
@@ -1,0 +1,51 @@
+---
+title: Use Native Types Instead of String
+impact: CRITICAL
+impactDescription: "2-10x storage reduction; enables compression and correct semantics"
+tags: [schema, data-types, storage]
+---
+
+## Use Native Types Instead of String
+
+**Impact: CRITICAL**
+
+Using String for all data wastes storage, prevents compression optimization, and makes comparisons slower. ClickHouse's column-oriented architecture benefits directly from optimal type selection.
+
+**Incorrect (String for everything):**
+
+```sql
+CREATE TABLE events (
+    event_id String,        -- "550e8400-e29b-41d4-a716-446655440000" = 36 bytes
+    user_id String,         -- "12345" = 5 bytes (no numeric operations)
+    created_at String,      -- "2024-01-15 10:30:00" = 19 bytes
+    count String,           -- "42" - can't do math!
+    is_active String        -- "true" = 4 bytes
+)
+```
+
+**Correct (native types):**
+
+```sql
+CREATE TABLE events (
+    event_id UUID DEFAULT generateUUIDv4(),     -- 16 bytes (vs 36)
+    user_id UInt64,                              -- 8 bytes, numeric ops
+    created_at DateTime DEFAULT now(),           -- 4 bytes (vs 19)
+    count UInt32 DEFAULT 0,                      -- 4 bytes, math works
+    is_active Bool DEFAULT true                  -- 1 byte (vs 4)
+)
+```
+
+**Type Selection Quick Reference:**
+
+| Data | Use | Avoid |
+|------|-----|-------|
+| Sequential IDs | UInt32/UInt64 | String |
+| UUIDs | UUID | String |
+| Status/Category | Enum8 or LowCardinality(String) | String |
+| Timestamps | DateTime | DateTime64, String |
+| Dates only | Date or Date32 | DateTime, String |
+| Counts | UInt8/16/32 (smallest that fits) | Int64, String |
+| Money | Decimal(P,S) or Int64 (cents) | Float64, String |
+| Booleans | Bool or UInt8 | String |
+
+Reference: [Select Data Types](https://clickhouse.com/docs/best-practices/select-data-types)

--- a/.claude/skills/clickhouse-js-node-coding/SKILL.md
+++ b/.claude/skills/clickhouse-js-node-coding/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: clickhouse-js-node-coding
+description: >
+  Write idiomatic application code with the ClickHouse Node.js client
+  (`@clickhouse/client`). Use this skill whenever a user is *building* against
+  the Node.js client — configuring the client, pinging, inserting rows in JSON
+  or raw formats, selecting and parsing results, binding query parameters,
+  managing sessions and temporary tables, working with data types or
+  customizing JSON parsing. Do NOT use for browser/Web client code.
+---
+
+# ClickHouse Node.js Client — Coding
+
+Reference: https://clickhouse.com/docs/integrations/javascript
+
+> **⚠️ Node.js runtime only.** This skill covers the `@clickhouse/client`
+> package running in a **Node.js runtime** exclusively — including **Next.js
+> Node runtime** API routes, React Server Components, Server Actions, and
+> standard Node.js processes. Do **not** apply this skill to browser client
+> components, Web Workers, **Next.js Edge runtime**, Cloudflare Workers, or
+> any usage of `@clickhouse/client-web`. For browser/edge environments, the
+> correct package is `@clickhouse/client-web`.
+
+---
+
+## How to Use This Skill
+
+1. **Match the user's intent** to a row in the Task Index below and read the
+   corresponding reference file before writing code. After reading it, scan any
+   **Answer checklist** in that reference and make sure the final answer covers
+   each relevant item; those checklists capture details users usually need but
+   are easy to omit in short answers.
+2. **Always import from `@clickhouse/client`** (never `@clickhouse/client-web`)
+   and create a client with `createClient({ url })` or rely on
+   supported defaults when appropriate. Close it with `await client.close()`
+   preferably when it's no longer needed or during graceful shutdown for global resources.
+3. **Prefer `JSONEachRow` for typical row inserts/selects** unless the user
+   has already chosen another format or is streaming raw bytes (CSV / TSV /
+   Parquet — see `examples/node/performance/`).
+   **Note on `clickhouse_settings`:** settings passed to `createClient` are
+   defaults for every request; they can be overridden per-call by passing
+   `clickhouse_settings` directly to `insert()`, `query()`, or `command()`.
+   Always mention this when the user configures settings at the client level.
+4. **Always use `query_params` for user-supplied values** — never template-
+   literal-interpolate them into SQL. See `reference/query-parameters.md`.
+   **When answering a parameter-binding question, your response must
+   explicitly name template-literal interpolation as a "SQL injection
+   risk"** — even when the user only asked about syntax and did not raise
+   security. The literal phrase "SQL injection" needs to appear; this is
+   the most common mistake from PostgreSQL/MySQL users and the security
+   framing is part of the correct answer, not an optional aside.
+5. **Pick the right method for the job:**
+   - `client.insert()` — write rows.
+   - `client.query()` + `resultSet.json()` / `.text()` / `.stream()` — read
+     rows that return data.
+   - `client.command()` — DDL and other statements that don't return rows
+     (`CREATE`, `DROP`, `TRUNCATE`, `ALTER`, `SET` in a session, etc.).
+   - `client.exec()` — when you need the raw response stream of an arbitrary
+     statement (rare in coding scenarios).
+   - `client.ping()` — health check; returns `{ success, error? }`, never
+     throws on connection failure.
+6. **Note version constraints** when relevant. Examples:
+   - `pathname` config option: client `>= 1.0.0`.
+   - `BigInt` values in `query_params`: client `>= 1.15.0`.
+   - `TupleParam` and JS `Map` in `query_params`: client `>= 1.9.0`.
+   - Configurable `json.parse` / `json.stringify`: client `>= 1.14.0`.
+   - `Time` / `Time64` data types: ClickHouse server `>= 25.6`.
+   - `QBit` data type: ClickHouse server `>= 25.10` (GA on `26.x`).
+   - `Dynamic` / `Variant` / new `JSON` types: ClickHouse server `>= 24.1` /
+     `24.5` / `24.8` (no longer experimental since `25.3`).
+
+---
+
+## Task Index
+
+Identify the user's task and read the matching reference file.
+
+| Task                                                     | Triggers / symptoms                                                                                                                                                                                                             | Reference file                      |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| **Configure / connect the client**                       | Building a `createClient` call, URL parameters, `clickhouse_settings`, default format, custom HTTP headers                                                                                                                      | `reference/client-configuration.md` |
+| **Compress requests / responses**                        | `compression`, gzip vs `zstd`, `{ codec }` option shape, Node version requirements, web limitations                                                                                                                             | `reference/compression.md`          |
+| **Ping the server**                                      | Health checks, readiness probes, "is ClickHouse up?"                                                                                                                                                                            | `reference/ping.md`                 |
+| **Choose an insert format**                              | "Which format should I use to insert?", JSON vs raw, `JSONEachRow` vs `JSON` vs `JSONObjectEachRow`                                                                                                                             | `reference/insert-formats.md`       |
+| **Insert into a subset of columns / different database** | `insert({ columns })`, excluding columns, ephemeral columns, cross-DB inserts                                                                                                                                                   | `reference/insert-columns.md`       |
+| **Insert values, expressions, dates, decimals**          | `INSERT … VALUES` with SQL functions, `Date`/`DateTime` from JS, `Decimal` precision, `INSERT … SELECT`; inserting a UUID into a `UInt128` column is tricky — use when the user is writing code that stores a UUID as `UInt128` | `reference/insert-values.md`        |
+| **Async inserts (server-side batching)**                 | `async_insert=1`, fire-and-forget vs wait-for-ack                                                                                                                                                                               | `reference/async-insert.md`         |
+| **Select and parse results**                             | `JSONEachRow` reads, `JSON` with metadata, picking a select format                                                                                                                                                              | `reference/select-formats.md`       |
+| **Parameterize queries**                                 | Binding values, special characters / escaping, "SQL injection?", `{name: Type}` syntax                                                                                                                                          | `reference/query-parameters.md`     |
+| **Sessions & temporary tables**                          | `session_id`, `CREATE TEMPORARY TABLE`, per-session `SET` commands                                                                                                                                                              | `reference/sessions.md`             |
+| **Modern data types**                                    | `Dynamic`, `Variant`, `JSON` (object), `Time`, `Time64`, `QBit` (vector search)                                                                                                                                                 | `reference/data-types.md`           |
+| **Custom JSON parse/stringify**                          | Plug in `JSONBig` / `safe-stable-stringify` / a `BigInt`-aware serializer                                                                                                                                                       | `reference/custom-json.md`          |
+
+---
+
+## Conventions used in answers
+
+- Always show `import { createClient } from '@clickhouse/client'` (Node, never
+  Web).
+- Always `await client.close()` at the end of self-contained snippets; in
+  long-running services, close on graceful shutdown.
+- For inserts, prefer `format: 'JSONEachRow'` and `values: [...]` unless the
+  user's scenario requires otherwise.
+- For selects, prefer `await (await client.query({...})).json<RowType>()` for
+  small / medium result sets; for bigger results suggest streaming.
+- When showing parameter binding, use ClickHouse's native `{name: Type}`
+  syntax — never `$1`, `?`, or `:name`.
+- For DDL inside a cluster or behind a load balancer, set
+  `clickhouse_settings: { wait_end_of_query: 1 }` on the `command()` call so
+  the server only acknowledges after the change is applied. See
+  https://clickhouse.com/docs/en/interfaces/http/#response-buffering.
+
+---
+
+## Out of scope
+
+This skill covers day-to-day coding against `@clickhouse/client` (Node).
+The following topics are intentionally **not** covered here:
+
+- **Errors, hangs, type mismatches, proxy pathname surprises, log silence,
+  socket hang-ups, `ECONNRESET`** → use the
+  `clickhouse-js-node-troubleshooting` skill.
+- **Streaming, Parquet, file streams, server-side bulk moves, progress
+  streaming, async-insert throughput tuning** — see
+  [`examples/node/performance/`](https://github.com/ClickHouse/clickhouse-js/tree/main/examples/node/performance).
+- **TLS, RBAC / read-only users, deeper SQL-injection guidance** — see
+  [`examples/node/security/`](https://github.com/ClickHouse/clickhouse-js/tree/main/examples/node/security).
+- **`CREATE TABLE` patterns, deployment-shaped connection strings,
+  replication / sharding choices** — see
+  [`examples/node/schema-and-deployments/`](https://github.com/ClickHouse/clickhouse-js/tree/main/examples/node/schema-and-deployments).
+- **Browser, Web Worker, Next.js Edge, Cloudflare Workers** — use
+  `@clickhouse/client-web` and see
+  [`examples/web/`](https://github.com/ClickHouse/clickhouse-js/tree/main/examples/web).
+
+---
+
+## Still Stuck?
+
+- [`examples/node/coding/`](https://github.com/ClickHouse/clickhouse-js/tree/main/examples/node/coding) — the runnable corpus this skill is built on.
+- [ClickHouse JS client docs](https://clickhouse.com/docs/integrations/javascript)
+- [ClickHouse supported formats](https://clickhouse.com/docs/interfaces/formats)
+- [ClickHouse data types](https://clickhouse.com/docs/sql-reference/data-types)

--- a/.claude/skills/clickhouse-js-node-coding/reference/async-insert.md
+++ b/.claude/skills/clickhouse-js-node-coding/reference/async-insert.md
@@ -1,0 +1,107 @@
+# Async Inserts
+
+> **Applies to:** all client versions; the relevant settings are server-side.
+> See https://clickhouse.com/docs/en/optimize/asynchronous-inserts.
+
+> **When to use async inserts:** when many small inserts arrive concurrently
+> (e.g., one per HTTP request) and you don't want to maintain a client-side
+> batching layer. ClickHouse will batch them server-side. This is also the
+> recommended ingestion pattern for **ClickHouse Cloud**.
+
+> **When _not_ to use async inserts:** when you already build large batches
+> client-side (e.g., from a stream). Plain inserts are simpler and lower
+> latency.
+
+## Setup
+
+Enable on the client level or per-request via `clickhouse_settings`:
+
+```ts
+import { createClient, ClickHouseError } from "@clickhouse/client";
+
+const client = createClient({
+  url: process.env.CLICKHOUSE_URL,
+  password: process.env.CLICKHOUSE_PASSWORD,
+  max_open_connections: 10,
+  clickhouse_settings: {
+    async_insert: 1,
+    wait_for_async_insert: 1, // wait for ack from server
+    async_insert_max_data_size: "1000000",
+    async_insert_busy_timeout_ms: 1000,
+  },
+});
+```
+
+## Concurrent small inserts
+
+Each call still uses the client's normal `insert()` API — the server merges
+the batches.
+
+```ts
+const promises = [...new Array(10)].map(async () => {
+  const values = [...new Array(1000).keys()].map(() => ({
+    id: Math.floor(Math.random() * 100_000) + 1,
+    data: Math.random().toString(36).slice(2),
+  }));
+
+  await client
+    .insert({ table: "async_insert_example", values, format: "JSONEachRow" })
+    .catch((err) => {
+      if (err instanceof ClickHouseError) {
+        // err.code matches a row in system.errors
+        console.error(`ClickHouse error ${err.code}:`, err);
+        return;
+      }
+      console.error("Insert failed:", err);
+    });
+});
+
+await Promise.all(promises);
+```
+
+## `wait_for_async_insert` — fire-and-forget vs ack
+
+| `wait_for_async_insert` | Promise resolves when…                            | Trade-off                                                           |
+| ----------------------- | ------------------------------------------------- | ------------------------------------------------------------------- |
+| `1` (default)           | Server has flushed the batch to the table         | Slower per call; insert errors surface to the client                |
+| `0`                     | Server accepted the row into its in-memory buffer | Faster; flush errors won't surface — only validation/parsing errors |
+
+With `wait_for_async_insert: 1`, expect each insert call to take roughly
+`async_insert_busy_timeout_ms` to resolve when traffic is light, because the
+server waits for more rows or for the timer to fire before flushing.
+
+## Combining DDL with async inserts
+
+When creating tables in scripts that immediately insert, ack the DDL with
+`wait_end_of_query: 1` so the table is ready before the first insert:
+
+```ts
+await client.command({
+  query: `
+    CREATE OR REPLACE TABLE async_insert_example (id Int32, data String)
+    ENGINE MergeTree ORDER BY id
+  `,
+  clickhouse_settings: { wait_end_of_query: 1 },
+});
+```
+
+Even better is to create a specialized client for inserts with the appropriate async
+settings and a separate client for DDL and other queries.
+
+## Common pitfalls
+
+- **Setting `async_insert` per call but expecting client-side batching.**
+  The client still issues each `insert()` as a separate HTTP request — the
+  batching happens on the server.
+- **Confusing `wait_for_async_insert` (async-insert ack) with
+  `wait_end_of_query` (DDL ack).** They are unrelated.
+- **Treating a resolved insert under `wait_for_async_insert: 0` as
+  durably written.** It only means the server accepted the bytes; flush
+  failures will not surface to the client.
+- **Not handling `ClickHouseError`.** It exposes `err.code`, which maps to
+  rows in the `system.errors` table — use it to decide whether to retry.
+
+## See also
+
+- For raw throughput tuning of large async-insert workloads,
+  see [`examples/node/performance/`](https://github.com/ClickHouse/clickhouse-js/tree/main/examples/node/performance).

--- a/.claude/skills/clickhouse-js-node-coding/reference/client-configuration.md
+++ b/.claude/skills/clickhouse-js-node-coding/reference/client-configuration.md
@@ -1,0 +1,123 @@
+# Client Configuration
+
+> **Applies to:** all versions, with these notable additions:
+>
+> - `pathname` config option: client `>= 1.0.0`.
+> - `clickhouse_setting_*` / `ch_*` URL parameters: client `>= 1.0.0`.
+> - `keep_alive.idle_socket_ttl` (Node-only): client `>= 1.0.0`.
+
+## Answer checklist
+
+When answering configuration questions, include the relevant points:
+
+- Show `createClient` from `@clickhouse/client` with explicit fields when the
+  user is writing code; this is easier to read and review than encoding
+  everything into a URL string.
+- When mentioning the URL form for environment variables / DSNs: show a **Bash**
+  `export` with the literal URL value, and `createClient({ url: process.env.CLICKHOUSE_URL })`
+  in the Node code. **Never construct a URL in application code** — no string
+  concatenation, no template literals, no query-string builders.
+- If URL parameters and object fields both set the same option, URL parameters
+  override the rest of the configuration object.
+- If `clickhouse_settings` appear on `createClient`, explain that they are
+  defaults for every request and can be overridden on individual `query()`,
+  `insert()`, `command()`, or `exec()` calls.
+- Remind long-running services to close the client during graceful shutdown.
+- The `application` field sets the name that appears in `system.query_log`.
+  Do **not** mention any specific HTTP header name — the client handles header
+  mapping internally and the header names are an implementation detail.
+
+## Minimal client
+
+```ts
+import { createClient } from "@clickhouse/client";
+
+const client = createClient({
+  url: process.env.CLICKHOUSE_URL, // defaults to 'http://localhost:8123'
+  username: process.env.CLICKHOUSE_USER, // defaults to 'default'
+  password: process.env.CLICKHOUSE_PASSWORD, // defaults to ''
+  database: "analytics", // defaults to 'default'
+});
+// ... your queries ...
+await client.close();
+```
+
+`url` accepts a string or a `URL` object. The accepted string format is:
+
+```
+http[s]://[username:password@]hostname:port[/database][?param1=value1&param2=value2]
+```
+
+## Configuration via URL
+
+Prefer explicit object fields in application code. Use the URL form when the
+application receives one connection string from an environment variable, secret
+manager, or config file. The URL value belongs in the environment, not in the
+source code — show it as a shell export and read it in Node:
+
+```bash
+# In your shell environment / deployment config (e.g. .env, Kubernetes secret):
+export CLICKHOUSE_URL='https://bob:secret@my.host:8124/analytics'
+```
+
+```ts
+// In your Node.js code — no URL construction needed:
+const client = createClient({ url: process.env.CLICKHOUSE_URL });
+```
+
+## Per-client vs per-request `clickhouse_settings` ⭐
+
+> **Always mention this when discussing `clickhouse_settings`:** settings set
+> on `createClient` are defaults; any individual call can override them.
+
+Settings on `createClient` apply to every request. Settings on a single
+operation (`query`, `insert`, `command`, `exec`) override the client defaults
+for **that call only**.
+
+```ts
+const client = createClient({
+  clickhouse_settings: {
+    output_format_json_quote_64bit_integers: 0, // applied to every request
+  },
+});
+
+const rows = await client.query({
+  query: "SELECT number FROM system.numbers LIMIT 2 FORMAT JSONEachRow",
+  clickhouse_settings: {
+    output_format_json_quote_64bit_integers: 1, // overrides client default for this call
+  },
+});
+```
+
+## `default_format` for `exec()`
+
+`client.exec()` runs an arbitrary statement and returns a stream. If your
+query has no trailing `FORMAT …` clause, set `default_format` so the server
+knows what to send back, then wrap the response in a `ResultSet`:
+
+```ts
+import { createClient, ResultSet } from "@clickhouse/client";
+
+const client = createClient();
+const format = "JSONCompactEachRowWithNamesAndTypes";
+const { stream, query_id } = await client.exec({
+  query: "SELECT database, name, engine FROM system.tables LIMIT 5",
+  clickhouse_settings: { default_format: format },
+});
+const rs = new ResultSet(stream, format, query_id);
+console.log(await rs.json());
+await client.close();
+```
+
+For ordinary `SELECT`s prefer `client.query({ format })` — `default_format` is
+only needed for raw `exec()`.
+
+## Common pitfalls
+
+- **Don't put a path in `url` and expect it to be the database name when
+  you're behind a proxy.** Use `pathname` for the proxy path and `database`
+  for the DB. (Symptom: "wrong database selected.") See the
+  troubleshooting skill for diagnosis.
+- **Don't create a client per request.** `createClient` opens a connection
+  pool; share one client across requests and `close()` on shutdown.
+- **`max_open_connections` must be `>= 1`** when set explicitly.

--- a/.claude/skills/clickhouse-js-node-coding/reference/compression.md
+++ b/.claude/skills/clickhouse-js-node-coding/reference/compression.md
@@ -1,0 +1,129 @@
+# Compression
+
+> **Applies to:** all versions support boolean `compression`. The explicit
+> codec object form, per-codec request options, and `zstd` support are a
+> Node-only addition in `@clickhouse/client` `>= 1.22.0`; Brotli
+> (`{ codec: "br" }`) is also added (any Node.js version, no minimum). Request
+> compression is Node-only regardless of codec; response decompression on the
+> web client is handled by the browser.
+
+The client can compress the outgoing request (insert) body and ask the server
+to compress the response (read) body. Both are configured under `compression`
+on `createClient`.
+
+## Answer checklist
+
+When answering compression questions, include the relevant points:
+
+- The option shape is `boolean | { codec }`, **not** a bare string. `true`
+  means gzip (backwards compatible); `{ codec: "zstd" }` selects zstd. There is
+  no `compression: { request: "zstd" }` shorthand — it must be
+  `{ request: { codec: "zstd" } }`.
+- `zstd` is **Node-only** (`@clickhouse/client`) and requires **Node.js >=
+  22.15.0** (the built-in `zlib` zstd APIs). On `@clickhouse/client-web` or an
+  older Node runtime, requesting `zstd` throws a clear error at `createClient`.
+- Supported codecs are `gzip`, `zstd`, and `br` (Brotli). Unlike `zstd`, `br`
+  works on any supported Node.js version (it ships in `zlib`). Request-body
+  compression is Node-only for every codec (the web client sends requests
+  uncompressed); for responses, the web client rejects `zstd` but allows
+  `gzip`/`br`, which the browser decompresses.
+- The request object takes a per-codec tuning option: a `level` for
+  `gzip`/`zstd`, a `quality` for `br` (`{ codec: "br", quality }`). Brotli
+  defaults to quality 4 — zlib's brotli default of 11 is far too slow for a
+  streaming insert.
+- Response compression cannot be enabled for a `readonly=1` user — the server
+  rejects the required `enable_http_compression` setting change.
+- Prefer `zstd` for write-heavy (insert) workloads: a similar-or-better ratio
+  than gzip at materially lower CPU, and ClickHouse decompresses gzip
+  single-threaded.
+
+## gzip (default, all versions)
+
+```ts
+import { createClient } from "@clickhouse/client";
+
+const client = createClient({
+  compression: {
+    request: true, // compress insert bodies with gzip
+    response: true, // ask the server for a gzip-compressed response
+  },
+});
+```
+
+`request: true` / `response: true` are equivalent to
+`{ codec: "gzip" }`.
+
+## zstd (Node.js >= 22.15.0)
+
+```ts
+const client = createClient({
+  compression: {
+    request: { codec: "zstd" },
+    response: { codec: "zstd" },
+  },
+});
+```
+
+You can mix codecs and directions, e.g. zstd inserts with uncompressed reads:
+
+```ts
+const client = createClient({
+  compression: {
+    request: { codec: "zstd" },
+    // response omitted → uncompressed reads
+  },
+});
+```
+
+## Brotli (any Node.js version)
+
+```ts
+const client = createClient({
+  compression: {
+    request: { codec: "br" }, // brotli insert bodies (quality 4 by default)
+    response: { codec: "br" }, // ask the server for a brotli-compressed response
+  },
+});
+```
+
+Unlike `zstd`, Brotli needs no minimum Node.js version. Request-body compression
+is Node-only (the web client sends requests uncompressed); `br` responses also
+work on the web client, decompressed by the browser. Its tuning option is
+`quality` (0-11), not `level`:
+
+```ts
+const client = createClient({
+  compression: {
+    request: { codec: "br", quality: 6 },
+  },
+});
+```
+
+## Request compression options (Node.js)
+
+The request object accepts a per-codec tuning option — a `level` for `gzip`
+(zlib level) and `zstd` (zstd compression level), or a `quality` for `br`
+(Brotli quality, 0-11). When omitted, the codec default is used (Brotli
+defaults to 4). This applies to the **request** direction only; the response
+compression options are chosen by the ClickHouse server.
+
+```ts
+const client = createClient({
+  compression: {
+    request: { codec: "zstd", level: 19 }, // higher ratio, more CPU
+  },
+});
+```
+
+## Common pitfalls
+
+- **`compression: { request: "zstd" }` is a type error.** Use the object form:
+  `{ request: { codec: "zstd" } }`.
+- **`zstd` on the web client throws.** `@clickhouse/client-web` does not
+  compress request bodies, and zstd response handling depends on the browser;
+  the web client rejects the `zstd` codec at `createClient`. Use Node, or gzip.
+- **`zstd` on Node < 22.15 throws at client creation**, not deep inside a later
+  insert/query. The error names the running Node version and tells you to use
+  gzip instead.
+- **Response compression + `readonly=1` user fails.** Response decompression
+  needs `enable_http_compression=1`, which a readonly user cannot set.

--- a/.claude/skills/clickhouse-js-node-coding/reference/custom-json.md
+++ b/.claude/skills/clickhouse-js-node-coding/reference/custom-json.md
@@ -1,0 +1,193 @@
+# Custom JSON `parse` / `stringify`
+
+> **Requires:** client `>= 1.14.0` (configurable `json.parse` and
+> `json.stringify`). Earlier versions cannot swap the JSON implementation.
+
+## Answer checklist
+
+When the user wants `UInt64`/`Int64` values back as `BigInt`:
+
+- State that configurable `json.parse` / `json.stringify` requires
+  `@clickhouse/client >= 1.14.0`.
+- Show the supported `createClient({ json: { parse, stringify } })` option,
+  usually with `json-bigint` and `useNativeBigInt: true`.
+- Combine it with `output_format_json_quote_64bit_integers: 0` so the server
+  emits unquoted 64-bit integers that the parser can turn into `BigInt`.
+- Mention that `output_format_json_quote_64bit_integers: 0` is the default
+  since ClickHouse `25.8`, but setting it explicitly is useful for older
+  servers or portable examples.
+- Warn that casting to JavaScript `Number` / `parseInt` / `parseFloat` loses
+  precision above `Number.MAX_SAFE_INTEGER`.
+
+## Why customize?
+
+The default `JSON.stringify` / `JSON.parse`:
+
+- Throws on `BigInt`.
+- Calls `Date.prototype.toJSON()` (ISO string) — fine for `DateTime` with
+  `date_time_input_format: 'best_effort'`, surprising in some workflows.
+- Loses precision for 64-bit integers returned as numbers (a separate
+  issue — covered in the troubleshooting skill).
+
+A custom `{ parse, stringify }` lets you plug in `JSONBig`,
+`safe-stable-stringify`, your own `BigInt`-aware serializer, etc.
+
+## Recipe: BigInt-safe stringify, custom Date handling
+
+```ts
+import { createClient } from "@clickhouse/client";
+
+const valueSerializer = (value: unknown): unknown => {
+  // Serialize Date as a UNIX millis number (instead of toJSON's ISO string)
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+
+  // Serialize BigInt as a string so JSON.stringify won't throw
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(valueSerializer);
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, valueSerializer(v)]),
+    );
+  }
+
+  return value;
+};
+
+const client = createClient({
+  json: {
+    parse: JSON.parse, // use default parsing
+    stringify: (obj: unknown) => JSON.stringify(valueSerializer(obj)),
+  },
+});
+
+await client.command({
+  query: `
+    CREATE OR REPLACE TABLE inserts_custom_json_handling
+    (id UInt64, dt DateTime64(3, 'UTC'))
+    ENGINE MergeTree
+    ORDER BY id
+  `,
+});
+
+await client.insert({
+  table: "inserts_custom_json_handling",
+  format: "JSONEachRow",
+  values: [
+    {
+      id: BigInt("250000000000000200"), // serialized as a string
+      dt: new Date(), // serialized as ms since epoch
+    },
+  ],
+});
+
+await client.close();
+```
+
+> The custom `valueSerializer` runs **before** `JSON.stringify`, so values
+> are transformed before the standard hooks (`Date.prototype.toJSON`,
+> object `toJSON()` methods, etc.) ever run.
+
+## Recipe: BigInt-safe parsing for 64-bit integer columns
+
+If you want `UInt64`/`Int64` to come back as `BigInt`s (instead of strings
+or precision-lossy numbers), plug in a `BigInt`-aware parser such as
+[`json-bigint`](https://www.npmjs.com/package/json-bigint):
+
+```ts
+import { createClient } from "@clickhouse/client";
+import JSONBig from "json-bigint";
+
+const bigJson = JSONBig({ useNativeBigInt: true });
+
+const client = createClient({
+  json: {
+    parse: bigJson.parse,
+    stringify: bigJson.stringify,
+  },
+  clickhouse_settings: {
+    output_format_json_quote_64bit_integers: 0,
+  },
+});
+```
+
+`output_format_json_quote_64bit_integers: 0` is the default since
+ClickHouse `25.8`; setting it explicitly is useful for older servers and
+makes the example self-contained. With it off, the server emits unquoted
+64-bit integers that `json-bigint` parses straight to `BigInt`. The
+`json` option applies to **both** outgoing JSON bodies and incoming
+JSON-format responses.
+
+## Recipe: Zero-dep BigInt parsing (no `npm install`)
+
+If adding a dependency is awkward (locked lockfile, restricted environment,
+or you just don't want to pull in `json-bigint`), you can plug in a
+hand-rolled reviver. This uses the `context.source` argument that
+`JSON.parse` revivers gained in Node `>= 20.16` / `>= 21.7`, so the raw
+numeric literal is available before it's coerced to a JS `number`:
+
+```ts
+import { createClient } from "@clickhouse/client";
+
+const parseBigInt = (text: string) =>
+  JSON.parse(text, function (key, value, context) {
+    if (key.endsWith("__bigint")) {
+      return BigInt(context.source);
+    }
+    return value;
+  });
+
+const client = createClient({
+  json: {
+    parse: parseBigInt,
+    stringify: JSON.stringify, // use default stringify
+  },
+  clickhouse_settings: { output_format_json_quote_64bit_integers: 0 },
+});
+
+const rs = await client.query({
+  query: "SELECT toUInt64(250000000000000200) AS id__bigint",
+});
+const { data } = await rs.json();
+console.log(data[0].id__bigint); // 250000000000000200
+
+await client.close();
+```
+
+Trade-offs versus `json-bigint`:
+
+- ✓ No new dependency to install.
+- ✓ Only promotes known to be 64-bit integers to `BigInt`.
+- ✗ Requires Node `>= 20.16` / `>= 21.7` for the reviver `context.source`.
+  On older Node, prefer `json-bigint` or upgrade Node.
+- ✗ Outgoing `stringify` still uses default `JSON.stringify`, which throws
+  on `BigInt`. Pair with the `valueSerializer` pattern above if your
+  inserts contain `BigInt` values.
+
+## Common pitfalls
+
+- **Setting `json.parse` only.** That only affects reading JSON responses;
+  outgoing JSON bodies use `json.stringify`. If you want consistent custom
+  handling in both directions, generally provide a matching `stringify` too
+  or a throwing serializer that prevents mismatches.
+- **Forgetting `bigint` handling in `stringify`.** Default `JSON.stringify`
+  throws on `BigInt`; if your data ever contains one, the insert will fail
+  with `TypeError: Do not know how to serialize a BigInt`.
+- **Targeting client `< 1.14.0`.** The `json` option doesn't exist; you'll
+  need to convert values manually before calling `insert()` / `query()` (or
+  upgrade).
+- **Casting 64-bit integers to `Number`.** JavaScript's `number` type has
+  only 53 bits of mantissa — values above `Number.MAX_SAFE_INTEGER` (2^53 − 1)
+  are silently rounded. Do **not** try to fix precision loss by calling
+  `Number()`, `parseInt()`, or `parseFloat()` on the value. The correct fix
+  is a `BigInt`-aware parser (shown above), not a lossy cast.
+- **Mixing BigInt and number for the same column.** If some values are `BigInt` and
+  others are `number`, your app code needs to handle both types. Otherwise
+  JavaScript will throw a `TypeError: Cannot mix BigInt and other types`.

--- a/.claude/skills/clickhouse-js-node-coding/reference/data-types.md
+++ b/.claude/skills/clickhouse-js-node-coding/reference/data-types.md
@@ -1,0 +1,329 @@
+# Modern Data Types: Dynamic, Variant, JSON, Time, Time64, QBit
+
+> **Applies to** (server side):
+>
+> - `Variant`: ClickHouse `>= 24.1`.
+> - `Dynamic`: ClickHouse `>= 24.5`.
+> - New `JSON` (object) type: ClickHouse `>= 24.8`.
+> - All three are **no longer experimental since `25.3`**; on older servers,
+>   you must enable the corresponding `allow_experimental_*_type` setting.
+> - `Time` / `Time64`: ClickHouse `>= 25.6` and require
+>   `enable_time_time64_type: 1`.
+> - `QBit`: ClickHouse `>= 25.10` (experimental, gated by
+>   `allow_experimental_qbit_type`); GA on `26.x`.
+
+## Answer checklist
+
+When answering about storing and reading JSON objects:
+
+- Use the new `JSON` column type, introduced in ClickHouse `>= 24.8`.
+- Say `JSON` is no longer experimental since ClickHouse `25.3`; on older
+  supported versions, enable `allow_experimental_json_type`.
+- **State the version policy in your explanation AND inline in the code.**
+  When you set `allow_experimental_json_type` (or any `allow_experimental_*_type`)
+  in code, you must do BOTH of the following:
+  1. Put an inline comment directly above the setting that names the version
+     where the type was introduced and the version where it became
+     non-experimental. The comment is the durable version provenance — it
+     lives in the user's source file long after the chat reply is gone.
+  2. Repeat the version policy in your prose reply.
+
+  For the `JSON` column type the inline comment must look like:
+
+  ```ts
+  clickhouse_settings: {
+    // JSON type introduced in ClickHouse 24.8, non-experimental since 25.3.
+    // This setting is required only on 24.8–25.2; harmless on >= 25.3.
+    allow_experimental_json_type: 1,
+  }
+  ```
+
+  Without the inline comment, a reader on a newer server has no idea the
+  setting is a no-op and a reader on an older server has no idea why it's
+  required.
+
+- Insert real JS objects with `format: 'JSONEachRow'`; do not
+  `JSON.stringify()` the column value.
+- Read with a JSON output format such as `JSONEachRow` and `resultSet.json()`;
+  `JSON` column values come back as parsed JS objects.
+
+## `Dynamic`, `Variant(...)`, `JSON`
+
+```ts
+import { createClient } from "@clickhouse/client";
+
+const client = createClient({
+  clickhouse_settings: {
+    // Variant introduced in 24.1, Dynamic in 24.5, JSON in 24.8.
+    // All three are non-experimental since 25.3; these settings are
+    // required only on 24.1–25.2 and are harmless on >= 25.3.
+    allow_experimental_variant_type: 1,
+    allow_experimental_dynamic_type: 1,
+    allow_experimental_json_type: 1,
+  },
+});
+
+await client.command({
+  query: `
+    CREATE OR REPLACE TABLE chjs_dynamic_variant_json
+    (
+      id      UInt64,
+      var     Variant(Int64, String),
+      dynamic Dynamic,
+      json    JSON
+    )
+    ENGINE MergeTree
+    ORDER BY id
+  `,
+});
+
+await client.insert({
+  table: "chjs_dynamic_variant_json",
+  format: "JSONEachRow",
+  values: [
+    { id: 1, var: 42, dynamic: "foo", json: { foo: "x" } },
+    { id: 2, var: "str", dynamic: 144, json: { bar: 10 } },
+  ],
+});
+
+const rs = await client.query({
+  query: `
+    SELECT *,
+           variantType(var),
+           dynamicType(dynamic),
+           dynamicType(json.foo),
+           dynamicType(json.bar)
+    FROM chjs_dynamic_variant_json
+  `,
+  format: "JSONEachRow",
+});
+console.log(await rs.json());
+```
+
+Outputs:
+
+```js
+[
+  {
+    id: "1",
+    var: "42",
+    dynamic: "foo",
+    json: { foo: "x" },
+    "variantType(var)": "Int64",
+    "dynamicType(dynamic)": "String",
+    "dynamicType(json.foo)": "String",
+    "dynamicType(json.bar)": "None",
+  },
+  {
+    id: "2",
+    var: "str",
+    dynamic: "144",
+    json: { bar: "10" },
+    "variantType(var)": "String",
+    "dynamicType(dynamic)": "Int64",
+    "dynamicType(json.foo)": "None",
+    "dynamicType(json.bar)": "Int64",
+  },
+];
+```
+
+### Notes
+
+- The `JSON` column type accepts a real JS object on insert and returns one
+  on select — no need for `JSON.stringify` / `JSON.parse` in your app code.
+- A JS number written into a `Dynamic` or `Variant` column defaults to
+  `Int64` on the server. In JSON formats, `output_format_json_quote_64bit_integers`
+  controls how 64-bit integers are returned: `1` returns them as JSON strings,
+  while `0` returns them as JSON numbers (and `0` is the default since CH `25.8`).
+  In JS, large 64-bit integers returned as numbers can lose precision, so use
+  quoted output if you need exact integer values in application code.
+- Use `variantType(...)`, `dynamicType(...)` to introspect what the server
+  ended up storing.
+
+## `Time` and `Time64(p)`
+
+`Time` is signed seconds (`-999:59:59` … `999:59:59`). `Time64(p)` adds
+sub-second precision (`p` digits, up to `9` for nanoseconds). Both require
+`enable_time_time64_type: 1` on `>= 25.6`.
+
+```ts
+const client = createClient({
+  clickhouse_settings: { enable_time_time64_type: 1 },
+});
+
+await client.command({
+  query: `
+    CREATE OR REPLACE TABLE chjs_time_time64
+    (
+      id    UInt64,
+      t     Time,
+      t64_0 Time64(0),
+      t64_3 Time64(3),
+      t64_6 Time64(6),
+      t64_9 Time64(9),
+    )
+    ENGINE MergeTree
+    ORDER BY id
+  `,
+});
+
+await client.insert({
+  table: "chjs_time_time64",
+  format: "JSONEachRow",
+  values: [
+    {
+      id: 1,
+      t: "12:34:56",
+      t64_0: "12:34:56",
+      t64_3: "12:34:56.123",
+      t64_6: "12:34:56.123456",
+      t64_9: "12:34:56.123456789",
+    },
+    {
+      id: 2,
+      t: "999:59:59",
+      t64_0: "999:59:59",
+      t64_3: "999:59:59.999",
+      t64_6: "999:59:59.999999",
+      t64_9: "999:59:59.999999999",
+    },
+    {
+      id: 3,
+      t: "-999:59:59",
+      t64_0: "-999:59:59",
+      t64_3: "-999:59:59.999",
+      t64_6: "-999:59:59.999999",
+      t64_9: "-999:59:59.999999999",
+    },
+  ],
+});
+```
+
+### Notes
+
+- Pass values as **strings** in the `HH:MM:SS[.fraction]` format. Negatives
+  are supported; the magnitude can exceed 24 hours.
+- For `Time64(p)` with `p > 3`, do not use JS `Date` — it tops out at
+  millisecond precision and will silently truncate. Store nanosecond values
+  separately and provide on stringify as needed.
+
+## `QBit` (vector search)
+
+`QBit(element_type, dimension)` stores float vectors in bit-sliced
+("transposed") form so approximate vector search can read only the most
+significant bit planes at query time, trading precision for I/O and CPU.
+
+- `element_type`: `BFloat16` | `Float32` | `Float64`.
+- `dimension`: number of elements in each vector.
+
+Introduced in ClickHouse `25.10` as an experimental type (gated by
+`allow_experimental_qbit_type`) and GA on `26.x`; the setting is a no-op on
+newer servers but required on `25.10`.
+
+Internally a `QBit` column is a `Tuple(FixedString(N), ...)` of bit planes, so
+the raw bytes are not valid UTF-8. JSON\* formats handle this transparently: the
+server serializes the column as the original numeric array on `SELECT` and
+accepts the same array shape on `INSERT`. Query the column as a vector and let
+ClickHouse handle the bit-plane layout — don't feed raw `FixedString` bytes
+through JSON yourself.
+
+```ts
+import { createClient } from "@clickhouse/client";
+
+const tableName = `chjs_qbit`;
+const client = createClient({
+  clickhouse_settings: {
+    // QBit introduced in ClickHouse 25.10 (experimental), GA since 26.x.
+    // This setting is required only on 25.10; harmless/no-op on >= 26.x.
+    allow_experimental_qbit_type: 1,
+  },
+});
+
+await client.command({
+  query: `
+    CREATE OR REPLACE TABLE ${tableName}
+    (
+      id  UInt64,
+      vec QBit(Float32, 8)
+    )
+    ENGINE MergeTree
+    ORDER BY id
+  `,
+});
+
+// Even though QBit is stored internally as a Tuple of FixedString bit planes,
+// JSON* formats accept (and return) the original Array(Float32) shape.
+const values = [
+  { id: 1, vec: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0] },
+  { id: 2, vec: [8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0] },
+  { id: 3, vec: [1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5] },
+];
+await client.insert({
+  table: tableName,
+  format: "JSONEachRow",
+  values,
+});
+
+// Round-trip via JSONEachRow: the vec column comes back as an array of numbers.
+const rs = await client.query({
+  query: `SELECT id, vec FROM ${tableName} ORDER BY id`,
+  format: "JSONEachRow",
+});
+const rows = await rs.json<{ id: number; vec: number[] }>();
+// vec comes back unchanged as the original Float32 array.
+console.log(rows);
+
+// Approximate vector search via L2DistanceTransposed.
+// The third argument is the precision in bits: lower = less I/O, less accurate.
+const search = await client.query({
+  query: `
+    SELECT id,
+           L2DistanceTransposed(vec, {ref:Array(Float32)}, {bits:UInt8}) AS dist
+    FROM ${tableName}
+    ORDER BY dist ASC
+  `,
+  query_params: {
+    ref: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+    bits: 16,
+  },
+  format: "JSONEachRow",
+});
+const nearest = await search.json<{ id: number; dist: number }>();
+// The reference vector is exactly row #1, so it's the closest match (dist 0).
+console.log(nearest);
+
+await client.close();
+```
+
+### Notes
+
+- Insert and read `QBit` columns as plain numeric arrays with `JSONEachRow`;
+  the server transposes them into bit planes for you.
+- Use `L2DistanceTransposed(vec, ref, bits)` for approximate nearest-neighbour
+  search. Bind `ref` and `bits` via `query_params` (`{ref:Array(Float32)}`,
+  `{bits:UInt8}`) — never interpolate them into the SQL string.
+- The `bits` argument is the precision in bits: lower values read fewer bit
+  planes (less I/O, faster, less accurate); higher values are more precise.
+- The bit-plane subcolumns (`vec.N`) are `FixedString` and **not** valid
+  UTF-8. Selecting them directly with a JSON\* format forces the server to
+  escape every byte as `\uXXXX`. If you need the raw planes, use a binary
+  format such as `RowBinary`, or read them as hex/base64 (e.g.
+  `hex(vec.1)`) to keep the JSON output UTF-8 safe.
+
+## Common pitfalls
+
+- **Targeting old ClickHouse servers without the `allow_experimental_*`
+  setting.** On `< 25.3`, `CREATE TABLE` will fail without them.
+- **Expecting `JSON`-column reads to be raw strings.** They come back as
+  parsed objects in JSON formats.
+- **Inserting `Time64(9)` from JS `Date` and losing precision.** Use a
+  string instead.
+- **Reading a `Variant`/`Dynamic` value of type `Int64` and being surprised
+  it's a string.** That's the standard 64-bit-integers-in-JSON behavior;
+  see the troubleshooting skill if you need to change it.
+- **Avoid parsing Variant/Dynamic/JSON columns that mix strings and 64-bit**
+  without checking their returned types first. Otherwise a number stored in
+  a string will come back as a number or vice versa.
+- **Selecting `QBit` bit-plane subcolumns (`vec.N`) directly in JSON formats.**
+  They are `FixedString` and not UTF-8; read them as hex/base64 or use a
+  binary format. Read the whole vector (`vec`) as a numeric array instead.

--- a/.claude/skills/clickhouse-js-node-coding/reference/insert-columns.md
+++ b/.claude/skills/clickhouse-js-node-coding/reference/insert-columns.md
@@ -1,0 +1,107 @@
+# Insert into Specific Columns / Other Databases
+
+> **Applies to:** all versions. The `columns` option (both forms) and the
+> `database` config field are universally supported.
+
+## Answer checklist
+
+When explaining partial-column inserts:
+
+- Show `columns: ['col_a', 'col_b']` for the allowlist form.
+- Also mention the inverse `columns: { except: ['col_to_skip'] }` form so the
+  user knows both supported shapes.
+- Explain that omitted columns receive their server-side defaults
+  (`DEFAULT`, `MATERIALIZED`, `ALIAS`, nullable/type defaults) and inserts can
+  still fail or produce surprising zero/empty values if the table definition
+  has no appropriate defaults.
+
+## Insert into specific columns
+
+Pass `columns: string[]` to limit the `INSERT` to a subset. Omitted columns
+get their declared default.
+
+```ts
+await client.insert({
+  table: "events",
+  columns: ["message"], // the rest of the events table columns get their DEFAULTs
+  format: "JSONEachRow",
+  values: [{ message: "foo" }],
+});
+```
+
+## Insert excluding columns
+
+Use `columns: { except: string[] }` for the inverse. Useful when most columns
+should default but you want to name only the few to skip.
+
+```ts
+await client.insert({
+  table: "events",
+  format: "JSONEachRow",
+  values: [{ message: "bar" }],
+  columns: { except: ["id"] },
+});
+```
+
+## Tables with EPHEMERAL columns
+
+[Ephemeral columns](https://clickhouse.com/docs/en/sql-reference/statements/create/table#ephemeral)
+are not stored — they only exist to drive `DEFAULT` expressions of other
+columns. To trigger that default logic, **the ephemeral column must be in the
+`columns` list**, even though no value will be persisted for it.
+
+```ts
+await client.command({
+  query: `
+    CREATE OR REPLACE TABLE events
+    (
+      id              UInt64,
+      message         String DEFAULT message_default,
+      message_default String EPHEMERAL
+    )
+    ENGINE MergeTree
+    ORDER BY id
+  `,
+});
+
+await client.insert({
+  table: "events",
+  format: "JSONEachRow",
+  values: [
+    { id: "42", message_default: "foo" },
+    { id: "144", message_default: "bar" },
+  ],
+  // Including the ephemeral column name triggers the DEFAULT expression
+  columns: ["id", "message_default"],
+});
+```
+
+## Insert into a different database
+
+If the client's default `database` is not the target, qualify the table name
+with `db.table`:
+
+```ts
+const client = createClient({ database: "system" });
+
+await client.command({ query: "CREATE DATABASE IF NOT EXISTS analytics" });
+
+await client.insert({
+  table: "analytics.events", // fully qualified
+  format: "JSONEachRow",
+  values: [{ id: 42, message: "foo" }],
+});
+```
+
+There is no per-call `database` override on `insert()` / `query()` — qualify
+the identifier, or create a second client with the desired `database`.
+
+## Common pitfalls
+
+- **Forgetting the ephemeral column in `columns`.** If you list only the
+  non-ephemeral columns, the `DEFAULT` expression that depends on the
+  ephemeral value won't fire and you'll get empty/zero defaults instead.
+- **Hoping `client.insert({ database: '…' })` works.** It doesn't — qualify
+  the `table` instead.
+- **Mixing the two `columns` forms.** Use either `string[]` _or_
+  `{ except: string[] }`, not both.

--- a/.claude/skills/clickhouse-js-node-coding/reference/insert-formats.md
+++ b/.claude/skills/clickhouse-js-node-coding/reference/insert-formats.md
@@ -1,0 +1,141 @@
+# Insert Data Formats
+
+> **Applies to:** all versions. The `JSON` type column / new JSON family is a
+> ClickHouse feature; the JSON _formats_ listed here are universally supported
+> by the client.
+
+> **Raw / binary formats (CSV, TSV, CustomSeparated, Parquet) require a Node
+> stream as input.** Suggest streaming when the user wants to insert from a file or `Readable`.
+
+## Answer checklist
+
+When answering "what format/call should I use for an array of JS objects?":
+
+- Use `client.insert({ table, values, format: 'JSONEachRow' })`.
+- Say the array of plain objects can be passed directly as `values` for
+  ordinary in-memory batches such as a few thousand or tens of thousands of
+  rows.
+- Do not steer the user to streaming, Parquet, or file APIs unless their input
+  is already a stream/file or the task is explicitly about throughput.
+- Warn not to wrap `JSONEachRow` rows in a `{ data: [...] }` envelope; that
+  shape belongs to single-document formats.
+- Mention `JSONCompactEachRow*` as a denser alternative for larger payloads
+  when the caller can provide positional arrays or explicit names/types.
+
+## Default choice: `JSONEachRow` with an array of objects
+
+This is the right answer for ~90% of inserts.
+
+```ts
+import { createClient } from "@clickhouse/client";
+
+const client = createClient();
+
+await client.insert({
+  table: "events",
+  format: "JSONEachRow",
+  values: [
+    { id: 42, name: "foo" },
+    { id: 43, name: "bar" },
+  ],
+});
+
+await client.close();
+```
+
+The shape of `values` must match the chosen format.
+
+## Streamable JSON formats (pass an array)
+
+| Format                                       | `values` shape                                      |
+| -------------------------------------------- | --------------------------------------------------- |
+| `JSONEachRow`                                | `Array<{ col: value, ... }>`                        |
+| `JSONStringsEachRow`                         | `Array<{ col: stringifiedValue, ... }>`             |
+| `JSONCompactEachRow`                         | `Array<[v1, v2, ...]>`                              |
+| `JSONCompactStringsEachRow`                  | `Array<[stringV1, stringV2, ...]>`                  |
+| `JSONCompactEachRowWithNames`                | First row = column names, then data rows            |
+| `JSONCompactEachRowWithNamesAndTypes`        | Row 1 = names, row 2 = types, then data             |
+| `JSONCompactStringsEachRowWithNames`         | First row = names, then stringified data rows       |
+| `JSONCompactStringsEachRowWithNamesAndTypes` | Row 1 = names, row 2 = types, then stringified data |
+
+```ts
+await client.insert({
+  table: "events",
+  format: "JSONCompactEachRowWithNamesAndTypes",
+  values: [
+    ["id", "name", "sku"],
+    ["UInt32", "String", "Array(UInt32)"],
+    [11, "foo", [1, 2, 3]],
+    [12, "bar", [4, 5, 6]],
+  ],
+});
+```
+
+These formats can be **streamed** — pass a Node stream of rows instead of an
+array. See
+[`examples/node/performance/`](https://github.com/ClickHouse/clickhouse-js/tree/main/examples/node/performance)
+for streaming guidance.
+
+## Single-document JSON formats (pass an object)
+
+These cannot be streamed — the entire body is sent in one shot.
+
+| Format                    | `values` shape (typed via `InputJSON<T>` / `InputJSONObjectEachRow<T>`)                                                   |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `JSON`                    | `{ meta: [], data: Array<{ col: value, ... }> }` — for TypeScript/client usage, pass `meta: []` if metadata is not needed |
+| `JSONCompact`             | `{ meta: [{ name, type }, ...], data: Array<[v1, v2, ...]> }`                                                             |
+| `JSONColumnsWithMetadata` | `{ meta: [...], data: { col1: [v, ...], col2: [v, ...] } }`                                                               |
+| `JSONObjectEachRow`       | `Record<string, { col: value, ... }>` (the record key labels each row but is not stored)                                  |
+
+```ts
+import type { InputJSON, InputJSONObjectEachRow } from "@clickhouse/client";
+
+const meta: InputJSON["meta"] = [
+  { name: "id", type: "UInt32" },
+  { name: "name", type: "String" },
+];
+
+await client.insert({
+  table: "events",
+  format: "JSONCompact",
+  values: {
+    meta,
+    data: [
+      [19, "foo"],
+      [20, "bar"],
+    ],
+  },
+});
+
+await client.insert({
+  table: "events",
+  format: "JSONObjectEachRow",
+  values: {
+    row_1: { id: 23, name: "foo" },
+    row_2: { id: 24, name: "bar" },
+  } satisfies InputJSONObjectEachRow<{ id: number; name: string }>,
+});
+```
+
+## Quick chooser
+
+| Use case                                     | Format                                                  |
+| -------------------------------------------- | ------------------------------------------------------- |
+| Insert plain JS objects                      | `JSONEachRow` _(default)_                               |
+| Insert tuples / column-positional rows       | `JSONCompactEachRow`                                    |
+| Insert with explicit column ordering / types | `JSONCompactEachRow*WithNames…`                         |
+| Insert a single document with metadata       | `JSON`, `JSONCompact`                                   |
+| Insert from a CSV / TSV / Parquet file       | Raw format + Node stream → `examples/node/performance/` |
+
+## Common pitfalls
+
+- **Wrong shape for the format.** The most common cause of insert failures —
+  e.g., passing `Array<{...}>` to `JSONCompact` (which expects
+  `{ meta, data }`).
+- **Don't wrap a `JSONEachRow` array in a `{ data: [...] }` envelope.** That
+  envelope only belongs to single-document formats (`JSON` / `JSONCompact` /
+  `JSONColumnsWithMetadata`).
+- For type guidance (`Decimal` strings, `Date` objects, `BigInt`), see
+  `insert-values.md` and `custom-json.md`.
+- **Use runtime type checkers like `zod` or `io-ts` if your app ingests untrusted JSON.**
+  It's easier to debug mismatches between your data and the format's expected shape with a validation library used at the place of ingestion than with ClickHouse errors, especially in the middle of a large insert batch or streaming operation.

--- a/.claude/skills/clickhouse-js-node-coding/reference/insert-values.md
+++ b/.claude/skills/clickhouse-js-node-coding/reference/insert-values.md
@@ -1,0 +1,211 @@
+# Insert Values, SQL Expressions, Dates, Decimals
+
+> **Applies to:** all versions. `wait_end_of_query: 1` is a server-side
+> setting available on every supported ClickHouse version.
+
+## `INSERT … SELECT` (no values payload)
+
+When the data already lives in ClickHouse, use `client.command()` with a raw
+`INSERT … SELECT`:
+
+```ts
+await client.command({
+  query: `
+    INSERT INTO target
+    SELECT * FROM source
+  `,
+});
+```
+
+Use `command()` (not `insert()`) — there is no row payload to send.
+
+## `INSERT … VALUES` with SQL functions
+
+When you need `unhex(...)`, `toUUID(...)`, `now()`, or any other SQL
+function around a value, keep the SQL shape static and pass values with
+ClickHouse `{name: Type}` parameters. Run it via `command()` and set
+`wait_end_of_query: 1` for safety in clustered setups.
+
+```ts
+await client.command({
+  query: `
+    INSERT INTO events (id, timestamp, email, name)
+    VALUES (
+      unhex({id: String}),
+      {timestamp: DateTime},
+      {email: String},
+      {name: Nullable(String)}
+    )
+  `,
+  query_params: {
+    id: "00112233445566778899aabbccddeeff",
+    timestamp: "2026-05-06 12:34:56",
+    email: "alice@example.com",
+    name: "Alice",
+  },
+  clickhouse_settings: { wait_end_of_query: 1 },
+});
+```
+
+Do not build `VALUES` rows with string interpolation or manual escaping. If
+you need to insert many ordinary JS rows, prefer `client.insert()` with
+`format: 'JSONEachRow'`; use this `command()` pattern when the SQL itself needs
+functions or expressions around the values.
+
+## Inserting JS `Date` objects
+
+JS `Date` objects work for `DateTime` and `DateTime64` columns once the
+server is set to accept ISO-8601 strings. Either set
+`date_time_input_format: 'best_effort'` per request, on the client, or
+session-wide.
+
+```ts
+await client.insert({
+  table: "events",
+  format: "JSONEachRow",
+  values: [{ id: "42", dt: new Date() }],
+  clickhouse_settings: {
+    date_time_input_format: "best_effort", // default on the Cloud
+  },
+});
+```
+
+> JS `Date` objects do **not** work for the `Date` type (date-only) — pass
+> `'YYYY-MM-DD'` strings for that.
+
+## Inserting `Decimal*` values
+
+**IMPORTANT:** Make sure that the application code you're working on or the user
+prompt clearly indicates that floats are not used anywhere for decimal values.
+The most common scenario is using floats for money amounts in the app while the
+database uses `Decimal` for them. In that case, the app code should be changed
+to use a proper decimal library and serialization strategy (custom serializer
+or a class using `toJSON()`) to `string` instead of JS `number`.
+
+Decimals must be passed as **strings** in JSON formats to avoid precision
+loss in JavaScript:
+
+```ts
+await client.command({
+  query: `
+    CREATE OR REPLACE TABLE prices (
+      id     UInt32,
+      dec32  Decimal(9, 2),
+      dec64  Decimal(18, 3),
+      dec128 Decimal(38, 10),
+      dec256 Decimal(76, 20)
+    )
+    ENGINE MergeTree ORDER BY id
+  `,
+});
+
+await client.insert({
+  table: "prices",
+  format: "JSONEachRow",
+  values: [
+    {
+      id: 1,
+      dec32: "1234567.89",
+      dec64: "123456789123456.789",
+      dec128: "1234567891234567891234567891.1234567891",
+      dec256:
+        "12345678912345678912345678911234567891234567891234567891.12345678911234567891",
+    },
+  ],
+});
+```
+
+When reading them back, cast to string in the SELECT to avoid the same
+precision loss:
+
+```ts
+const rs = await client.query({
+  query: `
+    SELECT toString(dec64)  AS decimal64,
+           toString(dec128) AS decimal128
+    FROM prices
+  `,
+  format: "JSONEachRow",
+});
+```
+
+## Inserting a `UUID` into a `UInt128` column
+
+ClickHouse converts a `UUID` into `UInt128` implicitly **only for the `VALUES`
+clause**. With the row-oriented JSON formats the client uses (e.g.
+`JSONEachRow`), sending a UUID string such as
+`'019982cb-3abf-7e12-9668-c788a9e3639c'` for a `UInt128` column fails with
+`CANNOT_PARSE_INPUT_ASSERTION_FAILED`. Use one of two patterns instead.
+
+**Pattern 1 — convert the UUID on the client and send it as a decimal string**
+(recommended). A JS `number` cannot hold 128 bits without precision loss, so
+always pass `UInt128` as a string:
+
+```ts
+import * as crypto from "node:crypto";
+
+function uuidToUInt128(uuid: string): string {
+  // 8-4-4-4-12 hex digits → 32 hex digits → BigInt → decimal string
+  return BigInt("0x" + uuid.replace(/-/g, "")).toString();
+}
+
+await client.command({
+  query: `
+    CREATE OR REPLACE TABLE events (id UInt128, description String)
+    ENGINE MergeTree ORDER BY id
+  `,
+});
+
+const uuid = crypto.randomUUID();
+await client.insert({
+  table: "events",
+  format: "JSONEachRow",
+  values: [{ id: uuidToUInt128(uuid), description: "converted on the client" }],
+});
+```
+
+`UInt128` values are also too wide for a JS `number` when reading back — cast
+them with `toString(id)` in the `SELECT` to avoid precision loss.
+
+**Pattern 2 — declare the UUID column as `EPHEMERAL`** and let ClickHouse
+populate the `UInt128` column via its `DEFAULT` expression:
+
+```ts
+await client.command({
+  query: `
+    CREATE OR REPLACE TABLE events
+    (
+      id          UInt128 DEFAULT id_uuid,
+      id_uuid     UUID EPHEMERAL,
+      description String
+    )
+    ENGINE MergeTree ORDER BY id
+  `,
+});
+
+await client.insert({
+  table: "events",
+  format: "JSONEachRow",
+  values: [{ id_uuid: uuid, description: "populated via EPHEMERAL column" }],
+  // The ephemeral column must be listed so the DEFAULT on `id` is evaluated.
+  columns: ["id_uuid", "description"],
+});
+```
+
+See `reference/insert-columns.md` for more on `EPHEMERAL` columns and why they
+must appear in `columns`.
+
+## Common pitfalls
+
+- **Using `client.insert()` for `INSERT … SELECT`.** There's nothing to
+  upload — use `client.command()` with the full SQL.
+- **Forgetting `date_time_input_format: 'best_effort'`** when inserting
+  `Date` objects (or ISO strings). The default input format does not accept
+  ISO-8601 with the `T`/`Z` separators.
+- **Hand-building `VALUES` with user input.** Always parameterize user data;
+  see `reference/query-parameters.md`.
+- **Using floats in the app and expect `Decimal` columns to store them safely.** Use a proper decimal library and pass them as strings to avoid precision loss.
+- **Sending a UUID string for a `UInt128` column in `JSONEachRow`.** The
+  implicit UUID → UInt128 cast only happens in the `VALUES` clause; in JSON
+  formats convert the UUID to its 128-bit decimal string on the client (or use
+  an `EPHEMERAL` UUID column with a `UInt128` `DEFAULT`).

--- a/.claude/skills/clickhouse-js-node-coding/reference/ping.md
+++ b/.claude/skills/clickhouse-js-node-coding/reference/ping.md
@@ -1,0 +1,141 @@
+# Ping the Server
+
+> **Applies to:** all versions. `ping()` returns a discriminated union
+> `PingResult = { success: true } | { success: false, error: Error }` —
+> it does **not** throw on connection failures.
+
+## Answer checklist
+
+When answering "how do I health-check / readiness-probe ClickHouse?":
+
+- Use `await client.ping()` (or `ping({ select: true })`) and branch on
+  `result.success` directly — **do not** wrap in `try/catch` as the only
+  check, and do not substitute `query('SELECT 1')`.
+- For a readiness probe / "can it serve traffic", recommend
+  `client.ping({ select: true })` so credentials and the query layer are
+  validated, not just the socket.
+- **Always contrast the two forms explicitly in your answer**, even when
+  you're recommending one: plain `client.ping()` hits `/ping` (TCP/HTTP
+  reachability only — does not validate credentials or query processing);
+  `client.ping({ select: true })` issues a lightweight `SELECT 1` (validates
+  auth and query path). Name both and say which to use for liveness vs
+  readiness.
+- Recommend lowering `request_timeout` on the client used for probes so
+  they fail fast instead of hanging on the default timeout — pick a value
+  comparable to the probe interval (e.g., `1500`–`2000` ms for a
+  2-second-interval probe).
+
+## Successful ping
+
+```ts
+import { createClient } from "@clickhouse/client";
+
+const client = createClient({
+  url: process.env.CLICKHOUSE_URL,
+  password: process.env.CLICKHOUSE_PASSWORD,
+});
+
+const pingResult = await client.ping();
+if (pingResult.success) {
+  console.info("ClickHouse is reachable");
+} else {
+  console.error("Ping failed:", pingResult.error);
+}
+await client.close();
+```
+
+Use `ping()` to:
+
+- Probe ClickHouse at application startup.
+- Wake up a ClickHouse Cloud instance that may be idling (a ping is enough to
+  bring it out of sleep).
+- Implement a `/healthz` / readiness endpoint.
+
+## Failure: host unreachable
+
+`ping()` does **not** throw — it resolves with
+`{ success: false, error: Error }`, so you can branch without `try/catch`:
+
+```ts
+import type { PingResult } from "@clickhouse/client";
+import { createClient } from "@clickhouse/client";
+
+const client = createClient({
+  url: "http://localhost:8100", // non-existing host
+  request_timeout: 50, // keep failure fast
+});
+
+const pingResult = await client.ping();
+if (hasConnectionRefusedError(pingResult)) {
+  console.info("Connection refused, as expected");
+} else {
+  console.error("Ping expected ECONNREFUSED, got:", pingResult);
+}
+await client.close();
+
+function hasConnectionRefusedError(
+  pingResult: PingResult,
+): pingResult is PingResult & { error: { code: "ECONNREFUSED" } } {
+  return (
+    !pingResult.success &&
+    "code" in pingResult.error &&
+    pingResult.error.code === "ECONNREFUSED"
+  );
+}
+```
+
+## Mapping to an HTTP health endpoint
+
+```ts
+app.get("/healthz", async (_req, res) => {
+  const r = await client.ping();
+  if (r.success) {
+    res.status(200).json({ ok: true });
+  } else {
+    res.status(503).json({ ok: false, error: String(r.error) });
+  }
+});
+```
+
+## `ping()` vs `ping({ select: true })`
+
+The default `ping()` hits ClickHouse's `/ping` HTTP endpoint — it verifies
+network connectivity but **does not check credentials or query processing**.
+A server that is reachable but has a bad password (or a broken query
+pipeline) will still return `{ success: true }` from a plain `ping()`.
+
+Pass `{ select: true }` to run a lightweight `SELECT 1` instead:
+
+```ts
+const r = await client.ping({ select: true });
+// success only if the server is reachable AND auth is correct AND it can run queries
+```
+
+|                         | `client.ping()` | `client.ping({ select: true })` |
+| ----------------------- | --------------- | ------------------------------- |
+| Endpoint                | `/ping` (HTTP)  | `SELECT 1` query                |
+| Checks auth             | **No**          | Yes                             |
+| Checks query processing | No              | **Yes**                         |
+| Overhead                | Minimal         | Slightly higher                 |
+
+**When to use which:**
+
+- **Liveness probe** (is the process alive?) — plain `ping()` is fine.
+- **Readiness probe** (can it serve traffic?) — use `ping({ select: true })`
+  so the probe fails if credentials are wrong or the query layer is broken.
+- **Waking a ClickHouse Cloud idle instance** — plain `ping()` is enough.
+
+## Common pitfalls
+
+- **Do not wrap `ping()` in `try/catch` as your only check.** It resolves on
+  failure; the `success` boolean is the source of truth.
+- **Lower `request_timeout` if you want pings to fail fast** (the example
+  above uses `50` ms). The default is high enough to be unsuitable for
+  liveness probes.
+- **Plain `ping()` does not check credentials.** If auth is part of what you
+  want to verify, use `ping({ select: true })`.
+- For ping that times out specifically, see the troubleshooting skill.
+- **Only ping the ClickHouse server in your app's liveness probe** if the app
+  has to be restarted to recover from a ClickHouse outage. If the app can recover
+  the connection to ClickHouse without a restart, put the ping in a readiness
+  probe instead so the app doesn't get killed unnecessarily.

--- a/.claude/skills/clickhouse-js-node-coding/reference/query-parameters.md
+++ b/.claude/skills/clickhouse-js-node-coding/reference/query-parameters.md
@@ -1,0 +1,152 @@
+# Query Parameter Binding
+
+> **Applies to:** all versions. NULL parameter binding fixed in `0.0.16`.
+> Special-character (tab/newline/quote/backslash) binding `>= 0.3.1`.
+> `TupleParam` and JS `Map` parameters `>= 1.9.0`. Boolean formatting in
+> `Array`/`Tuple`/`Map` parameters fixed in `>= 1.13.0`. `BigInt` query
+> parameters `>= 1.15.0`.
+
+## Answer checklist
+
+When the user passes user-controlled values into SQL:
+
+- Use ClickHouse `{name: Type}` placeholders and a `query_params` object.
+- **Your response must explicitly name template-literal / string
+  interpolation of user input as a SQL injection risk** — even when the
+  user only asked "how do I bind values" and did not mention security.
+  This is non-negotiable: the security framing is part of the right
+  answer, not an optional aside.
+- Do not suggest PostgreSQL/MySQL-style `$1`, `?`, or `:name` placeholders.
+- Pick the placeholder type to match the ClickHouse column type (`String`,
+  `Date`, `DateTime`, `Nullable(T)`, etc.).
+
+## Syntax: `{name: Type}`
+
+ClickHouse uses `{name: Type}` placeholders — **not** `$1`, `?`, or `:name`.
+
+```ts
+await client.query({
+  query: "SELECT plus({a: Int32}, {b: Int32})",
+  format: "JSONEachRow",
+  query_params: { a: 10, b: 20 },
+});
+```
+
+The `Type` must be a valid ClickHouse type (`Int32`, `String`, `Date`,
+`Array(UInt32)`, `Tuple(Int32, String)`, `Map(K, V)`, `Nullable(T)`, etc.).
+
+## ⚠️ Never use template literals for user values
+
+Interpolating user input into the SQL string bypasses server-side escaping
+and opens the door to SQL injection:
+
+```ts
+const userId = req.params.id;
+
+// ❌ Dangerous — never do this with user-controlled values
+await client.query({ query: `SELECT * FROM users WHERE id = ${userId}` });
+
+// ✓ Safe — parameterized
+await client.query({
+  query: "SELECT * FROM users WHERE id = {id: UInt32}",
+  query_params: { id: userId },
+});
+```
+
+This is the most common mistake for users coming from PostgreSQL/MySQL. Call
+it out explicitly when the user shows template-literal interpolation.
+
+## Common types
+
+```ts
+import { TupleParam } from "@clickhouse/client";
+
+await client.query({
+  query: `
+    SELECT
+      {var_int: Int32}                     AS var_int,
+      {var_float: Float32}                 AS var_float,
+      {var_str: String}                    AS var_str,
+      {var_array: Array(Int32)}            AS var_array,
+      {var_tuple: Tuple(Int32, String)}    AS var_tuple,
+      {var_map: Map(Int, Array(String))}   AS var_map,
+      {var_date: Date}                     AS var_date,
+      {var_datetime: DateTime}             AS var_datetime,
+      {var_datetime64_3: DateTime64(3)}    AS var_datetime64_3,
+      {var_datetime64_9: DateTime64(9)}    AS var_datetime64_9,
+      {var_decimal: Decimal(9, 2)}         AS var_decimal,
+      {var_uuid: UUID}                     AS var_uuid,
+      {var_ipv4: IPv4}                     AS var_ipv4,
+      {var_null: Nullable(String)}         AS var_null
+  `,
+  format: "JSONEachRow",
+  query_params: {
+    var_int: 10,
+    var_float: "10.557",
+    var_str: "hello",
+    var_array: [42, 144],
+    var_tuple: new TupleParam([42, "foo"]), // >= 1.9.0
+    var_map: new Map([
+      [42, ["a", "b"]],
+      [144, ["c", "d"]],
+    ]), // >= 1.9.0
+    var_date: "2022-01-01",
+    var_datetime: "2022-01-01 12:34:56", // or a Date
+    var_datetime64_3: "2022-01-01 12:34:56.789", // or a Date
+    var_datetime64_9: "2022-01-01 12:34:56.123456789", // string for ns precision
+    var_decimal: "123.45", // string to avoid precision loss
+    var_uuid: "01234567-89ab-cdef-0123-456789abcdef",
+    var_ipv4: "192.168.0.1",
+    var_null: null, // fixed in 0.0.16
+  },
+});
+```
+
+### Type-by-type tips
+
+- **Decimals** — pass as strings to avoid JS number precision loss.
+- **`DateTime64(>3)`** — pass as a string; JS `Date` only has millisecond
+  precision and will lose sub-millisecond digits.
+- **`DateTime64`** — strings can also be UNIX timestamps, including
+  fractional ones (e.g., `'1651490755.123456789'`).
+- **`BigInt`** — supported in `query_params` since `>= 1.15.0`. On older
+  clients, pass as a string.
+- **`Tuple(...)`** — wrap in `new TupleParam([...])` (`>= 1.9.0`); on older
+  clients, build the literal manually as a string.
+- **`Map(K, V)`** — pass a JS `Map` (`>= 1.9.0`); on older clients, build
+  it manually.
+- **`Nullable(T)`** — pass `null` directly (`>= 0.0.16`).
+
+## Special characters in string parameters (`>= 0.3.1`)
+
+Tabs, newlines, carriage returns, single quotes, and backslashes are
+escaped automatically by the client — just pass the JS string as-is:
+
+```ts
+await client.query({
+  query: `
+    SELECT
+      'foo_\t_bar'  = {tab: String}             AS has_tab,
+      'foo_\n_bar'  = {newline: String}         AS has_newline,
+      'foo_\\'_bar' = {single_quote: String}    AS has_single_quote,
+      'foo_\\_bar'  = {backslash: String}       AS has_backslash
+  `,
+  format: "JSONEachRow",
+  query_params: {
+    tab: "foo_\t_bar",
+    newline: "foo_\n_bar",
+    single_quote: "foo_'_bar",
+    backslash: "foo_\\_bar",
+  },
+});
+```
+
+## Common pitfalls
+
+- **`$1` / `?` / `:name` placeholders.** None work — use `{name: Type}`.
+- **Forgetting the type in the placeholder.** `{id}` is a syntax error;
+  it must be `{id: UInt32}`.
+- **Stringifying tuples/maps manually on `>= 1.9.0`.** Use `TupleParam`
+  and `Map` — both serialize correctly and respect special characters.
+- **Boolean array/tuple/map elements before `1.13.0`.** Boolean formatting
+  was fixed in 1.13.0 — earlier versions may misformat them.

--- a/.claude/skills/clickhouse-js-node-coding/reference/select-formats.md
+++ b/.claude/skills/clickhouse-js-node-coding/reference/select-formats.md
@@ -1,0 +1,109 @@
+# Select Data Formats
+
+> **Applies to:** all versions. `JSONEachRowWithProgress` requires client
+> `>= 1.7.0`; see the in-repo performance examples under
+> `examples/node/performance/`.
+
+## Default choice: `JSONEachRow` → `.json<T>()`
+
+Right answer for ~90% of selects when the result fits in memory.
+
+```ts
+import { createClient } from "@clickhouse/client";
+
+interface Row {
+  number: string;
+}
+
+const client = createClient();
+const rows = await client.query({
+  query: "SELECT number FROM system.numbers LIMIT 5",
+  format: "JSONEachRow",
+});
+const result = await rows.json<Row>(); // Row[]
+result.forEach((r) => console.log(r));
+// { number: '0' }
+// { number: '1' }
+// ...
+await client.close();
+```
+
+`UInt64`/`Int64` and other 64-bit integers are returned as **strings**
+when `output_format_json_quote_64bit_integers=1`, to avoid JS precision
+loss. If that setting is `0`, they may be returned as unquoted JSON
+numbers instead. Note that in ClickHouse `>= 25.8`, this setting can
+default to `0`; see the troubleshooting skill for ways to control that.
+
+## Single-document `JSON` format with metadata
+
+Use `JSON` (or `JSONCompact`) when you need ClickHouse's response envelope
+(rows + meta + statistics + row count). Type the result with
+`ResponseJSON<T>`:
+
+```ts
+import { createClient, type ResponseJSON } from "@clickhouse/client";
+
+const client = createClient();
+const rows = await client.query({
+  query: "SELECT number FROM system.numbers LIMIT 2",
+  format: "JSON",
+});
+const result = await rows.json<ResponseJSON<{ number: string }>>();
+console.info(result.meta, result.data, result.rows, result.statistics);
+await client.close();
+```
+
+> `JSON`, `JSONCompact`, `JSONStrings`, `JSONCompactStrings`,
+> `JSONColumnsWithMetadata`, `JSONObjectEachRow` are **single-document**
+> formats — they cannot be streamed. Use a `*EachRow` variant if you want
+> to stream.
+
+## Selecting raw text (CSV / TSV / CustomSeparated)
+
+Use `.text()` (not `.json()`) for raw textual formats:
+
+```ts
+const rs = await client.query({
+  query: "SELECT number, number * 2 AS doubled FROM system.numbers LIMIT 3",
+  format: "CSVWithNames",
+});
+console.log(await rs.text());
+```
+
+Streaming raw text/Parquet line-by-line belongs in
+[`examples/node/performance/`](https://github.com/ClickHouse/clickhouse-js/tree/main/examples/node/performance)
+— in particular, Parquet exports use `client.exec()` and pipe the raw
+response stream rather than `ResultSet.stream()` (see
+[`select_parquet_as_file.ts`](https://github.com/ClickHouse/clickhouse-js/blob/main/examples/node/performance/select_parquet_as_file.ts)).
+
+## Format chooser
+
+| Use case                                                 | Format                                                                                                                                                     |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Read rows as JS objects                                  | `JSONEachRow` _(default)_                                                                                                                                  |
+| Read rows as positional tuples (smaller payload)         | `JSONCompactEachRow`                                                                                                                                       |
+| Need `meta` / `statistics` / `rows` envelope             | `JSON` or `JSONCompact` + `ResponseJSON<T>`                                                                                                                |
+| Read all values as strings (avoid number-precision loss) | `JSONStringsEachRow` / `JSONCompactStringsEachRow`                                                                                                         |
+| Stream very large result                                 | `JSONEachRow` / `JSONCompactEachRow` (see [`examples/node/performance/`](https://github.com/ClickHouse/clickhouse-js/tree/main/examples/node/performance)) |
+| Export to CSV/TSV/Parquet                                | `CSV*`, `TabSeparated*`, `Parquet` (see [`examples/node/performance/`](https://github.com/ClickHouse/clickhouse-js/tree/main/examples/node/performance))   |
+
+## ResultSet methods
+
+| Method               | Returns                                          | Notes                                                                                                                                                                                                                                                                                                                                |
+| -------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `await rs.json<T>()` | `T[]` for `*EachRow`, single-doc shape otherwise | Buffers the full response                                                                                                                                                                                                                                                                                                            |
+| `await rs.text()`    | `string`                                         | Buffers the full response — for textual formats only (CSV/TSV/etc.)                                                                                                                                                                                                                                                                  |
+| `rs.stream()`        | Node `Readable` of `Row[]` chunks                | Use for large newline-delimited results (`JSONEachRow`/`JSONCompactEachRow`/`CSV`/`TSV`); **not** suitable for binary formats like `Parquet` — for those, use `client.exec()` and pipe the raw response stream (see [`examples/node/performance/`](https://github.com/ClickHouse/clickhouse-js/tree/main/examples/node/performance)) |
+| `rs.close()`         | `void` (synchronous)                             | Always call if you obtained `stream()` and stop reading early                                                                                                                                                                                                                                                                        |
+
+## Common pitfalls
+
+- **Calling `.json()` on a `JSON` (single-doc) result and expecting an
+  array.** You get a `ResponseJSON<T>` object; the rows are under
+  `.data`. Use `JSONEachRow` if you want a flat array.
+- **Leaving a `stream()` half-consumed.** This is a top cause of
+  `ECONNRESET` on the _next_ request — fully iterate the stream or call
+  `resultSet.close()` (synchronous — no `await`). (Diagnosis details live in the
+  troubleshooting skill.)
+- **Reaching for `.json()` on a CSV/TSV result.** Use `.text()` (or
+  `.stream()` for large results).

--- a/.claude/skills/clickhouse-js-node-coding/reference/sessions.md
+++ b/.claude/skills/clickhouse-js-node-coding/reference/sessions.md
@@ -1,0 +1,178 @@
+# Sessions and Temporary Tables
+
+> **Applies to:** all versions. `session_id` is a server-level concept; the
+> client just forwards it on every request that names it.
+
+## Answer checklist
+
+When answering "temp table disappears between calls" / "how do I share a
+session" / anything involving `session_id`:
+
+- State plainly that **temporary tables and session-scoped state are tied
+  to a `session_id`** — without a stable `session_id` across calls, every
+  request gets a fresh server-side session and the temp table is gone.
+- Set `session_id` via `crypto.randomUUID()` either on `createClient` or
+  per-call.
+- Warn that **`session_id` on a global / module-static client is an
+  anti-pattern** in any concurrent app (Express, server actions, workers,
+  etc.) — concurrent requests will share the same session and trip
+  `"Session is locked by a concurrent client"`. Recommend a short-lived
+  per-workflow client or per-call `session_id` instead.
+- If `session_id` is set on the client, also set `max_open_connections: 1`
+  to serialize calls and avoid the concurrent-session error.
+- For ClickHouse Cloud or any load-balanced deployment: **explicitly
+  recommend replica-aware routing or a single-node hostname** as the
+  primary remedy when sessions are needed. Sessions are pinned to one
+  node; behind an LB, consecutive requests may land on different nodes
+  and the temp table will appear to vanish. "Just collapse the workflow
+  into one handler" or "use a non-temporary table" are valid fallbacks
+  but secondary — name the routing fix first.
+
+## When you need a session
+
+Use a `session_id` whenever multiple calls must share **server-side state**:
+
+- `CREATE TEMPORARY TABLE` (the table only exists within its session).
+- `SET <setting> = <value>` to apply for subsequent queries on the same
+  session.
+- Any other server feature scoped per session (e.g., session-scoped
+  variables in newer ClickHouse versions).
+
+## ⚠️ `session_id` and concurrency
+
+ClickHouse **rejects concurrent queries within the same session** — if two
+requests arrive at the server at the same time sharing the same `session_id`,
+the second one gets an error like
+`"Session is locked by a concurrent client"`. This has two practical
+implications:
+
+1. **Do not set `session_id` on a global / module-static client** that handles
+   concurrent requests (e.g., an Express app's shared client). Every
+   in-flight request would share the same session and collide under load.
+2. **If you do set `session_id` on a client**, restrict its concurrency:
+   set `max_open_connections: 1` so at most one request is in flight at a
+   time, turning the pool into a serial queue. This is fine for a
+   dedicated per-workflow client but wrong for a shared application client.
+
+The right pattern for application code: create a **short-lived client** (or
+use per-request `session_id`) scoped to a single logical workflow, not to
+the entire process.
+
+## Per-client `session_id`
+
+Appropriate when **one client handles exactly one sequential workflow** (a
+script, a background job, a single user's session that you've already manually
+serialized in the code).
+
+```ts
+import { createClient } from "@clickhouse/client";
+import * as crypto from "node:crypto";
+
+const client = createClient({
+  session_id: crypto.randomUUID(),
+  max_open_connections: 1, // safeguard against concurrent-session errors
+});
+
+await client.command({
+  query: "CREATE TEMPORARY TABLE temporary_example (i Int32)",
+});
+
+await client.insert({
+  table: "temporary_example",
+  values: [{ i: 42 }, { i: 144 }],
+  format: "JSONEachRow",
+});
+
+const rs = await client.query({
+  query: "SELECT * FROM temporary_example",
+  format: "JSONEachRow",
+});
+console.info(await rs.json());
+await client.close();
+```
+
+## Session-level `SET` commands
+
+`SET` only persists within a session. With `session_id` defined on the
+client, every subsequent call inherits the change.
+
+```ts
+import { createClient } from "@clickhouse/client";
+import * as crypto from "node:crypto";
+
+const client = createClient({
+  session_id: crypto.randomUUID(),
+  max_open_connections: 1, // safe-guard against concurrent-session errors
+});
+
+await client.command({
+  query: "SET output_format_json_quote_64bit_integers = 0",
+  clickhouse_settings: { wait_end_of_query: 1 }, // ack before next call
+});
+
+const rs1 = await client.query({
+  query: "SELECT toInt64(42)",
+  format: "JSONEachRow",
+});
+// → 64-bit integers come back as numbers in this query
+
+await client.command({
+  query: "SET output_format_json_quote_64bit_integers = 1",
+  clickhouse_settings: { wait_end_of_query: 1 },
+});
+
+const rs2 = await client.query({
+  query: "SELECT toInt64(144)",
+  format: "JSONEachRow",
+});
+// → 64-bit integers come back as strings again
+
+await client.close();
+```
+
+> **`wait_end_of_query: 1` matters here.** Without it, a `SET` on one
+> connection in the pool may not yet be applied when the next query lands
+> on the same socket.
+
+## Per-request `session_id`
+
+You can also pass `session_id` on a single `query()` / `insert()` /
+`command()` call to override (or set) it for that one request.
+
+## ⚠️ Sessions and load balancers / ClickHouse Cloud
+
+Sessions are bound to a **specific ClickHouse node**. If a load balancer in
+front of ClickHouse routes consecutive requests to different nodes, the
+temporary table / `SET` won't be visible — you'll get
+`UNKNOWN_TABLE` / surprising results.
+
+Mitigations (in order of preference):
+
+- **For ClickHouse Cloud, use [replica-aware
+  routing](https://clickhouse.com/docs/manage/replica-aware-routing)** so
+  consecutive requests in the same session land on the same node. This is
+  the right primary fix when you need sessions in a Cloud deployment.
+- Talk to a single node directly (e.g., a node-pinned hostname) when
+  routing isn't an option.
+- As a fallback only: avoid sessions for cross-node workflows and persist
+  intermediate state in a regular (non-temporary) table instead. This
+  trades the session requirement away rather than fixing it — use it only
+  if replica-aware routing / single-node connections aren't available.
+
+## Common pitfalls
+
+- **Forgetting `session_id` and being surprised that
+  `CREATE TEMPORARY TABLE` "disappears."** Without a session, every request
+  may land on a different connection / server context.
+- **Setting `session_id` on a shared application client.** Under concurrent
+  load, two in-flight requests will share the same session and one will fail
+  with `"Session is locked by a concurrent client"`. Use per-request
+  `session_id` or a dedicated short-lived client instead.
+- **Reusing the same `session_id` across unrelated workflows.** A second
+  session-using consumer will trip over your temporary tables and `SET`
+  values. Generate a fresh UUID per logical session.
+- **Leaving session state pinned for the lifetime of the process.** If
+  long-lived clients accumulate `SET` / temp-table state, consider creating
+  a short-lived sub-client with its own `session_id` for the unit of work.
+- **Skipping `wait_end_of_query: 1` on `SET`** — race conditions between
+  `SET` and the next query can show up under load.

--- a/.claude/skills/clickhouse-js-node-troubleshooting/SKILL.md
+++ b/.claude/skills/clickhouse-js-node-troubleshooting/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: clickhouse-js-node-troubleshooting
+description: >
+  Troubleshoot and resolve common issues with the ClickHouse Node.js client
+  (@clickhouse/client). Use this skill whenever a user reports errors, unexpected
+  behavior, or configuration questions involving the Node.js client specifically —
+  including socket hang-up errors, Keep-Alive problems, stream handling issues, data
+  type mismatches, read-only user restrictions, proxy/TLS setup problems, or long-running
+  query timeouts. Trigger even when the user hasn't precisely named the issue; vague
+  symptoms like "my inserts keep failing" or "connection drops randomly" in a Node.js
+  context are strong signals to use this skill. Do NOT use for browser/Web client issues.
+---
+
+# ClickHouse Node.js Client Troubleshooting
+
+Reference: https://clickhouse.com/docs/integrations/javascript
+
+> **⚠️ Node.js runtime only.** This skill covers the `@clickhouse/client` package running in a **Node.js runtime** exclusively — including **Next.js Node runtime** API routes, React Server Components, Server Actions, and standard Node.js processes. Do **not** apply this skill to browser client components, Web Workers, **Next.js Edge runtime**, Cloudflare Workers, or any usage of `@clickhouse/client-web`. For browser/edge environments, the correct package is `@clickhouse/client-web`.
+
+---
+
+## How to Use This Skill
+
+1. **Identify the issue** — match symptoms to the Issue Index below and read the corresponding reference file.
+2. **Lead with the diagnosis** — explain what's likely causing the issue before giving the fix.
+3. **Note version constraints** — flag if a fix requires a minimum client version and check it against what the user provided.
+4. **Ask only what's missing** — if the fix is version-dependent and you don't know their version, ask; otherwise help immediately.
+
+---
+
+## Issue Index
+
+Identify the user's issue from the list below and read the corresponding reference file for detailed troubleshooting steps.
+
+| Issue                                      | Symptoms                                                                                                                                                                     | Reference file                     |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| **Socket Hang-Up / ECONNRESET**            | `socket hang up`, `ECONNRESET`, intermittent connection drops, long-running queries timing out                                                                               | `reference/socket-hangup.md`       |
+| **Data Type Mismatches**                   | Large integers returned as strings, decimal precision loss, Date/DateTime insertion failures, `CANNOT_PARSE_INPUT_ASSERTION_FAILED` inserting a UUID into a `UInt128` column | `reference/data-types.md`          |
+| **Read-Only User Errors**                  | Errors when using response compression with `readonly=1` users                                                                                                               | `reference/readonly-users.md`      |
+| **Proxy / Pathname URL Confusion**         | Wrong database selected, requests failing behind a proxy with a path prefix                                                                                                  | `reference/proxy-pathname.md`      |
+| **TLS / Certificate Errors**               | TLS handshake failures, certificate verification issues, mutual TLS setup                                                                                                    | `reference/tls.md`                 |
+| **Compression Not Working**                | GZIP compression not activating for requests or responses                                                                                                                    | `reference/compression.md`         |
+| **Logging Not Showing Anything**           | No log output, need custom logger integration                                                                                                                                | `reference/logging.md`             |
+| **Query Parameters Not Interpolated**      | Parameterized queries not working, SQL injection concerns                                                                                                                    | `reference/query-params.md`        |
+| **FORMAT Clause / `SHOW POLICIES` Errors** | Syntax error from a duplicate `FORMAT`, or `SHOW [ROW] POLICIES` failing even with a format provided                                                                         | `reference/query-format-clause.md` |
+
+---
+
+## Still Stuck?
+
+- [JS client source + full examples](https://github.com/ClickHouse/clickhouse-js/tree/main/examples)
+- [ClickHouse JS client docs](https://clickhouse.com/docs/integrations/javascript)
+- [ClickHouse supported formats](https://clickhouse.com/docs/interfaces/formats)

--- a/.claude/skills/clickhouse-js-node-troubleshooting/reference/compression.md
+++ b/.claude/skills/clickhouse-js-node-troubleshooting/reference/compression.md
@@ -1,0 +1,27 @@
+# Compression Not Working
+
+> **Applies to:** all versions. Response compression was enabled by default in `< 1.0.0` and **disabled by default since `>= 1.0.0`** — you must explicitly enable it. Request compression has always been opt-in.
+
+Both request and response compression are supported. Only **GZIP** is supported (via zlib).
+
+```js
+import { createClient } from "@clickhouse/client";
+const client = createClient({
+  compression: {
+    response: true,
+    request: true,
+  },
+});
+```
+
+## Compression enabled but getting an error?
+
+If you enable `compression.response: true` and get a ClickHouse settings error, you are likely connecting as a `readonly=1` user. Response compression requires the `enable_http_compression` setting, which read-only users cannot change.
+
+See [`reference/readonly-users.md`](./readonly-users.md) for the fix.
+
+## Compression enabled but response doesn't seem compressed?
+
+- Verify your version-specific defaults — response compression was enabled by default in `< 1.0.0` and is **disabled by default** in `>= 1.0.0`, so on newer versions you must enable `compression.response: true` explicitly.
+- Check that the ClickHouse server has HTTP compression enabled (`enable_http_compression = 1` in server config). By default this is enabled on ClickHouse Cloud and most self-hosted setups.
+- Request compression (`compression.request: true`) compresses the request body sent to ClickHouse. It has no effect on the response.

--- a/.claude/skills/clickhouse-js-node-troubleshooting/reference/data-types.md
+++ b/.claude/skills/clickhouse-js-node-troubleshooting/reference/data-types.md
@@ -1,0 +1,113 @@
+# Data Type Mismatches
+
+## Large integers returned as strings
+
+> **Applies to:** all versions. The `output_format_json_quote_64bit_integers` ClickHouse setting is server-side and can be passed via `clickhouse_settings` in any client version.
+
+`UInt64`, `Int64`, `UInt128`, `Int128`, `UInt256`, `Int256` are serialized as **strings** in `JSON*` formats to prevent overflow (they exceed `Number.MAX_SAFE_INTEGER`).
+
+To receive them as numbers (use with caution — precision loss possible):
+
+```js
+const resultSet = await client.query({
+  query: "SELECT toUInt64(9007199254740993)",
+  format: "JSONEachRow",
+  clickhouse_settings: { output_format_json_quote_64bit_integers: 0 },
+});
+```
+
+> **Tip (`>= 1.15.0`):** BigInt values are now supported in query parameters, so you can safely pass large integers as bind params without string workarounds.
+
+## Decimals losing precision on read
+
+> **Applies to:** all versions (this is a ClickHouse JSON serialization behavior). For custom JSON parse/stringify (e.g., using a BigInt-safe parser), see `>= 1.14.0` which added configurable `json.parse` and `json.stringify` functions.
+
+ClickHouse returns Decimals as numbers by default in `JSON*` formats. Cast to string in the query:
+
+```js
+const resultSet = await client.query({
+  query: `
+    SELECT toString(my_decimal) AS my_decimal
+    FROM my_table
+  `,
+  format: "JSONEachRow",
+});
+```
+
+When inserting, always use the string representation to avoid precision loss:
+
+```js
+await client.insert({
+  table: "my_table",
+  values: [{ dec64: "123456789123456.789" }],
+  format: "JSONEachRow",
+});
+```
+
+## Inserting a UUID into a `UInt128` column fails (`CANNOT_PARSE_INPUT_ASSERTION_FAILED`)
+
+> **Applies to:** all versions. This is a ClickHouse input-parsing behavior, not a client bug.
+
+ClickHouse converts a `UUID` into `UInt128` implicitly **only for the `VALUES` clause**. With the row-oriented JSON formats the client uses (e.g. `JSONEachRow`), sending a UUID string such as `'019982cb-3abf-7e12-9668-c788a9e3639c'` for a `UInt128` column fails with `CANNOT_PARSE_INPUT_ASSERTION_FAILED`.
+
+Fix it with one of two patterns:
+
+**Pattern 1 — convert the UUID on the client and send it as a decimal string** (recommended). A JS `number` cannot hold 128 bits without precision loss, so always pass `UInt128` as a string:
+
+```js
+import * as crypto from "node:crypto";
+
+function uuidToUInt128(uuid) {
+  // 8-4-4-4-12 hex digits → 32 hex digits → BigInt → decimal string
+  return BigInt("0x" + uuid.replace(/-/g, "")).toString();
+}
+
+const uuid = crypto.randomUUID();
+await client.insert({
+  table: "events",
+  format: "JSONEachRow",
+  values: [{ id: uuidToUInt128(uuid), description: "converted on the client" }],
+});
+```
+
+Read `UInt128` back with `toString(id)` in the `SELECT` to avoid the same precision loss.
+
+**Pattern 2 — declare the UUID column as `EPHEMERAL`** and let ClickHouse populate the `UInt128` column via its `DEFAULT` expression. The ephemeral column must be listed in `columns` so the `DEFAULT` is evaluated:
+
+```js
+// CREATE TABLE events (id UInt128 DEFAULT id_uuid, id_uuid UUID EPHEMERAL, description String) ...
+await client.insert({
+  table: "events",
+  format: "JSONEachRow",
+  values: [{ id_uuid: uuid, description: "populated via EPHEMERAL column" }],
+  columns: ["id_uuid", "description"],
+});
+```
+
+## Format Selection Quick Reference
+
+| Use case                    | Recommended format                  | Min version                           |
+| --------------------------- | ----------------------------------- | ------------------------------------- |
+| Insert/select JS objects    | `JSONEachRow`                       | all                                   |
+| Bulk insert arrays          | `JSONEachRow`                       | all                                   |
+| Stream large result sets    | `JSONEachRow`, `JSONCompactEachRow` | all                                   |
+| CSV file streaming          | `CSV`, `CSVWithNames`               | all                                   |
+| Parquet file streaming      | `Parquet`                           | `>= 0.2.6`                            |
+| Single JSON object response | `JSON`, `JSONCompact`               | `JSON` all; `JSONCompact` `>= 0.0.14` |
+| Stream with progress        | `JSONEachRowWithProgress`           | `>= 1.7.0`                            |
+
+> ⚠️ `JSON` and `JSONCompact` return a single object and **cannot be streamed**.
+
+## Date/DateTime insertion fails or produces wrong values
+
+> **Applies to:** all versions. Note that `>= 0.2.1` changed Date object serialization to use time-zone-agnostic Unix timestamps instead of timezone-naive datetime strings, which fixed timezone mismatch issues between client and server.
+
+- `Date` / `Date32` columns accept **strings only** (e.g., `'2024-01-15'`).
+- `DateTime` / `DateTime64` columns accept strings **or** JS `Date` objects. To use `Date` objects, set:
+
+```js
+import { createClient } from "@clickhouse/client";
+const client = createClient({
+  clickhouse_settings: { date_time_input_format: "best_effort" },
+});
+```

--- a/.claude/skills/clickhouse-js-node-troubleshooting/reference/logging.md
+++ b/.claude/skills/clickhouse-js-node-troubleshooting/reference/logging.md
@@ -1,0 +1,44 @@
+# Logging Not Showing Anything
+
+> **Requires:** `>= 0.2.0` (explicit `log.level` config option introduced in 0.2.0, replacing the `CLICKHOUSE_LOG_LEVEL` env var from 0.0.11). Custom `LoggerClass` also available since `>= 0.2.0`. In `>= 1.18.1`, the default changed from `OFF` to `WARN` and logging became lazy (messages only constructed if the log level matches). In `>= 1.18.1`, structured context fields (`connection_id`, `query_id`, `request_id`, `socket_id`) are available in logger `args`.
+
+The default log level is **OFF** (for `< 1.18.1`) or **WARN** (for `>= 1.18.1`). Enable it explicitly:
+
+```js
+import { ClickHouseLogLevel, createClient } from "@clickhouse/client";
+
+const client = createClient({
+  log: {
+    level: ClickHouseLogLevel.DEBUG, // TRACE | DEBUG | INFO | WARN | ERROR
+  },
+});
+```
+
+To use a custom logger (e.g., to pipe to your observability stack), implement the `Logger` interface:
+
+```ts
+import { ClickHouseLogLevel, createClient } from "@clickhouse/client";
+import type { Logger } from "@clickhouse/client";
+
+class MyLogger implements Logger {
+  debug({ module, message, args }) {
+    /* ... */
+  }
+  info({ module, message, args }) {
+    /* ... */
+  }
+  warn({ module, message, args, err }) {
+    /* ... */
+  }
+  error({ module, message, args, err }) {
+    /* ... */
+  }
+  trace({ module, message, args }) {
+    /* ... */
+  }
+}
+
+const client = createClient({
+  log: { LoggerClass: MyLogger, level: ClickHouseLogLevel.INFO },
+});
+```

--- a/.claude/skills/clickhouse-js-node-troubleshooting/reference/proxy-pathname.md
+++ b/.claude/skills/clickhouse-js-node-troubleshooting/reference/proxy-pathname.md
@@ -1,0 +1,32 @@
+# Proxy / Pathname URL Confusion
+
+> **Requires:** `>= 1.0.0` (the `pathname` config option and URL-based configuration were introduced in 1.0.0). For `< 1.0.0`, a partial fix for pathname handling in the `host` parameter was shipped in `0.2.5`.
+
+**Symptom:** Wrong database is selected, or requests fail when ClickHouse is behind a proxy with a path prefix (e.g., `http://proxy:8123/clickhouse_server`).
+
+**Cause:** Passing the pathname in `url` makes the client treat it as the database name.
+
+**Fix:** Use the `pathname` option separately:
+
+```js
+import { createClient } from "@clickhouse/client";
+
+const client = createClient({
+  url: "http://proxy:8123",
+  pathname: "/clickhouse_server", // leading slash optional; multiple segments supported
+});
+```
+
+For proxies that require custom auth headers:
+
+> **Requires:** `>= 1.0.0` (`http_headers` config option; replaces the deprecated `additional_headers` from `>= 0.2.9`). Per-request `http_headers` overrides are available since `>= 1.11.0`.
+
+```js
+import { createClient } from "@clickhouse/client";
+
+const client = createClient({
+  http_headers: {
+    "My-Auth-Header": "secret",
+  },
+});
+```

--- a/.claude/skills/clickhouse-js-node-troubleshooting/reference/query-format-clause.md
+++ b/.claude/skills/clickhouse-js-node-troubleshooting/reference/query-format-clause.md
@@ -1,0 +1,49 @@
+# `query()` FORMAT Clause Errors (incl. `SHOW [ROW] POLICIES`)
+
+> **Applies to:** all versions.
+
+`client.query()` is for statements that return a result set (such as `SELECT`). It **always appends `FORMAT <format>`** to the end of the `query` string, where `<format>` comes from the `format` option (default `JSON`). You should therefore **not** include a `FORMAT` clause in the `query` yourself.
+
+```js
+// What you write:
+await client.query({ query: "SELECT 1", format: "JSONEachRow" });
+
+// What the client actually sends:
+// SELECT 1
+// FORMAT JSONEachRow
+```
+
+## Duplicate `FORMAT` — syntax error
+
+If the `query` string already contains a `FORMAT` clause, the client still appends another one, producing a duplicate `FORMAT` and a server-side syntax error. This is intended behavior.
+
+```js
+// ❌ Wrong — ends up as `... FORMAT CSV FORMAT JSON` → syntax error
+await client.query({ query: "SELECT 1 FORMAT CSV" });
+
+// ✓ Correct — let the client append FORMAT via the option
+await client.query({ query: "SELECT 1", format: "CSV" });
+```
+
+If you genuinely need to write the full SQL yourself (including the `FORMAT` clause), or you're running a statement where the appended `FORMAT` suffix is not supported, use `client.exec()` instead of `client.query()`. Use `client.insert()` for data insertion and `client.command()` for DDLs.
+
+## `SHOW [ROW] POLICIES` fails even with a format
+
+Some statements are not parsed by the server with a trailing `FORMAT` clause, so the `FORMAT` suffix that `query()` always appends triggers a syntax error. The most common case is the **short** form of `SHOW POLICIES` / `SHOW ROW POLICIES` — at the server SQL parser level it does not accept the `FORMAT` suffix.
+
+```js
+// ❌ Fails — query() appends `FORMAT JSON`, which the short SHOW POLICIES syntax rejects
+await client.query({ query: "SHOW POLICIES", format: "JSON" });
+await client.query({ query: "SHOW ROW POLICIES", format: "JSON" });
+```
+
+**Fix:** use the full syntax `SHOW POLICIES ON *` (or `SHOW POLICIES ON db.table`), which the parser accepts together with the appended `FORMAT`:
+
+```js
+// ✓ Works — full syntax accepts the appended FORMAT clause
+await client.query({ query: "SHOW POLICIES ON *", format: "JSON" });
+```
+
+Alternatively, run the short statement through `client.exec()`, where you control the full SQL and no `FORMAT` suffix is appended.
+
+This behavior is easy to misdiagnose because the error looks like a generic syntax error rather than a client/format problem. See the upstream issue: https://github.com/ClickHouse/ClickHouse/issues/105899

--- a/.claude/skills/clickhouse-js-node-troubleshooting/reference/query-params.md
+++ b/.claude/skills/clickhouse-js-node-troubleshooting/reference/query-params.md
@@ -1,0 +1,103 @@
+# Query Parameters Not Interpolated
+
+> **Applies to:** all versions. NULL parameter binding was fixed in `0.0.16`. Tuple support via `TupleParam` wrapper and JS `Map` as a query parameter were added in `>= 1.9.0`. BigInt values in query parameters are supported since `>= 1.15.0`. Boolean formatting in `Array`/`Tuple`/`Map` params was fixed in `>= 1.13.0`.
+
+Use the `{name: type}` syntax in the query string and pass values via `query_params`:
+
+```js
+await client.query({
+  query: "SELECT plus({val1: Int32}, {val2: Int32})",
+  format: "CSV",
+  query_params: { val1: 10, val2: 20 },
+});
+```
+
+## Never use template literals for user values
+
+When `$1`/`?` don't work, a common instinct is to interpolate values directly with a template literal. Don't — this bypasses ClickHouse's server-side escaping and opens the door to SQL injection:
+
+```js
+// ❌ Dangerous — never do this with user-controlled values
+const userId = req.params.id;
+await client.query({ query: `SELECT * FROM users WHERE id = ${userId}` });
+
+// ✓ Safe — parameterized
+await client.query({
+  query: "SELECT * FROM users WHERE id = {id: UInt32}",
+  query_params: { id: userId },
+});
+```
+
+Always bring this up when answering query-params questions, especially when the user is coming from another database (PostgreSQL, MySQL, etc.) — they're the most likely to reach for template literals as a fallback.
+
+## Common mistake: wrong parameter syntax
+
+The ClickHouse JS client uses ClickHouse's native `{name: type}` syntax — not `$1`/`?`/`:name` placeholders from other databases:
+
+```js
+// ❌ Wrong — these don't work
+await client.query({
+  query: "SELECT * FROM t WHERE id = $1",
+  query: "SELECT * FROM t WHERE id = ?",
+  query: "SELECT * FROM t WHERE id = :id",
+  query_params: { id: 42 },
+});
+
+// ✓ Correct
+await client.query({
+  query: "SELECT * FROM t WHERE id = {id: UInt32}",
+  query_params: { id: 42 },
+});
+```
+
+## Array parameters
+
+```js
+await client.query({
+  query: "SELECT * FROM t WHERE id IN {ids: Array(UInt32)}",
+  format: "JSONEachRow",
+  query_params: { ids: [1, 2, 3] },
+});
+```
+
+## Tuple parameters (`>= 1.9.0`)
+
+Use the `TupleParam` wrapper to pass a tuple:
+
+```js
+import { TupleParam, createClient } from "@clickhouse/client";
+
+const client = createClient({
+  url: "http://localhost:8123",
+});
+
+await client.query({
+  query: "SELECT {t: Tuple(UInt32, String)}",
+  format: "JSONEachRow",
+  query_params: { t: new TupleParam([42, "hello"]) },
+});
+```
+
+## Map parameters (`>= 1.9.0`)
+
+Pass a JS `Map` directly:
+
+```js
+await client.query({
+  query: "SELECT {m: Map(String, UInt32)}",
+  format: "JSONEachRow",
+  query_params: { m: new Map([["key", 1]]) },
+});
+```
+
+## NULL parameters
+
+Pass `null` directly — binding fixed in `0.0.16`:
+
+```js
+await client.query({
+  query: "SELECT {val: Nullable(String)}",
+  format: "JSONEachRow",
+  query_params: { val: null },
+});
+```

--- a/.claude/skills/clickhouse-js-node-troubleshooting/reference/readonly-users.md
+++ b/.claude/skills/clickhouse-js-node-troubleshooting/reference/readonly-users.md
@@ -1,0 +1,25 @@
+# Read-Only User Errors
+
+> **Applies to:** all versions. In `>= 1.0.0`, `compression.response` was changed to **disabled by default** specifically to avoid this confusing error for read-only users. If you are on `< 1.0.0`, response compression was enabled by default and you must explicitly disable it.
+
+**Symptom:** Error when using `compression: { response: true }` with a `readonly=1` user.
+
+**Cause:** Response compression requires the `enable_http_compression` setting, which `readonly=1` users cannot change. Note: **request compression** (`compression: { request: true }`) is unaffected by this restriction — only response compression triggers the error.
+
+**Fix:** Remove response compression for read-only users:
+
+```js
+import { createClient } from "@clickhouse/client";
+
+// Don't do this with a readonly=1 user:
+// compression: { response: true }
+
+const client = createClient({
+  username: "my_readonly_user",
+  password: "...",
+  // compression omitted, or explicitly set to false
+  compression: {
+    response: false,
+  },
+});
+```

--- a/.claude/skills/clickhouse-js-node-troubleshooting/reference/socket-hangup.md
+++ b/.claude/skills/clickhouse-js-node-troubleshooting/reference/socket-hangup.md
@@ -1,0 +1,204 @@
+# Socket Hang-Up / ECONNRESET
+
+**Symptom:** `socket hang up` or `ECONNRESET` errors, often intermittent.
+
+**Root cause:** The server or load balancer closes the Keep-Alive connection before the client detects it and stops reusing the socket.
+
+**Quick triage:**
+
+- Errors on every request → likely dangling stream (Step 1–2)
+- Errors only after idle periods → Keep-Alive timeout mismatch (Step 3)
+- Errors on long-running queries (INSERT FROM SELECT, etc.) → load balancer idle timeout (Step 4)
+- Can't diagnose → disable Keep-Alive as a last resort (Step 5)
+
+## Step 1 — Enable WARN-level logging to find dangling streams
+
+> **Requires:** `>= 0.2.0` (logging support with `log.level` config option). In `>= 1.18.1`, the default log level changed from `OFF` to `WARN`, so this step may already be active. In `>= 1.18.2`, the client auto-emits a WARN log with Keep-Alive troubleshooting hints when an `ECONNRESET` is detected. In `>= 1.12.0`, a warning is logged when a socket is closed without fully consuming the stream.
+
+```js
+import { createClient, ClickHouseLogLevel } from "@clickhouse/client";
+
+const client = createClient({
+  log: { level: ClickHouseLogLevel.WARN },
+});
+```
+
+Look for log lines about unconsumed or dangling streams — these are a common hidden cause. A **dangling stream** is a query response stream that was never fully consumed or explicitly closed with `ResultSet.close()`. Because the Node.js client reuses sockets (Keep-Alive), leaving a stream open corrupts the socket and causes the _next_ request to fail with `ECONNRESET`. Errors on **every request** strongly suggest dangling streams rather than a Keep-Alive timeout mismatch.
+
+**Common dangling stream patterns:**
+
+```js
+// ❌ Wrong — result stream never consumed; socket is left open
+const resultSet = await client.query({ query: "SELECT ..." });
+// result is abandoned without calling .json(), .text(), .stream(), or .close()
+
+// ❌ Wrong — stream created but not fully piped/iterated
+const resultSet = await client.query({
+  query: "SELECT ...",
+  format: "JSONEachRow",
+});
+const stream = resultSet.stream();
+// stream is never iterated and resultSet is never closed
+
+// ✓ Correct — consume via .json()
+const resultSet = await client.query({ query: "SELECT ..." });
+const data = await resultSet.json();
+
+// ✓ Correct — consume via async iteration
+const resultSet = await client.query({
+  query: "SELECT ...",
+  format: "JSONEachRow",
+});
+for await (const rows of resultSet.stream()) {
+  // process rows
+}
+
+// ✓ Correct — explicitly close; this destroys the underlying socket immediately
+const resultSet = await client.query({ query: "SELECT ..." });
+resultSet.close();
+```
+
+## Step 2 — Check your ESLint setup
+
+Add the [`no-floating-promises`](https://typescript-eslint.io/rules/no-floating-promises/) ESLint rule. Unhandled promises leave streams dangling, which can cause the server to close the socket.
+
+Even with `await`, if the returned `ResultSet` is not consumed (no `.json()`, `.text()`, `.close()`, or full stream iteration), the socket is left open. The ESLint rule catches the promise case; code review is needed for the "awaited but unconsumed result" case.
+
+## Step 3 — Find the server's Keep-Alive timeout
+
+```bash
+curl -v --data-binary "SELECT 1" <your_clickhouse_url>
+```
+
+Check the response headers:
+
+```
+< Connection: Keep-Alive
+< Keep-Alive: timeout=10
+```
+
+> **Requires:** `>= 0.3.0` (`keep_alive.idle_socket_ttl` was introduced in 0.3.0 with a default of 2500 ms, replacing the older `keep_alive.socket_ttl` from 0.1.1 which was removed in 0.3.0).
+
+The default `idle_socket_ttl` in the client is **2500 ms**, which is safe for servers with a 3 s timeout (common in ClickHouse < 23.11). If your server has a higher timeout (e.g., 10 s), you can safely increase:
+
+```js
+const client = createClient({
+  keep_alive: {
+    idle_socket_ttl: 9000, // stay ~500ms below the server's timeout
+  },
+});
+```
+
+> ⚠️ If you still get errors after increasing, **lower** the value, not raise it.
+
+> **Tip (`>= 1.18.3`):** Enable `keep_alive.eagerly_destroy_stale_sockets: true` to proactively destroy sockets that have been idle longer than `idle_socket_ttl` before each request. This helps when event loop delays prevent the idle timeout callback from firing on time.
+
+## Step 4 — Long-running queries with no data in/out (INSERT FROM SELECT, etc.)
+
+> **Requires:** `>= 1.0.0` (`request_timeout` default was fixed to 30 000 ms in 0.3.0; `url`-based configuration including `request_timeout` via URL params available since 1.0.0).
+
+Load balancers may close idle connections mid-query. Force periodic progress headers:
+
+```js
+const client = createClient({
+  request_timeout: 400_000, // e.g. 400s for long queries
+  clickhouse_settings: {
+    send_progress_in_http_headers: 1,
+    http_headers_progress_interval_ms: "110000", // string — UInt64 type; set ~10s below LB idle timeout
+  },
+});
+```
+
+### ⚠️ Critical: 16 KB Node.js Header Size Limit
+
+**Node.js defaults to a total received HTTP header limit of approximately 16 KB (this can be increased via the `--max-http-header-size` CLI flag[^max-header-size]).** ClickHouse sends a new progress header with each interval (~200 bytes), and after ~75 progress headers accumulate, Node.js will throw an exception and terminate the request unless that limit is raised.
+
+[^max-header-size]: Since `>= 1.18.5`, the ClickHouse JS Node client forwards a per-client header limit via the `max_response_headers_size` (bytes) option on `createClient` (it maps to Node's `http(s).request({ maxHeaderSize })`). On older versions, the practical workarounds are the `--max-http-header-size` CLI flag / `NODE_OPTIONS` (process-wide) or supplying a custom `http.Agent` configured with `maxHeaderSize`.
+
+**Maximum safe query duration formula:**
+
+```
+Max duration (seconds) ≈ http_headers_progress_interval_ms × 75 ÷ 1000
+```
+
+**Examples:**
+
+- `http_headers_progress_interval_ms: '10000'` (10s) → **~12.5 minutes** max safe duration
+- `http_headers_progress_interval_ms: '60000'` (60s) → **~75 minutes** max safe duration
+- `http_headers_progress_interval_ms: '120000'` (120s) → **~2.5 hours** max safe duration
+
+> **Note:** `http_headers_progress_interval_ms` is a `UInt64` ClickHouse setting, so it must be passed as a **string** (e.g., `'10000'`).
+
+**Raising the Node.js header limit (e.g., to 64 KB):**
+
+If you need a longer max safe duration without lengthening the progress interval, raise Node's HTTP header limit. For example, increasing it from the default 16 KB to **64 KB** quadruples the max safe duration (≈300 progress headers instead of ≈75).
+
+```ts
+// Option 1 (recommended, since `>= 1.18.5`) — per-client, no process-wide flag needed
+const client = createClient({
+  request_timeout: 400_000,
+  max_response_headers_size: 65536, // 64 KB; lifts the per-request header cap
+  clickhouse_settings: {
+    send_progress_in_http_headers: 1,
+    http_headers_progress_interval_ms: "110000",
+  },
+});
+```
+
+```bash
+# Option 2 — CLI flag when launching your app (process-wide; older client versions)
+node --max-http-header-size=65536 app.js
+
+# Option 3 — environment variable (works with any Node entry point, including npm/ts-node)
+NODE_OPTIONS="--max-http-header-size=65536" node app.js
+```
+
+With `maxHeaderSize = 65536` (64 KB), the formula becomes:
+Max duration (seconds) ≈ http_headers_progress_interval_ms × 300 ÷ 1000
+
+```
+Max duration ≈ http_headers_progress_interval_ms ÷ 1000 × 300
+```
+
+Examples at 64 KB:
+
+- `http_headers_progress_interval_ms: '10000'` (10s) → **~50 minutes** max safe duration
+- `http_headers_progress_interval_ms: '60000'` (60s) → **~5 hours** max safe duration
+- `http_headers_progress_interval_ms: '120000'` (120s) → **~10 hours** max safe duration
+
+**Guidelines for choosing the interval** (subject to your load balancer's idle timeout — see trade-offs below):
+
+1. **For queries under 12 minutes:** Use `'10000'` ms (10s) intervals, if your LB idle timeout allows
+2. **For queries 12 min – 1 hour:** Use `'60000'` ms (60s) intervals, if your LB idle timeout allows
+3. **For queries 1–2 hours:** Use `'120000'` ms (120s) intervals, if your LB idle timeout allows
+4. **For mutations over 2 hours:** Use the fire-and-forget pattern (see below)
+5. **For SELECT queries over 2 hours:** Increase `http_headers_progress_interval_ms` to extend the safe duration, while keeping it below your LB idle timeout and within Node.js header-limit constraints
+
+Use this command to experiment and debug:
+
+```bash
+curl -v "http://localhost:8123/?function_sleep_max_microseconds_per_block=10000000&wait_end_of_query=1&send_progress_in_http_headers=1&max_block_size=1&query=select+sum(sleepEachRow(1))+from+numbers(10)+FORMAT+JSONEachRow"
+```
+
+Experimenting with the exact load balancer stack might be required.
+
+**Important trade-offs:**
+
+- **Shorter intervals** = better load balancer keep-alive (prevents idle timeout) but **lower max duration**
+- **Longer intervals** = higher max duration but **higher risk of LB idle timeout**
+
+As a rule of thumb, set the interval slightly **below** your load balancer's idle timeout—typically by a few seconds (for example, often around 5–20 seconds), depending on your load balancer, proxies, and network behavior—while staying under the header limit for your expected query duration.
+
+**Alternatively — fire-and-forget (mutations only):** Mutations (`INSERT ... SELECT`, `OPTIMIZE`, `ALTER`) are not cancelled on the server when the client connection is lost. You can send the mutation and immediately close the connection, then poll `system.query_log` or `system.mutations` for status. This bypasses both the load balancer idle timeout and the Node.js header limit. See the [client repo examples](https://github.com/ClickHouse/clickhouse-js/tree/main/examples) for a concrete implementation.
+
+## Step 5 — Disable Keep-Alive entirely (last resort)
+
+> **Requires:** `>= 0.1.1` (Keep-Alive disable option introduced in 0.1.1).
+
+Adds overhead (new TCP connection per request) but eliminates all Keep-Alive issues:
+
+```js
+const client = createClient({
+  keep_alive: { enabled: false },
+});
+```

--- a/.claude/skills/clickhouse-js-node-troubleshooting/reference/tls.md
+++ b/.claude/skills/clickhouse-js-node-troubleshooting/reference/tls.md
@@ -1,0 +1,91 @@
+# TLS / Certificate Errors
+
+> **Requires:** `>= 0.0.8` (basic and mutual TLS support added in 0.0.8). For custom HTTP agent with TLS, see `>= 1.2.0` (`http_agent` option); note that when using a custom agent, the `tls` config option is ignored.
+
+## Basic TLS (CA certificate only)
+
+```js
+import fs from "fs";
+import { createClient } from "@clickhouse/client";
+
+const client = createClient({
+  url: "https://<hostname>:<port>",
+  username: "<user>",
+  password: "<pass>",
+  tls: {
+    ca_cert: fs.readFileSync("certs/CA.pem"),
+  },
+});
+```
+
+## Mutual TLS (client certificate + key)
+
+```js
+import fs from "fs";
+import { createClient } from "@clickhouse/client";
+
+const client = createClient({
+  url: "https://<hostname>:<port>",
+  username: "<user>",
+  tls: {
+    ca_cert: fs.readFileSync("certs/CA.pem"),
+    cert: fs.readFileSync("certs/client.crt"),
+    key: fs.readFileSync("certs/client.key"),
+  },
+});
+```
+
+> **Tip (`>= 1.2.0`):** If you need a custom HTTP(S) agent, use the `http_agent` option. Only set `set_basic_auth_header: false` if you must avoid sending the basic-auth `Authorization` header (for example, due to a header conflict); in that case, provide alternative auth headers such as `X-ClickHouse-User` / `X-ClickHouse-Key` via `http_headers`.
+
+## Common TLS errors
+
+### `UNABLE_TO_VERIFY_LEAF_SIGNATURE` / `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`
+
+**Scenario A — Private/internal CA (most common for self-hosted):** The server's certificate was issued by a private CA that Node.js doesn't trust. Pass the CA certificate explicitly:
+
+```js
+tls: {
+  ca_cert: fs.readFileSync('certs/CA.pem'),
+}
+```
+
+**Scenario B — ClickHouse Cloud:** The CA is a well-known public CA; this error typically means the system CA bundle is outdated or the URL/hostname is wrong. Updating Node.js or the system certificates usually resolves it.
+
+### `self signed certificate` / `self signed certificate in certificate chain`
+
+The server uses a self-signed cert (the certificate is its own CA). Options in order of preference:
+
+1. Pass the self-signed cert as the CA:
+
+   ```js
+   tls: {
+     ca_cert: fs.readFileSync("certs/server.crt"),
+   }
+   ```
+
+2. For development only — disable verification via a custom agent (`>= 1.2.0`):
+
+   ```js
+   import https from "https";
+   import { createClient } from "@clickhouse/client";
+
+   const client = createClient({
+     url: "https://<hostname>:<port>",
+     username: "<user>",
+     password: "<pass>",
+     http_agent: new https.Agent({ rejectUnauthorized: false }),
+     // Optional: only disable the basic-auth Authorization header if you need to
+     // provide alternative auth headers instead.
+     set_basic_auth_header: false,
+     http_headers: {
+       "X-ClickHouse-User": "<user>",
+       "X-ClickHouse-Key": "<pass>",
+     },
+   });
+   ```
+
+   > ⚠️ Never use `rejectUnauthorized: false` in production — it disables all certificate verification.
+
+### `ERR_SSL_WRONG_VERSION_NUMBER` / `ECONNREFUSED` on HTTPS URL
+
+The client is connecting with HTTPS but the server is listening on plain HTTP. Change the URL scheme to `http://` or enable TLS on the ClickHouse server.

--- a/.claude/skills/testing-bun/SKILL.md
+++ b/.claude/skills/testing-bun/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: [Read, Edit, Grep, Glob, Bash]
 - Use `bun:test` imports (`describe`, `test`, `expect`, etc.)
 - Use Bun test runner, typically via workspace scripts (`bun run test`)
 - Do not introduce Vitest or Jest in this repo
-- For local e2e/integration runs that need env vars, use Doppler (`bun run test:env`)
+- For local e2e/integration runs, provide required env vars through the shell or `.env`
 
 ## Test Strategy
 - **Default to API integration tests against real infrastructure** (real Postgres, real ClickHouse). Call a real endpoint, let data flow through the API into the DB, then verify by calling another endpoint. This is "e2e" from the API perspective only — frontend is out of scope here.
@@ -79,11 +79,11 @@ describe('integration', () => {
 - E2E tests must never be conditional on env availability
 - Never use `skip`, `skipIf`, guard `return`, or branching that bypasses e2e execution when env vars are absent
 - Missing required env vars must cause test failure immediately
-- Local e2e execution must use Doppler so required vars are injected
+- Local e2e execution must provide the required vars through the shell or `.env`
 
 ```bash
 # Required local command for env-dependent suites
-bun run test:env
+bun run test:integration
 ```
 
 ### 5. Prefer Inline Setup Over `beforeEach`
@@ -123,5 +123,5 @@ assert(checkoutRecord)
 When adding new env vars for tests, update:
 1. Package's `turbo.json` → `passThroughEnv` array
 2. `.github/workflows/ci.yml` → `env` section
-3. Run local e2e/integration suites with `bun run test:env`
+3. Run local e2e/integration suites with `bun run test:integration`
 4. Treat missing vars as a hard failure, not a skip path

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,6 @@ coverage/
 .context
 
 # Local agent/editor skill installs
-skills-lock.json
 .agents/skills/posthog-debugger/
 .agents/skills/vercel-react-best-practices/
 .codex/skills/
@@ -58,6 +57,10 @@ skills-lock.json
 # skills actually committed here.
 .claude/skills/*
 !.claude/skills/api-testing/
+!.claude/skills/clickhouse-architecture-advisor/
+!.claude/skills/clickhouse-best-practices/
+!.claude/skills/clickhouse-js-node-coding/
+!.claude/skills/clickhouse-js-node-troubleshooting/
 !.claude/skills/clickhouse-query/
 !.claude/skills/code-architecture/
 !.claude/skills/environment-variables/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,8 @@ A platform for ingesting, storing, and analyzing Claude Code / Codex session tra
 To test local chkit changes without publishing:
 
 ```bash
-# Link to local chkit (at /Users/marc/Workspace/chkit or CHKIT_PATH)
-bun run chkit:link
+# Link to a local chkit checkout
+CHKIT_PATH=/path/to/chkit bun run chkit:link
 
 # Restore to published versions
 bun run chkit:unlink
@@ -120,14 +120,6 @@ The `prd_local` Doppler config sets `APP_URL=http://localhost:4010` and `ALLOWED
 
 The web app's Vite config proxies `/api` and `/rpc` requests to `http://localhost:4010`, so the web dev server only needs to be started with `bun run --cwd apps/web dev` (no Doppler needed for the frontend).
 
-Alternatively, the API has a convenience script:
-
-```bash
-bun run --cwd apps/api dev:env
-```
-
-This runs `doppler run --project rudel --config prd_local -- bun --watch src/index.ts`.
-
 ## Wrapped card avatars
 
 Wrapped card profile avatars persist to Postgres in the `user_avatar` sidecar table (one row per user, keyed by `user_id`, with a stable `public_id` UUID and the raw bytes in `image_data` bytea). `user.image` stores a relative URL `/api/avatar/<public_id>`; never absolutize it at write time so production shares don't capture localhost from `prd_local` dev.
@@ -168,20 +160,19 @@ doppler run --project rudel --config ci -- <command>
 
 chcli (`@obsessiondb/chcli`) is installed as a local devDependency in `packages/ch-schema` and optionally globally (`npm install -g @obsessiondb/chcli`).
 
-**Env var mapping required.** Doppler provides `CLICKHOUSE_URL` and `CLICKHOUSE_USERNAME`, but chcli expects different env var names. The `chcli` and `chcli:prd` scripts in `packages/ch-schema/package.json` handle this mapping automatically:
+**Env var mapping required.** Rudel uses `CLICKHOUSE_URL` and `CLICKHOUSE_USERNAME`, but chcli expects different env var names. The `chcli` script in `packages/ch-schema/package.json` handles this mapping automatically:
 
-| Doppler var | chcli var | Transformation |
+| Rudel var | chcli var | Transformation |
 |---|---|---|
-| `CLICKHOUSE_URL` | `CLICKHOUSE_HOST` | Strip `https://` prefix |
+| `CLICKHOUSE_URL` | `CLICKHOUSE_HOST` | Parse the URL and use its hostname |
 | `CLICKHOUSE_USERNAME` | `CLICKHOUSE_USER` | Same value, different name |
-| (not in Doppler) | `CLICKHOUSE_SECURE` | Must be `true` (not `1`) |
-| (not in Doppler) | `CLICKHOUSE_PORT` | `443` (behind reverse proxy, not default 8123) |
+| URL protocol | `CLICKHOUSE_SECURE` | `true` for HTTPS, otherwise `false` |
+| URL port and protocol | `CLICKHOUSE_PORT` | Explicit port, otherwise `443` for HTTPS or `8123` for HTTP |
 | `CLICKHOUSE_PASSWORD` | `CLICKHOUSE_PASSWORD` | No mapping needed |
 
 ```bash
 # From packages/ch-schema:
-bun run chcli -- -q "SELECT 1" -F json        # CI
-bun run chcli:prd -- -q "SHOW TABLES" -F json  # PRD
+bun run chcli -- -q "SELECT 1" -F json
 ```
 
 ## ClickHouse Schema Management (chkit)
@@ -190,7 +181,7 @@ Schema definitions live in `packages/ch-schema/src/db/schema/*.ts`. The toolkit 
 
 **Important**: chkit must run with `bun --bun` (not plain `bun`) because the `.exe` spawns Node.js which cannot load `.ts` config files. All scripts below already handle this.
 
-**Important**: Doppler sets `CLICKHOUSE_DB=rudel`, but chkit needs to connect to `default` first (to run `CREATE DATABASE`). The `ch:migrate` scripts override this with `CLICKHOUSE_DB=default`. The `ch:generate` and `ch:codegen` scripts don't need the override since they don't connect to ClickHouse or only read schema files.
+**Important**: chkit needs to connect to `default` first (to run `CREATE DATABASE`). The `ch:migrate` script overrides any configured database with `CLICKHOUSE_DB=default`. The `ch:generate` and `ch:codegen` scripts don't need the override since they don't connect to ClickHouse or only read schema files.
 
 ### Workflow
 
@@ -205,19 +196,16 @@ bun run ch:generate:dryrun
 # 3. Generate migration SQL + update snapshot/journal
 bun run ch:generate
 
-# 4. Apply pending migrations to CI ClickHouse
+# 4. Apply pending migrations to the configured ClickHouse
 bun run ch:migrate
 
-# 5. Apply pending migrations to PRD ClickHouse
-bun run ch:migrate:prd
-
-# 6. Regenerate TypeScript types from schema
+# 5. Regenerate TypeScript types from schema
 bun run ch:codegen
 
-# 7. Check migration status
+# 6. Check migration status
 bun run ch:status
 
-# 8. Check schema drift (snapshot vs live ClickHouse)
+# 7. Check schema drift (snapshot vs live ClickHouse)
 bun run ch:drift
 ```
 
@@ -226,28 +214,18 @@ bun run ch:drift
 `chcli` is the preferred tool for ad-hoc queries. It supports `-q` (inline SQL), `-f` (SQL file), and various output formats (`-F json`, `-F pretty`, `-F csv`, etc.).
 
 ```bash
-# Inline query against CI
+# Inline query against the configured ClickHouse
 bun run chcli -- -q "SELECT count() FROM rudel.session_analytics" -F pretty
 
-# Run a SQL file against CI
+# Run a SQL file
 bun run chcli -- -f scripts/example.sql -v
-
-# Query PRD
-bun run chcli:prd -- -q "SHOW TABLES FROM rudel" -F pretty
-```
-
-The `ch:query` and `ch:describe` scripts use raw curl and are kept as fallbacks:
-
-```bash
-bun run ch:query scripts/my_query.sql
-bun run ch:describe rudel.claude_sessions
 ```
 
 ### Resetting from scratch
 
 To drop everything and recreate:
 
-1. Drop the database via `ch:query` or curl
+1. Drop the database via `bun run chcli -- -q "DROP DATABASE IF EXISTS rudel"`
 2. Delete `chx/migrations/`, reset `chx/meta/journal.json` to `{"version":1,"applied":[]}`, reset `chx/meta/snapshot.json` to `{"version":1,"generatedAt":"","definitions":[]}`
 3. Run `bun run ch:generate` to create a fresh migration from current schema (codegen plugin may fail — ignore, migration file is still created)
 4. **Manually reorder** the migration SQL: database -> tables -> materialized views (see known issues below)
@@ -265,7 +243,7 @@ To drop everything and recreate:
 
 **Codegen plugin failure.** `bun run ch:generate` may fail with `Plugin "codegen" failed in generate integration with exit code 1`. The migration file and snapshot are still created despite this error. Run `bun run ch:codegen` separately if needed.
 
-**`CLICKHOUSE_DB=default` override.** Doppler sets `CLICKHOUSE_DB=rudel`. When the `rudel` database doesn't exist yet (e.g., during initial migration), chkit fails to connect. The `ch:migrate` script overrides this with `CLICKHOUSE_DB=default` inside a bash subshell so the override happens after Doppler injects env vars.
+**`CLICKHOUSE_DB=default` override.** When the `rudel` database doesn't exist yet (e.g., during initial migration), chkit fails to connect. The `ch:migrate` script overrides configured shell or `.env` values with `CLICKHOUSE_DB=default` inside a bash subshell.
 
 **ClickHouse Cloud silent INSERT behavior.** `INSERT ... SELECT` via the HTTP interface may silently return 200 with 0 rows written. Use `SETTINGS async_insert=0` as a workaround. Additionally, `INSERT INTO table_x SELECT ... FROM table_x` (same source and target table) silently writes 0 rows even with `async_insert=0` — you must read from a different source table. The API uses `client.command()` with `FORMAT JSONEachRow` and `async_insert=0` (see `apps/api/src/clickhouse.ts`).
 
@@ -275,7 +253,7 @@ To drop everything and recreate:
 
 **`bun run` resolves binaries from local `node_modules/.bin/`, not global PATH.** When running package.json scripts, `bun run` looks for binaries in `node_modules/.bin/` first. If a tool like `chcli` is only installed globally, `bun run` won't find it. Fix: add the tool as a local devDependency (e.g., `@obsessiondb/chcli` in `packages/ch-schema`). Bun also rewrites `npx` to `bun x` in scripts, which has the same local-first resolution behavior.
 
-**chcli env var mapping.** Doppler provides `CLICKHOUSE_URL` (e.g., `https://host.example.com`) and `CLICKHOUSE_USERNAME`, but chcli expects `CLICKHOUSE_HOST` (hostname only), `CLICKHOUSE_USER`, `CLICKHOUSE_SECURE=true`, and `CLICKHOUSE_PORT=443`. The `chcli`/`chcli:prd` scripts in `packages/ch-schema/package.json` handle this mapping via `bash -c` with shell parameter expansion (`${CLICKHOUSE_URL#https://}`).
+**chcli env var mapping.** Rudel uses `CLICKHOUSE_URL` (e.g., `https://host.example.com`) and `CLICKHOUSE_USERNAME`, but chcli expects `CLICKHOUSE_HOST`, `CLICKHOUSE_USER`, `CLICKHOUSE_SECURE`, and `CLICKHOUSE_PORT`. The `chcli` script in `packages/ch-schema/package.json` parses the URL in `scripts/chcli-connect.ts`, maps the hostname and username, and derives the secure flag and default port from the URL protocol.
 
 **`CLICKHOUSE_SECURE` must be the string `true`, not `1`.** chcli does not recognize `1` or other truthy values for `CLICKHOUSE_SECURE`. Always use `CLICKHOUSE_SECURE=true`.
 
@@ -301,16 +279,13 @@ The plugin uses `session_date` for time windowing, configured via `defaults.time
 # From packages/ch-schema
 
 # Preview what the backfill will do
-bun run ch:backfill:plan -- --target rudel.session_analytics --from 2025-01-01 --to 2026-03-01        # CI
-bun run ch:backfill:plan:prd -- --target rudel.session_analytics --from 2025-01-01 --to 2026-03-01    # PRD
+bun run ch:backfill:plan -- --target rudel.session_analytics --from 2025-01-01 --to 2026-03-01
 
 # Run the backfill
-bun run ch:backfill:run -- --plan-id <plan-id>         # CI
-bun run ch:backfill:run:prd -- --plan-id <plan-id>     # PRD
+bun run ch:backfill:run -- --plan-id <plan-id>
 
 # Check backfill status
-bun run ch:backfill:status -- --plan-id <plan-id>      # CI
-bun run ch:backfill:status:prd -- --plan-id <plan-id>  # PRD
+bun run ch:backfill:status -- --plan-id <plan-id>
 ```
 
 ### Codegen (TypeScript types)
@@ -329,7 +304,7 @@ The generated `RudelSessionAnalyticsRow` type includes both source columns (from
 
 ```bash
 # Run API with production databases (prd_local Doppler config)
-bun run --cwd apps/api dev:env
+doppler run --project rudel --config prd_local -- bun --watch apps/api/src/index.ts
 
 # Run tests locally
 doppler run --project rudel --config ci -- bun run verify

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,6 @@
 	"type": "module",
 	"scripts": {
 		"dev": "bun --watch src/index.ts",
-		"dev:env": "doppler run --project rudel --config prd_local -- bun --watch src/index.ts",
 		"backfill:session-ownership": "bun src/scripts/backfill-session-ownership.ts",
 		"resolve:session-ownership": "bun src/scripts/resolve-session-ownership.ts",
 		"check-types": "tsc --noEmit",

--- a/bun.lock
+++ b/bun.lock
@@ -179,6 +179,7 @@
         "zod": "^3.24.0",
       },
       "devDependencies": {
+        "@obsessiondb/chcli": "0.1.1-beta.4",
         "@rudel/typescript-config": "workspace:*",
         "bun-types": "latest",
         "typescript": "5.9.2",
@@ -545,6 +546,8 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@obsessiondb/chcli": ["@obsessiondb/chcli@0.1.1-beta.4", "", { "dependencies": { "@clickhouse/client": "^1.17.0" }, "peerDependencies": { "typescript": "^5" }, "bin": { "chcli": "dist/chcli.js" } }, "sha512-jsapc7STpKdHlMvyOnRa9kkFB/nZ7AAG6ZBmZeVYghsqHx89QP+bd3p+SePMDiGfHDf74rD6vazg9olX5Q445Q=="],
 
     "@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
 		"check-types": "turbo run check-types",
 		"test": "turbo run test",
 		"test:integration": "turbo run test:integration --concurrency=1",
-		"test:env": "doppler run --project rudel --config ci -- bun run test:integration",
 		"verify": "turbo run lint check-types test build",
 		"release:cli": "bun run ./scripts/release-cli.ts",
 		"deploy": "turbo run build",

--- a/packages/ch-schema/package.json
+++ b/packages/ch-schema/package.json
@@ -14,24 +14,16 @@
 		"check-types": "tsc --noEmit",
 		"test": "bun test",
 		"test:integration": "bun test --max-concurrency=1 ./src/__tests__/codex-mv.integration.ts ./src/__tests__/ingest-clickhouse.integration.ts ./src/__tests__/filter-version-migration.integration.ts",
-		"ch:generate": "doppler run --project rudel --config ci -- bun --bun chkit generate",
-		"ch:generate:dryrun": "doppler run --project rudel --config ci -- bun --bun chkit generate --dryrun",
-		"ch:migrate": "doppler run --project rudel --config ci -- bash -c 'CLICKHOUSE_DB=default bun --bun chkit migrate --apply'",
-		"ch:migrate:prd": "doppler run --project rudel --config prd -- bash -c 'CLICKHOUSE_DB=default bun --bun chkit migrate --apply'",
-		"ch:status": "doppler run --project rudel --config ci -- bash -c 'CLICKHOUSE_DB=default bun --bun chkit status'",
-		"ch:status:prd": "doppler run --project rudel --config prd -- bash -c 'CLICKHOUSE_DB=default bun --bun chkit status'",
-		"ch:codegen": "doppler run --project rudel --config ci -- bun --bun chkit codegen",
-		"ch:drift": "doppler run --project rudel --config ci -- bash -c 'CLICKHOUSE_DB=default bun --bun chkit drift'",
-		"ch:backfill:plan": "doppler run --project rudel --config ci -- bash -c 'CLICKHOUSE_DB=default bun --bun chkit backfill plan \"$@\"' --",
-		"ch:backfill:plan:prd": "doppler run --project rudel --config prd -- bash -c 'CLICKHOUSE_DB=default bun --bun chkit backfill plan \"$@\"' --",
-		"ch:backfill:run": "doppler run --project rudel --config ci -- bash -c 'CLICKHOUSE_DB=default bun --bun chkit backfill run \"$@\"' --",
-		"ch:backfill:run:prd": "doppler run --project rudel --config prd -- bash -c 'CLICKHOUSE_DB=default bun --bun chkit backfill run \"$@\"' --",
-		"ch:backfill:status": "doppler run --project rudel --config ci -- bash -c 'CLICKHOUSE_DB=default bun --bun chkit backfill status \"$@\"' --",
-		"ch:backfill:status:prd": "doppler run --project rudel --config prd -- bash -c 'CLICKHOUSE_DB=default bun --bun chkit backfill status \"$@\"' --",
-		"ch:query": "doppler run --project rudel --config ci -- bash -c 'curl -sk \"${CLICKHOUSE_URL}/?user=${CLICKHOUSE_USERNAME}&password=${CLICKHOUSE_PASSWORD}\" --data-binary @\"$1\"' --",
-		"ch:describe": "doppler run --project rudel --config ci -- bash -c 'curl -sk \"${CLICKHOUSE_URL}/?user=${CLICKHOUSE_USERNAME}&password=${CLICKHOUSE_PASSWORD}\" --data-binary \"DESCRIBE $1 FORMAT Pretty\"' --",
-		"chcli": "doppler run --project rudel --config ci -- bash -c 'CLICKHOUSE_HOST=${CLICKHOUSE_URL#https://} CLICKHOUSE_USER=$CLICKHOUSE_USERNAME CLICKHOUSE_SECURE=true CLICKHOUSE_PORT=443 chcli \"$@\"' --",
-		"chcli:prd": "doppler run --project rudel --config prd -- bash -c 'CLICKHOUSE_HOST=${CLICKHOUSE_URL#https://} CLICKHOUSE_USER=$CLICKHOUSE_USERNAME CLICKHOUSE_SECURE=true CLICKHOUSE_PORT=443 chcli \"$@\"' --"
+		"ch:generate": "bun --bun chkit generate",
+		"ch:generate:dryrun": "bun --bun chkit generate --dryrun",
+		"ch:migrate": "bash -c 'CLICKHOUSE_DB=default bun --bun chkit migrate --apply'",
+		"ch:status": "bash -c 'CLICKHOUSE_DB=default bun --bun chkit status'",
+		"ch:codegen": "bun --bun chkit codegen",
+		"ch:drift": "bash -c 'CLICKHOUSE_DB=default bun --bun chkit drift'",
+		"ch:backfill:plan": "bash -c 'CLICKHOUSE_DB=default bun --bun chkit backfill plan \"$@\"' --",
+		"ch:backfill:run": "bash -c 'CLICKHOUSE_DB=default bun --bun chkit backfill run \"$@\"' --",
+		"ch:backfill:status": "bash -c 'CLICKHOUSE_DB=default bun --bun chkit backfill status \"$@\"' --",
+		"chcli": "bun scripts/chcli-connect.ts"
 	},
 	"dependencies": {
 		"@chkit/clickhouse": "0.1.0-beta.16",
@@ -45,6 +37,7 @@
 		"zod": "^3.24.0"
 	},
 	"devDependencies": {
+		"@obsessiondb/chcli": "0.1.1-beta.4",
 		"@rudel/typescript-config": "workspace:*",
 		"bun-types": "latest",
 		"typescript": "5.9.2"

--- a/packages/ch-schema/scripts/chcli-connect.ts
+++ b/packages/ch-schema/scripts/chcli-connect.ts
@@ -1,0 +1,42 @@
+export async function runChcliConnect(): Promise<number> {
+	const rawUrl = process.env.CLICKHOUSE_URL;
+	if (rawUrl === undefined || rawUrl.trim().length === 0) {
+		throw new Error("CLICKHOUSE_URL is required to run chcli.");
+	}
+
+	let url: URL;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		throw new Error("CLICKHOUSE_URL must be a valid URL.");
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		throw new Error("CLICKHOUSE_URL must use HTTP or HTTPS.");
+	}
+
+	const subprocess = Bun.spawn(["chcli", ...process.argv.slice(2)], {
+		env: {
+			...process.env,
+			CLICKHOUSE_HOST: url.hostname,
+			CLICKHOUSE_PORT: url.port || (url.protocol === "https:" ? "443" : "8123"),
+			CLICKHOUSE_SECURE: url.protocol === "https:" ? "true" : "false",
+			CLICKHOUSE_USER:
+				process.env.CLICKHOUSE_USERNAME ?? process.env.CLICKHOUSE_USER,
+		},
+		stdin: "inherit",
+		stdout: "inherit",
+		stderr: "inherit",
+	});
+
+	return subprocess.exited;
+}
+
+if (import.meta.main) {
+	try {
+		process.exitCode = await runChcliConnect();
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		console.error(`Failed to run chcli: ${message}`);
+		process.exitCode = 1;
+	}
+}

--- a/packages/ch-schema/src/__tests__/codex-mv.integration.ts
+++ b/packages/ch-schema/src/__tests__/codex-mv.integration.ts
@@ -23,8 +23,8 @@ const executor = createTestExecutor();
 
 afterAll(async () => {
 	// The incremental MV writes a separate target row on insert; deleting its source
-	// row does not propagate. Clean both tables so persistent environments used by
-	// `test:env` do not accumulate fixtures.
+	// row does not propagate. Clean both tables so `test:integration` does not
+	// accumulate fixtures in persistent environments.
 	// The executor reuses one ClickHouse session, so commands must be sequential;
 	// concurrent deletes fail with SESSION_IS_LOCKED.
 	// Best-effort like ingest-clickhouse's cleanup: rows are scoped to this run's

--- a/packages/ch-schema/tsconfig.json
+++ b/packages/ch-schema/tsconfig.json
@@ -4,6 +4,6 @@
 		"noEmit": true,
 		"types": ["bun-types"]
 	},
-	"include": ["src"],
+	"include": ["src", "scripts/chcli-connect.ts"],
 	"exclude": ["src/generated"]
 }

--- a/packages/sql-schema/package.json
+++ b/packages/sql-schema/package.json
@@ -12,9 +12,7 @@
 		"check-types": "tsc --noEmit",
 		"drizzle:check": "drizzle-kit check",
 		"drizzle:generate": "drizzle-kit generate",
-		"migrate": "bun run src/migrate.ts",
-		"migrate:ci": "doppler run --project rudel --config ci -- bun run src/migrate.ts",
-		"migrate:prd": "doppler run --project rudel --config prd -- bun run src/migrate.ts"
+		"migrate": "bun run src/migrate.ts"
 	},
 	"dependencies": {
 		"drizzle-orm": "0.45.1",

--- a/scripts/chkit-link.ts
+++ b/scripts/chkit-link.ts
@@ -2,9 +2,6 @@ import { execSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 
-const CHKIT_PATH =
-	process.env.CHKIT_PATH || "/Users/marc/Workspace/chkit";
-
 const PACKAGE_MAP: Record<string, string> = {
 	chkit: "cli",
 	"@chkit/core": "core",
@@ -29,8 +26,16 @@ if (mode !== "link" && mode !== "unlink") {
 const rootPkg = JSON.parse(readFileSync(ROOT_PKG_PATH, "utf-8"));
 
 if (mode === "link") {
+	const chkitPath = process.env.CHKIT_PATH?.trim();
+	if (!chkitPath) {
+		console.error(
+			"CHKIT_PATH is required. Set it to the root of your local chkit checkout.",
+		);
+		process.exit(1);
+	}
+
 	for (const [pkg, dir] of Object.entries(PACKAGE_MAP)) {
-		const absPath = join(CHKIT_PATH, "packages", dir);
+		const absPath = join(chkitPath, "packages", dir);
 		const relPath = relative(ROOT, absPath);
 		rootPkg.overrides[pkg] = `file:${relPath}`;
 	}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,29 @@
+{
+	"version": 1,
+	"skills": {
+		"clickhouse-architecture-advisor": {
+			"source": "clickhouse/agent-skills",
+			"sourceType": "github",
+			"skillPath": "skills/clickhouse-architecture-advisor/SKILL.md",
+			"computedHash": "5cecc53a1aa47ff41f84b7f984c1242d70af09b8bbce4f52d423dd5a06f5ae0b"
+		},
+		"clickhouse-best-practices": {
+			"source": "clickhouse/agent-skills",
+			"sourceType": "github",
+			"skillPath": "skills/clickhouse-best-practices/SKILL.md",
+			"computedHash": "4523a31bd5911ec70b68533d7d15bc445bca2e77b1bd6f649d5a36d52bdcc099"
+		},
+		"clickhouse-js-node-coding": {
+			"source": "clickhouse/agent-skills",
+			"sourceType": "github",
+			"skillPath": "skills/clickhouse-js-node-coding/SKILL.md",
+			"computedHash": "0a1de8c68328512c8c6e40e57a976dcf793c70cc71912cd261db6ff65ced257f"
+		},
+		"clickhouse-js-node-troubleshooting": {
+			"source": "clickhouse/agent-skills",
+			"sourceType": "github",
+			"skillPath": "skills/clickhouse-js-node-troubleshooting/SKILL.md",
+			"computedHash": "5b07cae87b545082c9c651638b842ff58092105fac45ecbe1e20200c1d306256"
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Remove Doppler and production aliases from ClickHouse, SQL schema, API, and test scripts; rely on shell or .env configuration.
- Add a shell-free chcli URL adapter, declare the local chcli dependency, and require CHKIT_PATH for local linking.
- Refresh documentation and agent guidance, and vendor the four official ClickHouse agent skills with lock metadata for Claude and Codex discovery.

## Test plan
- [x] bun run verify — 16/16 tasks passed
- [x] Focused chcli URL mapping, argument forwarding, exit-code, secret-safety, and local-binary checks
- [ ] Docker-local startup, migrations, and signup — skipped by request