### PR TITLE
fix(api): ignore dangling org memberships on upload

### DIFF
--- a/apps/api/src/__tests__/session-sharing.integration.ts
+++ b/apps/api/src/__tests__/session-sharing.integration.ts
@@ -90,6 +90,13 @@ beforeAll(async () => {
 		DELETE FROM organization
 		WHERE id = ${orgless.userId}
 	`;
+	await sqlClient.begin(async (transaction) => {
+		await transaction.unsafe("SET LOCAL session_replication_role = replica");
+		await transaction.unsafe(
+			"INSERT INTO member (id, organization_id, user_id, role) VALUES ($1, $2, $3, 'owner')",
+			[crypto.randomUUID(), orgless.userId, orgless.userId],
+		);
+	});
 
 	const activeOrganizationResponse = await fetch(
 		`${server.baseUrl}/api/auth/organization/set-active`,
@@ -579,7 +586,7 @@ describe("organization session ownership", () => {
 		);
 	}, 60_000);
 
-	test("routes an org-less API-key upload to its only remaining organization", async () => {
+	test("ignores dangling memberships when routing an org-less API-key upload", async () => {
 		const input = createSessionInput(ORGLESS_SESSION_ID, "org-less-api-key");
 		delete input.organizationId;
 

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -201,11 +201,13 @@ async function resolveIngestOrganizationId(
 	// Two rows are enough to distinguish a sole membership from an ambiguous choice.
 	// Prefer the personal workspace when it exists; creation time makes the fallback deterministic.
 	const memberships = await sqlClient<Array<{ organization_id: string }>>`
-		SELECT organization_id
-		FROM member
-		WHERE user_id = ${userId}
-		GROUP BY organization_id
-		ORDER BY (organization_id = ${userId}) DESC, MIN(created_at) ASC
+		SELECT m.organization_id
+		FROM member m
+		INNER JOIN organization o
+			ON o.id = m.organization_id
+		WHERE m.user_id = ${userId}
+		GROUP BY m.organization_id
+		ORDER BY (m.organization_id = ${userId}) DESC, MIN(m.created_at) ASC
 		LIMIT 2
 	`;
 	const personalWorkspace = memberships.find(


### PR DESCRIPTION
## Summary
- ignore dangling membership rows when resolving an org-less upload destination
- preserve the production dangling-personal-workspace shape as an API integration regression

## Root cause
The resolver queried `member` without joining `organization`, preferred the deleted personal-workspace membership, and passed that nonexistent organization ID into `session_ownership`.

## Receipts
- production org-less probe: HTTP 500, request `625b7d34-d08e-46d4-b21f-56e9621f7d26`
- explicit-org control using the same session: HTTP 200
- red CI: dangling-membership test received 500 instead of 200
- green CI: integration, verify, title, security, and required checks pass
- local: `bun run verify`

## Post-merge gate
- [ ] main-push deploy succeeds
- [ ] identical production org-less probe returns 200/400
