### PR TITLE
fix(web): bound transcript blocks and keys

### DIFF
--- a/apps/web/browser-tests/message-content-harness.tsx
+++ b/apps/web/browser-tests/message-content-harness.tsx
@@ -1,6 +1,9 @@
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
-import { MessageContent } from "../src/components/conversation/MessageContent";
+import {
+	MAX_RENDERED_MESSAGE_BLOCKS,
+	MessageContent,
+} from "../src/components/conversation/MessageContent";
 import {
 	MAX_FORMATTED_MESSAGE_PARTS,
 	MAX_HIGHLIGHTED_CODE_BLOCK_UNITS,
@@ -24,7 +27,9 @@ const scenario = new URLSearchParams(window.location.search).get("scenario");
 const adversarialContent =
 	scenario === "array"
 		? createAdversarialArrayContent()
-		: createAdversarialMessage(scenario);
+		: scenario === "blocks"
+			? createExcessMessageBlocks()
+			: createAdversarialMessage(scenario);
 const root = createRoot(messageRoot);
 const renderStartedAt = performance.now();
 
@@ -49,11 +54,15 @@ requestAnimationFrame(() => {
 	renderResult.dataset.xmlBlocks = String(
 		messageRoot.querySelectorAll('[data-testid="message-xml-block"]').length,
 	);
+	renderResult.dataset.textBlocks = String(
+		messageRoot.querySelectorAll('[data-testid="message-text-block"]').length,
+	);
+	renderResult.dataset.maxMessageBlocks = String(MAX_RENDERED_MESSAGE_BLOCKS);
 	renderResult.textContent = "Rendered";
 });
 
 function createAdversarialArrayContent() {
-	const blockCount = MAX_FORMATTED_MESSAGE_PARTS * 2;
+	const blockCount = MAX_FORMATTED_MESSAGE_PARTS + 2;
 	const codeLine = "const value = 1;\n";
 	const fenceLength = "```js\n\n```".length;
 	const codeUnitsPerBlock =
@@ -69,7 +78,21 @@ function createAdversarialArrayContent() {
 	}));
 }
 
+function createExcessMessageBlocks() {
+	return Array.from(
+		{ length: MAX_RENDERED_MESSAGE_BLOCKS + 1 },
+		(_, blockIndex) => ({
+			type: "text" as const,
+			text: `Plain text block ${blockIndex}`,
+		}),
+	);
+}
+
 function createAdversarialMessage(scenario: string | null) {
+	if (scenario === "duplicate-xml") {
+		return "<metadata><field>first</field><field>second</field></metadata>";
+	}
+
 	if (scenario === "large-code") {
 		const codeLine = "const value = 1;\n";
 		const highlightedCode = codeLine.repeat(

--- a/apps/web/browser-tests/message-content.pw.ts
+++ b/apps/web/browser-tests/message-content.pw.ts
@@ -58,3 +58,44 @@ for (const scenario of ["array", "code", "large-code", "xml"]) {
 		}
 	});
 }
+
+test("caps the outer message block loop", async ({ page }) => {
+	await page.goto("/browser-tests/message-content.html?scenario=blocks");
+
+	const renderResult = page.locator("#render-result");
+	await expect(renderResult).toHaveAttribute("data-complete", "true");
+	await expect(page.getByTestId("message-block-limit-notice")).toHaveText(
+		"Additional content not shown (1 block omitted).",
+	);
+
+	const textBlocks = Number(
+		await renderResult.getAttribute("data-text-blocks"),
+	);
+	const maxMessageBlocks = Number(
+		await renderResult.getAttribute("data-max-message-blocks"),
+	);
+
+	expect(textBlocks).toBe(maxMessageBlocks);
+});
+
+test("renders repeated XML fields without duplicate React keys", async ({
+	page,
+}) => {
+	const duplicateKeyErrors: string[] = [];
+	page.on("console", (message) => {
+		if (
+			message.type() === "error" &&
+			/same key|unique "key"/i.test(message.text())
+		) {
+			duplicateKeyErrors.push(message.text());
+		}
+	});
+
+	await page.goto("/browser-tests/message-content.html?scenario=duplicate-xml");
+	await expect(page.locator("#render-result")).toHaveAttribute(
+		"data-complete",
+		"true",
+	);
+
+	expect(duplicateKeyErrors).toEqual([]);
+});

--- a/apps/web/src/components/conversation/MessageContent.tsx
+++ b/apps/web/src/components/conversation/MessageContent.tsx
@@ -21,26 +21,28 @@ type MessageBlock =
 	| ToolUseContent
 	| ToolResultContent;
 
