### PR TITLE
fix: bound Wrapped share API and renderer resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Verify
         run: bun run turbo run lint check-types test build
 
+      - name: Verify Wrapped resource budget in Chrome
+        run: bun run --cwd apps/web test:wrapped:chrome
+
   integration:
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,7 @@
 		"check-types": "tsc --noEmit",
 		"test": "bun test",
 		"test:clickhouse": "bun test src/__tests__/clickhouse.integration.ts",
-		"test:integration": "bun test --max-concurrency=1 ./src/__tests__/ingest-clickhouse.integration.ts ./src/__tests__/ingest-rate-limit.integration.ts ./src/__tests__/session-ingest-content.integration.ts ./src/__tests__/clickhouse.integration.ts ./src/__tests__/clickhouse-credentials.integration.ts ./src/__tests__/delete-sessions.integration.ts ./src/__tests__/deletion-data-loss.integration.ts ./src/__tests__/session-sharing.integration.ts ./src/__tests__/session-analytics-values.integration.ts ./src/__tests__/team-invite-link.integration.ts ./src/__tests__/wrapped-share-rate-limit.integration.ts",
+		"test:integration": "bun test --max-concurrency=1 ./src/__tests__/ingest-clickhouse.integration.ts ./src/__tests__/ingest-rate-limit.integration.ts ./src/__tests__/session-ingest-content.integration.ts ./src/__tests__/clickhouse.integration.ts ./src/__tests__/clickhouse-credentials.integration.ts ./src/__tests__/delete-sessions.integration.ts ./src/__tests__/deletion-data-loss.integration.ts ./src/__tests__/session-sharing.integration.ts ./src/__tests__/session-analytics-values.integration.ts ./src/__tests__/team-invite-link.integration.ts ./src/__tests__/wrapped-share-rate-limit.integration.ts ./src/__tests__/wrapped-share-resource-budget.integration.ts",
 		"test:analytics": "bun test src/__tests__/session-analytics-values.integration.ts",
 		"test:migrate": "bun test src/__tests__/migrate-sessions.integration.ts",
 		"test:delete-sessions": "bun test src/__tests__/delete-sessions.integration.ts"

--- a/apps/api/src/__tests__/helpers/api-test-server.ts
+++ b/apps/api/src/__tests__/helpers/api-test-server.ts
@@ -4,6 +4,7 @@ const MONOREPO_ROOT = resolve(import.meta.dir, "..", "..", "..", "..", "..");
 
 export interface ApiTestServer {
 	baseUrl: string;
+	pid: number;
 	readOutput: () => string;
 	stop: () => Promise<void>;
 }
