### PR TITLE
fix(adapters): harden session ingestion

### DIFF
--- a/apps/api/src/__tests__/delete-sessions.integration.ts
+++ b/apps/api/src/__tests__/delete-sessions.integration.ts
@@ -76,7 +76,10 @@ async function ingestSession(
 		gitBranch: "main",
 		gitSha: "deadbeef",
 		tag: "tests",
-		content: "delete-sessions integration test",
+		content: JSON.stringify({
+			type: "user",
+			timestamp: "2026-07-29T10:00:00.000Z",
+		}),
 		subagents: [],
 	};
 	const adapter = getAdapter(input.source);

--- a/apps/api/src/__tests__/deletion-data-loss.integration.ts
+++ b/apps/api/src/__tests__/deletion-data-loss.integration.ts
@@ -408,7 +408,10 @@ async function ingestSession(
 	organizationId: string,
 ): Promise<void> {
 	const input: IngestSessionInput = {
-		content: "deletion hardening integration test",
+		content: JSON.stringify({
+			type: "user",
+			timestamp: "2026-07-29T10:00:00.000Z",
+		}),
 		projectPath: "/test/deletion-hardening",
 		sessionId,
 		source: "claude_code",

--- a/apps/api/src/__tests__/ingest-clickhouse.integration.ts
+++ b/apps/api/src/__tests__/ingest-clickhouse.integration.ts
@@ -75,7 +75,10 @@ describe("ingestSession", () => {
 			gitBranch: "feature-branch",
 			gitSha: "deadbeef",
 			tag: "tests",
-			content: "integration test content",
+			content: JSON.stringify({
+				type: "user",
+				timestamp: "2026-07-29T10:00:00.000Z",
+			}),
 			subagents: [{ agentId: "sub-1", content: "subagent content" }],
 		};
 
@@ -104,5 +107,28 @@ describe("ingestSession", () => {
 		expect(results[0]?.tag).toBe("tests");
 		expect(results[0]?.user_id).toBe("test_user");
 		expect(results[0]?.organization_id).toBe("test_org");
+	}, 120000);
+
+	test.each([
+		{ source: "claude_code" as const },
+		{ source: "codex" as const },
+	])("rejects a timestamp-less $source session before insertion", async ({
+		source,
+	}) => {
+		const input: IngestSessionInput = {
+			source,
+			sessionId: `${testId}_timestamp_less_${source}`,
+			projectPath: "/test/api-ingest/rejected",
+			content: "timestamp-less integration test content",
+		};
+		const adapter = getAdapter(source);
+
+		await expect(
+			adapter.ingest(executor, input, {
+				ingestedAt: new Date("2026-07-29T10:00:00.000Z"),
+				userId: "test_user",
+				organizationId: "test_org",
+			}),
+		).rejects.toThrow("transcript contains no valid timestamp");
 	}, 120000);
 });

--- a/apps/api/src/__tests__/ingest.test.ts
+++ b/apps/api/src/__tests__/ingest.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { claudeCodeAdapter } from "@rudel/agent-adapters";
+import {
+	claudeCodeAdapter,
+	codexAdapter,
+	toClickHouseDateTime,
+} from "@rudel/agent-adapters";
 
 describe("extractTimestamps", () => {
 	test("returns min/max timestamps from user and assistant lines", () => {
@@ -12,12 +16,12 @@ describe("extractTimestamps", () => {
 		const result = claudeCodeAdapter.extractTimestamps(content);
 
 		expect(result).toEqual({
-			sessionDate: "2026-02-15T10:00:00Z",
-			lastInteractionDate: "2026-02-15T10:10:00Z",
+			sessionDate: "2026-02-15T10:00:00.000Z",
+			lastInteractionDate: "2026-02-15T10:10:00.000Z",
 		});
 	});
 
-	test("ignores non-user/assistant lines", () => {
+	test("uses only timestamps consumed by Claude analytics", () => {
 		const content = [
 			'{"type":"system","timestamp":"2026-02-15T09:00:00Z"}',
 			'{"type":"user","timestamp":"2026-02-15T10:00:00Z","message":"hello"}',
@@ -27,28 +31,111 @@ describe("extractTimestamps", () => {
 		const result = claudeCodeAdapter.extractTimestamps(content);
 
 		expect(result).toEqual({
-			sessionDate: "2026-02-15T10:00:00Z",
-			lastInteractionDate: "2026-02-15T10:00:00Z",
+			sessionDate: "2026-02-15T10:00:00.000Z",
+			lastInteractionDate: "2026-02-15T10:00:00.000Z",
 		});
 	});
 
-	test("returns null when no timestamps found", () => {
+	test("returns null when no valid timestamps are found", () => {
 		expect(claudeCodeAdapter.extractTimestamps("not json")).toBeNull();
 		expect(claudeCodeAdapter.extractTimestamps("")).toBeNull();
 		expect(claudeCodeAdapter.extractTimestamps('{"type":"user"}')).toBeNull();
+		expect(
+			claudeCodeAdapter.extractTimestamps(
+				'{"type":"system","timestamp":"not-a-date"}',
+			),
+		).toBeNull();
+		expect(
+			claudeCodeAdapter.extractTimestamps(
+				'{"type":"system","timestamp":"2026-02-15T09:00:00Z"}',
+			),
+		).toBeNull();
 	});
 
-	test("skips lines without timestamp field", () => {
+	test("skips lines without a valid timestamp", () => {
 		const content = [
 			'{"type":"user","message":"no timestamp"}',
+			'{"type":"system","timestamp":"not-a-date"}',
 			'{"type":"assistant","timestamp":"2026-02-15T10:05:00Z","message":"hi"}',
 		].join("\n");
 
 		const result = claudeCodeAdapter.extractTimestamps(content);
 
 		expect(result).toEqual({
-			sessionDate: "2026-02-15T10:05:00Z",
-			lastInteractionDate: "2026-02-15T10:05:00Z",
+			sessionDate: "2026-02-15T10:05:00.000Z",
+			lastInteractionDate: "2026-02-15T10:05:00.000Z",
+		});
+	});
+
+	test("Codex also rejects invalid timestamp values", () => {
+		expect(
+			codexAdapter.extractTimestamps(
+				'{"type":"session_meta","timestamp":"not-a-date"}',
+			),
+		).toBeNull();
+	});
+
+	test.each([
+		{ adapter: claudeCodeAdapter, name: "Claude Code" },
+		{ adapter: codexAdapter, name: "Codex" },
+	])("$name orders timestamps by instant, not ISO string", ({ adapter }) => {
+		const content = [
+			'{"type":"user","timestamp":"2026-02-15T09:00:00-05:00"}',
+			'{"type":"assistant","timestamp":"2026-02-15T12:00:00Z"}',
+		].join("\n");
+
+		expect(adapter.extractTimestamps(content)).toEqual({
+			sessionDate: "2026-02-15T12:00:00.000Z",
+			lastInteractionDate: "2026-02-15T14:00:00.000Z",
+		});
+	});
+
+	test("normalizes offsets before formatting ClickHouse dates", () => {
+		expect(toClickHouseDateTime("2026-02-15T13:00:00+02:00")).toBe(
+			"2026-02-15 11:00:00.000",
+		);
+	});
+
+	test.each([
+		{ adapter: claudeCodeAdapter, name: "Claude Code" },
+		{ adapter: codexAdapter, name: "Codex" },
+	])("$name ingestion reuses timestamps supplied by the API", async ({
+		adapter,
+	}) => {
+		let insertedRows: Record<string, unknown>[] = [];
+		const ingestor = {
+			async insert({
+				values,
+			}: {
+				table: string;
+				values: Record<string, unknown>[];
+			}) {
+				insertedRows = values;
+			},
+		};
+
+		await adapter.ingest(
+			ingestor,
+			{
+				source: adapter.source,
+				sessionId: "precomputed-timestamps",
+				projectPath: "/test/project",
+				content: "not parsed again",
+			},
+			{
+				ingestedAt: new Date("2026-02-15T12:00:00.000Z"),
+				organizationId: "test-organization",
+				userId: "test-user",
+				timestamps: {
+					sessionDate: "2026-02-15T10:00:00.000Z",
+					lastInteractionDate: "2026-02-15T11:00:00.000Z",
+				},
+			},
+		);
+
+		expect(insertedRows[0]).toMatchObject({
+			session_date: "2026-02-15 10:00:00.000",
+			last_interaction_date: "2026-02-15 11:00:00.000",
 		});
 	});
 });

--- a/apps/api/src/__tests__/session-sharing.integration.ts
+++ b/apps/api/src/__tests__/session-sharing.integration.ts
@@ -35,6 +35,7 @@ const LEGACY_SHADOW_SESSION_ID = `${TEST_RUN_ID}_legacy_shadow`;
 const CROSS_ORG_SESSION_ID = `${TEST_RUN_ID}_cross_org`;
 const UNAUTHORIZED_SESSION_ID = `${TEST_RUN_ID}_unauthorized`;
 const CASCADE_SESSION_ID = `${TEST_RUN_ID}_cascade`;
+const TIMESTAMPLESS_SESSION_ID = `${TEST_RUN_ID}_timestampless`;
 
 setDefaultTimeout(60_000);
 
@@ -134,6 +135,28 @@ afterAll(async () => {
 });
 
 describe("organization session ownership", () => {
+	test("rejects timestamp-less transcripts before claiming ownership", async () => {
+		const input = createSessionInput(TIMESTAMPLESS_SESSION_ID, "invalid");
+		input.content = JSON.stringify({
+			result: "Meaningful transcript data without a timestamp",
+			type: "result",
+		});
+
+		const response = await callRpc(owner.token, "ingestSession", input);
+		expect(response.status).toBe(400);
+		expect(JSON.stringify(response.body)).toContain(
+			"Claude Code transcript contains no valid timestamp",
+		);
+
+		const ownership = await sqlClient<Array<{ session_id: string }>>`
+			SELECT session_id
+			FROM session_ownership
+			WHERE organization_id = ${organizationId}
+				AND session_id = ${TIMESTAMPLESS_SESSION_ID}
+		`;
+		expect(ownership).toHaveLength(0);
+	}, 60_000);
+
 	test("keeps teammate transcripts private and prevents replacement", async () => {
 		const ownerUpload = await callRpc(
 			owner.token,

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1,6 +1,9 @@
 import { getLogger } from "@logtape/logtape";
 import { ORPCError } from "@orpc/server";
-import { getAdapter } from "@rudel/agent-adapters";
+import {
+	getAdapter,
+	getMissingTranscriptTimestampMessage,
+} from "@rudel/agent-adapters";
 import {
 	INGEST_AGGREGATE_CONTENT_MAX_BYTES,
 	type IngestSessionInput,
@@ -210,6 +213,14 @@ const ingestSessionHandler = os.ingestSession
 				: undefined,
 			filter_version: FILTER_VERSION,
 		};
+		const adapter = getAdapter(filteredInput.source);
+		const timestamps = adapter.extractTimestamps(filteredInput.content);
+
+		if (!timestamps) {
+			throw new ORPCError("BAD_REQUEST", {
+				message: getMissingTranscriptTimestampMessage(filteredInput.source),
+			});
+		}
 
 		const activeOrgId =
 			context.session &&
@@ -279,11 +290,11 @@ const ingestSessionHandler = os.ingestSession
 		// Give each request a distinct millisecond RMT version even when the
 		// process clock has not advanced, so FINAL and hash bookkeeping agree.
 		const ingestedAt = getNextIngestedAt();
-		const adapter = getAdapter(filteredInput.source);
 		await adapter.ingest(getClickhouse(), filteredInput, {
 			ingestedAt,
 			userId: context.user.id,
 			organizationId: orgId,
+			timestamps,
 		});
 
 		try {

--- a/apps/cli/src/__tests__/api-upload.integration.ts
+++ b/apps/cli/src/__tests__/api-upload.integration.ts
@@ -197,9 +197,10 @@ describe("CLI upload to local API", () => {
 					sessionId: "e2e-test-session",
 				}),
 				JSON.stringify({
-					type: "message",
+					type: "user",
 					role: "human",
 					content: "test",
+					timestamp: "2026-07-29T10:00:00.000Z",
 				}),
 			].join("\n"),
 		);
@@ -280,9 +281,10 @@ describe("CLI upload to local API", () => {
 					sessionId: "rejected-session",
 				}),
 				JSON.stringify({
-					type: "message",
+					type: "user",
 					role: "human",
 					content: "test",
+					timestamp: "2026-07-29T10:00:00.000Z",
 				}),
 			].join("\n"),
 		);

--- a/apps/cli/src/__tests__/api-upload.integration.ts
+++ b/apps/cli/src/__tests__/api-upload.integration.ts
@@ -131,7 +131,14 @@ describe("CLI upload to local API", () => {
 			gitBranch: "main",
 			gitSha: "abc123",
 			tag: "tests",
-			content: "cli api integration test content",
+			content: JSON.stringify({
+				type: "user",
+				timestamp: "2026-07-31T10:00:00.000Z",
+				message: {
+					role: "user",
+					content: "cli api integration test content",
+				},
+			}),
 			subagents: [{ agentId: "sub-1", content: "subagent content" }],
 		};
 

--- a/apps/cli/src/__tests__/batch-upload.test.ts
+++ b/apps/cli/src/__tests__/batch-upload.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MissingTranscriptTimestampError } from "@rudel/agent-adapters";
+import { type BatchUploadItem, batchUpload } from "../lib/batch-upload.js";
+import {
+	loadFailedUploads,
+	recordFailedUpload,
+} from "../lib/failed-uploads.js";
+
+describe("batchUpload", () => {
+	let configDir: string;
+	let originalConfigDir: string | undefined;
+
+	beforeAll(async () => {
+		originalConfigDir = process.env.RUDEL_CONFIG_DIR;
+		configDir = await mkdtemp(join(tmpdir(), "rudel-batch-upload-test-"));
+		process.env.RUDEL_CONFIG_DIR = configDir;
+	});
+
+	afterAll(async () => {
+		if (originalConfigDir === undefined) {
+			delete process.env.RUDEL_CONFIG_DIR;
+		} else {
+			process.env.RUDEL_CONFIG_DIR = originalConfigDir;
+		}
+		await rm(configDir, { recursive: true, force: true });
+	});
+
+	test("skips timestamp-less sessions without poisoning the retry queue", async () => {
+		const items: BatchUploadItem[] = [
+			{
+				sessionId: "client-validation",
+				label: "client-validation",
+				transcriptPath: "/sessions/client-validation.jsonl",
+				projectPath: "/project",
+				source: "claude_code",
+			},
+			{
+				sessionId: "server-validation",
+				label: "server-validation",
+				transcriptPath: "/sessions/server-validation.jsonl",
+				projectPath: "/project",
+				source: "codex",
+			},
+		];
+
+		for (const item of items) {
+			await recordFailedUpload({
+				sessionId: item.sessionId,
+				transcriptPath: item.transcriptPath,
+				projectPath: item.projectPath,
+				source: item.source,
+				organizationId: item.organizationId,
+				error: "stale retry entry",
+			});
+		}
+
+		const summary = await batchUpload({
+			items,
+			upload: async (item) => {
+				if (item.sessionId === "client-validation") {
+					throw new MissingTranscriptTimestampError("claude_code");
+				}
+				return {
+					success: false,
+					error: "Codex transcript contains no valid timestamp",
+					retryable: false,
+				};
+			},
+		});
+
+		expect(summary).toMatchObject({
+			succeeded: 0,
+			failed: 0,
+			skipped: 2,
+			total: 2,
+			errors: [],
+			skippedItems: [
+				{
+					label: "client-validation",
+					reason: "Claude Code transcript contains no valid timestamp",
+				},
+				{
+					label: "server-validation",
+					reason: "Codex transcript contains no valid timestamp",
+				},
+			],
+		});
+		expect(await loadFailedUploads()).toEqual([]);
+	});
+});

--- a/apps/cli/src/__tests__/helpers/ingest-stub.ts
+++ b/apps/cli/src/__tests__/helpers/ingest-stub.ts
@@ -175,9 +175,10 @@ export async function createCliFixture(
 					payload: { id: sessionId, cwd: projectPath },
 				}),
 				JSON.stringify({
-					type: "message",
+					type: source === "codex" ? "message" : "user",
 					role: "human",
 					content: "endpoint security integration test",
+					timestamp: "2026-07-29T10:00:01.000Z",
 				}),
 			].join("\n"),
 		),

--- a/apps/cli/src/__tests__/packed-cli-smoke.integration.ts
+++ b/apps/cli/src/__tests__/packed-cli-smoke.integration.ts
@@ -195,10 +195,16 @@ test("over-budget transcript aborts with zero requests seen", async () => {
 	const stub = startIngestStub();
 	const fixture = await createCliFixture("claude_code");
 	try {
-		// The transcript is one whole secret: redaction would replace 100% of
-		// the content, far beyond the 20% budget, so the CLI must abort before
-		// any transport attempt.
-		await writeFile(fixture.transcriptPath, AWS_CANARY);
+		// Keep the fixture valid for timestamp extraction while making the secret
+		// large enough to exceed the 20% budget before any transport attempt.
+		await writeFile(
+			fixture.transcriptPath,
+			JSON.stringify({
+				type: "user",
+				timestamp: "2026-07-31T10:00:00.000Z",
+				message: `${AWS_CANARY} ${AWS_CANARY}`,
+			}),
+		);
 
 		const result = await runBuiltCli(
 			[
@@ -221,6 +227,44 @@ test("over-budget transcript aborts with zero requests seen", async () => {
 		expect(result.stderr).toContain("above the 20% transcript budget");
 		expect(result.stderr).not.toContain(AWS_CANARY);
 		expect(result.stdout).not.toContain(AWS_CANARY);
+		expect(stub.requests).toHaveLength(0);
+	} finally {
+		await stub.server.stop(true);
+		await rm(fixture.home, { recursive: true, force: true });
+	}
+}, 60_000);
+
+test("timestamp-less single upload reports a friendly error", async () => {
+	const packedCliPath = requirePackedCliPath();
+	const stub = startIngestStub();
+	const fixture = await createCliFixture("claude_code");
+	try {
+		await writeFile(
+			fixture.transcriptPath,
+			JSON.stringify({ type: "user", message: "No timestamp" }),
+		);
+
+		const result = await runBuiltCli(
+			[
+				"upload",
+				fixture.transcriptPath,
+				"--endpoint",
+				`${stub.loopbackBase}/rpc`,
+			],
+			{
+				home: fixture.home,
+				configDir: fixtureConfigDir(fixture),
+				cliPath: packedCliPath,
+				env: { RUDEL_ALLOW_INSECURE_ENDPOINT: "" },
+			},
+		);
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain(
+			"This transcript has no timestamped user/assistant messages, so it cannot be uploaded.",
+		);
+		expect(result.stderr).not.toContain("MissingTranscriptTimestampError");
+		expect(result.stderr).not.toContain("at ClaudeCodeAdapter");
 		expect(stub.requests).toHaveLength(0);
 	} finally {
 		await stub.server.stop(true);

--- a/apps/cli/src/__tests__/upload.integration.test.ts
+++ b/apps/cli/src/__tests__/upload.integration.test.ts
@@ -1,9 +1,18 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, readdirSync } from "node:fs";
-import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import {
+	mkdir,
+	mkdtemp,
+	readdir,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
+	claudeCodeAdapter,
+	codexAdapter,
 	extractAgentIds,
 	readFileWithRetry,
 	readSubagentFiles,
@@ -13,16 +22,21 @@ import { resolveSession } from "../lib/session-resolver.js";
 
 // Sample JSONL content mimicking a real Claude session
 const SAMPLE_SESSION_CONTENT = [
-	JSON.stringify({ type: "summary", sessionId: "test-session-1" }),
 	JSON.stringify({
-		type: "message",
-		role: "human",
-		content: "Hello, help me fix a bug",
+		type: "summary",
+		sessionId: "test-session-1",
 	}),
 	JSON.stringify({
-		type: "message",
+		type: "user",
+		role: "human",
+		content: "Hello, help me fix a bug",
+		timestamp: "2026-07-29T10:00:00.000Z",
+	}),
+	JSON.stringify({
+		type: "assistant",
 		role: "assistant",
 		content: "Sure, let me look at the code",
+		timestamp: "2026-07-29T10:00:01.000Z",
 	}),
 	JSON.stringify({
 		toolUseResult: { agentId: "sub-agent-001", result: "done" },
@@ -82,14 +96,18 @@ async function findRealSessionId(): Promise<string> {
 	for (const dir of projectDirs) {
 		const fullDir = join(sessionsBase, dir);
 		const files = await readdir(fullDir).catch(() => [] as string[]);
-		const sessionFile = files.find(
-			(f) =>
-				f.endsWith(".jsonl") &&
-				!f.startsWith("agent-") &&
-				f !== "sessions-index.json",
+		const sessionFiles = files.filter(
+			(file) =>
+				file.endsWith(".jsonl") &&
+				!file.startsWith("agent-") &&
+				file !== "sessions-index.json",
 		);
-		if (sessionFile) {
-			return sessionFile.replace(/\.jsonl$/, "");
+
+		for (const sessionFile of sessionFiles) {
+			const content = await readFileWithRetry(join(fullDir, sessionFile));
+			if (claudeCodeAdapter.extractTimestamps(content)) {
+				return sessionFile.replace(/\.jsonl$/, "");
+			}
 		}
 	}
 
@@ -188,6 +206,23 @@ describe("transcript reader", () => {
 		const agentIds = extractAgentIds(content);
 		expect(agentIds).toEqual(["valid-agent"]);
 	});
+
+	test.each([
+		{ name: "non-string", agentId: 42 },
+		{ name: "forward-slash traversal", agentId: "../../../secret" },
+		{ name: "Windows-style traversal", agentId: "..\\..\\secret" },
+		{ name: "absolute path", agentId: "/tmp/secret" },
+		{
+			name: "Windows absolute path",
+			agentId: ["C:", "\\", "temp", "\\", "secret"].join(""),
+		},
+		{ name: "dot segment", agentId: ".." },
+		{ name: "encoded separator", agentId: "..%2f..%2fsecret" },
+	])("rejects $name agent IDs", ({ agentId }) => {
+		const content = JSON.stringify({ toolUseResult: { agentId } });
+
+		expect(extractAgentIds(content)).toEqual([]);
+	});
 });
 
 describe("subagent reader", () => {
@@ -233,6 +268,56 @@ describe("subagent reader", () => {
 		expect(subagents).toHaveLength(1);
 		expect(subagents[0]?.agentId).toBe("new-agent");
 	});
+
+	test("rejects invalid IDs even when called directly", async () => {
+		const sessionDir = join(tempDir, "subagent-invalid-id-test");
+		await mkdir(sessionDir, { recursive: true });
+		await writeFile(join(sessionDir, "secret.jsonl"), "must not be read");
+
+		const subagents = await readSubagentFiles(sessionDir, ["../../secret"]);
+
+		expect(subagents).toEqual([]);
+	});
+
+	test.skipIf(process.platform === "win32")(
+		"does not follow a subagent file symlink outside the session directory",
+		async () => {
+			const sessionDir = join(tempDir, "subagent-file-symlink-test");
+			const outsideFile = join(tempDir, "outside-subagent.jsonl");
+			await mkdir(sessionDir, { recursive: true });
+			await writeFile(outsideFile, "must not be read");
+			await symlink(outsideFile, join(sessionDir, "agent-escape.jsonl"));
+
+			const subagents = await readSubagentFiles(sessionDir, ["escape"]);
+
+			expect(subagents).toEqual([]);
+		},
+	);
+
+	test.skipIf(process.platform === "win32")(
+		"does not follow a subagents directory symlink outside the session directory",
+		async () => {
+			const sessionDir = join(tempDir, "subagent-directory-symlink-test");
+			const sessionId = "safe-session-id";
+			const nestedSessionDir = join(sessionDir, sessionId);
+			const outsideDir = join(tempDir, "outside-subagents");
+			await mkdir(nestedSessionDir, { recursive: true });
+			await mkdir(outsideDir, { recursive: true });
+			await writeFile(
+				join(outsideDir, "agent-escape.jsonl"),
+				"must not be read",
+			);
+			await symlink(outsideDir, join(nestedSessionDir, "subagents"));
+
+			const subagents = await readSubagentFiles(
+				sessionDir,
+				["escape"],
+				sessionId,
+			);
+
+			expect(subagents).toEqual([]);
+		},
+	);
 });
 
 describe("git info", () => {
@@ -254,6 +339,41 @@ describe("git info", () => {
 });
 
 describe("full upload pipeline (dry-run)", () => {
+	test.each([
+		{
+			adapter: claudeCodeAdapter,
+			name: "Claude Code",
+			error: "Claude Code transcript contains no valid timestamp",
+		},
+		{
+			adapter: codexAdapter,
+			name: "Codex",
+			error: "Codex transcript contains no valid timestamp",
+		},
+	])("rejects a timestamp-less $name transcript before upload", async ({
+		adapter,
+		error,
+		name,
+	}) => {
+		const sessionId = `timestamp-less-${name.toLowerCase().replaceAll(" ", "-")}`;
+		const sessionFile = join(tempDir, `${sessionId}.jsonl`);
+		await writeFile(sessionFile, '{"type":"result","result":{"ok":true}}');
+
+		await expect(
+			adapter.buildUploadRequest(
+				{
+					sessionId,
+					transcriptPath: sessionFile,
+					projectPath: tempDir,
+				},
+				{
+					gitInfo: {},
+					uploadMode: "manual",
+				},
+			),
+		).rejects.toThrow(error);
+	});
+
 	test("resolves session by path, reads transcript, extracts subagents, and builds request", async () => {
 		// Set up a realistic session directory
 		const projectDir = join(tempDir, "pipeline-test");

--- a/apps/cli/src/__tests__/uploader.test.ts
+++ b/apps/cli/src/__tests__/uploader.test.ts
@@ -13,6 +13,10 @@ import {
 	getSecretFilterUploadFailure,
 	uploadSession,
 } from "../lib/uploader.js";
+import {
+	INGEST_STUB_TEST_TOKEN,
+	startIngestStub,
+} from "./helpers/ingest-stub.js";
 
 describe("formatUploadError", () => {
 	test("explains API key rate limits from ingest auth", () => {
@@ -177,6 +181,62 @@ describe("uploadSession aggregate size guard", () => {
 				"Session transcript payload is 2.00 MiB, above the 1.00 MiB per-session limit. Reduce the transcript/subagent payload before retrying.",
 			attempts: 0,
 		});
+	});
+});
+
+describe("uploadSession timestamp validation", () => {
+	test.each([
+		{
+			source: "claude_code" as const,
+			message: "Claude Code transcript contains no valid timestamp",
+		},
+		{
+			source: "codex" as const,
+			message: "Codex transcript contains no valid timestamp",
+		},
+	])("marks a $source server rejection as not retryable", async ({
+		source,
+		message,
+	}) => {
+		const stub = startIngestStub({
+			respond: () =>
+				Response.json(
+					{
+						json: {
+							defined: false,
+							code: "BAD_REQUEST",
+							status: 400,
+							message,
+						},
+					},
+					{ status: 400 },
+				),
+		});
+
+		try {
+			const result = await uploadSession(
+				{
+					source,
+					sessionId: `${source}-server-timestamp-validation`,
+					projectPath: "/test/project",
+					content: '{"type":"user","timestamp":"2026-07-31T10:00:00.000Z"}',
+				},
+				{
+					endpoint: `${stub.loopbackBase}/rpc`,
+					token: INGEST_STUB_TEST_TOKEN,
+					allowInsecureEndpoint: false,
+				},
+			);
+
+			expect(result).toEqual({
+				success: false,
+				error: message,
+				attempts: 1,
+				retryable: false,
+			});
+		} finally {
+			await stub.server.stop(true);
+		}
 	});
 });
 

--- a/apps/cli/src/commands/enable.ts
+++ b/apps/cli/src/commands/enable.ts
@@ -244,25 +244,18 @@ async function runEnable(): Promise<undefined | Error> {
 				if (!session) {
 					return { success: false, error: "Session not found" };
 				}
-				try {
-					const request = await adapter.buildUploadRequest(session, {
-						gitInfo,
-						organizationId: selectedOrgId,
-						uploadMode: "manual",
-					});
-					return uploadSession(request, {
-						endpoint,
-						token: credentials.token,
-						allowInsecureEndpoint: allowPlaintextEndpoint,
-						authType: credentials.authType,
-						onRetry,
-					});
-				} catch (error) {
-					return {
-						success: false,
-						error: error instanceof Error ? error.message : String(error),
-					};
-				}
+				const request = await adapter.buildUploadRequest(session, {
+					gitInfo,
+					organizationId: selectedOrgId,
+					uploadMode: "manual",
+				});
+				return uploadSession(request, {
+					endpoint,
+					token: credentials.token,
+					allowInsecureEndpoint: allowPlaintextEndpoint,
+					authType: credentials.authType,
+					onRetry,
+				});
 			},
 		});
 

--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -2,10 +2,11 @@ import * as p from "@clack/prompts";
 import {
 	claudeCodeAdapter,
 	getAdapter,
+	MissingTranscriptTimestampError,
 	type ScannedProject,
 	type SessionFile,
 } from "@rudel/agent-adapters";
-import type { Source } from "@rudel/api-routes";
+import type { IngestSessionInput, Source } from "@rudel/api-routes";
 import { buildCommand } from "@stricli/core";
 import type { BatchUploadItem } from "../lib/batch-upload.js";
 import { renderBatchSummary, runBatchUpload } from "../lib/batch-upload-ui.js";
@@ -238,12 +239,22 @@ async function runSingleUpload(
 		projectPath: sessionInfo.projectPath,
 	};
 
-	const request = await claudeCodeAdapter.buildUploadRequest(sessionFile, {
-		tag: flags.tag,
-		gitInfo,
-		organizationId,
-		uploadMode: "manual",
-	});
+	let request: IngestSessionInput;
+	try {
+		request = await claudeCodeAdapter.buildUploadRequest(sessionFile, {
+			tag: flags.tag,
+			gitInfo,
+			organizationId,
+			uploadMode: "manual",
+		});
+	} catch (error) {
+		if (error instanceof MissingTranscriptTimestampError) {
+			return new Error(
+				"This transcript has no timestamped user/assistant messages, so it cannot be uploaded.",
+			);
+		}
+		throw error;
+	}
 
 	write(`Transcript: ${request.content.length} bytes`);
 	if (request.subagents && request.subagents.length > 0) {

--- a/apps/cli/src/lib/batch-upload-ui.ts
+++ b/apps/cli/src/lib/batch-upload-ui.ts
@@ -39,7 +39,9 @@ export async function runBatchUpload<T extends BatchUploadItem>(
 	bar.stop(
 		summary.failed > 0
 			? `Completed with ${summary.failed} error(s)`
-			: "Upload complete",
+			: summary.skipped > 0
+				? `Completed with ${summary.skipped} skipped`
+				: "Upload complete",
 	);
 
 	return summary;
@@ -76,6 +78,15 @@ export function renderBatchSummary(
 		}
 		if (summary.errors.length > maxErrors) {
 			lines.push(`  ...and ${summary.errors.length - maxErrors} more`);
+		}
+	}
+	if (summary.skipped > 0) {
+		lines.push(`${prefix}${summary.skipped} session(s) skipped`);
+		for (const item of summary.skippedItems.slice(0, maxErrors)) {
+			lines.push(`  ${item.label}: ${item.reason}`);
+		}
+		if (summary.skippedItems.length > maxErrors) {
+			lines.push(`  ...and ${summary.skippedItems.length - maxErrors} more`);
 		}
 	}
 

--- a/apps/cli/src/lib/batch-upload.ts
+++ b/apps/cli/src/lib/batch-upload.ts
@@ -1,3 +1,4 @@
+import { MissingTranscriptTimestampError } from "@rudel/agent-adapters";
 import type { Source } from "@rudel/api-routes";
 import {
 	mergeRedactionCounts,
@@ -35,8 +36,10 @@ export interface BatchUploadOptions<T extends BatchUploadItem> {
 export interface BatchUploadSummary {
 	succeeded: number;
 	failed: number;
+	skipped: number;
 	total: number;
 	errors: Array<{ label: string; error: string }>;
+	skippedItems: Array<{ label: string; reason: string }>;
 	redacted: RedactionCounts;
 	redactedBytes: number;
 }
@@ -49,9 +52,12 @@ export async function batchUpload<T extends BatchUploadItem>(
 	let succeeded = 0;
 	let failed = 0;
 	let skipped = 0;
+	let deferred = 0;
 	let completed = 0;
 	let rateLimited = false;
 	const errors: Array<{ label: string; error: string }> = [];
+	const skippedItems: Array<{ label: string; reason: string }> = [];
+	const skippedSessionIds = new Set<string>();
 	let redacted: RedactionCounts = {};
 	let redactedBytes = 0;
 
@@ -59,7 +65,7 @@ export async function batchUpload<T extends BatchUploadItem>(
 		items,
 		async (item) => {
 			if (rateLimited) {
-				skipped++;
+				deferred++;
 				const error =
 					"Skipped — rate limit reached. Run `rudel upload --retry` to upload remaining sessions.";
 				await recordFailedUpload({
@@ -90,6 +96,13 @@ export async function batchUpload<T extends BatchUploadItem>(
 					redacted = mergeRedactionCounts(redacted, result.redacted ?? {});
 					redactedBytes += result.redactedBytes ?? 0;
 					await removeFailedUpload(item.sessionId);
+				} else if (result.retryable === false) {
+					skipped++;
+					skippedItems.push({
+						label: item.label,
+						reason: result.error ?? "Upload cannot be retried",
+					});
+					skippedSessionIds.add(item.sessionId);
 				} else {
 					failed++;
 					const error = result.error ?? "Unknown error";
@@ -107,17 +120,23 @@ export async function batchUpload<T extends BatchUploadItem>(
 					});
 				}
 			} catch (err) {
-				failed++;
 				const error = err instanceof Error ? err.message : String(err);
-				errors.push({ label: item.label, error });
-				await recordFailedUpload({
-					sessionId: item.sessionId,
-					transcriptPath: item.transcriptPath,
-					projectPath: item.projectPath,
-					source: item.source,
-					organizationId: item.organizationId,
-					error,
-				});
+				if (err instanceof MissingTranscriptTimestampError) {
+					skipped++;
+					skippedItems.push({ label: item.label, reason: error });
+					skippedSessionIds.add(item.sessionId);
+				} else {
+					failed++;
+					errors.push({ label: item.label, error });
+					await recordFailedUpload({
+						sessionId: item.sessionId,
+						transcriptPath: item.transcriptPath,
+						projectPath: item.projectPath,
+						source: item.source,
+						organizationId: item.organizationId,
+						error,
+					});
+				}
 			} finally {
 				completed++;
 				onItemComplete?.(completed, total);
@@ -126,13 +145,26 @@ export async function batchUpload<T extends BatchUploadItem>(
 		{ concurrency, stopOnError: false },
 	);
 
-	if (rateLimited && skipped > 0) {
-		errors.push({
-			label: "Rate limit",
-			error: `${skipped} session(s) skipped. Run \`rudel upload --retry\` later to upload them.`,
-		});
-		failed += skipped;
+	for (const sessionId of skippedSessionIds) {
+		await removeFailedUpload(sessionId);
 	}
 
-	return { succeeded, failed, total, errors, redacted, redactedBytes };
+	if (rateLimited && deferred > 0) {
+		errors.push({
+			label: "Rate limit",
+			error: `${deferred} session(s) skipped. Run \`rudel upload --retry\` later to upload them.`,
+		});
+		failed += deferred;
+	}
+
+	return {
+		succeeded,
+		failed,
+		skipped,
+		total,
+		errors,
+		skippedItems,
+		redacted,
+		redactedBytes,
+	};
 }

--- a/apps/cli/src/lib/hook-upload-failure.ts
+++ b/apps/cli/src/lib/hook-upload-failure.ts
@@ -1,5 +1,9 @@
 import type { Logger } from "@logtape/logtape";
-import { type FailedUpload, recordFailedUpload } from "./failed-uploads.js";
+import {
+	type FailedUpload,
+	recordFailedUpload,
+	removeFailedUpload,
+} from "./failed-uploads.js";
 import type { UploadResult } from "./types.js";
 
 /**
@@ -16,6 +20,11 @@ export async function reportHookUploadFailure(
 		sessionId: failure.sessionId,
 		error: uploadError,
 	});
+
+	if (result.retryable === false) {
+		await removeFailedUpload(failure.sessionId);
+		return;
+	}
 
 	if (result.endpointRejected) {
 		process.stderr.write(

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -25,6 +25,8 @@ export interface UploadResult {
 	error?: string;
 	attempts?: number;
 	rateLimited?: boolean;
+	/** Whether a failed upload belongs in the durable retry queue. */
+	retryable?: boolean;
 	redacted?: RedactionCounts;
 	redactedBytes?: number;
 	redactionBudgetExceeded?: boolean;

--- a/apps/cli/src/lib/uploader.ts
+++ b/apps/cli/src/lib/uploader.ts
@@ -1,6 +1,7 @@
 import { createORPCClient, ORPCError } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
 import type { ContractRouterClient } from "@orpc/contract";
+import { isMissingTranscriptTimestampMessage } from "@rudel/agent-adapters";
 import {
 	type contract,
 	INGEST_AGGREGATE_CONTENT_MAX_BYTES,
@@ -368,6 +369,19 @@ export async function uploadSession(
 					filteredText.redactedBytes + (response.redactedBytes ?? 0),
 			};
 		} catch (error) {
+			if (
+				error instanceof ORPCError &&
+				error.status === 400 &&
+				isMissingTranscriptTimestampMessage(request.source, error.message)
+			) {
+				return {
+					success: false,
+					error: error.message,
+					attempts: attempt,
+					retryable: false,
+				};
+			}
+
 			const errorMessage = formatUploadError(error);
 
 			if (isRateLimited(error) || isApiKeyRateLimited(error)) {

--- a/packages/agent-adapters/src/adapters/claude-code/index.ts
+++ b/packages/agent-adapters/src/adapters/claude-code/index.ts
@@ -1,17 +1,19 @@
-import { readdir, readFile, stat } from "node:fs/promises";
+import { readdir, readFile, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, relative, sep } from "node:path";
 import type { IngestSessionInput } from "@rudel/api-routes";
 import {
 	type Ingestor,
 	ingestRudelClaudeSessions,
 	type RudelClaudeSessionsRow,
 } from "@rudel/ch-schema/generated";
+import { MissingTranscriptTimestampError } from "../../errors.js";
 import type {
 	AgentAdapter,
 	IngestContext,
 	ScannedProject,
 	SessionFile,
+	SessionTimestamps,
 	UploadContext,
 } from "../../types.js";
 import {
@@ -27,6 +29,7 @@ import {
 } from "./settings.js";
 
 const SESSIONS_BASE_DIR = join(homedir(), ".claude", "projects");
+const SAFE_BASENAME_PATTERN = /^[A-Za-z0-9_-]{1,200}$/;
 
 // ── Exported utilities ──
 
@@ -88,9 +91,12 @@ export function extractAgentIds(sessionContent: string): string[] {
 		if (!line.trim()) continue;
 
 		try {
-			const entry = JSON.parse(line);
-			if (entry.toolUseResult?.agentId) {
-				agentIds.add(entry.toolUseResult.agentId);
+			const entry: unknown = JSON.parse(line);
+			if (!isRecord(entry) || !isRecord(entry.toolUseResult)) continue;
+
+			const agentId = entry.toolUseResult.agentId;
+			if (isSafeBasename(agentId)) {
+				agentIds.add(agentId);
 			}
 		} catch {
 			// Skip malformed lines
@@ -111,16 +117,20 @@ export async function readSubagentFiles(
 	sessionId?: string,
 ): Promise<SubagentFile[]> {
 	const subagents: SubagentFile[] = [];
+	const subagentDirs = await resolveSubagentDirectories(sessionDir, sessionId);
 
 	for (const agentId of agentIds) {
-		const possiblePaths = [
-			join(sessionDir, `agent-${agentId}.jsonl`),
-			...(sessionId
-				? [join(sessionDir, sessionId, "subagents", `agent-${agentId}.jsonl`)]
-				: []),
-		];
+		if (!isSafeBasename(agentId)) continue;
 
-		for (const agentPath of possiblePaths) {
+		for (const subagentDir of subagentDirs) {
+			let agentPath: string;
+			try {
+				agentPath = await realpath(join(subagentDir, `agent-${agentId}.jsonl`));
+			} catch {
+				continue;
+			}
+			if (!isContainedPath(subagentDir, agentPath)) continue;
+
 			try {
 				const content = await readFile(agentPath, "utf-8");
 				subagents.push({ agentId, content });
@@ -221,6 +231,9 @@ class ClaudeCodeAdapter implements AgentAdapter {
 		context: UploadContext,
 	): Promise<IngestSessionInput> {
 		const content = await readFileWithRetry(session.transcriptPath);
+		if (!this.extractTimestamps(content)) {
+			throw new MissingTranscriptTimestampError(this.source);
+		}
 
 		const agentIds = extractAgentIds(content);
 		const sessionDir = dirname(session.transcriptPath);
@@ -246,28 +259,34 @@ class ClaudeCodeAdapter implements AgentAdapter {
 		};
 	}
 
-	extractTimestamps(content: string): {
-		sessionDate: string;
-		lastInteractionDate: string;
-	} | null {
+	extractTimestamps(content: string): SessionTimestamps | null {
 		let min: string | null = null;
 		let max: string | null = null;
+		let minTime = Number.POSITIVE_INFINITY;
+		let maxTime = Number.NEGATIVE_INFINITY;
 
 		for (const line of content.split("\n")) {
 			if (!line) continue;
-			let parsed: { type?: string; timestamp?: string };
+			let parsed: unknown;
 			try {
 				parsed = JSON.parse(line);
 			} catch {
 				continue;
 			}
-			if (
-				(parsed.type === "user" || parsed.type === "assistant") &&
-				parsed.timestamp
-			) {
-				const ts = parsed.timestamp;
-				if (!min || ts < min) min = ts;
-				if (!max || ts > max) max = ts;
+			if (!isRecord(parsed)) continue;
+			if (parsed.type !== "user" && parsed.type !== "assistant") continue;
+			if (typeof parsed.timestamp !== "string") continue;
+			const timestampTime = Date.parse(parsed.timestamp);
+			if (!Number.isFinite(timestampTime)) continue;
+
+			const timestamp = new Date(timestampTime).toISOString();
+			if (timestampTime < minTime) {
+				min = timestamp;
+				minTime = timestampTime;
+			}
+			if (timestampTime > maxTime) {
+				max = timestamp;
+				maxTime = timestampTime;
 			}
 		}
 
@@ -298,15 +317,17 @@ class ClaudeCodeAdapter implements AgentAdapter {
 			}
 		}
 
-		const timestamps = this.extractTimestamps(input.content);
+		const timestamps =
+			context.timestamps ?? this.extractTimestamps(input.content);
+		if (!timestamps) {
+			throw new MissingTranscriptTimestampError(this.source);
+		}
 
 		return {
-			session_date: timestamps
-				? toClickHouseDateTime(timestamps.sessionDate)
-				: now,
-			last_interaction_date: timestamps
-				? toClickHouseDateTime(timestamps.lastInteractionDate)
-				: now,
+			session_date: toClickHouseDateTime(timestamps.sessionDate),
+			last_interaction_date: toClickHouseDateTime(
+				timestamps.lastInteractionDate,
+			),
 			session_id: input.sessionId,
 			organization_id: context.organizationId,
 			project_path: input.projectPath,
@@ -367,3 +388,51 @@ class ClaudeCodeAdapter implements AgentAdapter {
 }
 
 export const claudeCodeAdapter = new ClaudeCodeAdapter();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isSafeBasename(value: unknown): value is string {
+	return typeof value === "string" && SAFE_BASENAME_PATTERN.test(value);
+}
+
+async function resolveSubagentDirectories(
+	sessionDir: string,
+	sessionId: string | undefined,
+): Promise<string[]> {
+	let canonicalSessionDir: string;
+	try {
+		canonicalSessionDir = await realpath(sessionDir);
+	} catch {
+		return [];
+	}
+
+	const directories = [canonicalSessionDir];
+	if (!isSafeBasename(sessionId)) {
+		return directories;
+	}
+
+	try {
+		const nestedDir = await realpath(
+			join(canonicalSessionDir, sessionId, "subagents"),
+		);
+		if (isContainedPath(canonicalSessionDir, nestedDir)) {
+			directories.push(nestedDir);
+		}
+	} catch {
+		// The nested subagent directory is optional.
+	}
+
+	return directories;
+}
+
+function isContainedPath(parentPath: string, candidatePath: string): boolean {
+	const pathFromParent = relative(parentPath, candidatePath);
+	return (
+		pathFromParent !== "" &&
+		pathFromParent !== ".." &&
+		!pathFromParent.startsWith(`..${sep}`) &&
+		!isAbsolute(pathFromParent)
+	);
+}

--- a/packages/agent-adapters/src/adapters/codex/index.ts
+++ b/packages/agent-adapters/src/adapters/codex/index.ts
@@ -7,11 +7,13 @@ import {
 	ingestRudelCodexSessions,
 	type RudelCodexSessionsRow,
 } from "@rudel/ch-schema/generated";
+import { MissingTranscriptTimestampError } from "../../errors.js";
 import type {
 	AgentAdapter,
 	IngestContext,
 	ScannedProject,
 	SessionFile,
+	SessionTimestamps,
 	UploadContext,
 } from "../../types.js";
 import {
@@ -172,6 +174,9 @@ class CodexAdapter implements AgentAdapter {
 		context: UploadContext,
 	): Promise<IngestSessionInput> {
 		const content = await readFile(session.transcriptPath, "utf-8");
+		if (!this.extractTimestamps(content)) {
+			throw new MissingTranscriptTimestampError(this.source);
+		}
 
 		return {
 			source: this.source,
@@ -189,25 +194,32 @@ class CodexAdapter implements AgentAdapter {
 		};
 	}
 
-	extractTimestamps(content: string): {
-		sessionDate: string;
-		lastInteractionDate: string;
-	} | null {
+	extractTimestamps(content: string): SessionTimestamps | null {
 		let min: string | null = null;
 		let max: string | null = null;
+		let minTime = Number.POSITIVE_INFINITY;
+		let maxTime = Number.NEGATIVE_INFINITY;
 
 		for (const line of content.split("\n")) {
 			if (!line) continue;
-			let parsed: { timestamp?: string };
+			let parsed: unknown;
 			try {
 				parsed = JSON.parse(line);
 			} catch {
 				continue;
 			}
-			if (parsed.timestamp) {
-				const ts = parsed.timestamp;
-				if (!min || ts < min) min = ts;
-				if (!max || ts > max) max = ts;
+			if (!isRecord(parsed) || typeof parsed.timestamp !== "string") continue;
+			const timestampTime = Date.parse(parsed.timestamp);
+			if (!Number.isFinite(timestampTime)) continue;
+
+			const timestamp = new Date(timestampTime).toISOString();
+			if (timestampTime < minTime) {
+				min = timestamp;
+				minTime = timestampTime;
+			}
+			if (timestampTime > maxTime) {
+				max = timestamp;
+				maxTime = timestampTime;
 			}
 		}
 
@@ -231,15 +243,17 @@ class CodexAdapter implements AgentAdapter {
 	): RudelCodexSessionsRow {
 		const now = context.ingestedAt.toISOString().replace("Z", "");
 
-		const timestamps = this.extractTimestamps(input.content);
+		const timestamps =
+			context.timestamps ?? this.extractTimestamps(input.content);
+		if (!timestamps) {
+			throw new MissingTranscriptTimestampError(this.source);
+		}
 
 		return {
-			session_date: timestamps
-				? toClickHouseDateTime(timestamps.sessionDate)
-				: now,
-			last_interaction_date: timestamps
-				? toClickHouseDateTime(timestamps.lastInteractionDate)
-				: now,
+			session_date: toClickHouseDateTime(timestamps.sessionDate),
+			last_interaction_date: toClickHouseDateTime(
+				timestamps.lastInteractionDate,
+			),
 			session_id: input.sessionId,
 			organization_id: context.organizationId,
 			project_path: input.projectPath,
@@ -258,3 +272,7 @@ class CodexAdapter implements AgentAdapter {
 }
 
 export const codexAdapter = new CodexAdapter();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/packages/agent-adapters/src/errors.ts
+++ b/packages/agent-adapters/src/errors.ts
@@ -1,0 +1,24 @@
+import type { Source } from "@rudel/api-routes";
+
+const SOURCE_DISPLAY_NAMES: Record<Source, string> = {
+	claude_code: "Claude Code",
+	codex: "Codex",
+};
+
+export function getMissingTranscriptTimestampMessage(source: Source): string {
+	return `${SOURCE_DISPLAY_NAMES[source]} transcript contains no valid timestamp`;
+}
+
+export function isMissingTranscriptTimestampMessage(
+	source: Source,
+	message: string,
+): boolean {
+	return message === getMissingTranscriptTimestampMessage(source);
+}
+
+export class MissingTranscriptTimestampError extends Error {
+	constructor(source: Source) {
+		super(getMissingTranscriptTimestampMessage(source));
+		this.name = "MissingTranscriptTimestampError";
+	}
+}

--- a/packages/agent-adapters/src/index.ts
+++ b/packages/agent-adapters/src/index.ts
@@ -10,6 +10,11 @@ export {
 	readCodexSessionMeta,
 } from "./adapters/codex/index.js";
 export {
+	getMissingTranscriptTimestampMessage,
+	isMissingTranscriptTimestampMessage,
+	MissingTranscriptTimestampError,
+} from "./errors.js";
+export {
 	getAdapter,
 	getAllAdapters,
 	getAvailableAdapters,
@@ -21,6 +26,7 @@ export type {
 	IngestContext,
 	ScannedProject,
 	SessionFile,
+	SessionTimestamps,
 	UploadContext,
 } from "./types.js";
 export {

--- a/packages/agent-adapters/src/types.ts
+++ b/packages/agent-adapters/src/types.ts
@@ -32,10 +32,16 @@ export interface UploadContext {
 	uploadMode: IngestSessionInput["upload_mode"];
 }
 
+export interface SessionTimestamps {
+	sessionDate: string;
+	lastInteractionDate: string;
+}
+
 export interface IngestContext {
 	userId: string;
 	organizationId: string;
 	ingestedAt: Date;
+	timestamps?: SessionTimestamps;
 }
 
 export interface AgentAdapter {
@@ -61,10 +67,7 @@ export interface AgentAdapter {
 	): Promise<IngestSessionInput>;
 
 	// Ingestion (API)
-	extractTimestamps(content: string): {
-		sessionDate: string;
-		lastInteractionDate: string;
-	} | null;
+	extractTimestamps(content: string): SessionTimestamps | null;
 	ingest(
 		ingestor: Ingestor,
 		input: IngestSessionInput,

--- a/packages/agent-adapters/src/utils.ts
+++ b/packages/agent-adapters/src/utils.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 export function toClickHouseDateTime(isoString: string): string {
-	return isoString.replace("T", " ").replace("Z", "").replace(/\+.*$/, "");
+	return new Date(isoString).toISOString().replace("T", " ").replace("Z", "");
 }
 
 export async function readFileWithRetry(


### PR DESCRIPTION
## Summary
- Harden Claude subagent ingestion with strict basename validation and canonical path containment before file reads ([RUD-249](https://linear.app/nuahq/issue/RUD-249/contain-claude-agentid-subagent-file-reads)).
- Make Claude and Codex timestamps deterministic and UTC-normalized with millisecond ClickHouse precision, reuse API extraction, classify timestamp-less batch uploads as permanent skips, and report single-file skips without stack traces.
- **Behavior change:** the `session_date = now()` fallback is removed, so timestamp-less transcripts now receive HTTP 400; old CLI versions will see this error instead of a silent junk-dated ingest ([RUD-231](https://linear.app/nuahq/issue/RUD-231/non-deterministic-session-date-fallback-mints-permanent-duplicate-rows)).
- **Known data note:** already-ingested sessions with non-Z timezone offsets can compute a different `session_date` on re-ingest (for example, after a `FILTER_VERSION` bump), leaving unreplaced ReplacingMergeTree rows; the small blast radius is accepted and cleanup is TBD with the mutable-sorting-key work.

## Test plan
- [x] `bun run verify`
- [x] packed CLI smoke matrix: Ubuntu Node 20/22/24, macOS Node 20, Windows Node 20
- [x] ClickHouse/Postgres integration suite
- [ ] Production failure-rate measurement (no least-privilege production read-only credentials were available)