### PR TITLE
fix(api): pass lookup limits through Turbo dev

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -9,6 +9,16 @@ BETTER_AUTH_SECRET=
 # ALLOWED_ORIGIN=http://localhost:4011
 # TRUSTED_ORIGINS=http://localhost:4011,http://127.0.0.1:4011,http://localhost:4015
 
+# Number of trusted reverse proxies in front of the API, or in front of Fly
+# Proxy. Leave at 0 for direct connections and direct Fly deployments.
+# TRUSTED_PROXY_HOPS=0
+
+# Anonymous Wrapped share lookup limits per API process.
+# RATE_LIMIT_WRAPPED_SHARE_LOOKUP_MAX=180
+# RATE_LIMIT_WRAPPED_SHARE_LOOKUP_WINDOW=60
+# RATE_LIMIT_WRAPPED_SHARE_LOOKUP_CAPACITY=5000
+# RATE_LIMIT_WRAPPED_SHARE_LOOKUP_SOURCE_MAX=600
+
 # ClickHouse (get hosted credentials at https://obsessiondb.com)
 CLICKHOUSE_URL=http://localhost:8123
 CLICKHOUSE_USERNAME=default

--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -1,6 +1,16 @@
 {
 	"extends": ["//"],
 	"tasks": {
+		"dev": {
+			"passThroughEnv": [
+				"$TURBO_EXTENDS$",
+				"TRUSTED_PROXY_HOPS",
+				"RATE_LIMIT_WRAPPED_SHARE_LOOKUP_MAX",
+				"RATE_LIMIT_WRAPPED_SHARE_LOOKUP_WINDOW",
+				"RATE_LIMIT_WRAPPED_SHARE_LOOKUP_CAPACITY",
+				"RATE_LIMIT_WRAPPED_SHARE_LOOKUP_SOURCE_MAX"
+			]
+		},
 		"test": {},
 		"test:integration": {
 			"passThroughEnv": [


### PR DESCRIPTION
## Summary

- Preserve inherited database variables while forwarding trusted-proxy and Wrapped lookup-limiter settings through the API development task.
- Document the forwarded settings and defaults in the API environment template.

## Test plan

- [x] `bun run verify`
- [x] Confirmed `turbo run dev --filter=@rudel/api --dry=json` resolves all inherited and added variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