@@ -38,6 +39,7 @@ export async function startApiTestServer(
 
 	return {
 		baseUrl: `http://localhost:${port}`,
+		pid: processHandle.pid,
 		readOutput() {
 			return processOutput;
 		},

--- a/apps/api/src/__tests__/wrapped-share-card-image.test.ts
+++ b/apps/api/src/__tests__/wrapped-share-card-image.test.ts
@@ -76,17 +76,15 @@ describe("wrapped share card image", () => {
 	});
 
 	test("serves only the browser-captured social image for OG cards", () => {
-		const snapshot = {
-			...sampleSnapshot,
-			socialImageDataUrl: SAMPLE_SOCIAL_IMAGE_DATA_URL,
-		};
-		const png = getWrappedShareCardImagePng(snapshot);
+		const png = getWrappedShareCardImagePng(SAMPLE_SOCIAL_IMAGE_DATA_URL);
 
 		expect(png).not.toBeNull();
 		expect([...(png ?? new Uint8Array()).subarray(0, 8)]).toEqual([
 			137, 80, 78, 71, 13, 10, 26, 10,
 		]);
-		expect(getWrappedShareCardImageMetadata(snapshot)).toEqual({
+		expect(
+			getWrappedShareCardImageMetadata(SAMPLE_SOCIAL_IMAGE_DATA_URL),
+		).toEqual({
 			height: 1,
 			type: "image/png",
 			width: 1,
@@ -94,8 +92,8 @@ describe("wrapped share card image", () => {
 	});
 
 	test("does not fall back to the server SVG card for OG images", () => {
-		expect(getWrappedShareCardImagePng(sampleSnapshot)).toBeNull();
-		expect(getWrappedShareCardImageMetadata(sampleSnapshot)).toBeNull();
+		expect(getWrappedShareCardImagePng(null)).toBeNull();
+		expect(getWrappedShareCardImageMetadata(null)).toBeNull();
 	});
 });
 

--- a/apps/api/src/__tests__/wrapped-share-resource-budget.integration.ts
+++ b/apps/api/src/__tests__/wrapped-share-resource-budget.integration.ts
@@ -1,0 +1,625 @@
+import {
+	afterAll,
+	beforeAll,
+	describe,
+	expect,
+	setDefaultTimeout,
+	test,
+} from "bun:test";
+import assert from "node:assert/strict";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+	getWrappedShareSnapshotByteLength,
+	WRAPPED_SHARE_RESOURCE_LIMITS,
+	WRAPPED_SHARE_SOCIAL_IMAGE_DATA_URL_MAX_LENGTH,
+	type WrappedShareSnapshot,
+} from "@rudel/api-routes";
+import postgres from "postgres";
+import { sqlClient } from "../db.js";
+import {
+	type ApiTestServer,
+	startApiTestServer,
+} from "./helpers/api-test-server.js";
+
+const CONNECTION_STRING = process.env.PG_CONNECTION_STRING;
+if (!CONNECTION_STRING) {
+	throw new Error("PG_CONNECTION_STRING environment variable is required");
+}
+
+const TEST_RUN_ID = `wrapped_resource_${Date.now()}_${randomUUID()}`;
+const TEST_EMAIL = `${TEST_RUN_ID}@example.com`;
+const TEST_PASSWORD = "wrapped-resource-budget-test-password";
+const LOOKUP_REQUEST_COUNT = 1_000;
+const LOOKUP_CONCURRENCY = 25;
+const MAXIMUM_RSS_GROWTH_BYTES = 128 * 1024 * 1024;
+const MAXIMUM_LOOKUP_P95_MS = 1_500;
+const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10] as const;
+const migrationSchemas: string[] = [];
+const exactSnapshot = createExactSnapshotByteLimit();
+const exactImageBytes = createPngBytes(
+	WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes,
+);
+const exactImageDataUrl = createPngDataUrl(exactImageBytes);
+
+let api: ApiTestServer;
+let authToken: string;
+let shareId: string;
+let userId: string;
+
+setDefaultTimeout(120_000);
+
+beforeAll(async () => {
+	api = await startApiTestServer({
+		RATE_LIMIT_WRAPPED_SHARE_LOOKUP_CAPACITY: "2500",
+		RATE_LIMIT_WRAPPED_SHARE_LOOKUP_MAX: "1500",
+		RATE_LIMIT_WRAPPED_SHARE_LOOKUP_SOURCE_MAX: "1500",
+		STATIC_DIR: "../../apps/web",
+	});
+
+	const signupResponse = await fetch(`${api.baseUrl}/api/auth/sign-up/email`, {
+		body: JSON.stringify({
+			email: TEST_EMAIL,
+			name: "Wrapped Resource Budget",
+			password: TEST_PASSWORD,
+		}),
+		headers: { "Content-Type": "application/json" },
+		method: "POST",
+	});
+	expect(signupResponse.ok).toBe(true);
+	const signupBody: unknown = await signupResponse.json();
+	assert(isAuthResponse(signupBody));
+	authToken = signupBody.token;
+
+	const meResponse = await callRpc(api.baseUrl, "me", undefined, authToken);
+	expect(meResponse.status).toBe(200);
+	userId = readRpcStringProperty(meResponse.body, "id");
+
+	expect(getWrappedShareSnapshotByteLength(exactSnapshot)).toBe(
+		WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes,
+	);
+	const createResponse = await callRpc(
+		api.baseUrl,
+		"wrappedShare/create",
+		{
+			snapshot: exactSnapshot,
+			socialImageDataUrl: exactImageDataUrl,
+			variant: "normal",
+		},
+		authToken,
+	);
+	expect(createResponse.status).toBe(200);
+	shareId = readRpcStringProperty(createResponse.body, "id");
+});
+
+afterAll(async () => {
+	await api?.stop();
+
+	for (const schemaName of migrationSchemas) {
+		await sqlClient.unsafe(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+	}
+
+	if (userId) {
+		await sqlClient`DELETE FROM organization WHERE id = ${userId}`;
+		await sqlClient`DELETE FROM "user" WHERE id = ${userId}`;
+	}
+});
+
+describe("wrapped share PostgreSQL migration", () => {
+	test("extracts only bounded images and leaves malformed legacy JSON deployable", async () => {
+		const schemaName = `wrapped_migration_${randomUUID().replaceAll("-", "")}`;
+		migrationSchemas.push(schemaName);
+		const migrationClient = postgres(CONNECTION_STRING, {
+			max: 1,
+			prepare: false,
+		});
+		const migrationPath = resolve(
+			import.meta.dir,
+			"../../../../packages/sql-schema/db/migrations/0019_wrapped_share_social_image.sql",
+		);
+		const migrationSql = await readFile(migrationPath, "utf8");
+		const fiveMiBImage = createPngDataUrl(createPngBytes(5 * 1024 * 1024));
+		const oneByteOverImage = createPngDataUrl(
+			createPngBytes(WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes + 1),
+		);
+		const oversizedLegacySnapshot = createLegacySnapshotAtByteLength(
+			fiveMiBImage,
+			7.25 * 1024 * 1024,
+		);
+		const exactImageSnapshot = JSON.stringify({
+			marker: "exact",
+			socialImageDataUrl: exactImageDataUrl,
+		});
+		const overImageSnapshot = JSON.stringify({
+			marker: "over",
+			socialImageDataUrl: oneByteOverImage,
+		});
+
+		await migrationClient.unsafe(`CREATE SCHEMA "${schemaName}"`);
+		await migrationClient.unsafe(
+			`CREATE TABLE "${schemaName}".wrapped_share (id text PRIMARY KEY, snapshot_json text NOT NULL)`,
+		);
+		await migrationClient.unsafe(
+			`
+				INSERT INTO "${schemaName}".wrapped_share (id, snapshot_json)
+				VALUES
+					($1, $2),
+					($3, $4),
+					($5, $6),
+					($7, $8),
+					($9, $10)
+			`,
+			[
+				"legacy-oversized",
+				oversizedLegacySnapshot,
+				"exact-image",
+				exactImageSnapshot,
+				"over-image",
+				overImageSnapshot,
+				"malformed",
+				"{not-json",
+				"no-image",
+				JSON.stringify({ marker: "no-image" }),
+			],
+		);
+		await migrationClient.unsafe(`SET search_path TO "${schemaName}"`);
+		await migrationClient.unsafe(migrationSql);
+
+		const rows = await migrationClient.unsafe<
+			Array<{
+				id: string;
+				snapshot_json: string;
+				social_image_data_url: string | null;
+			}>
+		>(
+			`
+				SELECT id, snapshot_json, social_image_data_url
+				FROM "${schemaName}".wrapped_share
+				ORDER BY id
+			`,
+		);
+		await migrationClient.end();
+
+		const exactImageRow = rows.find((row) => row.id === "exact-image");
+		const legacyOversizedRow = rows.find(
+			(row) => row.id === "legacy-oversized",
+		);
+		const malformedRow = rows.find((row) => row.id === "malformed");
+		const noImageRow = rows.find((row) => row.id === "no-image");
+		const overImageRow = rows.find((row) => row.id === "over-image");
+		assert(exactImageRow);
+		assert(legacyOversizedRow);
+		assert(malformedRow);
+		assert(noImageRow);
+		assert(overImageRow);
+
+		expect(Buffer.byteLength(oversizedLegacySnapshot)).toBe(7.25 * 1024 * 1024);
+		expect(exactImageRow.social_image_data_url).toBe(exactImageDataUrl);
+		expect(exactImageRow.snapshot_json).not.toContain("socialImageDataUrl");
+		expect(legacyOversizedRow.social_image_data_url).toBeNull();
+		expect(legacyOversizedRow.snapshot_json).not.toContain(
+			"socialImageDataUrl",
+		);
+		expect(overImageRow.social_image_data_url).toBeNull();
+		expect(overImageRow.snapshot_json).not.toContain("socialImageDataUrl");
+		expect(malformedRow).toEqual({
+			id: "malformed",
+			snapshot_json: "{not-json",
+			social_image_data_url: null,
+		});
+		expect(noImageRow.snapshot_json).toBe(
+			JSON.stringify({ marker: "no-image" }),
+		);
+		expect(noImageRow.social_image_data_url).toBeNull();
+	});
+});
+
+describe("wrapped share real API resource budget", () => {
+	test("accepts exact limits and rejects one byte over before changing the row", async () => {
+		const [storedShare] = await sqlClient<
+			Array<{
+				imageBytes: number;
+				snapshotBytes: number;
+				snapshotJson: string;
+			}>
+		>`
+			SELECT
+				octet_length(social_image_data_url) AS "imageBytes",
+				octet_length(snapshot_json) AS "snapshotBytes",
+				snapshot_json AS "snapshotJson"
+			FROM wrapped_share
+			WHERE id = ${shareId}
+		`;
+		assert(storedShare);
+		expect(storedShare.snapshotBytes).toBe(
+			WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes,
+		);
+		expect(storedShare.imageBytes).toBe(
+			WRAPPED_SHARE_SOCIAL_IMAGE_DATA_URL_MAX_LENGTH,
+		);
+		expect(storedShare.snapshotJson).not.toContain("socialImageDataUrl");
+
+		const overSnapshot = createOneByteOverSnapshot(exactSnapshot);
+		expect(getWrappedShareSnapshotByteLength(overSnapshot)).toBe(
+			WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes + 1,
+		);
+		const overSnapshotResponse = await callRpc(
+			api.baseUrl,
+			"wrappedShare/create",
+			{
+				snapshot: overSnapshot,
+				socialImageDataUrl: exactImageDataUrl,
+				variant: "normal",
+			},
+			authToken,
+		);
+		expect(overSnapshotResponse.status).toBe(400);
+
+		const overImageDataUrl = createPngDataUrl(
+			Buffer.concat([exactImageBytes, Buffer.of(0)]),
+		);
+		const overImageResponse = await callRpc(
+			api.baseUrl,
+			"wrappedShare/create",
+			{
+				snapshot: exactSnapshot,
+				socialImageDataUrl: overImageDataUrl,
+				variant: "normal",
+			},
+			authToken,
+		);
+		expect(overImageResponse.status).toBe(400);
+
+		const fiveMiBImage = createPngDataUrl(createPngBytes(5 * 1024 * 1024));
+		const legacySnapshot = JSON.parse(
+			createLegacySnapshotAtByteLength(fiveMiBImage, 7.25 * 1024 * 1024),
+		);
+		const legacySnapshotResponse = await callRpc(
+			api.baseUrl,
+			"wrappedShare/create",
+			{
+				snapshot: legacySnapshot,
+				variant: "normal",
+			},
+			authToken,
+		);
+		expect(legacySnapshotResponse.status).toBe(400);
+
+		const [unchangedShare] = await sqlClient<
+			Array<{ imageBytes: number; snapshotBytes: number }>
+		>`
+			SELECT
+				octet_length(social_image_data_url) AS "imageBytes",
+				octet_length(snapshot_json) AS "snapshotBytes"
+			FROM wrapped_share
+			WHERE id = ${shareId}
+		`;
+		expect(unchangedShare).toEqual({
+			imageBytes: WRAPPED_SHARE_SOCIAL_IMAGE_DATA_URL_MAX_LENGTH,
+			snapshotBytes: WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes,
+		});
+	});
+
+	test("keeps the image out of ordinary RPC and page responses", async () => {
+		const rpcResponse = await callRpc(api.baseUrl, "wrappedShare/getPublic", {
+			shareId,
+		});
+		expect(rpcResponse.status).toBe(200);
+		expect(rpcResponse.bodyText).not.toContain("socialImageDataUrl");
+		expect(rpcResponse.bodyText).not.toContain("data:image/png;base64,");
+		expect(Buffer.byteLength(rpcResponse.bodyText)).toBeLessThanOrEqual(
+			WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes + 2_048,
+		);
+
+		const pageResponse = await fetch(`${api.baseUrl}/wrapped/${shareId}`);
+		const pageHtml = await pageResponse.text();
+		expect(pageResponse.status).toBe(200);
+		expect(pageHtml).not.toContain("data:image/png;base64,");
+		expect(pageHtml).toContain(`/wrapped/${shareId}/x-card.png`);
+
+		const imageResponse = await fetch(
+			`${api.baseUrl}/wrapped/${shareId}/x-card.png`,
+		);
+		const imageBytes = Buffer.from(await imageResponse.arrayBuffer());
+		expect(imageResponse.status).toBe(200);
+		expect(imageBytes.byteLength).toBe(
+			WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes,
+		);
+		expect(hashBytes(imageBytes)).toBe(hashBytes(exactImageBytes));
+	});
+
+	test("does not touch social-image TOAST blocks on ordinary database projections", async () => {
+		const toastRelationBytes = await readWrappedShareToastRelationBytes();
+		expect(toastRelationBytes).toBeGreaterThan(
+			WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes,
+		);
+
+		const beforeOrdinaryReads = await readWrappedShareToastBlocks();
+		const ordinaryClient = postgres(CONNECTION_STRING, {
+			max: 1,
+			prepare: false,
+		});
+		await ordinaryClient`
+			SELECT snapshot_json
+			FROM wrapped_share
+			WHERE id = ${shareId}
+				AND octet_length(snapshot_json) <= ${WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes}
+		`;
+		await ordinaryClient`
+			SELECT social_image_data_url IS NOT NULL AS "hasSocialImage"
+			FROM wrapped_share
+			WHERE id = ${shareId}
+				AND octet_length(snapshot_json) <= ${WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes}
+		`;
+		await ordinaryClient.end();
+		const afterOrdinaryReads = await readWrappedShareToastBlocks();
+		expect(afterOrdinaryReads).toBe(beforeOrdinaryReads);
+
+		const imageClient = postgres(CONNECTION_STRING, {
+			max: 1,
+			prepare: false,
+		});
+		await imageClient`
+			SELECT
+				CASE
+					WHEN octet_length(social_image_data_url) <= ${WRAPPED_SHARE_SOCIAL_IMAGE_DATA_URL_MAX_LENGTH}
+						THEN social_image_data_url
+					ELSE NULL
+				END AS "socialImageDataUrl"
+			FROM wrapped_share
+			WHERE id = ${shareId}
+		`;
+		await imageClient.end();
+		const afterImageRead = await readWrappedShareToastBlocks();
+		expect(afterImageRead).toBeGreaterThan(afterOrdinaryReads);
+	});
+
+	test("keeps p95 latency, response bytes, and API memory bounded under load", async () => {
+		for (let request = 0; request < LOOKUP_CONCURRENCY; request += 1) {
+			const warmup = await callPublicShare(api.baseUrl, shareId);
+			expect(warmup.status).toBe(200);
+		}
+
+		const rssBefore = readProcessRssBytes(api.pid);
+		const results: PublicLookupResult[] = [];
+
+		for (
+			let offset = 0;
+			offset < LOOKUP_REQUEST_COUNT;
+			offset += LOOKUP_CONCURRENCY
+		) {
+			const batchSize = Math.min(
+				LOOKUP_CONCURRENCY,
+				LOOKUP_REQUEST_COUNT - offset,
+			);
+			const batch = await Promise.all(
+				Array.from({ length: batchSize }, () =>
+					callPublicShare(api.baseUrl, shareId),
+				),
+			);
+			results.push(...batch);
+		}
+
+		const rssAfter = readProcessRssBytes(api.pid);
+		const sortedDurations = results
+			.map((result) => result.durationMs)
+			.sort((left, right) => left - right);
+		const p95Index = Math.ceil(sortedDurations.length * 0.95) - 1;
+		const p95Duration = sortedDurations[p95Index];
+		assert(p95Duration !== undefined);
+
+		expect(results).toHaveLength(LOOKUP_REQUEST_COUNT);
+		expect(results.every((result) => result.status === 200)).toBe(true);
+		expect(
+			results.every(
+				(result) =>
+					result.responseBytes <=
+					WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes + 2_048,
+			),
+		).toBe(true);
+		expect(p95Duration).toBeLessThan(MAXIMUM_LOOKUP_P95_MS);
+		expect(rssAfter - rssBefore).toBeLessThan(MAXIMUM_RSS_GROWTH_BYTES);
+	});
+});
+
+interface RpcCallResult {
+	body: unknown;
+	bodyText: string;
+	status: number;
+}
+
+interface PublicLookupResult {
+	durationMs: number;
+	responseBytes: number;
+	status: number;
+}
+
+async function callRpc(
+	baseUrl: string,
+	path: string,
+	input: Record<string, unknown> | undefined,
+	token?: string,
+): Promise<RpcCallResult> {
+	const response = await fetch(`${baseUrl}/rpc/${path}`, {
+		body: JSON.stringify(input ? { json: input } : {}),
+		headers: {
+			...(token ? { Authorization: `Bearer ${token}` } : {}),
+			"Content-Type": "application/json",
+		},
+		method: "POST",
+	});
+	const bodyText = await response.text();
+
+	return {
+		body: JSON.parse(bodyText),
+		bodyText,
+		status: response.status,
+	};
+}
+
+async function callPublicShare(
+	baseUrl: string,
+	publicShareId: string,
+): Promise<PublicLookupResult> {
+	const startedAt = performance.now();
+	const response = await fetch(`${baseUrl}/rpc/wrappedShare/getPublic`, {
+		body: JSON.stringify({ json: { shareId: publicShareId } }),
+		headers: { "Content-Type": "application/json" },
+		method: "POST",
+	});
+	const responseBytes = (await response.arrayBuffer()).byteLength;
+
+	return {
+		durationMs: performance.now() - startedAt,
+		responseBytes,
+		status: response.status,
+	};
+}
+
+function createExactSnapshotByteLimit(): WrappedShareSnapshot {
+	const text = "界".repeat(250);
+	const maximumText = `${text}${"界".repeat(6)}`;
+	const backMetrics = Array.from({ length: 20 }, (_, index) => ({
+		label: index * 2 < 17 ? maximumText : text,
+		value: index * 2 + 1 < 17 ? maximumText : text,
+	}));
+
+	return {
+		archetypeLabel: maximumText,
+		backMetrics,
+		headerLeftMetric: { label: text, title: text, value: text },
+		headerRightMetric: { label: text, title: text, value: text },
+		row: {
+			activeDays: 6,
+			cost: 42,
+			displayName: text,
+			favoriteModel: text,
+			hasActivity: true,
+			imageUrl: "界".repeat(WRAPPED_SHARE_RESOURCE_LIMITS.imageUrlLength),
+			inputTokens: 120,
+			lastActiveDate: text,
+			outputTokens: 240,
+			role: text,
+			totalSessions: 12,
+			totalTokens: 360,
+		},
+		shellClassName: "界".repeat(WRAPPED_SHARE_RESOURCE_LIMITS.classNameLength),
+		statItems: Array.from(
+			{ length: WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount },
+			(_, index) => ({
+				key: `stat-${index}`,
+				label: text,
+				title: text,
+				value: text,
+			}),
+		),
+		theme: "light",
+	};
+}
+
+function createOneByteOverSnapshot(
+	snapshot: WrappedShareSnapshot,
+): WrappedShareSnapshot {
+	return {
+		...snapshot,
+		row: {
+			...snapshot.row,
+			displayName: `${snapshot.row.displayName}x`,
+		},
+	};
+}
+
+function createPngBytes(byteLength: number) {
+	const bytes = randomBytes(byteLength);
+	bytes.set(PNG_SIGNATURE);
+	return bytes;
+}
+
+function createPngDataUrl(bytes: Uint8Array) {
+	return `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`;
+}
+
+function createLegacySnapshotAtByteLength(
+	socialImageDataUrl: string,
+	targetBytes: number,
+) {
+	const snapshot = {
+		marker: "legacy-oversized",
+		padding: "",
+		socialImageDataUrl,
+	};
+	const emptyPaddingJson = JSON.stringify(snapshot);
+	const paddingBytes = targetBytes - Buffer.byteLength(emptyPaddingJson);
+	if (paddingBytes < 0) {
+		throw new Error("Legacy fixture target is smaller than its social image");
+	}
+
+	return JSON.stringify({
+		...snapshot,
+		padding: "x".repeat(paddingBytes),
+	});
+}
+
+async function readWrappedShareToastRelationBytes() {
+	const [row] = await sqlClient<Array<{ bytes: string | number }>>`
+		SELECT pg_total_relation_size(reltoastrelid) AS bytes
+		FROM pg_class
+		WHERE oid = to_regclass('public.wrapped_share')
+	`;
+	assert(row);
+	return Number(row.bytes);
+}
+
+async function readWrappedShareToastBlocks() {
+	const [row] = await sqlClient<Array<{ blocks: string | number }>>`
+		SELECT
+			COALESCE(toast_blks_read, 0) + COALESCE(toast_blks_hit, 0) AS blocks
+		FROM pg_statio_user_tables
+		WHERE schemaname = 'public'
+			AND relname = 'wrapped_share'
+	`;
+	assert(row);
+	return Number(row.blocks);
+}
+
+function readProcessRssBytes(pid: number) {
+	const result = Bun.spawnSync(["ps", "-o", "rss=", "-p", String(pid)]);
+	expect(result.exitCode).toBe(0);
+	const rssKiB = Number(new TextDecoder().decode(result.stdout).trim());
+	expect(Number.isFinite(rssKiB)).toBe(true);
+	return rssKiB * 1024;
+}
+
+function hashBytes(bytes: Uint8Array) {
+	return createHash("sha256").update(bytes).digest("hex");
+}
+
+function isAuthResponse(value: unknown): value is { token: string } {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"token" in value &&
+		typeof value.token === "string"
+	);
+}
+
+function readRpcStringProperty(body: unknown, property: string) {
+	if (
+		typeof body !== "object" ||
+		body === null ||
+		!("json" in body) ||
+		typeof body.json !== "object" ||
+		body.json === null
+	) {
+		throw new Error(`RPC response is missing string property: ${property}`);
+	}
+
+	const value = Reflect.get(body.json, property);
+
+	if (typeof value !== "string") {
+		throw new Error(`RPC response is missing string property: ${property}`);
+	}
+
+	return value;
+}

--- a/apps/api/src/__tests__/wrapped-share.service.test.ts
+++ b/apps/api/src/__tests__/wrapped-share.service.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import assert from "node:assert";
-import type { WrappedShareSnapshot } from "@rudel/api-routes";
+import {
+	getWrappedShareSnapshotByteLength,
+	WRAPPED_SHARE_RESOURCE_LIMITS,
+	type WrappedShareSnapshot,
+} from "@rudel/api-routes";
 import {
 	WRAPPED_SHARE_LOOKUP_MAX_REQUESTS,
 	WRAPPED_SHARE_LOOKUP_SOURCE_MAX_REQUESTS,
@@ -47,6 +51,7 @@ mock.module("../db.js", () => ({
 const {
 	createWrappedShare,
 	getPublicWrappedShare,
+	getPublicWrappedShareForPageMetadata,
 	getPublicWrappedShareWithSocialImage,
 } = await import("../services/wrapped-share.service.js");
 
@@ -81,6 +86,25 @@ describe("wrapped share service", () => {
 		expect(getSqlQuery(2).values[0]).toBe("evren");
 	});
 
+	test("persists the social image outside the replay snapshot", async () => {
+		insertRows = [{ id: "evren" }];
+		const socialImageDataUrl = createSocialImageDataUrl(3);
+
+		await createWrappedShare({
+			organizationId: "org-1",
+			snapshot: createSnapshot({ displayName: "Evren" }),
+			socialImageDataUrl,
+			userId: "user-1",
+			variant: "normal",
+		});
+
+		const insertQuery = getSqlQuery(2);
+		const snapshotJson = insertQuery.values[3];
+		assert.strictEqual(typeof snapshotJson, "string");
+		expect(insertQuery.values[4]).toBe(socialImageDataUrl);
+		expect(snapshotJson).not.toContain("socialImageDataUrl");
+	});
+
 	test("keeps the same link for later creates by the same user", async () => {
 		const existingCreatedAt = "2026-04-22T10:00:00.000Z";
 		selectRows = [{ createdAt: existingCreatedAt, id: "evren" }];
@@ -97,8 +121,8 @@ describe("wrapped share service", () => {
 		expect(record.created_at).toBe(existingCreatedAt);
 		expect(sqlQueries).toHaveLength(2);
 		expect(getSqlQuery(1).sql.startsWith("UPDATE wrapped_share")).toBe(true);
-		expect(getSqlQuery(1).values[4]).toBe("evren");
-		expect(getSqlQuery(1).values[5]).toBe("user-1");
+		expect(getSqlQuery(1).values[5]).toBe("evren");
+		expect(getSqlQuery(1).values[6]).toBe("user-1");
 	});
 
 	test("renames a legacy uuid link to the card name for the same user", async () => {
@@ -126,8 +150,8 @@ describe("wrapped share service", () => {
 		]);
 		expect(getSqlQuery(2).sql.startsWith("UPDATE wrapped_share")).toBe(true);
 		expect(getSqlQuery(2).values[0]).toBe("evren");
-		expect(getSqlQuery(2).values[5]).toBe(legacyShareId);
-		expect(getSqlQuery(2).values[6]).toBe("user-1");
+		expect(getSqlQuery(2).values[6]).toBe(legacyShareId);
+		expect(getSqlQuery(2).values[7]).toBe("user-1");
 	});
 
 	test("hydrates an older public share without an image from the account profile", async () => {
@@ -192,6 +216,23 @@ describe("wrapped share service", () => {
 			getPublicWrappedShareWithSocialImage(shareId, source),
 		).rejects.toThrow("Wrapped share lookup is temporarily rate limited");
 		expect(sqlQueries).toHaveLength(WRAPPED_SHARE_LOOKUP_MAX_REQUESTS);
+
+		const pageShareId = `throttled-page-share-${crypto.randomUUID()}`;
+		const pageSource = `throttled-page-source-${crypto.randomUUID()}`;
+
+		for (
+			let request = 0;
+			request < WRAPPED_SHARE_LOOKUP_MAX_REQUESTS;
+			request += 1
+		) {
+			await getPublicWrappedShareForPageMetadata(pageShareId, pageSource);
+		}
+
+		expect(sqlQueries).toHaveLength(WRAPPED_SHARE_LOOKUP_MAX_REQUESTS * 2);
+		await expect(
+			getPublicWrappedShareForPageMetadata(pageShareId, pageSource),
+		).rejects.toThrow("Wrapped share lookup is temporarily rate limited");
+		expect(sqlQueries).toHaveLength(WRAPPED_SHARE_LOOKUP_MAX_REQUESTS * 2);
 	});
 
 	test("rejects source churn before loading another attacker-chosen ID", async () => {
@@ -213,6 +254,186 @@ describe("wrapped share service", () => {
 			getPublicWrappedShare(`churning-share-${crypto.randomUUID()}`, source),
 		).rejects.toThrow("Wrapped share lookup is temporarily rate limited");
 		expect(sqlQueries).toHaveLength(WRAPPED_SHARE_LOOKUP_SOURCE_MAX_REQUESTS);
+	});
+
+	test("loads the largest supported public card without selecting its social image", async () => {
+		selectRows = [
+			{
+				createdAt: "2026-04-22T10:00:00.000Z",
+				expiresAt: new Date(Date.now() + 60_000).toISOString(),
+				id: "evren",
+				payloadVersion: 1,
+				snapshotJson: JSON.stringify(
+					createSnapshot({
+						backMetricCount: WRAPPED_SHARE_RESOURCE_LIMITS.backMetricCount,
+						displayName: "Evren",
+						statItemCount: WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount,
+					}),
+				),
+				socialImageDataUrl: createSocialImageDataUrl(
+					WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes,
+				),
+				userImage: null,
+			},
+		];
+
+		const share = await getPublicWrappedShare(
+			"evren",
+			WRAPPED_SHARE_TEST_SOURCE,
+		);
+
+		assert(share);
+		expect(share.snapshot.statItems).toHaveLength(
+			WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount,
+		);
+		expect(share.snapshot.backMetrics).toHaveLength(
+			WRAPPED_SHARE_RESOURCE_LIMITS.backMetricCount,
+		);
+		expect(getSqlQuery(0).sql).toContain(
+			"octet_length(wrapped_share.snapshot_json)",
+		);
+		expect(getSqlQuery(0).sql).not.toContain("social_image_data_url");
+		expect(getSqlQuery(0).values).toEqual([
+			"evren",
+			WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes,
+		]);
+	});
+
+	test("loads the social image only for the specialized card-image lookup", async () => {
+		const socialImageDataUrl = createSocialImageDataUrl(
+			WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes,
+		);
+		selectRows = [
+			{
+				createdAt: "2026-04-22T10:00:00.000Z",
+				expiresAt: new Date(Date.now() + 60_000).toISOString(),
+				id: "evren",
+				payloadVersion: 1,
+				snapshotJson: JSON.stringify(createSnapshot({ displayName: "Evren" })),
+				socialImageDataUrl,
+				userImage: null,
+			},
+		];
+
+		const share = await getPublicWrappedShareWithSocialImage(
+			"evren",
+			WRAPPED_SHARE_TEST_SOURCE,
+		);
+
+		assert(share);
+		expect(share.socialImageDataUrl).toBe(socialImageDataUrl);
+		expect(getSqlQuery(0).sql).toContain("social_image_data_url");
+		expect(getSqlQuery(0).sql).toContain(
+			"octet_length(wrapped_share.social_image_data_url)",
+		);
+	});
+
+	test("checks image availability for page metadata without selecting the blob", async () => {
+		selectRows = [
+			{
+				createdAt: "2026-04-22T10:00:00.000Z",
+				expiresAt: new Date(Date.now() + 60_000).toISOString(),
+				hasSocialImage: true,
+				id: "evren",
+				payloadVersion: 1,
+				snapshotJson: JSON.stringify(createSnapshot({ displayName: "Evren" })),
+				userImage: null,
+			},
+		];
+
+		const share = await getPublicWrappedShareForPageMetadata(
+			"evren",
+			WRAPPED_SHARE_TEST_SOURCE,
+		);
+
+		assert(share);
+		expect(share.hasSocialImage).toBe(true);
+		expect(getSqlQuery(0).sql).toContain(
+			'wrapped_share.social_image_data_url IS NOT NULL AS "hasSocialImage"',
+		);
+		expect(getSqlQuery(0).sql).not.toContain('AS "socialImageDataUrl"');
+	});
+
+	test("fails closed when a legacy row has one stat item over the limit", async () => {
+		selectRows = [
+			{
+				createdAt: "2026-04-22T10:00:00.000Z",
+				expiresAt: new Date(Date.now() + 60_000).toISOString(),
+				id: "evren",
+				payloadVersion: 1,
+				snapshotJson: JSON.stringify(
+					createSnapshot({
+						displayName: "Evren",
+						statItemCount: WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount + 1,
+					}),
+				),
+				userImage: null,
+			},
+		];
+
+		const share = await getPublicWrappedShare(
+			"evren",
+			WRAPPED_SHARE_TEST_SOURCE,
+		);
+
+		expect(share).toBeNull();
+	});
+
+	test("rejects oversized creation before querying the database", async () => {
+		await expect(
+			createWrappedShare({
+				organizationId: "org-1",
+				snapshot: createSnapshot({
+					displayName: "Evren",
+					statItemCount: WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount + 1,
+				}),
+				userId: "user-1",
+				variant: "normal",
+			}),
+		).rejects.toThrow();
+		expect(sqlQueries).toHaveLength(0);
+	});
+
+	test("rejects aggregate snapshot bytes before querying the database", async () => {
+		const maximumText = "界".repeat(WRAPPED_SHARE_RESOURCE_LIMITS.textLength);
+		const snapshot = createSnapshot({
+			backMetricCount: WRAPPED_SHARE_RESOURCE_LIMITS.backMetricCount,
+			displayName: maximumText,
+			imageUrl: "界".repeat(WRAPPED_SHARE_RESOURCE_LIMITS.imageUrlLength),
+			shellClassName: "界".repeat(
+				WRAPPED_SHARE_RESOURCE_LIMITS.classNameLength,
+			),
+			statItemCount: WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount,
+			text: maximumText,
+		});
+
+		expect(getWrappedShareSnapshotByteLength(snapshot)).toBeGreaterThan(
+			WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes,
+		);
+		await expect(
+			createWrappedShare({
+				organizationId: "org-1",
+				snapshot,
+				userId: "user-1",
+				variant: "normal",
+			}),
+		).rejects.toThrow(/Wrapped share snapshot must be at most/u);
+		expect(sqlQueries).toHaveLength(0);
+	});
+
+	test("rejects an oversized social image before querying the database", async () => {
+		await expect(
+			createWrappedShare({
+				organizationId: "org-1",
+				snapshot: createSnapshot({ displayName: "Evren" }),
+				socialImageDataUrl: createSocialImageDataUrl(
+					WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes + 1,
+				),
+				userId: "user-1",
+				variant: "normal",
+			}),
+		).rejects.toThrow(/social image must be at most/u);
+		expect(sqlQueries).toHaveLength(0);
 	});
 
 	test("keeps a saved share image ahead of the account profile fallback", async () => {
@@ -553,32 +774,58 @@ describe("wrapped share service", () => {
 });
 
 function createSnapshot(input: {
+	backMetricCount?: number;
 	displayName: string;
 	imageUrl?: string | null;
+	shellClassName?: string;
+	statItemCount?: number;
+	text?: string;
 }): WrappedShareSnapshot {
+	const text = input.text ?? "x";
+
 	return {
-		archetypeLabel: "Builder",
-		backMetrics: [],
-		headerLeftMetric: { label: "Sessions", value: "12" },
-		headerRightMetric: { label: "Days", value: "6" },
+		archetypeLabel: text,
+		backMetrics: Array.from({ length: input.backMetricCount ?? 0 }, () => ({
+			label: text,
+			value: text,
+		})),
+		headerLeftMetric: { label: text, title: text, value: text },
+		headerRightMetric: { label: text, title: text, value: text },
 		row: {
 			activeDays: 6,
 			cost: 42,
 			displayName: input.displayName,
-			favoriteModel: "o3",
+			favoriteModel: text,
 			hasActivity: true,
 			imageUrl: input.imageUrl ?? null,
 			inputTokens: 120,
-			lastActiveDate: "2026-04-22",
+			lastActiveDate: text,
 			outputTokens: 240,
-			role: "Builder",
+			role: text,
 			totalSessions: 12,
 			totalTokens: 360,
 		},
-		shellClassName: "team-lineup-shell",
-		statItems: [],
+		shellClassName: input.shellClassName ?? "team-lineup-shell",
+		statItems: Array.from({ length: input.statItemCount ?? 0 }, (_, index) => ({
+			key: `stat-${index}`,
+			label: text,
+			title: text,
+			value: text,
+		})),
 		theme: "light",
 	};
+}
+
+function createSocialImageDataUrl(byteLength: number) {
+	const prefix = "data:image/png;base64,";
+	const base64Length = Math.ceil(byteLength / 3) * 4;
+	const paddingLength = (3 - (byteLength % 3)) % 3;
+
+	return (
+		prefix +
+		"A".repeat(base64Length - paddingLength) +
+		"=".repeat(paddingLength)
+	);
 }
 
 function getSqlQuery(index: number) {

--- a/apps/api/src/handlers/wrapped-share.ts
+++ b/apps/api/src/handlers/wrapped-share.ts
@@ -18,6 +18,7 @@ const create = os.wrappedShare.create
 
 		const shareOptions = {
 			organizationId: context.organizationId,
+			socialImageDataUrl: input.socialImageDataUrl,
 			snapshot: input.snapshot,
 			userId: context.user.id,
 			variant: input.variant,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -22,11 +22,11 @@ import { setupLogging } from "./logging.js";
 import type { ApiKeyAuthFailure } from "./middleware.js";
 import { getWrappedShareLookupRateLimitMetrics } from "./rate-limit.js";
 import { router } from "./router.js";
-import { getPublicWrappedShareWithSocialImage } from "./services/wrapped-share.service.js";
 import {
-	getWrappedShareCardImageMetadata,
-	getWrappedShareCardImagePng,
-} from "./services/wrapped-share-card-image.js";
+	getPublicWrappedShareForPageMetadata,
+	getPublicWrappedShareWithSocialImage,
+} from "./services/wrapped-share.service.js";
+import { getWrappedShareCardImagePng } from "./services/wrapped-share-card-image.js";
 import {
 	buildWrappedSharePageMetadata,
 	injectWrappedSharePageMetadata,
@@ -449,7 +449,7 @@ async function handleWrappedShareCardImageRequest(input: {
 			return new Response("Not found", { headers: cors, status: 404 });
 		}
 
-		const image = getWrappedShareCardImagePng(share.snapshot);
+		const image = getWrappedShareCardImagePng(share.socialImageDataUrl);
 		if (!image) {
 			return new Response("Not found", { headers: cors, status: 404 });
 		}
@@ -512,7 +512,7 @@ async function handleWrappedPublicPageRequest(input: {
 	const indexHtml = await indexFile.text();
 
 	try {
-		const share = await getPublicWrappedShareWithSocialImage(shareId, source);
+		const share = await getPublicWrappedShareForPageMetadata(shareId, source);
 
 		if (!share) {
 			return new Response(method === "HEAD" ? null : indexHtml, {
@@ -521,20 +521,16 @@ async function handleWrappedPublicPageRequest(input: {
 		}
 
 		const publicUrl = new URL(requestPathname, publicOrigin).toString();
-		const imageMetadata = getWrappedShareCardImageMetadata(share.snapshot);
 		const html = injectWrappedSharePageMetadata(
 			indexHtml,
 			buildWrappedSharePageMetadata({
-				...(imageMetadata
+				...(share.hasSocialImage
 					? {
-							imageHeight: imageMetadata.height,
-							imageType: imageMetadata.type,
 							imageUrl: buildWrappedShareCardImageUrl({
 								publicOrigin,
 								requestPathname,
 								share,
 							}),
-							imageWidth: imageMetadata.width,
 						}
 					: {}),
 				publicUrl,

--- a/apps/api/src/services/wrapped-share-card-image.ts
+++ b/apps/api/src/services/wrapped-share-card-image.ts
@@ -1,5 +1,8 @@
 import { Resvg } from "@resvg/resvg-js";
-import type { WrappedShareSnapshot } from "@rudel/api-routes";
+import {
+	WRAPPED_SHARE_RESOURCE_LIMITS,
+	type WrappedShareSnapshot,
+} from "@rudel/api-routes";
 
 const CARD_WIDTH = 1200;
 const CARD_HEIGHT = 630;
@@ -11,7 +14,6 @@ const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10] as const;
 const PNG_IHDR_WIDTH_OFFSET = 16;
 const PNG_IHDR_HEIGHT_OFFSET = 20;
 const PNG_IHDR_MIN_BYTE_LENGTH = 24;
-const WRAPPED_SHARE_SOCIAL_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
 
 interface WrappedShareCardPalette {
 	accent: string;
@@ -60,14 +62,14 @@ const WRAPPED_SHARE_CARD_PALETTES: Record<
 	},
 };
 
-export function getWrappedShareCardImagePng(snapshot: WrappedShareSnapshot) {
-	return getWrappedShareSocialImagePng(snapshot);
+export function getWrappedShareCardImagePng(socialImageDataUrl: string | null) {
+	return getWrappedShareSocialImagePng(socialImageDataUrl);
 }
 
 export function getWrappedShareCardImageMetadata(
-	snapshot: WrappedShareSnapshot,
+	socialImageDataUrl: string | null,
 ) {
-	const image = getWrappedShareSocialImagePng(snapshot);
+	const image = getWrappedShareSocialImagePng(socialImageDataUrl);
 	const size = image ? getPngImageSize(image) : null;
 
 	if (!size) {
@@ -81,14 +83,16 @@ export function getWrappedShareCardImageMetadata(
 	};
 }
 
-export function getWrappedShareSocialImagePng(snapshot: WrappedShareSnapshot) {
-	const dataUrl = snapshot.socialImageDataUrl;
-
-	if (!dataUrl?.startsWith(SOCIAL_IMAGE_DATA_URL_PREFIX)) {
+export function getWrappedShareSocialImagePng(
+	socialImageDataUrl: string | null,
+) {
+	if (!socialImageDataUrl?.startsWith(SOCIAL_IMAGE_DATA_URL_PREFIX)) {
 		return null;
 	}
 
-	const base64Data = dataUrl.slice(SOCIAL_IMAGE_DATA_URL_PREFIX.length);
+	const base64Data = socialImageDataUrl.slice(
+		SOCIAL_IMAGE_DATA_URL_PREFIX.length,
+	);
 
 	if (!base64Data || !BASE64_DATA_REGEX.test(base64Data)) {
 		return null;
@@ -96,7 +100,7 @@ export function getWrappedShareSocialImagePng(snapshot: WrappedShareSnapshot) {
 
 	const image = Buffer.from(base64Data, "base64");
 
-	if (image.byteLength > WRAPPED_SHARE_SOCIAL_IMAGE_MAX_BYTES) {
+	if (image.byteLength > WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes) {
 		return null;
 	}
 

--- a/apps/api/src/services/wrapped-share.service.ts
+++ b/apps/api/src/services/wrapped-share.service.ts
@@ -8,7 +8,10 @@ import type {
 import {
 	AVATAR_URL_PATH_REGEX,
 	WRAPPED_SHARE_PAYLOAD_VERSION,
+	WRAPPED_SHARE_RESOURCE_LIMITS,
+	WRAPPED_SHARE_SOCIAL_IMAGE_DATA_URL_MAX_LENGTH,
 	WrappedShareSnapshotSchema,
+	WrappedShareSocialImageDataUrlSchema,
 } from "@rudel/api-routes";
 import { sqlClient } from "../db.js";
 import { checkWrappedShareLookupRateLimit } from "../rate-limit.js";
@@ -20,14 +23,38 @@ import {
 
 interface CreateWrappedShareOptions {
 	organizationId: string;
+	socialImageDataUrl?: string;
 	snapshot: WrappedShareSnapshot;
 	userId: string;
 	variant: WrappedShareVariant;
 }
 
-interface PublicWrappedShareWithSocialImage
-	extends Omit<PublicWrappedShare, "snapshot"> {
-	snapshot: WrappedShareSnapshot;
+interface PublicWrappedShareWithSocialImage extends PublicWrappedShare {
+	socialImageDataUrl: string | null;
+}
+
+interface PublicWrappedShareForPageMetadata extends PublicWrappedShare {
+	hasSocialImage: boolean;
+}
+
+interface WrappedShareDatabaseRow {
+	createdAt: Date | string;
+	expiresAt: Date | string;
+	id: string;
+	payloadVersion: number;
+	snapshotJson: string;
+	userImage: string | null;
+	variant: WrappedShareVariant | null;
+}
+
+interface WrappedShareDatabaseRowWithSocialImage
+	extends WrappedShareDatabaseRow {
+	socialImageDataUrl: string | null;
+}
+
+interface WrappedShareDatabaseRowForPageMetadata
+	extends WrappedShareDatabaseRow {
+	hasSocialImage: boolean;
 }
 
 const WRAPPED_SHARE_TTL_DAYS = 30;
@@ -40,7 +67,13 @@ const WRAPPED_SHARE_ID_INSERT_ATTEMPTS = 20;
 export async function createWrappedShare(
 	options: CreateWrappedShareOptions,
 ): Promise<WrappedShareRecord> {
-	const { organizationId, snapshot, userId, variant } = options;
+	const { organizationId, userId, variant } = options;
+	const snapshot = WrappedShareSnapshotSchema.parse(options.snapshot);
+	const socialImageDataUrl =
+		options.socialImageDataUrl === undefined
+			? null
+			: WrappedShareSocialImageDataUrlSchema.parse(options.socialImageDataUrl);
+	const snapshotJson = JSON.stringify(snapshot);
 
 	if (variant === "decimal") {
 		await assertDecimalEntitled(userId);
@@ -67,7 +100,8 @@ export async function createWrappedShare(
 				organizationId,
 				share: existingShare,
 				shareIdBase,
-				snapshot,
+				socialImageDataUrl,
+				snapshotJson,
 				userId,
 				variant,
 			});
@@ -77,7 +111,8 @@ export async function createWrappedShare(
 			expiresAtIso,
 			organizationId,
 			share: existingShare,
-			snapshot,
+			socialImageDataUrl,
+			snapshotJson,
 			userId,
 			variant,
 		});
@@ -97,6 +132,7 @@ export async function createWrappedShare(
 				organization_id,
 				payload_version,
 				snapshot_json,
+				social_image_data_url,
 				user_id,
 				variant,
 				created_at,
@@ -106,7 +142,8 @@ export async function createWrappedShare(
 				${shareId},
 				${organizationId},
 				${WRAPPED_SHARE_PAYLOAD_VERSION},
-				${JSON.stringify(snapshot)},
+				${snapshotJson},
+				${socialImageDataUrl},
 				${userId},
 				${variant},
 				${createdAtIso},
@@ -137,7 +174,8 @@ export async function createWrappedShare(
 				expiresAtIso,
 				organizationId,
 				share: concurrentlyCreatedShare,
-				snapshot,
+				socialImageDataUrl,
+				snapshotJson,
 				userId,
 				variant,
 			});
@@ -169,18 +207,27 @@ async function updateWrappedShareSnapshot(input: {
 	expiresAtIso: string;
 	organizationId: string;
 	share: { createdAt: Date; id: string };
-	snapshot: WrappedShareSnapshot;
+	socialImageDataUrl: string | null;
+	snapshotJson: string;
 	userId: string;
 	variant: WrappedShareVariant;
 }) {
-	const { expiresAtIso, organizationId, share, snapshot, userId, variant } =
-		input;
+	const {
+		expiresAtIso,
+		organizationId,
+		share,
+		socialImageDataUrl,
+		snapshotJson,
+		userId,
+		variant,
+	} = input;
 	const updatedRows = await sqlClient<Array<{ id: string }>>`
 		UPDATE wrapped_share
 		SET
 			organization_id = ${organizationId},
 			payload_version = ${WRAPPED_SHARE_PAYLOAD_VERSION},
-			snapshot_json = ${JSON.stringify(snapshot)},
+			snapshot_json = ${snapshotJson},
+			social_image_data_url = ${socialImageDataUrl},
 			expires_at = ${expiresAtIso}
 		WHERE id = ${share.id}
 			AND user_id = ${userId}
@@ -206,7 +253,8 @@ async function renameWrappedShareAndUpdateSnapshot(input: {
 	organizationId: string;
 	share: { createdAt: Date; id: string };
 	shareIdBase: string;
-	snapshot: WrappedShareSnapshot;
+	socialImageDataUrl: string | null;
+	snapshotJson: string;
 	userId: string;
 	variant: WrappedShareVariant;
 }) {
@@ -215,7 +263,8 @@ async function renameWrappedShareAndUpdateSnapshot(input: {
 		organizationId,
 		share,
 		shareIdBase,
-		snapshot,
+		socialImageDataUrl,
+		snapshotJson,
 		userId,
 		variant,
 	} = input;
@@ -232,7 +281,8 @@ async function renameWrappedShareAndUpdateSnapshot(input: {
 				id = ${shareId},
 				organization_id = ${organizationId},
 				payload_version = ${WRAPPED_SHARE_PAYLOAD_VERSION},
-				snapshot_json = ${JSON.stringify(snapshot)},
+				snapshot_json = ${snapshotJson},
+				social_image_data_url = ${socialImageDataUrl},
 				expires_at = ${expiresAtIso}
 			WHERE id = ${share.id}
 				AND user_id = ${userId}
@@ -296,16 +346,8 @@ export async function getPublicWrappedShare(
 	source: string,
 ): Promise<PublicWrappedShare | null> {
 	checkWrappedShareLookupRateLimit(shareId, source);
-	const share = await getPublicWrappedShareById(shareId);
-
-	if (!share) {
-		return null;
-	}
-
-	return {
-		...share,
-		snapshot: stripWrappedShareSocialImage(share.snapshot),
-	};
+	const row = await getPublicWrappedShareRow(shareId);
+	return buildPublicWrappedShare(row);
 }
 
 export async function getPublicWrappedShareWithSocialImage(
@@ -313,23 +355,41 @@ export async function getPublicWrappedShareWithSocialImage(
 	source: string,
 ): Promise<PublicWrappedShareWithSocialImage | null> {
 	checkWrappedShareLookupRateLimit(shareId, source);
-	return getPublicWrappedShareById(shareId);
+	const row = await getPublicWrappedShareRowWithSocialImage(shareId);
+	const share = buildPublicWrappedShare(row);
+
+	if (!share || !row) {
+		return null;
+	}
+
+	return {
+		...share,
+		socialImageDataUrl: parseWrappedShareSocialImage(row.socialImageDataUrl),
+	};
 }
 
-async function getPublicWrappedShareById(
+export async function getPublicWrappedShareForPageMetadata(
 	shareId: string,
-): Promise<PublicWrappedShareWithSocialImage | null> {
-	const [row] = await sqlClient<
-		Array<{
-			createdAt: Date | string;
-			expiresAt: Date | string;
-			id: string;
-			payloadVersion: number;
-			snapshotJson: string;
-			userImage: string | null;
-			variant: WrappedShareVariant | null;
-		}>
-	>`
+	source: string,
+): Promise<PublicWrappedShareForPageMetadata | null> {
+	checkWrappedShareLookupRateLimit(shareId, source);
+	const row = await getPublicWrappedShareRowForPageMetadata(shareId);
+	const share = buildPublicWrappedShare(row);
+
+	if (!share || !row) {
+		return null;
+	}
+
+	return {
+		...share,
+		hasSocialImage: row.hasSocialImage,
+	};
+}
+
+async function getPublicWrappedShareRow(
+	shareId: string,
+): Promise<WrappedShareDatabaseRow | null> {
+	const [row] = await sqlClient<Array<WrappedShareDatabaseRow>>`
 		SELECT
 			wrapped_share.id,
 			wrapped_share.created_at AS "createdAt",
@@ -341,9 +401,66 @@ async function getPublicWrappedShareById(
 		FROM wrapped_share
 		LEFT JOIN "user" ON "user".id = wrapped_share.user_id
 		WHERE wrapped_share.id = ${shareId}
+			AND octet_length(wrapped_share.snapshot_json) <= ${WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes}
 		LIMIT 1
 	`;
 
+	return row ?? null;
+}
+
+async function getPublicWrappedShareRowWithSocialImage(
+	shareId: string,
+): Promise<WrappedShareDatabaseRowWithSocialImage | null> {
+	const [row] = await sqlClient<Array<WrappedShareDatabaseRowWithSocialImage>>`
+		SELECT
+			wrapped_share.id,
+			wrapped_share.created_at AS "createdAt",
+			wrapped_share.expires_at AS "expiresAt",
+			wrapped_share.payload_version AS "payloadVersion",
+			wrapped_share.snapshot_json AS "snapshotJson",
+			CASE
+				WHEN octet_length(wrapped_share.social_image_data_url) <= ${WRAPPED_SHARE_SOCIAL_IMAGE_DATA_URL_MAX_LENGTH}
+					THEN wrapped_share.social_image_data_url
+				ELSE NULL
+			END AS "socialImageDataUrl",
+			wrapped_share.variant AS "variant",
+			"user".image AS "userImage"
+		FROM wrapped_share
+		LEFT JOIN "user" ON "user".id = wrapped_share.user_id
+		WHERE wrapped_share.id = ${shareId}
+			AND octet_length(wrapped_share.snapshot_json) <= ${WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes}
+		LIMIT 1
+	`;
+
+	return row ?? null;
+}
+
+async function getPublicWrappedShareRowForPageMetadata(
+	shareId: string,
+): Promise<WrappedShareDatabaseRowForPageMetadata | null> {
+	const [row] = await sqlClient<Array<WrappedShareDatabaseRowForPageMetadata>>`
+		SELECT
+			wrapped_share.id,
+			wrapped_share.created_at AS "createdAt",
+			wrapped_share.expires_at AS "expiresAt",
+			wrapped_share.payload_version AS "payloadVersion",
+			wrapped_share.snapshot_json AS "snapshotJson",
+			wrapped_share.social_image_data_url IS NOT NULL AS "hasSocialImage",
+			wrapped_share.variant AS "variant",
+			"user".image AS "userImage"
+		FROM wrapped_share
+		LEFT JOIN "user" ON "user".id = wrapped_share.user_id
+		WHERE wrapped_share.id = ${shareId}
+			AND octet_length(wrapped_share.snapshot_json) <= ${WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes}
+		LIMIT 1
+	`;
+
+	return row ?? null;
+}
+
+function buildPublicWrappedShare(
+	row: WrappedShareDatabaseRow | null,
+): PublicWrappedShare | null {
 	if (!row) {
 		return null;
 	}
@@ -359,31 +476,57 @@ async function getPublicWrappedShareById(
 		return null;
 	}
 
+	const snapshot = parseWrappedShareSnapshot(row.snapshotJson);
+
+	if (!snapshot) {
+		return null;
+	}
+
 	return {
 		created_at: createdAt.toISOString(),
 		expires_at: expiresAt.toISOString(),
 		id: row.id,
 		snapshot: hydrateWrappedShareSnapshotProfile({
 			profileImageUrl: row.userImage,
-			snapshot: parseWrappedShareSnapshot(row.snapshotJson),
+			snapshot,
 		}),
 		variant: row.variant ?? "normal",
 	};
 }
 
-function stripWrappedShareSocialImage(
-	snapshot: WrappedShareSnapshot,
-): PublicWrappedShare["snapshot"] {
-	const { socialImageDataUrl, ...publicSnapshot } = snapshot;
-	void socialImageDataUrl;
-	return publicSnapshot;
+// Stored rows can predate the current budget. Invalid or oversized snapshots
+// fail closed as a missing public share instead of reaching anonymous renderers.
+function parseWrappedShareSnapshot(
+	snapshotJson: string,
+): WrappedShareSnapshot | null {
+	if (
+		new TextEncoder().encode(snapshotJson).byteLength >
+		WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes
+	) {
+		return null;
+	}
+
+	let parsedSnapshot: unknown;
+	try {
+		parsedSnapshot = JSON.parse(snapshotJson);
+	} catch {
+		return null;
+	}
+
+	const result = WrappedShareSnapshotSchema.safeParse(parsedSnapshot);
+	return result.success ? result.data : null;
 }
 
-// Validate the stored JSON on the way out so corrupt or stale payloads fail
-// loudly at the service boundary instead of leaking invalid UI state downstream.
-function parseWrappedShareSnapshot(snapshotJson: string): WrappedShareSnapshot {
-	const parsedSnapshot = JSON.parse(snapshotJson) as unknown;
-	return WrappedShareSnapshotSchema.parse(parsedSnapshot);
+function parseWrappedShareSocialImage(
+	socialImageDataUrl: string | null,
+): string | null {
+	if (!socialImageDataUrl) {
+		return null;
+	}
+
+	const result =
+		WrappedShareSocialImageDataUrlSchema.safeParse(socialImageDataUrl);
+	return result.success ? result.data : null;
 }
 
 function hydrateWrappedShareSnapshotProfile(input: {
@@ -430,6 +573,10 @@ function getSafePublicProfileImageUrl(imageUrl: string | null) {
 	const trimmedImageUrl = imageUrl?.trim();
 
 	if (!trimmedImageUrl) {
+		return null;
+	}
+
+	if (trimmedImageUrl.length > WRAPPED_SHARE_RESOURCE_LIMITS.imageUrlLength) {
 		return null;
 	}
 

--- a/apps/web/e2e/wrapped-resource-budget.spec.ts
+++ b/apps/web/e2e/wrapped-resource-budget.spec.ts
@@ -1,0 +1,233 @@
+import { type CDPSession, expect, type Page, test } from "@playwright/test";
+import { WRAPPED_SHARE_RESOURCE_LIMITS } from "@rudel/api-routes";
+
+interface PerformanceMetric {
+	name: string;
+	value: number;
+}
+
+interface ResourceMeasurements {
+	callbacks: number[];
+	layouts: number[];
+	taskDurations: number[];
+}
+
+const VIEWPORT_CASES = [
+	{
+		name: "desktop",
+		initial: { height: 720, width: 1280 },
+		resized: { height: 840, width: 1200 },
+	},
+	{
+		name: "phone",
+		initial: { height: 844, width: 390 },
+		resized: { height: 915, width: 412 },
+	},
+] as const;
+
+const ITERATIONS_PER_VIEWPORT = 20;
+
+test("caps public card DOM and observer work across repeated Google Chrome renders", async ({
+	page,
+}) => {
+	test.setTimeout(120_000);
+
+	await page.addInitScript(() => {
+		const NativeResizeObserver = window.ResizeObserver;
+		const activeObservers = new Map<object, Set<Element>>();
+		let callbacks = 0;
+
+		class WrappedResizeObserver implements ResizeObserver {
+			private readonly nativeObserver: ResizeObserver;
+			private readonly observedTargets = new Set<Element>();
+
+			constructor(callback: ResizeObserverCallback) {
+				this.nativeObserver = new NativeResizeObserver((entries) => {
+					if (
+						entries.some((entry) =>
+							entry.target.matches(
+								"[data-wrapped-stat-section], [data-wrapped-stat-tile]",
+							),
+						)
+					) {
+						callbacks += 1;
+					}
+					callback(entries, this);
+				});
+			}
+
+			disconnect() {
+				activeObservers.delete(this);
+				this.observedTargets.clear();
+				this.nativeObserver.disconnect();
+			}
+
+			observe(target: Element, options?: ResizeObserverOptions) {
+				if (
+					target.matches(
+						"[data-wrapped-stat-section], [data-wrapped-stat-tile]",
+					)
+				) {
+					this.observedTargets.add(target);
+					activeObservers.set(this, this.observedTargets);
+				}
+				this.nativeObserver.observe(target, options);
+			}
+
+			unobserve(target: Element) {
+				this.observedTargets.delete(target);
+				this.nativeObserver.unobserve(target);
+			}
+		}
+
+		window.ResizeObserver = WrappedResizeObserver;
+		Object.defineProperty(window, "__wrappedObserverStats", {
+			value: {
+				get activeObserverCount() {
+					return activeObservers.size;
+				},
+				get callbackCount() {
+					return callbacks;
+				},
+				get observedTargetCount() {
+					return [...activeObservers.values()].reduce(
+						(count, targets) => count + targets.size,
+						0,
+					);
+				},
+			},
+		});
+	});
+
+	const cdp = await page.context().newCDPSession(page);
+	await cdp.send("Performance.enable");
+
+	for (const viewportCase of VIEWPORT_CASES) {
+		const measurements: ResourceMeasurements = {
+			callbacks: [],
+			layouts: [],
+			taskDurations: [],
+		};
+
+		for (let iteration = 1; iteration <= ITERATIONS_PER_VIEWPORT; iteration++) {
+			await test.step(`${viewportCase.name} render ${iteration}`, async () => {
+				await page.setViewportSize(viewportCase.initial);
+				await page.goto("/dev/wrapped?stage=public&overStats=1", {
+					waitUntil: "networkidle",
+				});
+				await page.evaluate(() => document.fonts.ready);
+
+				const statTiles = page.locator("[data-wrapped-stat-tile]");
+				await expect(statTiles).toHaveCount(
+					WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount,
+				);
+				await expect(statTiles.first()).toBeVisible();
+				await expect(statTiles.last()).toBeVisible();
+				expect(await getStatTileRowCounts(page)).toEqual([2, 2, 2, 2]);
+
+				const observerStats = await getObserverStats(page);
+
+				expect(observerStats.activeObserverCount).toBe(1);
+				expect(observerStats.callbackCount).toBeGreaterThan(0);
+				expect(observerStats.observedTargetCount).toBe(
+					WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount + 1,
+				);
+
+				const beforeResize = await getPerformanceMetrics(cdp);
+				await page.setViewportSize(viewportCase.resized);
+				await waitForTwoAnimationFrames(page);
+				const afterResize = await getPerformanceMetrics(cdp);
+				const afterResizeObserverStats = await getObserverStats(page);
+
+				measurements.callbacks.push(
+					afterResizeObserverStats.callbackCount - observerStats.callbackCount,
+				);
+				measurements.layouts.push(
+					afterResize.LayoutCount - beforeResize.LayoutCount,
+				);
+				measurements.taskDurations.push(
+					afterResize.TaskDuration - beforeResize.TaskDuration,
+				);
+			});
+		}
+
+		expect(percentile(measurements.callbacks, 95)).toBeLessThanOrEqual(4);
+		expect(percentile(measurements.layouts, 95)).toBeLessThanOrEqual(8);
+		expect(percentile(measurements.taskDurations, 95)).toBeLessThan(1);
+	}
+});
+
+async function getStatTileRowCounts(page: Page) {
+	return page.locator("[data-wrapped-stat-tile]").evaluateAll((tiles) => {
+		const rows = new Map<number, number>();
+
+		for (const tile of tiles) {
+			const bounds = tile.getBoundingClientRect();
+			if (bounds.width <= 0 || bounds.height <= 0) {
+				throw new Error("Wrapped stat tile has no visible area");
+			}
+
+			const rowTop = Math.round(bounds.top);
+			rows.set(rowTop, (rows.get(rowTop) ?? 0) + 1);
+		}
+
+		return [...rows.values()];
+	});
+}
+
+async function getObserverStats(page: Page) {
+	return page.evaluate(() => {
+		const stats = (
+			window as Window & {
+				__wrappedObserverStats: {
+					activeObserverCount: number;
+					callbackCount: number;
+					observedTargetCount: number;
+				};
+			}
+		).__wrappedObserverStats;
+
+		return {
+			activeObserverCount: stats.activeObserverCount,
+			callbackCount: stats.callbackCount,
+			observedTargetCount: stats.observedTargetCount,
+		};
+	});
+}
+
+async function getPerformanceMetrics(cdp: CDPSession) {
+	const result = await cdp.send("Performance.getMetrics");
+
+	return {
+		LayoutCount: getMetric(result.metrics, "LayoutCount"),
+		TaskDuration: getMetric(result.metrics, "TaskDuration"),
+	};
+}
+
+function getMetric(metrics: PerformanceMetric[], name: string) {
+	const metric = metrics.find((candidate) => candidate.name === name);
+
+	if (!metric) {
+		throw new Error(`Chrome performance metric is missing: ${name}`);
+	}
+
+	return metric.value;
+}
+
+function percentile(values: number[], percentileValue: number) {
+	const sortedValues = [...values].sort((first, second) => first - second);
+	const index = Math.ceil((percentileValue / 100) * sortedValues.length) - 1;
+
+	return sortedValues[index];
+}
+
+async function waitForTwoAnimationFrames(page: Page) {
+	await page.evaluate(
+		() =>
+			new Promise<void>((resolve) => {
+				requestAnimationFrame(() => {
+					requestAnimationFrame(() => resolve());
+				});
+			}),
+	);
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
 		"build": "tsc -b && vite build",
 		"check-types": "tsc -b",
 		"test": "vitest run",
+		"test:wrapped:chrome": "playwright test --config playwright.config.ts",
 		"preview": "vite preview",
 		"preset:sync": "node ./scripts/sync-preset.mjs"
 	},

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+	fullyParallel: false,
+	outputDir: "../../.context/playwright/wrapped-resource-budget",
+	projects: [
+		{
+			name: "Google Chrome",
+			use: {
+				...devices["Desktop Chrome"],
+				channel: "chrome",
+			},
+		},
+	],
+	testDir: "./e2e",
+	use: {
+		baseURL: "http://127.0.0.1:4173",
+		headless: true,
+		trace: "retain-on-failure",
+	},
+	webServer: {
+		command: "bun run dev --host 127.0.0.1 --port 4173",
+		reuseExistingServer: !process.env.CI,
+		timeout: 120_000,
+		url: "http://127.0.0.1:4173/dev/wrapped?stage=public&overStats=1",
+	},
+});

--- a/apps/web/src/features/wrapped/WrappedPublicMockPage.tsx
+++ b/apps/web/src/features/wrapped/WrappedPublicMockPage.tsx
@@ -184,6 +184,29 @@ export function WrappedPublicMockPage(props: WrappedPublicMockPageProps) {
 	const { debugControls } = props;
 	const navigate = useNavigate();
 	const [searchParams] = useSearchParams();
+	const statItems = searchParams.has("overStats")
+		? [
+				...MOCK_PUBLIC_SHARE_STAT_ITEMS,
+				{
+					key: "over-limit-seven",
+					label: "SEVEN",
+					title: "Seventh stat item",
+					value: "7",
+				},
+				{
+					key: "over-limit-eight",
+					label: "EIGHT",
+					title: "Eighth stat item",
+					value: "8",
+				},
+				{
+					key: "over-limit-nine",
+					label: "NINE",
+					title: "Ninth stat item",
+					value: "9",
+				},
+			]
+		: MOCK_PUBLIC_SHARE_STAT_ITEMS;
 	const onboardingMetrics = searchParams.has("longSkill")
 		? {
 				...MOCK_PUBLIC_SHARE_ONBOARDING_METRICS,
@@ -232,7 +255,7 @@ export function WrappedPublicMockPage(props: WrappedPublicMockPageProps) {
 			row={MOCK_PUBLIC_SHARE_ROW}
 			shellClassName={MOCK_PUBLIC_SHARE_ARCHETYPE.shellClassName}
 			shellStyle={MOCK_PUBLIC_SHARE_SHELL_STYLE}
-			statItems={MOCK_PUBLIC_SHARE_STAT_ITEMS}
+			statItems={statItems}
 			statLayerOpacities={MOCK_PUBLIC_SHARE_STAT_LAYER_OPACITIES}
 			theme={MOCK_PUBLIC_SHARE_ARCHETYPE.theme}
 		/>

--- a/apps/web/src/features/wrapped/team-card/card.resource-budget.test.tsx
+++ b/apps/web/src/features/wrapped/team-card/card.resource-budget.test.tsx
@@ -1,0 +1,96 @@
+import { WRAPPED_SHARE_RESOURCE_LIMITS } from "@rudel/api-routes";
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
+import {
+	WrappedTeamMemberCard,
+	type WrappedTeamMemberCardStatItem,
+} from "./card";
+
+const DEFAULT_RESIZE_OBSERVER = globalThis.ResizeObserver;
+let observedTargets = new Set<Element>();
+let resizeObserverCount = 0;
+
+afterEach(() => {
+	globalThis.ResizeObserver = DEFAULT_RESIZE_OBSERVER;
+});
+
+describe("WrappedTeamMemberCard resource budget", () => {
+	it("renders the maximum supported stat item count", () => {
+		const { container } = render(
+			<WrappedTeamMemberCard
+				row={ROW}
+				statItems={createStatItems(WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount)}
+			/>,
+		);
+
+		expect(container.querySelectorAll('[title^="Stat "]')).toHaveLength(
+			WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount,
+		);
+	});
+
+	it("caps one-over input before creating DOM and observer work", () => {
+		observedTargets = new Set<Element>();
+		resizeObserverCount = 0;
+		globalThis.ResizeObserver = RecordingResizeObserver;
+
+		const { container } = render(
+			<WrappedTeamMemberCard
+				row={ROW}
+				statItems={createStatItems(
+					WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount + 1,
+				)}
+			/>,
+		);
+
+		expect(container.querySelectorAll('[title^="Stat "]')).toHaveLength(
+			WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount,
+		);
+		expect(resizeObserverCount).toBe(1);
+		expect(observedTargets.size).toBe(
+			WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount + 1,
+		);
+	});
+});
+
+class RecordingResizeObserver implements ResizeObserver {
+	constructor(_callback: ResizeObserverCallback) {
+		resizeObserverCount += 1;
+	}
+
+	disconnect() {}
+
+	observe(target: Element) {
+		observedTargets.add(target);
+	}
+
+	unobserve(target: Element) {
+		observedTargets.delete(target);
+	}
+}
+
+function createStatItems(count: number): WrappedTeamMemberCardStatItem[] {
+	return Array.from({ length: count }, (_, index) => ({
+		key: `stat-${index}`,
+		label: "STAT",
+		title: `Stat ${index}`,
+		value: `${index}`,
+	}));
+}
+
+const ROW: TeamPageMemberRow = {
+	activeDays: 6,
+	cost: 42,
+	displayName: "Evren",
+	email: null,
+	favoriteModel: "o3",
+	hasActivity: true,
+	imageUrl: null,
+	inputTokens: 120,
+	lastActiveDate: "2026-04-22",
+	outputTokens: 240,
+	role: "Builder",
+	totalSessions: 12,
+	totalTokens: 360,
+	userId: "user-1",
+};

--- a/apps/web/src/features/wrapped/team-card/card.tsx
+++ b/apps/web/src/features/wrapped/team-card/card.tsx
@@ -1,4 +1,5 @@
-import { type CSSProperties, type ReactNode, useState } from "react";
+import { WRAPPED_SHARE_RESOURCE_LIMITS } from "@rudel/api-routes";
+import { type CSSProperties, type ReactNode, useMemo, useState } from "react";
 import type { TeamCardTone } from "@/features/team/data/team-card-types";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
 import statSectionTextureWebp from "@/features/wrapped/assets/team-card-stat-texture.webp";
@@ -164,6 +165,13 @@ export function WrappedTeamMemberCard(props: {
 	const shouldRenderPortraitImage = Boolean(
 		row.imageUrl && row.imageUrl !== failedPortraitImageUrl,
 	);
+	// Keep the component safe when it is called outside the validated API path.
+	// Eight tiles produce at most eight stat subtrees and one ResizeObserver
+	// instance observing nine targets: the section plus each tile.
+	const boundedStatItems = useMemo(
+		() => statItems.slice(0, WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount),
+		[statItems],
+	);
 	const animalFaceEmoji = getWrappedAnimalFaceEmoji(
 		`${row.userId}:${row.displayName}`,
 	);
@@ -172,7 +180,7 @@ export function WrappedTeamMemberCard(props: {
 	const { statSectionRef, statSurfaceStyles, statTileRefs } =
 		useWrappedStatSurfaceStyles({
 			bleedPx: STAT_SURFACE_BLEED_PX,
-			statItems,
+			statItems: boundedStatItems,
 		});
 	const resolvedStatLayerOpacities: WrappedTeamMemberCardStatLayerOpacities = {
 		...DEFAULT_STAT_LAYER_OPACITIES,
@@ -506,6 +514,7 @@ export function WrappedTeamMemberCard(props: {
 
 					<div
 						className="relative z-10"
+						data-wrapped-stat-section=""
 						ref={statSectionRef}
 						style={statSectionStyle}
 					>
@@ -513,13 +522,14 @@ export function WrappedTeamMemberCard(props: {
 							className="relative grid grid-cols-2 [font-family:var(--dashboard-01-font-roster-mono)] font-normal text-[#4b4d49]"
 							style={statGridStyle}
 						>
-							{statItems.map((stat) => (
+							{boundedStatItems.map((stat) => (
 								<div
 									key={stat.key}
 									className={cn(
 										"relative z-10 min-w-0 overflow-hidden",
 										statTileClassName,
 									)}
+									data-wrapped-stat-tile={stat.key}
 									ref={(node) => {
 										statTileRefs.current[stat.key] = node;
 									}}

--- a/apps/web/src/features/wrapped/team-card/share-media.test.ts
+++ b/apps/web/src/features/wrapped/team-card/share-media.test.ts
@@ -33,13 +33,11 @@ describe("wrapped share media policy", () => {
 		).toBeNull();
 	});
 
-	it("keeps data and blob urls for designer-controlled local media", () => {
-		expect(getWrappedShareSafeImageUrl("data:image/png;base64,abc")).toBe(
-			"data:image/png;base64,abc",
-		);
-		expect(getWrappedShareSafeImageUrl("blob:https://rudel.ai/1234")).toBe(
-			"blob:https://rudel.ai/1234",
-		);
+	it("rejects inline and browser-local image blobs", () => {
+		expect(getWrappedShareSafeImageUrl("data:image/png;base64,abc")).toBeNull();
+		expect(
+			getWrappedShareSafeImageUrl("blob:https://rudel.ai/1234"),
+		).toBeNull();
 	});
 
 	it("rejects empty/null/whitespace input", () => {

--- a/apps/web/src/features/wrapped/team-card/share-media.ts
+++ b/apps/web/src/features/wrapped/team-card/share-media.ts
@@ -1,19 +1,17 @@
 import { AVATAR_URL_PATH_REGEX } from "@rudel/api-routes";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
 
-const SAFE_EMBEDDED_IMAGE_PROTOCOLS = new Set(["blob:", "data:"]);
-
 // Public replay should keep real account avatars from providers such as GitHub
 // and Google, but still reject protocols we would not want to persist into an
 // anonymous route.
 //
 // Rules:
 // - HTTPS provider avatar URLs are allowed for public replay
-// - data/blob URLs are allowed
 // - the relative `/api/avatar/<uuid>` path is allowed (resolved by the
 //   share-page origin at render time; never absolutized at write time so prod
 //   shares don't capture localhost in dev)
-// - everything else (other relatives, http:, untrusted protocols) → null
+// - everything else (embedded data/blob images, other relatives, http:,
+//   untrusted protocols) → null
 export function getWrappedShareSafeImageUrl(
 	imageUrl: string | null | undefined,
 ) {
@@ -31,10 +29,6 @@ export function getWrappedShareSafeImageUrl(
 		parsedImageUrl = new URL(trimmed);
 	} catch {
 		return null;
-	}
-
-	if (SAFE_EMBEDDED_IMAGE_PROTOCOLS.has(parsedImageUrl.protocol)) {
-		return parsedImageUrl.toString();
 	}
 
 	if (parsedImageUrl.protocol === "https:") {

--- a/apps/web/src/features/wrapped/team-card/share.test.ts
+++ b/apps/web/src/features/wrapped/team-card/share.test.ts
@@ -1,7 +1,11 @@
+import { WRAPPED_SHARE_RESOURCE_LIMITS } from "@rudel/api-routes";
 import { toast } from "sonner";
 import { describe, expect, it, vi } from "vitest";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
-import { createWrappedTeamCardShareActions } from "@/features/wrapped/team-card/share";
+import {
+	captureWrappedTeamCardSocialImageDataUrl,
+	createWrappedTeamCardShareActions,
+} from "@/features/wrapped/team-card/share";
 import { copyTextToClipboardWithResult } from "@/lib/clipboard";
 import {
 	captureElement,
@@ -284,6 +288,41 @@ describe("createWrappedTeamCardShareActions", () => {
 		expect(toast.success).toHaveBeenCalledWith(
 			"Post copied. X is open. Paste the image into the post; your card link is included.",
 			{ duration: 7000 },
+		);
+	});
+});
+
+describe("captureWrappedTeamCardSocialImageDataUrl", () => {
+	it("drops a generated PNG above the shared image budget", async () => {
+		vi.clearAllMocks();
+		const requestAnimationFrame = vi
+			.spyOn(window, "requestAnimationFrame")
+			.mockImplementation((callback) => {
+				callback(0);
+				return 1;
+			});
+		const oversizedImage = new Blob(
+			[new Uint8Array(WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes + 1)],
+			{ type: "image/png" },
+		);
+		const sharePostRef = { current: document.createElement("div") };
+		vi.mocked(captureElement).mockResolvedValue(oversizedImage);
+
+		try {
+			await expect(
+				captureWrappedTeamCardSocialImageDataUrl(sharePostRef),
+			).resolves.toBeUndefined();
+		} finally {
+			requestAnimationFrame.mockRestore();
+		}
+
+		expect(captureElement).toHaveBeenCalledTimes(1);
+		expect(captureElement).toHaveBeenCalledWith(
+			sharePostRef.current,
+			expect.objectContaining({
+				outputHeight: 630,
+				outputWidth: 1200,
+			}),
 		);
 	});
 });

--- a/apps/web/src/features/wrapped/team-card/share.ts
+++ b/apps/web/src/features/wrapped/team-card/share.ts
@@ -1,4 +1,7 @@
-import type { WrappedSourceSplit } from "@rudel/api-routes";
+import {
+	WRAPPED_SHARE_RESOURCE_LIMITS,
+	type WrappedSourceSplit,
+} from "@rudel/api-routes";
 import type { RefObject } from "react";
 import { toast } from "sonner";
 import type { TeamPageMemberRow } from "@/features/team/use-team-page-data";
@@ -13,11 +16,8 @@ const TEAM_CARD_SHARE_CLIPBOARD_CAPTURE_SIZE = 3000;
 const TEAM_CARD_SHARE_OUTPUT_SIZE = 4096;
 const TEAM_CARD_SHARE_SOCIAL_IMAGE_CAPTURE_WIDTH = 2400;
 const TEAM_CARD_SHARE_SOCIAL_IMAGE_CAPTURE_HEIGHT = 1260;
-const TEAM_CARD_SHARE_SOCIAL_IMAGE_OUTPUT_WIDTH = 2400;
-const TEAM_CARD_SHARE_SOCIAL_IMAGE_OUTPUT_HEIGHT = 1260;
-const TEAM_CARD_SHARE_SOCIAL_IMAGE_FALLBACK_OUTPUT_WIDTH = 1200;
-const TEAM_CARD_SHARE_SOCIAL_IMAGE_FALLBACK_OUTPUT_HEIGHT = 630;
-const TEAM_CARD_SHARE_SOCIAL_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+const TEAM_CARD_SHARE_SOCIAL_IMAGE_OUTPUT_WIDTH = 1200;
+const TEAM_CARD_SHARE_SOCIAL_IMAGE_OUTPUT_HEIGHT = 630;
 const TEAM_CARD_SHARE_REFERENCE_SIZE = 464;
 const TEAM_CARD_SHARE_FRONT_CARD_SCALE = 0.96;
 const TEAM_CARD_SHARE_SPREAD_CARD_SCALE = 0.72;
@@ -36,13 +36,6 @@ const TEAM_CARD_SHARE_SOCIAL_IMAGE_CAPTURE_OPTIONS =
 		captureWidth: TEAM_CARD_SHARE_SOCIAL_IMAGE_CAPTURE_WIDTH,
 		outputHeight: TEAM_CARD_SHARE_SOCIAL_IMAGE_OUTPUT_HEIGHT,
 		outputWidth: TEAM_CARD_SHARE_SOCIAL_IMAGE_OUTPUT_WIDTH,
-	});
-const TEAM_CARD_SHARE_SOCIAL_IMAGE_FALLBACK_CAPTURE_OPTIONS =
-	buildTeamCardShareLandscapeCaptureOptions({
-		captureHeight: TEAM_CARD_SHARE_SOCIAL_IMAGE_CAPTURE_HEIGHT,
-		captureWidth: TEAM_CARD_SHARE_SOCIAL_IMAGE_CAPTURE_WIDTH,
-		outputHeight: TEAM_CARD_SHARE_SOCIAL_IMAGE_FALLBACK_OUTPUT_HEIGHT,
-		outputWidth: TEAM_CARD_SHARE_SOCIAL_IMAGE_FALLBACK_OUTPUT_WIDTH,
 	});
 
 type WrappedShareActionKind =
@@ -194,16 +187,13 @@ export async function captureWrappedTeamCardSocialImageDataUrl(
 		return undefined;
 	}
 
-	let imageBlob = await captureElement(
+	const imageBlob = await captureElement(
 		sharePostElement,
 		TEAM_CARD_SHARE_SOCIAL_IMAGE_CAPTURE_OPTIONS,
 	);
 
-	if (imageBlob.size > TEAM_CARD_SHARE_SOCIAL_IMAGE_MAX_BYTES) {
-		imageBlob = await captureElement(
-			sharePostElement,
-			TEAM_CARD_SHARE_SOCIAL_IMAGE_FALLBACK_CAPTURE_OPTIONS,
-		);
+	if (imageBlob.size > WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes) {
+		return undefined;
 	}
 
 	return blobToDataUrl(imageBlob);

--- a/apps/web/src/features/wrapped/team-card/use-share.ts
+++ b/apps/web/src/features/wrapped/team-card/use-share.ts
@@ -59,13 +59,13 @@ export function useWrappedTeamCardShare(
 		setIsCreatingShare(true);
 		setHasShareError(false);
 
-		const shareRequest = resolveWrappedShareSnapshotWithSocialImage({
+		const shareRequest = resolveWrappedShareSocialImageDataUrl(
 			resolveSocialImageDataUrl,
-			snapshot,
-		})
-			.then((snapshotWithSocialImage) =>
+		)
+			.then((socialImageDataUrl) =>
 				client.wrappedShare.create({
-					snapshot: snapshotWithSocialImage,
+					socialImageDataUrl,
+					snapshot,
 					variant,
 				}),
 			)
@@ -106,28 +106,14 @@ export function useWrappedTeamCardShare(
 	};
 }
 
-async function resolveWrappedShareSnapshotWithSocialImage(input: {
-	resolveSocialImageDataUrl: (() => Promise<string | undefined>) | undefined;
-	snapshot: WrappedShareSnapshot;
-}) {
-	const { resolveSocialImageDataUrl, snapshot } = input;
-
+async function resolveWrappedShareSocialImageDataUrl(
+	resolveSocialImageDataUrl: (() => Promise<string | undefined>) | undefined,
+) {
 	if (!resolveSocialImageDataUrl) {
-		return snapshot;
+		return undefined;
 	}
 
-	const socialImageDataUrl = await resolveSocialImageDataUrl().catch(
-		() => undefined,
-	);
-
-	if (!socialImageDataUrl) {
-		return snapshot;
-	}
-
-	return {
-		...snapshot,
-		socialImageDataUrl,
-	};
+	return resolveSocialImageDataUrl().catch(() => undefined);
 }
 
 // The share URL is browser-derived because the server only needs to persist the

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 const { version } = JSON.parse(
 	readFileSync(new URL("./package.json", import.meta.url), "utf-8"),
@@ -112,6 +112,7 @@ export default defineConfig(async ({ mode }) => {
 					url: "http://localhost:4011",
 				},
 			},
+			exclude: [...configDefaults.exclude, "e2e/**"],
 			setupFiles: ["./src/test/setup.ts"],
 		},
 	};

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.0",
+        "@playwright/test": "1.61.1",
         "bun-types": "1.3.10",
         "turbo": "^2.8.9",
         "typescript": "5.9.2",
@@ -601,6 +602,8 @@
     "@orpc/standard-server-peer": ["@orpc/standard-server-peer@1.13.6", "", { "dependencies": { "@orpc/shared": "1.13.6", "@orpc/standard-server": "1.13.6" } }, "sha512-WTqjNS6A9sxR4HVxWUb9ZoBHeQiesHeANmVBFdM/QjAaPUZYKn6WACYU6Q2eGmsCUeTQFfMssk0BG2EsgRNEYw=="],
 
     "@orpc/tanstack-query": ["@orpc/tanstack-query@1.13.14", "", { "dependencies": { "@orpc/shared": "1.13.14" }, "peerDependencies": { "@orpc/client": "1.13.14", "@tanstack/query-core": ">=5.80.2" } }, "sha512-5rq1Z1anVTVBseYeNBi5RJSgWPxpD0MqK7MYej3xnt56jjc6mFmWpUGNz9xy0BXPh3KmA/xDTNuB23kKgJ5JmQ=="],
+
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@posthog/core": ["@posthog/core@1.23.4", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-gSM1gnIuw5UOBUOTz0IhCTH8jOHoFr5rzSDb5m7fn9ofLHvz3boZT1L1f+bcuk+mvzNJfrJ3ByVQGKmUQnKQ8g=="],
 
@@ -1808,6 +1811,10 @@
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
+
     "postal-mime": ["postal-mime@2.7.3", "", {}, "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
@@ -2341,6 +2348,8 @@
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.0",
+		"@playwright/test": "1.61.1",
 		"bun-types": "1.3.10",
 		"turbo": "^2.8.9",
 		"typescript": "5.9.2"

--- a/packages/api-routes/src/__tests__/wrapped-share-schema.test.ts
+++ b/packages/api-routes/src/__tests__/wrapped-share-schema.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "bun:test";
+import {
+	CreateWrappedShareInputSchema,
+	getWrappedShareSnapshotByteLength,
+	WRAPPED_SHARE_RESOURCE_LIMITS,
+	type WrappedShareSnapshot,
+	WrappedShareSnapshotSchema,
+} from "../schemas/wrapped-share.js";
+
+const SOCIAL_IMAGE_DATA_URL_PREFIX = "data:image/png;base64,";
+
+describe("wrapped share snapshot resource budget", () => {
+	test("accepts the maximum supported arrays and strings", () => {
+		const maximumText = "x".repeat(WRAPPED_SHARE_RESOURCE_LIMITS.textLength);
+		const snapshot = createSnapshot({
+			archetypeLabel: maximumText,
+			backMetricCount: WRAPPED_SHARE_RESOURCE_LIMITS.backMetricCount,
+			imageUrl: "x".repeat(WRAPPED_SHARE_RESOURCE_LIMITS.imageUrlLength),
+			shellClassName: "x".repeat(WRAPPED_SHARE_RESOURCE_LIMITS.classNameLength),
+			statItemCount: WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount,
+			text: maximumText,
+		});
+
+		expect(getWrappedShareSnapshotByteLength(snapshot)).toBeLessThanOrEqual(
+			WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes,
+		);
+		expect(WrappedShareSnapshotSchema.safeParse(snapshot).success).toBe(true);
+	});
+
+	test("rejects one item over either array limit", () => {
+		const tooManyStats = createSnapshot({
+			statItemCount: WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount + 1,
+		});
+		const tooManyBackMetrics = createSnapshot({
+			backMetricCount: WRAPPED_SHARE_RESOURCE_LIMITS.backMetricCount + 1,
+		});
+
+		expect(WrappedShareSnapshotSchema.safeParse(tooManyStats).success).toBe(
+			false,
+		);
+		expect(
+			WrappedShareSnapshotSchema.safeParse(tooManyBackMetrics).success,
+		).toBe(false);
+	});
+
+	test("rejects overlong strings used by the public renderer", () => {
+		const overlongText = "x".repeat(
+			WRAPPED_SHARE_RESOURCE_LIMITS.textLength + 1,
+		);
+		const baseSnapshot = createSnapshot();
+		const invalidSnapshots = [
+			{ ...baseSnapshot, archetypeLabel: overlongText },
+			{
+				...baseSnapshot,
+				backMetrics: [{ label: overlongText, value: "1" }],
+			},
+			{
+				...baseSnapshot,
+				headerLeftMetric: { label: overlongText, value: "1" },
+			},
+			{
+				...baseSnapshot,
+				row: { ...baseSnapshot.row, displayName: overlongText },
+			},
+			{
+				...baseSnapshot,
+				row: { ...baseSnapshot.row, favoriteModel: overlongText },
+			},
+			{
+				...baseSnapshot,
+				row: { ...baseSnapshot.row, lastActiveDate: overlongText },
+			},
+			{
+				...baseSnapshot,
+				row: { ...baseSnapshot.row, role: overlongText },
+			},
+			{
+				...baseSnapshot,
+				statItems: [{ key: "sessions", title: overlongText, value: "1" }],
+			},
+			{
+				...baseSnapshot,
+				shellClassName: "x".repeat(
+					WRAPPED_SHARE_RESOURCE_LIMITS.classNameLength + 1,
+				),
+			},
+			{
+				...baseSnapshot,
+				row: {
+					...baseSnapshot.row,
+					imageUrl: "x".repeat(
+						WRAPPED_SHARE_RESOURCE_LIMITS.imageUrlLength + 1,
+					),
+				},
+			},
+		];
+
+		for (const invalidSnapshot of invalidSnapshots) {
+			expect(
+				WrappedShareSnapshotSchema.safeParse(invalidSnapshot).success,
+			).toBe(false);
+		}
+	});
+
+	test("rejects individually valid fields whose aggregate is too large", () => {
+		const maximumMultibyteText = "界".repeat(
+			WRAPPED_SHARE_RESOURCE_LIMITS.textLength,
+		);
+		const snapshot = createSnapshot({
+			imageUrl: "界".repeat(WRAPPED_SHARE_RESOURCE_LIMITS.imageUrlLength),
+			backMetricCount: WRAPPED_SHARE_RESOURCE_LIMITS.backMetricCount,
+			shellClassName: "界".repeat(
+				WRAPPED_SHARE_RESOURCE_LIMITS.classNameLength,
+			),
+			statItemCount: WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount,
+			text: maximumMultibyteText,
+		});
+
+		expect(getWrappedShareSnapshotByteLength(snapshot)).toBeGreaterThan(
+			WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes,
+		);
+		expect(WrappedShareSnapshotSchema.safeParse(snapshot).success).toBe(false);
+	});
+
+	test("rejects a 7.25 MiB legacy snapshot containing a 5 MiB image", () => {
+		const fiveMiBImage = createSocialImageDataUrl(5 * 1024 * 1024);
+		const legacySnapshot = createLegacySnapshotAtByteLength(
+			createSnapshot(),
+			fiveMiBImage,
+			7.25 * 1024 * 1024,
+		);
+
+		expect(getWrappedShareSnapshotByteLength(legacySnapshot)).toBe(
+			7.25 * 1024 * 1024,
+		);
+		expect(WrappedShareSnapshotSchema.safeParse(legacySnapshot).success).toBe(
+			false,
+		);
+	});
+
+	test("rejects oversized unknown data nested inside the snapshot", () => {
+		const snapshot = createSnapshot();
+		const snapshotWithUnknownRowData = {
+			...snapshot,
+			row: {
+				...snapshot.row,
+				legacyData: "x".repeat(WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes),
+			},
+		};
+
+		expect(
+			WrappedShareSnapshotSchema.safeParse(snapshotWithUnknownRowData).success,
+		).toBe(false);
+	});
+
+	test("bounds the separately stored social image at one decoded MiB", () => {
+		const snapshot = createSnapshot();
+		const maximumImage = createSocialImageDataUrl(
+			WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes,
+		);
+		const overLimitImage = createSocialImageDataUrl(
+			WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes + 1,
+		);
+
+		expect(
+			CreateWrappedShareInputSchema.safeParse({
+				snapshot,
+				socialImageDataUrl: maximumImage,
+			}).success,
+		).toBe(true);
+		expect(
+			CreateWrappedShareInputSchema.safeParse({
+				snapshot,
+				socialImageDataUrl: overLimitImage,
+			}).success,
+		).toBe(false);
+	});
+});
+
+function createSnapshot(
+	input: {
+		archetypeLabel?: string;
+		backMetricCount?: number;
+		imageUrl?: string | null;
+		shellClassName?: string;
+		statItemCount?: number;
+		text?: string;
+	} = {},
+): WrappedShareSnapshot {
+	const text = input.text ?? "x";
+
+	return {
+		archetypeLabel: input.archetypeLabel ?? "Builder",
+		backMetrics: Array.from({ length: input.backMetricCount ?? 0 }, () => ({
+			label: text,
+			value: text,
+		})),
+		headerLeftMetric: {
+			label: text,
+			title: text,
+			value: text,
+		},
+		headerRightMetric: {
+			label: text,
+			title: text,
+			value: text,
+		},
+		row: {
+			activeDays: 6,
+			cost: 42,
+			displayName: text,
+			favoriteModel: text,
+			hasActivity: true,
+			imageUrl: input.imageUrl ?? null,
+			inputTokens: 120,
+			lastActiveDate: text,
+			outputTokens: 240,
+			role: text,
+			totalSessions: 12,
+			totalTokens: 360,
+		},
+		shellClassName: input.shellClassName ?? text,
+		statItems: Array.from({ length: input.statItemCount ?? 0 }, (_, index) => ({
+			key: `stat-${index}`,
+			label: text,
+			title: text,
+			value: text,
+		})),
+		theme: "light",
+	};
+}
+
+function createSocialImageDataUrl(byteLength: number) {
+	const base64Length = Math.ceil(byteLength / 3) * 4;
+	const paddingLength = (3 - (byteLength % 3)) % 3;
+
+	return (
+		SOCIAL_IMAGE_DATA_URL_PREFIX +
+		"A".repeat(base64Length - paddingLength) +
+		"=".repeat(paddingLength)
+	);
+}
+
+function createLegacySnapshotAtByteLength(
+	snapshot: WrappedShareSnapshot,
+	socialImageDataUrl: string,
+	targetBytes: number,
+) {
+	const legacySnapshot = {
+		...snapshot,
+		padding: "",
+		socialImageDataUrl,
+	};
+	const paddingBytes =
+		targetBytes - getWrappedShareSnapshotByteLength(legacySnapshot);
+
+	if (paddingBytes < 0) {
+		throw new Error("Legacy fixture target is smaller than its social image");
+	}
+
+	return {
+		...legacySnapshot,
+		padding: "x".repeat(paddingBytes),
+	};
+}

--- a/packages/api-routes/src/schemas/wrapped-share.ts
+++ b/packages/api-routes/src/schemas/wrapped-share.ts
@@ -4,6 +4,27 @@ import { z } from "zod";
 // persisted snapshots if the share card shape changes after launch.
 export const WRAPPED_SHARE_PAYLOAD_VERSION = 1 as const;
 
+// One shared budget protects storage, anonymous API reads, and browser rendering.
+// Replay JSON and the optional social image are stored and loaded independently.
+export const WRAPPED_SHARE_RESOURCE_LIMITS = {
+	backMetricCount: 20,
+	classNameLength: 512,
+	imageUrlLength: 2048,
+	snapshotBytes: 64 * 1024,
+	socialImageBytes: 1024 * 1024,
+	statItemCount: 8,
+	textLength: 256,
+} as const;
+
+const WRAPPED_SHARE_SOCIAL_IMAGE_DATA_URL_PREFIX = "data:image/png;base64,";
+export const WRAPPED_SHARE_SOCIAL_IMAGE_DATA_URL_MAX_LENGTH =
+	WRAPPED_SHARE_SOCIAL_IMAGE_DATA_URL_PREFIX.length +
+	Math.ceil(WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes / 3) * 4;
+const WrappedShareTextSchema = z
+	.string()
+	.max(WRAPPED_SHARE_RESOURCE_LIMITS.textLength);
+const WrappedShareRequiredTextSchema = WrappedShareTextSchema.min(1);
+
 // This schema is the public contract for wrapped sharing. It is intentionally
 // narrower than the private wrapped page data so public replay only exposes the
 // fields we are comfortable showing outside the authenticated product.
@@ -20,89 +41,123 @@ export const WrappedShareIdSchema = z
 	.max(128)
 	.regex(/^[A-Za-z0-9_-]+$/u);
 
-export const WrappedShareHeaderMetricSchema = z.object({
-	label: z.string().optional(),
-	title: z.string().optional(),
-	value: z.string().min(1),
-});
+export const WrappedShareHeaderMetricSchema = z
+	.object({
+		label: WrappedShareTextSchema.optional(),
+		title: WrappedShareTextSchema.optional(),
+		value: WrappedShareRequiredTextSchema,
+	})
+	.strict();
 
 export const WrappedShareStatItemIconSchema = z.enum(["claude", "codex"]);
 
-export const WrappedShareStatItemSchema = z.object({
-	icon: WrappedShareStatItemIconSchema.optional(),
-	key: z.string().min(1),
-	label: z.string().optional(),
-	title: z.string().optional(),
-	value: z.string().min(1),
-});
+export const WrappedShareStatItemSchema = z
+	.object({
+		icon: WrappedShareStatItemIconSchema.optional(),
+		key: WrappedShareRequiredTextSchema.regex(/^[A-Za-z0-9][A-Za-z0-9_-]*$/u),
+		label: WrappedShareTextSchema.optional(),
+		title: WrappedShareTextSchema.optional(),
+		value: WrappedShareRequiredTextSchema,
+	})
+	.strict();
 
-export const WrappedShareBackMetricSchema = z.object({
-	label: z.string(),
-	slot: z.enum(["body", "footer"]).optional(),
-	value: z.string().min(1),
-});
+export const WrappedShareBackMetricSchema = z
+	.object({
+		label: WrappedShareTextSchema,
+		slot: z.enum(["body", "footer"]).optional(),
+		value: WrappedShareRequiredTextSchema,
+	})
+	.strict();
 
-export const WrappedShareRevealMetricsSchema = z.object({
-	avgSessionMin: z.number().nonnegative().nullable(),
-	commitRate: z.number().min(0).max(100).nullable(),
-	daysSinceFirst: z.number().nonnegative(),
-	distinctProjectCount: z.number().nonnegative(),
-	longestSessionMin: z.number().nonnegative().nullable(),
-});
+export const WrappedShareRevealMetricsSchema = z
+	.object({
+		avgSessionMin: z.number().nonnegative().nullable(),
+		commitRate: z.number().min(0).max(100).nullable(),
+		daysSinceFirst: z.number().nonnegative(),
+		distinctProjectCount: z.number().nonnegative(),
+		longestSessionMin: z.number().nonnegative().nullable(),
+	})
+	.strict();
 
-export const WrappedShareAppearanceSchema = z.object({
-	layoutMode: WrappedShareLayoutModeSchema,
-	showArchetypeLabel: z.boolean(),
-});
-const WrappedShareSocialImageDataUrlSchema = z
+export const WrappedShareAppearanceSchema = z
+	.object({
+		layoutMode: WrappedShareLayoutModeSchema,
+		showArchetypeLabel: z.boolean(),
+	})
+	.strict();
+export const WrappedShareSocialImageDataUrlSchema = z
 	.string()
-	.max(7_000_000)
-	.regex(/^data:image\/png;base64,[A-Za-z0-9+/]+={0,2}$/u);
+	.max(WRAPPED_SHARE_SOCIAL_IMAGE_DATA_URL_MAX_LENGTH)
+	.regex(/^data:image\/png;base64,[A-Za-z0-9+/]+={0,2}$/u)
+	.refine(isWrappedShareSocialImageWithinByteLimit, {
+		message: `Wrapped share social image must be at most ${WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes} bytes`,
+	});
 
-export const WrappedShareRowSchema = z.object({
-	// These are the card-safe fields needed to faithfully replay the selected card
-	// on a public route. We do not include email, internal ids, or raw analytics
-	// records here because the public page only needs the rendered snapshot values.
-	activeDays: z.number().nonnegative(),
-	cost: z.number().nonnegative(),
-	displayName: z.string().min(1),
-	favoriteModel: z.string().nullable(),
-	hasActivity: z.boolean(),
-	imageUrl: z.string().nullable(),
-	inputTokens: z.number().nonnegative(),
-	lastActiveDate: z.string().nullable(),
-	outputTokens: z.number().nonnegative(),
-	role: z.string().min(1),
-	totalSessions: z.number().nonnegative(),
-	totalTokens: z.number().nonnegative(),
-});
+export const WrappedShareRowSchema = z
+	.object({
+		// These are the card-safe fields needed to faithfully replay the selected card
+		// on a public route. We do not include email, internal ids, or raw analytics
+		// records here because the public page only needs the rendered snapshot values.
+		activeDays: z.number().nonnegative(),
+		cost: z.number().nonnegative(),
+		displayName: WrappedShareRequiredTextSchema,
+		favoriteModel: WrappedShareTextSchema.nullable(),
+		hasActivity: z.boolean(),
+		imageUrl: z
+			.string()
+			.max(WRAPPED_SHARE_RESOURCE_LIMITS.imageUrlLength)
+			.nullable(),
+		inputTokens: z.number().nonnegative(),
+		lastActiveDate: WrappedShareTextSchema.nullable(),
+		outputTokens: z.number().nonnegative(),
+		role: WrappedShareRequiredTextSchema,
+		totalSessions: z.number().nonnegative(),
+		totalTokens: z.number().nonnegative(),
+	})
+	.strict();
 
-export const WrappedShareSnapshotSchema = z.object({
-	// The snapshot is a fully materialized replay payload. The public page should
-	// not need to recompute metrics or hit private analytics queries.
-	appearance: WrappedShareAppearanceSchema.optional(),
-	archetypeLabel: z.string().min(1),
-	backMetrics: z.array(WrappedShareBackMetricSchema).optional(),
-	headerLeftMetric: WrappedShareHeaderMetricSchema.optional(),
-	headerRightMetric: WrappedShareHeaderMetricSchema.optional(),
-	revealMetrics: WrappedShareRevealMetricsSchema.optional(),
-	row: WrappedShareRowSchema,
-	shellClassName: z.string().min(1),
-	socialImageDataUrl: WrappedShareSocialImageDataUrlSchema.optional(),
-	statItems: z.array(WrappedShareStatItemSchema),
-	theme: WrappedShareThemeSchema,
-});
+const WrappedShareSnapshotObjectSchema = z
+	.object({
+		// The snapshot is a fully materialized replay payload. The public page should
+		// not need to recompute metrics or hit private analytics queries.
+		appearance: WrappedShareAppearanceSchema.optional(),
+		archetypeLabel: WrappedShareRequiredTextSchema,
+		backMetrics: z
+			.array(WrappedShareBackMetricSchema)
+			.max(WRAPPED_SHARE_RESOURCE_LIMITS.backMetricCount)
+			.optional(),
+		headerLeftMetric: WrappedShareHeaderMetricSchema.optional(),
+		headerRightMetric: WrappedShareHeaderMetricSchema.optional(),
+		revealMetrics: WrappedShareRevealMetricsSchema.optional(),
+		row: WrappedShareRowSchema,
+		shellClassName: z
+			.string()
+			.min(1)
+			.max(WRAPPED_SHARE_RESOURCE_LIMITS.classNameLength),
+		statItems: z
+			.array(WrappedShareStatItemSchema)
+			.max(WRAPPED_SHARE_RESOURCE_LIMITS.statItemCount),
+		theme: WrappedShareThemeSchema,
+	})
+	.strict();
 
-export const PublicWrappedShareSnapshotSchema = WrappedShareSnapshotSchema.omit(
-	{
-		socialImageDataUrl: true,
-	},
-);
+export const WrappedShareSnapshotSchema =
+	WrappedShareSnapshotObjectSchema.refine(
+		isWrappedShareSnapshotWithinByteLimit,
+		{
+			message: `Wrapped share snapshot must be at most ${WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes} bytes`,
+		},
+	);
 
-export const CreateWrappedShareInputSchema = z.object({
-	snapshot: WrappedShareSnapshotSchema,
-	variant: WrappedShareVariantSchema.default("normal"),
-});
+export const PublicWrappedShareSnapshotSchema = WrappedShareSnapshotSchema;
+
+export const CreateWrappedShareInputSchema = z
+	.object({
+		socialImageDataUrl: WrappedShareSocialImageDataUrlSchema.optional(),
+		snapshot: WrappedShareSnapshotSchema,
+		variant: WrappedShareVariantSchema.default("normal"),
+	})
+	.strict();
 
 export const GetPublicWrappedShareInputSchema = z.object({
 	// This accepts both current display-name share ids and older UUID rows.
@@ -138,6 +193,9 @@ export type WrappedShareRevealMetrics = z.infer<
 export type WrappedShareAppearance = z.infer<
 	typeof WrappedShareAppearanceSchema
 >;
+export type WrappedShareSocialImageDataUrl = z.infer<
+	typeof WrappedShareSocialImageDataUrlSchema
+>;
 export type WrappedShareRow = z.infer<typeof WrappedShareRowSchema>;
 export type WrappedShareSnapshot = z.infer<typeof WrappedShareSnapshotSchema>;
 export type PublicWrappedShareSnapshot = z.infer<
@@ -151,3 +209,37 @@ export type GetPublicWrappedShareInput = z.infer<
 >;
 export type WrappedShareRecord = z.infer<typeof WrappedShareRecordSchema>;
 export type PublicWrappedShare = z.infer<typeof PublicWrappedShareSchema>;
+
+export function getWrappedShareSnapshotByteLength(snapshot: object) {
+	const snapshotJson = JSON.stringify(snapshot);
+
+	if (snapshotJson === undefined) {
+		return 0;
+	}
+
+	return new TextEncoder().encode(snapshotJson).byteLength;
+}
+
+function isWrappedShareSnapshotWithinByteLimit(snapshot: object) {
+	return (
+		getWrappedShareSnapshotByteLength(snapshot) <=
+		WRAPPED_SHARE_RESOURCE_LIMITS.snapshotBytes
+	);
+}
+
+function isWrappedShareSocialImageWithinByteLimit(dataUrl: string) {
+	const base64 = dataUrl.slice(
+		WRAPPED_SHARE_SOCIAL_IMAGE_DATA_URL_PREFIX.length,
+	);
+	const paddingLength = base64.endsWith("==")
+		? 2
+		: base64.endsWith("=")
+			? 1
+			: 0;
+	const decodedBytes = (base64.length * 3) / 4 - paddingLength;
+
+	return (
+		Number.isInteger(decodedBytes) &&
+		decodedBytes <= WRAPPED_SHARE_RESOURCE_LIMITS.socialImageBytes
+	);
+}

--- a/packages/sql-schema/db/migrations/0019_wrapped_share_social_image.sql
+++ b/packages/sql-schema/db/migrations/0019_wrapped_share_social_image.sql
@@ -1,0 +1,39 @@
+ALTER TABLE "wrapped_share"
+	ADD COLUMN "social_image_data_url" text;
+
+WITH "valid_snapshots" AS MATERIALIZED (
+	SELECT
+		"id",
+		"snapshot_json"::jsonb AS "snapshot"
+	FROM "wrapped_share"
+	WHERE pg_input_is_valid("snapshot_json", 'jsonb')
+),
+"legacy_images" AS MATERIALIZED (
+	SELECT
+		"id",
+		"snapshot",
+		"snapshot" ->> 'socialImageDataUrl' AS "data_url",
+		substring("snapshot" ->> 'socialImageDataUrl' FROM 23) AS "base64"
+	FROM "valid_snapshots"
+	WHERE "snapshot" ? 'socialImageDataUrl'
+)
+UPDATE "wrapped_share" AS "target"
+SET
+	"social_image_data_url" = CASE
+		WHEN
+			"legacy_images"."data_url" ~ '^data:image/png;base64,[A-Za-z0-9+/]+={0,2}$'
+			AND length("legacy_images"."base64") % 4 = 0
+			AND (
+				(length("legacy_images"."base64")::bigint * 3) / 4
+				- CASE
+					WHEN right("legacy_images"."base64", 2) = '==' THEN 2
+					WHEN right("legacy_images"."base64", 1) = '=' THEN 1
+					ELSE 0
+				END
+			) <= 1048576
+			THEN "legacy_images"."data_url"
+		ELSE NULL
+	END,
+	"snapshot_json" = ("legacy_images"."snapshot" - 'socialImageDataUrl')::text
+FROM "legacy_images"
+WHERE "target"."id" = "legacy_images"."id";

--- a/packages/sql-schema/db/migrations/meta/_journal.json
+++ b/packages/sql-schema/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
 			"when": 1785240000000,
 			"tag": "0018_team_invite_links",
 			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "7",
+			"when": 1785426102000,
+			"tag": "0019_wrapped_share_social_image",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/sql-schema/src/wrapped-share-schema.ts
+++ b/packages/sql-schema/src/wrapped-share-schema.ts
@@ -24,6 +24,7 @@ export const wrappedShare = pgTable(
 		// public share contract changes after launch.
 		payloadVersion: integer("payload_version").notNull().default(1),
 		snapshotJson: text("snapshot_json").notNull(),
+		socialImageDataUrl: text("social_image_data_url"),
 		userId: text("user_id")
 			.notNull()
 			.references(() => user.id, { onDelete: "cascade" }),


### PR DESCRIPTION
## Summary
- Centralize strict Wrapped limits for 64 KiB replay snapshots, 1 MiB social images, bounded strings and arrays, and eight rendered stat items.
- Move social image data into migration 0019 separate storage so ordinary public RPC and page reads avoid the TOAST blob while the specialized image path remains bounded.
- Add real PostgreSQL boundary, TOAST, and load coverage plus repeated branded Chrome phone and desktop resource tests wired into CI.

## Test plan
- [x] `bun run verify`
- [x] Focused schema, card, API integration, Playwright, and Wrapped HIG checks