### PR TITLE
fix(deploy): pin production VM resources

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -3,6 +3,10 @@ primary_region = "fra"
 
 [build]
 
+[[vm]]
+  size = "shared-cpu-2x"
+  memory = "2gb"
+
 [http_service]
   internal_port = 3000
   force_https = true


### PR DESCRIPTION
## Summary
- pin Fly Machines to `shared-cpu-2x` with 2 GB of memory
- prevent deploys and scale-from-zero events from reverting production to the default VM size

## Test plan
- [x] `flyctl config validate --config fly.toml`
- [x] `bun run verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)