-function getMessageBlockIdentity(block: MessageBlock): string {
+// Keep room for the formatted-part limit plus a plain-text fallback while
+// bounding every message-level loop in this component.
+export const MAX_RENDERED_MESSAGE_BLOCKS = 128;
+
+function getMessageBlockKey(block: MessageBlock, blockIndex: number): string {
+	// Parsed transcript blocks are immutable; their position is a bounded key
+	// that does not copy arbitrarily large message text into React's key space.
 	if (typeof block === "string") {
-		return `string:${block}`;
+		return `string:${blockIndex}`;
 	}
 
-	switch (block.type) {
-		case "text":
-			return `text:${block.text}`;
-		case "thinking":
-			return `thinking:${block.thinking}`;
-		case "tool_use":
-			return `tool-use:${block.id}`;
-		case "tool_result":
-			return `tool-result:${block.tool_use_id}`;
-	}
+	return `${block.type}:${blockIndex}`;
 }
 
 interface MessageContentProps {
 	content: string | MessageBlock[];
 	className?: string;
+}
+
+interface MessageRenderPlan {
+	readonly visibleBlocks: ReadonlyArray<MessageBlock>;
+	readonly textPartsByBlock: ReadonlyArray<ReadonlyArray<TextPart> | null>;
 }
 
 /**
@@ -117,8 +119,12 @@ function XmlBlock({
 					id={panelId}
 					className="divide-y divide-[color:var(--dashboardy-divider)]"
 				>
-					{entries.map((entry) => (
-						<div key={entry.key} className="flex gap-4 px-4 py-3">
+					{entries.map((entry, entryIndex) => (
+						<div
+							// biome-ignore lint/suspicious/noArrayIndexKey: parsed XML fields are static and may repeat names
+							key={`${entry.key}:${entryIndex}`}
+							className="flex gap-4 px-4 py-3"
+						>
 							<p className="min-w-[6.5rem] shrink-0 text-[0.8125rem] font-medium text-[color:var(--dashboardy-muted)]">
 								{formatTagLabel(entry.key)}
 							</p>
@@ -135,7 +141,7 @@ function XmlBlock({
 
 function renderTextParts(parts: ReadonlyArray<TextPart>, key: string) {
 	return (
-		<div key={key} className="space-y-3.5">
+		<div key={key} data-testid="message-text-block" className="space-y-3.5">
 			{parts.map((part, partIdx) => {
 				if (part.type === "code") {
 					return (
@@ -195,16 +201,25 @@ function getMessageBlockText(block: MessageBlock): string | null {
 }
 
 export function MessageContent({ content, className }: MessageContentProps) {
-	const textPartsByBlock = useMemo(() => {
+	const renderPlan = useMemo<MessageRenderPlan>(() => {
 		if (typeof content === "string") {
-			return parseMessageTextBlocks([content]);
+			return {
+				visibleBlocks: [],
+				textPartsByBlock: parseMessageTextBlocks([content]),
+			};
 		}
 
 		if (!Array.isArray(content)) {
-			return [];
+			return { visibleBlocks: [], textPartsByBlock: [] };
 		}
 
-		return parseMessageTextBlocks(content.map(getMessageBlockText));
+		const visibleBlocks = content.slice(0, MAX_RENDERED_MESSAGE_BLOCKS);
+		return {
+			visibleBlocks,
+			textPartsByBlock: parseMessageTextBlocks(
+				visibleBlocks.map(getMessageBlockText),
+			),
+		};
 	}, [content]);
 
 	if (!content) {
@@ -223,7 +238,7 @@ export function MessageContent({ content, className }: MessageContentProps) {
 	if (typeof content === "string") {
 		return (
 			<div className={cn("space-y-3.5", className)}>
-				{renderTextParts(textPartsByBlock[0] ?? [], "plain-content")}
+				{renderTextParts(renderPlan.textPartsByBlock[0] ?? [], "plain-content")}
 			</div>
 		);
 	}
@@ -243,9 +258,9 @@ export function MessageContent({ content, className }: MessageContentProps) {
 
 	const toolUses = new Map<string, ToolUseContent>();
 	const toolResults = new Map<string, ToolResultContent>();
-	const blockIdentityCounts = new Map<string, number>();
+	const omittedBlockCount = content.length - renderPlan.visibleBlocks.length;
 
-	for (const block of content) {
+	for (const block of renderPlan.visibleBlocks) {
 		if (typeof block === "string") continue;
 		if (block.type === "tool_use") {
 			toolUses.set(block.id, block);
@@ -256,21 +271,20 @@ export function MessageContent({ content, className }: MessageContentProps) {
 
 	return (
 		<div className={cn("space-y-3.5", className)}>
-			{content.map((block, blockIndex) => {
-				const blockIdentity = getMessageBlockIdentity(block);
-				const identityOccurrence =
-					(blockIdentityCounts.get(blockIdentity) ?? 0) + 1;
-				blockIdentityCounts.set(blockIdentity, identityOccurrence);
-				const blockKey = `${blockIdentity}:${identityOccurrence}`;
+			{renderPlan.visibleBlocks.map((block, blockIndex) => {
+				const blockKey = getMessageBlockKey(block, blockIndex);
 
 				if (typeof block === "string") {
-					return renderTextParts(textPartsByBlock[blockIndex] ?? [], blockKey);
+					return renderTextParts(
+						renderPlan.textPartsByBlock[blockIndex] ?? [],
+						blockKey,
+					);
 				}
 
 				switch (block.type) {
 					case "text":
 						return renderTextParts(
-							textPartsByBlock[blockIndex] ?? [],
+							renderPlan.textPartsByBlock[blockIndex] ?? [],
 							blockKey,
 						);
 
@@ -353,6 +367,15 @@ export function MessageContent({ content, className }: MessageContentProps) {
 						return null;
 				}
 			})}
+			{omittedBlockCount > 0 ? (
+				<p
+					data-testid="message-block-limit-notice"
+					className="whitespace-pre-wrap break-words text-[0.8125rem] leading-5 text-[color:var(--dashboardy-muted)] italic [overflow-wrap:anywhere]"
+				>
+					Additional content not shown ({omittedBlockCount}{" "}
+					{omittedBlockCount === 1 ? "block" : "blocks"} omitted).
+				</p>
+			) : null}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- cap array-shaped transcript work at 128 blocks before parsing, tool pairing, or rendering
- show an explicit notice for omitted blocks instead of silently doing unbounded work
- replace content-sized React keys and make repeated XML field keys duplicate-safe
- add real-Chrome regressions for the outer cap and duplicate-key warnings

## Stack
- stacked on #411; merge #411 first
- after #411 is squash-merged, rebase this branch with `git rebase --onto main feature/rud-248`

## Test plan
- [x] `bun run verify`
- [x] `bun run --cwd apps/web test:resource-budgets:chrome` (7 tests)
