### PR TITLE
fix(ingest): protect uploads and retain failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,7 @@ CLICKHOUSE_PASSWORD=
 # INGEST_FILTER_QUEUE_PER_USER_MAX_JOBS=5
 # Applies separately to queue wait and active filtering.
 # INGEST_FILTER_QUEUE_TIMEOUT_MS=30000
+# SESSION_INGEST_QUIESCED=false # Set true before the token-counting rebuild.
 
 # Browser verification URL shown by `rudel login` device-code auth.
 # Local dev should point at the Vite web app. Default:

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -26,6 +26,7 @@ BETTER_AUTH_SECRET=
 # INGEST_FILTER_QUEUE_PER_USER_MAX_JOBS=5
 # Applies separately to queue wait and active filtering.
 # INGEST_FILTER_QUEUE_TIMEOUT_MS=30000
+# SESSION_INGEST_QUIESCED=false # Set true before the token-counting rebuild.
 
 # ClickHouse (get hosted credentials at https://obsessiondb.com)
 CLICKHOUSE_URL=http://localhost:8123

--- a/apps/api/src/__tests__/ingest-content-hash.test.ts
+++ b/apps/api/src/__tests__/ingest-content-hash.test.ts
@@ -122,7 +122,9 @@ describe("computeIngestContentHash", () => {
 		expect(routerSource).toContain(
 			"ownership.lastContentSha256 === contentHash",
 		);
-		expect(routerSource).toContain("contentHash,\n\t\t\t\tingestedAt,");
+		expect(routerSource).toContain("contentShape.contentBytes,");
+		expect(routerSource).toContain("contentShape.assistantLineCount,");
+		expect(routerSource).toContain("await hasRawSessionRow({");
 		expect(routerSource).toContain("await filterSessionTextFieldsOffThread({");
 		expect(routerSource).not.toContain("filterSessionTextFields({");
 	});

--- a/apps/api/src/__tests__/ingest-filter.service.test.ts
+++ b/apps/api/src/__tests__/ingest-filter.service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	MAX_FILTER_PASSES,
 	SecretFilterConvergenceError,
+	SecretFilterJsonIntegrityError,
 } from "@rudel/secret-filter";
 import {
 	createIngestFilterWorkerError,
@@ -91,6 +92,21 @@ describe("filterSessionTextFieldsOffThread", () => {
 		});
 		expect(error).toBeInstanceOf(SecretFilterConvergenceError);
 		expect(error).toMatchObject({ maxPasses: MAX_FILTER_PASSES });
+	});
+
+	test("preserves a JSON-integrity failure across worker serialization", () => {
+		const response = createIngestFilterWorkerError(
+			43,
+			new SecretFilterJsonIntegrityError(),
+		);
+		const error = getIngestFilterWorkerError(response);
+
+		expect(response).toEqual({
+			status: "error",
+			requestId: 43,
+			reason: "json-integrity",
+		});
+		expect(error).toBeInstanceOf(SecretFilterJsonIntegrityError);
 	});
 });
 

--- a/apps/api/src/__tests__/org-session.service.test.ts
+++ b/apps/api/src/__tests__/org-session.service.test.ts
@@ -63,6 +63,8 @@ describe("getOrgSessionCount", () => {
 		expect(queryCalls).toHaveLength(2);
 		expect(queryCalls[0]?.query).toContain("FROM rudel.claude_sessions");
 		expect(queryCalls[1]?.query).toContain("FROM rudel.codex_sessions");
+		expect(queryCalls[0]?.query).toContain("rudel.claude_sessions FINAL");
+		expect(queryCalls[1]?.query).toContain("rudel.codex_sessions FINAL");
 		expect(queryCalls[0]?.query).not.toContain("user_id = {userId:String}");
 		expect(queryCalls[1]?.query).not.toContain("user_id = {userId:String}");
 	});

--- a/apps/api/src/__tests__/session-ingest-content.integration.ts
+++ b/apps/api/src/__tests__/session-ingest-content.integration.ts
@@ -7,7 +7,12 @@ import {
 	test,
 } from "bun:test";
 import assert from "node:assert/strict";
+import {
+	type IngestSessionInput,
+	SESSION_UPLOAD_SHRINK_REJECTED_CODE,
+} from "@rudel/api-routes";
 import { sqlClient } from "../db.js";
+import { getIngestContentShape } from "../lib/ingest-content-shape.js";
 import {
 	claimSessionIngestOwnership,
 	recordSessionIngestContent,
@@ -22,13 +27,16 @@ setDefaultTimeout(30_000);
 const TEST_RUN_ID = `session_ingest_content_${crypto.randomUUID()}`;
 const CLAIM_SESSION_ID = `${TEST_RUN_ID}_claim`;
 const MONOTONIC_SESSION_ID = `${TEST_RUN_ID}_monotonic`;
+const LEGACY_PASS_SESSION_ID = `${TEST_RUN_ID}_legacy_pass`;
+const LEGACY_SHRINK_SESSION_ID = `${TEST_RUN_ID}_legacy_shrink`;
 
 let server: ApiTestServer;
 let userId: string;
+let bearerToken: string;
 
 beforeAll(async () => {
 	server = await startApiTestServer();
-	userId = await createTestUser(server.baseUrl);
+	({ bearerToken, userId } = await createTestUser(server.baseUrl));
 });
 
 afterAll(async () => {
@@ -58,6 +66,9 @@ describe("session ingest content bookkeeping", () => {
 			userId,
 			CLAIM_SESSION_ID,
 			contentHash,
+			contentShape(12_345, 42),
+			5,
+			new Date("2026-07-24T09:30:00.000Z"),
 			new Date("2026-07-24T10:00:00.000Z"),
 		);
 
@@ -68,6 +79,10 @@ describe("session ingest content bookkeeping", () => {
 		);
 		assert(repeatedClaim.owned);
 		expect(repeatedClaim.lastContentSha256).toBe(contentHash);
+		expect(repeatedClaim.lastContentBytes).toBe(12_345);
+		expect(repeatedClaim.lastAssistantLineCount).toBe(42);
+		expect(repeatedClaim.lastContentShape).toEqual(contentShape(12_345, 42));
+		expect(repeatedClaim.lastFilterVersion).toBe(5);
 	});
 
 	test("does not let older bookkeeping overwrite a newer ingest", async () => {
@@ -84,32 +99,76 @@ describe("session ingest content bookkeeping", () => {
 			userId,
 			MONOTONIC_SESSION_ID,
 			newerHash,
+			contentShape(20_000, 20),
+			5,
+			new Date("2026-07-24T09:30:00.000Z"),
 			newerIngestedAt,
 		);
 		await recordSessionIngestContent(
 			userId,
 			MONOTONIC_SESSION_ID,
 			"c".repeat(64),
+			contentShape(10_000, 10),
+			5,
+			new Date("2026-07-24T09:30:00.000Z"),
 			new Date("2026-07-24T11:00:00.000Z"),
 		);
 
 		const [row] = await sqlClient<
 			Array<{
+				last_assistant_line_count: number | null;
+				last_content_bytes: number | null;
 				last_content_sha256: string | null;
 				last_ingested_at: string | null;
 			}>
 		>`
-			SELECT last_content_sha256, last_ingested_at
+			SELECT
+				last_content_sha256,
+				last_content_bytes,
+				last_assistant_line_count,
+				last_ingested_at
 			FROM session_ownership
 			WHERE organization_id = ${userId}
 				AND session_id = ${MONOTONIC_SESSION_ID}
 		`;
 		expect(row?.last_content_sha256).toBe(newerHash);
+		expect(row?.last_content_bytes).toBe(20_000);
+		expect(row?.last_assistant_line_count).toBe(20);
 		expect(new Date(row?.last_ingested_at ?? "")).toEqual(newerIngestedAt);
+	});
+
+	test("drives the legacy fallback through total-vs-total pass and shrink rejection", async () => {
+		const completeInput = makeClaudeInput(LEGACY_PASS_SESSION_ID, 5);
+		await seedLegacyContentShape(completeInput);
+
+		const legitimateResponse = await callIngest(completeInput);
+		expect(legitimateResponse.status).toBe(200);
+
+		const legacyShrinkBaseline = makeClaudeInput(LEGACY_SHRINK_SESSION_ID, 5);
+		await seedLegacyContentShape(legacyShrinkBaseline);
+		const truncatedInput = makeClaudeInput(LEGACY_SHRINK_SESSION_ID, 0);
+
+		const shrinkResponse = await callIngest(truncatedInput);
+		expect(shrinkResponse.status).toBe(409);
+		expect(readRpcErrorCode(shrinkResponse.body)).toBe(
+			SESSION_UPLOAD_SHRINK_REJECTED_CODE,
+		);
 	});
 });
 
-async function createTestUser(baseUrl: string): Promise<string> {
+function contentShape(contentBytes: number, assistantLineCount: number) {
+	return {
+		assistantLineCount,
+		contentBytes,
+		main: { assistantLineCount, contentBytes },
+		subagents: {},
+		version: 1 as const,
+	};
+}
+
+async function createTestUser(
+	baseUrl: string,
+): Promise<{ bearerToken: string; userId: string }> {
 	const response = await fetch(`${baseUrl}/api/auth/sign-up/email`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
@@ -134,7 +193,100 @@ async function createTestUser(baseUrl: string): Promise<string> {
 	expect(meResponse.ok).toBe(true);
 	const meBody: unknown = await meResponse.json();
 	assert(isMeResponse(meBody));
-	return meBody.json.id;
+	return { bearerToken: body.token, userId: meBody.json.id };
+}
+
+async function seedLegacyContentShape(
+	input: IngestSessionInput,
+): Promise<void> {
+	const ownership = await claimSessionIngestOwnership(
+		userId,
+		input.sessionId,
+		userId,
+	);
+	assert(ownership.owned);
+	const shape = getIngestContentShape(input);
+
+	await sqlClient`
+		UPDATE session_ownership
+		SET
+			last_content_bytes = ${shape.contentBytes},
+			last_assistant_line_count = ${shape.assistantLineCount},
+			last_content_shape_json = NULL
+		WHERE organization_id = ${userId}
+			AND session_id = ${input.sessionId}
+	`;
+}
+
+async function callIngest(input: IngestSessionInput) {
+	const response = await fetch(`${server.baseUrl}/rpc/ingestSession`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${bearerToken}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ json: input }),
+	});
+
+	return { body: await response.json(), status: response.status };
+}
+
+function makeClaudeInput(
+	sessionId: string,
+	subagentAssistantLines: number,
+): IngestSessionInput {
+	const assistantLine = (index: number) =>
+		JSON.stringify({
+			message: {
+				content: `Assistant content ${index}`,
+				role: "assistant",
+				usage: { input_tokens: 2, output_tokens: 1 },
+			},
+			timestamp: `2026-07-24T09:30:${String(index).padStart(2, "0")}.000Z`,
+			type: "assistant",
+		});
+
+	return {
+		content: [
+			JSON.stringify({
+				message: { content: "Session content", role: "user" },
+				timestamp: "2026-07-24T09:30:00.000Z",
+				type: "user",
+			}),
+			assistantLine(1),
+		].join("\n"),
+		projectPath: "/test/session-ingest-content",
+		sessionId,
+		source: "claude_code",
+		subagents:
+			subagentAssistantLines === 0
+				? []
+				: [
+						{
+							agentId: "worker",
+							content: Array.from(
+								{ length: subagentAssistantLines },
+								(_, index) => assistantLine(index + 2),
+							).join("\n"),
+						},
+					],
+		upload_mode: "manual",
+	};
+}
+
+function readRpcErrorCode(value: unknown): string {
+	if (
+		typeof value === "object" &&
+		value !== null &&
+		"json" in value &&
+		typeof value.json === "object" &&
+		value.json !== null &&
+		"code" in value.json &&
+		typeof value.json.code === "string"
+	) {
+		return value.json.code;
+	}
+	throw new Error("RPC response did not include json.code");
 }
 
 function isAuthResponse(value: unknown): value is { token: string } {

--- a/apps/api/src/lib/ingest-content-shape.test.ts
+++ b/apps/api/src/lib/ingest-content-shape.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "bun:test";
+import type { IngestSessionInput } from "@rudel/api-routes";
+import {
+	getIngestContentShape,
+	INGEST_SHRINK_MIN_BYTE_TOLERANCE,
+	INGEST_SHRINK_MIN_LINE_TOLERANCE,
+	isUnexpectedIngestShrink,
+	resolvePreviousIngestContentShape,
+} from "./ingest-content-shape.js";
+
+describe("getIngestContentShape", () => {
+	test("counts Claude assistant lines in the main transcript and subagents", () => {
+		const input = makeInput({
+			content: [
+				'{"type":"user"}',
+				'{"type":"assistant"}',
+				"not json",
+				'{"type":"assistant"}',
+			].join("\n"),
+			subagents: [
+				{
+					agentId: "agent-1",
+					content: '{"type":"assistant","message":{"role":"assistant"}}',
+				},
+			],
+		});
+
+		expect(getIngestContentShape(input)).toEqual({
+			assistantLineCount: 3,
+			contentBytes:
+				Buffer.byteLength(input.content, "utf8") +
+				Buffer.byteLength(input.subagents?.[0]?.content ?? "", "utf8"),
+			main: {
+				assistantLineCount: 2,
+				contentBytes: Buffer.byteLength(input.content, "utf8"),
+			},
+			subagents: {
+				"agent-1": {
+					assistantLineCount: 1,
+					contentBytes: Buffer.byteLength(
+						input.subagents?.[0]?.content ?? "",
+						"utf8",
+					),
+				},
+			},
+			version: 1,
+		});
+	});
+
+	test("counts Codex assistant response items and ignores unpersisted subagents", () => {
+		const input = makeInput({
+			source: "codex",
+			content: [
+				'{"type":"response_item","payload":{"type":"message","role":"assistant"}}',
+				'{"type":"response_item","payload":{"type":"message","role":"user"}}',
+			].join("\n"),
+			subagents: [{ agentId: "ignored", content: '{"type":"assistant"}' }],
+		});
+
+		expect(getIngestContentShape(input)).toEqual({
+			assistantLineCount: 1,
+			contentBytes: Buffer.byteLength(input.content, "utf8"),
+			main: {
+				assistantLineCount: 1,
+				contentBytes: Buffer.byteLength(input.content, "utf8"),
+			},
+			subagents: {},
+			version: 1,
+		});
+	});
+});
+
+describe("isUnexpectedIngestShrink", () => {
+	test("rejects a truncated re-upload when assistant lines disappear", () => {
+		expect(isUnexpectedIngestShrink(shape(4, 3_000), shape(2, 2_900))).toBe(
+			true,
+		);
+	});
+
+	test("allows small byte drift when assistant coverage is intact", () => {
+		expect(isUnexpectedIngestShrink(shape(3, 100_000), shape(3, 96_000))).toBe(
+			false,
+		);
+	});
+
+	test("rejects byte loss beyond the larger absolute/relative tolerance", () => {
+		expect(isUnexpectedIngestShrink(shape(3, 100_000), shape(3, 94_999))).toBe(
+			true,
+		);
+		expect(
+			isUnexpectedIngestShrink(
+				shape(0, 10_000),
+				shape(0, 10_000 - INGEST_SHRINK_MIN_BYTE_TOLERANCE),
+			),
+		).toBe(false);
+	});
+
+	test("allows line-count drift within the same tolerance policy", () => {
+		expect(
+			isUnexpectedIngestShrink(
+				shape(10, 10_000),
+				shape(10 - INGEST_SHRINK_MIN_LINE_TOLERANCE, 10_000),
+			),
+		).toBe(false);
+	});
+
+	test("checks the main transcript and every existing subagent independently", () => {
+		const previous = shape(10, 10_000, {
+			worker: { assistantLineCount: 5, contentBytes: 5_000 },
+		});
+		const missingWorker = shape(20, 20_000);
+
+		expect(isUnexpectedIngestShrink(previous, missingWorker)).toBe(true);
+	});
+
+	test("compares aggregate totals for a legacy ownership fallback", () => {
+		const legacyTotal = shape(6, 12_000);
+		const sameTotalWithSubagent = shape(1, 2_000, {
+			worker: { assistantLineCount: 5, contentBytes: 10_000 },
+		});
+		const smallerTotal = shape(1, 2_000);
+
+		expect(
+			isUnexpectedIngestShrink(legacyTotal, sameTotalWithSubagent, {
+				compareTotalsOnly: true,
+			}),
+		).toBe(false);
+		expect(
+			isUnexpectedIngestShrink(legacyTotal, smallerTotal, {
+				compareTotalsOnly: true,
+			}),
+		).toBe(true);
+	});
+});
+
+describe("resolvePreviousIngestContentShape", () => {
+	test("synthesizes a main-only shape for legacy ownership rows", () => {
+		expect(
+			resolvePreviousIngestContentShape({
+				lastAssistantLineCount: 42,
+				lastContentBytes: 12_345,
+				lastContentShape: null,
+			}),
+		).toEqual({
+			assistantLineCount: 42,
+			contentBytes: 12_345,
+			main: { assistantLineCount: 42, contentBytes: 12_345 },
+			subagents: {},
+			version: 1,
+		});
+	});
+
+	test("keeps the component shape when the ownership row has one", () => {
+		const previous = shape(4, 20_000, {
+			worker: { assistantLineCount: 2, contentBytes: 10_000 },
+		});
+
+		expect(
+			resolvePreviousIngestContentShape({
+				lastAssistantLineCount: 99,
+				lastContentBytes: 99_999,
+				lastContentShape: previous,
+			}),
+		).toBe(previous);
+	});
+});
+
+function shape(
+	assistantLineCount: number,
+	contentBytes: number,
+	subagents: Record<
+		string,
+		{ assistantLineCount: number; contentBytes: number }
+	> = {},
+) {
+	const subagentShapes = Object.values(subagents);
+	return {
+		assistantLineCount: subagentShapes.reduce(
+			(total, item) => total + item.assistantLineCount,
+			assistantLineCount,
+		),
+		contentBytes: subagentShapes.reduce(
+			(total, item) => total + item.contentBytes,
+			contentBytes,
+		),
+		main: { assistantLineCount, contentBytes },
+		subagents,
+		version: 1 as const,
+	};
+}
+
+function makeInput(overrides: Partial<IngestSessionInput>): IngestSessionInput {
+	return {
+		content: '{"type":"assistant"}',
+		projectPath: "/project",
+		sessionId: "session-1",
+		source: "claude_code",
+		...overrides,
+	};
+}

--- a/apps/api/src/lib/ingest-content-shape.ts
+++ b/apps/api/src/lib/ingest-content-shape.ts
@@ -1,0 +1,165 @@
+import type { IngestSessionInput } from "@rudel/api-routes";
+
+export const INGEST_SHRINK_MAX_RELATIVE_BYTE_LOSS = 0.05;
+export const INGEST_SHRINK_MIN_BYTE_TOLERANCE = 4 * 1024;
+export const INGEST_SHRINK_MAX_RELATIVE_LINE_LOSS = 0.05;
+export const INGEST_SHRINK_MIN_LINE_TOLERANCE = 1;
+
+export interface IngestContentComponentShape {
+	assistantLineCount: number;
+	contentBytes: number;
+}
+
+export interface IngestContentShape extends IngestContentComponentShape {
+	main: IngestContentComponentShape;
+	subagents: Readonly<Record<string, IngestContentComponentShape>>;
+	version: 1;
+}
+
+export function resolvePreviousIngestContentShape(input: {
+	lastAssistantLineCount: number | null;
+	lastContentBytes: number | null;
+	lastContentShape: IngestContentShape | null;
+}): IngestContentShape | null {
+	if (input.lastContentShape !== null) {
+		return input.lastContentShape;
+	}
+	if (
+		input.lastAssistantLineCount === null ||
+		input.lastContentBytes === null
+	) {
+		return null;
+	}
+
+	const main = {
+		assistantLineCount: input.lastAssistantLineCount,
+		contentBytes: input.lastContentBytes,
+	};
+	return {
+		...main,
+		main,
+		subagents: {},
+		version: 1,
+	};
+}
+
+export function getIngestContentShape(
+	input: IngestSessionInput,
+): IngestContentShape {
+	const main = getContentComponentShape(input.content, input.source);
+	const subagents =
+		input.source === "claude_code"
+			? Object.fromEntries(
+					(input.subagents ?? []).map((subagent) => [
+						subagent.agentId,
+						getContentComponentShape(subagent.content, input.source),
+					]),
+				)
+			: {};
+	const subagentShapes = Object.values(subagents);
+
+	return {
+		assistantLineCount: subagentShapes.reduce(
+			(total, shape) => total + shape.assistantLineCount,
+			main.assistantLineCount,
+		),
+		contentBytes: subagentShapes.reduce(
+			(total, shape) => total + shape.contentBytes,
+			main.contentBytes,
+		),
+		main,
+		subagents,
+		version: 1,
+	};
+}
+
+export function isUnexpectedIngestShrink(
+	previous: IngestContentShape,
+	current: IngestContentShape,
+	options: { compareTotalsOnly?: boolean } = {},
+): boolean {
+	if (options.compareTotalsOnly) {
+		return isComponentShrink(previous, current);
+	}
+	if (isComponentShrink(previous.main, current.main)) {
+		return true;
+	}
+	for (const [agentId, previousSubagent] of Object.entries(
+		previous.subagents,
+	)) {
+		const currentSubagent = current.subagents[agentId];
+		if (
+			!currentSubagent ||
+			isComponentShrink(previousSubagent, currentSubagent)
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function isComponentShrink(
+	previous: IngestContentComponentShape,
+	current: IngestContentComponentShape,
+): boolean {
+	const allowedLineLoss = Math.max(
+		INGEST_SHRINK_MIN_LINE_TOLERANCE,
+		Math.floor(
+			previous.assistantLineCount * INGEST_SHRINK_MAX_RELATIVE_LINE_LOSS,
+		),
+	);
+	if (
+		current.assistantLineCount <
+		previous.assistantLineCount - allowedLineLoss
+	) {
+		return true;
+	}
+	const allowedByteLoss = Math.max(
+		INGEST_SHRINK_MIN_BYTE_TOLERANCE,
+		Math.floor(previous.contentBytes * INGEST_SHRINK_MAX_RELATIVE_BYTE_LOSS),
+	);
+	return current.contentBytes < previous.contentBytes - allowedByteLoss;
+}
+
+function getContentComponentShape(
+	content: string,
+	source: IngestSessionInput["source"],
+): IngestContentComponentShape {
+	return {
+		assistantLineCount: countAssistantLines(content, source),
+		contentBytes: Buffer.byteLength(content, "utf8"),
+	};
+}
+
+function countAssistantLines(
+	content: string,
+	source: IngestSessionInput["source"],
+): number {
+	let count = 0;
+	let start = 0;
+	while (start <= content.length) {
+		const newline = content.indexOf("\n", start);
+		const end = newline === -1 ? content.length : newline;
+		const line = content.slice(start, end);
+		if (
+			(source === "claude_code" &&
+				hasJsonStringField(line, "type", "assistant")) ||
+			(source === "codex" &&
+				hasJsonStringField(line, "type", "response_item") &&
+				hasJsonStringField(line, "type", "message") &&
+				hasJsonStringField(line, "role", "assistant"))
+		) {
+			count += 1;
+		}
+		if (newline === -1) break;
+		start = newline + 1;
+	}
+	return count;
+}
+
+function hasJsonStringField(line: string, key: string, value: string): boolean {
+	return (
+		line.includes(`"${key}":"${value}"`) ||
+		line.includes(`"${key}": "${value}"`)
+	);
+}

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -10,12 +10,15 @@ import {
 	PRODUCT_ANALYTICS_EVENTS,
 	REDACTION_BUDGET_EXCEEDED_CODE,
 	REDACTION_DID_NOT_CONVERGE_CODE,
+	SECRET_FILTER_JSON_INTEGRITY_CODE,
 	SESSION_OWNERSHIP_CONFLICT_CODE,
+	SESSION_UPLOAD_SHRINK_REJECTED_CODE,
 } from "@rudel/api-routes";
 import {
 	FILTER_VERSION,
 	getRedactionBudgetAnomaly,
 	SecretFilterConvergenceError,
+	SecretFilterJsonIntegrityError,
 } from "@rudel/secret-filter";
 import { getClickhouse } from "./clickhouse.js";
 import { sqlClient } from "./db.js";
@@ -27,7 +30,13 @@ import { teamInviteLinkRouter } from "./handlers/team-invite-link.js";
 import { wrappedDecimalClaimRouter } from "./handlers/wrapped-decimal-claim.js";
 import { wrappedResumeRouter } from "./handlers/wrapped-resume.js";
 import { wrappedShareRouter } from "./handlers/wrapped-share.js";
+import { readBooleanEnv } from "./lib/env.js";
 import { computeIngestContentHash } from "./lib/ingest-content-hash.js";
+import {
+	getIngestContentShape,
+	isUnexpectedIngestShrink,
+	resolvePreviousIngestContentShape,
+} from "./lib/ingest-content-shape.js";
 import { enforceIngestAggregateSize } from "./lib/ingest-size.js";
 import {
 	bucketContentSize,
@@ -60,6 +69,7 @@ import {
 	getCachedOrgSessionCount,
 	hasOrgUploadsInLastDays,
 } from "./services/org-session.service.js";
+import { hasRawSessionRow } from "./services/raw-session.service.js";
 import {
 	claimSessionIngestOwnership,
 	recordSessionIngestContent,
@@ -233,6 +243,13 @@ async function resolveIngestOrganizationId(
 const ingestSessionHandler = os.ingestSession
 	.use(ingestAuthMiddleware)
 	.handler(async ({ input, context, errors, signal }) => {
+		if (readBooleanEnv("SESSION_INGEST_QUIESCED", false)) {
+			throw new ORPCError("SERVICE_UNAVAILABLE", {
+				data: { reason: "session_ingest_quiesced" },
+				message:
+					"Session uploads are temporarily paused for an analytics rebuild. Retry shortly.",
+			});
+		}
 		checkIngestRequestRateLimit(context.user.id);
 		const aggregateBytes = enforceIngestAggregateSize(
 			input,
@@ -252,6 +269,9 @@ const ingestSessionHandler = os.ingestSession
 				throw errors[REDACTION_DID_NOT_CONVERGE_CODE]({
 					data: { maxPasses: error.maxPasses },
 				});
+			}
+			if (error instanceof SecretFilterJsonIntegrityError) {
+				throw errors[SECRET_FILTER_JSON_INTEGRITY_CODE]();
 			}
 			if (error instanceof IngestFilterQueueFullError) {
 				throw new ORPCError("SERVICE_UNAVAILABLE", {
@@ -345,6 +365,37 @@ const ingestSessionHandler = os.ingestSession
 		if (!ownership.owned) {
 			throw errors[SESSION_OWNERSHIP_CONFLICT_CODE]();
 		}
+		const contentShape = getIngestContentShape(filteredInput);
+		const previousContentShape = resolvePreviousIngestContentShape(ownership);
+		if (
+			!input.force_replace &&
+			(ownership.lastFilterVersion === null ||
+				ownership.lastFilterVersion === FILTER_VERSION) &&
+			previousContentShape !== null &&
+			isUnexpectedIngestShrink(previousContentShape, contentShape, {
+				compareTotalsOnly: ownership.lastContentShape === null,
+			})
+		) {
+			logger.warn(
+				"Refusing smaller session re-upload (organization_id={organizationId} session_id={sessionId} previous_content_bytes={previousContentBytes} current_content_bytes={currentContentBytes} previous_assistant_lines={previousAssistantLineCount} current_assistant_lines={currentAssistantLineCount})",
+				{
+					currentAssistantLineCount: contentShape.assistantLineCount,
+					currentContentBytes: contentShape.contentBytes,
+					organizationId: orgId,
+					previousAssistantLineCount: previousContentShape.assistantLineCount,
+					previousContentBytes: previousContentShape.contentBytes,
+					sessionId: input.sessionId,
+				},
+			);
+			throw errors[SESSION_UPLOAD_SHRINK_REJECTED_CODE]({
+				data: {
+					currentAssistantLineCount: contentShape.assistantLineCount,
+					currentContentBytes: contentShape.contentBytes,
+					previousAssistantLineCount: previousContentShape.assistantLineCount,
+					previousContentBytes: previousContentShape.contentBytes,
+				},
+			});
+		}
 
 		// Hash the exact bytes and filter version stored by the server. This makes
 		// an old unfiltered CLI upload and a current pre-filtered CLI upload
@@ -360,7 +411,16 @@ const ingestSessionHandler = os.ingestSession
 		// This is a best-effort cost optimization, not a cross-instance
 		// security control. Concurrent identical requests can both reach the
 		// ClickHouse insert before either records its successful hash.
-		if (ownership.lastContentSha256 === contentHash) {
+		if (
+			ownership.lastContentSha256 === contentHash &&
+			(await hasRawSessionRow({
+				organizationId: orgId,
+				sessionDate: ownership.lastSessionDate,
+				sessionId: input.sessionId,
+				table: adapter.rawTableName,
+				userId: context.user.id,
+			}))
+		) {
 			logger.info(
 				"Skipping duplicate session ingest (organization_id={organizationId} session_id={sessionId})",
 				{ organizationId: orgId, sessionId: input.sessionId },
@@ -384,6 +444,9 @@ const ingestSessionHandler = os.ingestSession
 				orgId,
 				input.sessionId,
 				contentHash,
+				contentShape,
+				FILTER_VERSION,
+				new Date(timestamps.sessionDate),
 				ingestedAt,
 			);
 		} catch (error) {

--- a/apps/api/src/services/ingest-filter.error.ts
+++ b/apps/api/src/services/ingest-filter.error.ts
@@ -1,4 +1,7 @@
-import { SecretFilterConvergenceError } from "@rudel/secret-filter";
+import {
+	SecretFilterConvergenceError,
+	SecretFilterJsonIntegrityError,
+} from "@rudel/secret-filter";
 import type { IngestFilterWorkerErrorResponse } from "./ingest-filter.types.js";
 
 export function createIngestFilterWorkerError(
@@ -11,6 +14,13 @@ export function createIngestFilterWorkerError(
 			requestId,
 			reason: "did-not-converge",
 			maxPasses: error.maxPasses,
+		};
+	}
+	if (error instanceof SecretFilterJsonIntegrityError) {
+		return {
+			status: "error",
+			requestId,
+			reason: "json-integrity",
 		};
 	}
 	return {
@@ -29,6 +39,9 @@ export function getIngestFilterWorkerError(
 ): Error {
 	if (response.reason === "did-not-converge") {
 		return new SecretFilterConvergenceError(response.maxPasses);
+	}
+	if (response.reason === "json-integrity") {
+		return new SecretFilterJsonIntegrityError();
 	}
 	return new Error(response.message);
 }

--- a/apps/api/src/services/ingest-filter.types.ts
+++ b/apps/api/src/services/ingest-filter.types.ts
@@ -25,6 +25,11 @@ export type IngestFilterWorkerErrorResponse =
 	| {
 			readonly status: "error";
 			readonly requestId: number;
+			readonly reason: "json-integrity";
+	  }
+	| {
+			readonly status: "error";
+			readonly requestId: number;
 			readonly reason: "worker-error";
 			readonly message: string;
 	  };

--- a/apps/api/src/services/org-session.service.ts
+++ b/apps/api/src/services/org-session.service.ts
@@ -99,7 +99,7 @@ export async function getOrgSessionCount(
 	const results = await Promise.all(
 		tables.map((table) =>
 			querySessionCount({
-				query: `SELECT count() as count FROM ${getSafeClickHouseTable(table)} WHERE organization_id = {orgId:String}`,
+				query: `SELECT count() as count FROM ${getSafeClickHouseTable(table)} FINAL WHERE organization_id = {orgId:String}`,
 				query_params: {
 					orgId,
 				},

--- a/apps/api/src/services/raw-session.service.test.ts
+++ b/apps/api/src/services/raw-session.service.test.ts
@@ -4,6 +4,7 @@ import { hasRawSessionRow } from "./raw-session.service.js";
 
 describe("hasRawSessionRow", () => {
 	test("queries the tenant, owner, session, and a one-day date tolerance", async () => {
+		let queryCount = 0;
 		let statement: Parameters<ClickHouseExecutor["query"]>[0] | undefined;
 		const present = await hasRawSessionRow(
 			{
@@ -15,6 +16,7 @@ describe("hasRawSessionRow", () => {
 			},
 			{
 				query: async <T>(next: Parameters<ClickHouseExecutor["query"]>[0]) => {
+					queryCount += 1;
 					statement = next;
 					return [{ present: 1 } as T];
 				},
@@ -22,6 +24,7 @@ describe("hasRawSessionRow", () => {
 		);
 
 		expect(present).toBe(true);
+		expect(queryCount).toBe(1);
 		expect(statement?.query).toContain("FROM rudel.claude_sessions");
 		expect(statement?.query).toContain(
 			"session_date BETWEEN parseDateTime64BestEffort({sessionDate:String}, 3, 'UTC') - INTERVAL 1 DAY",
@@ -33,6 +36,55 @@ describe("hasRawSessionRow", () => {
 			sessionId: "session-1",
 			userId: "user-1",
 		});
+	});
+
+	test("retries a bounded miss without the date bound", async () => {
+		const statements: Parameters<ClickHouseExecutor["query"]>[0][] = [];
+		const present = await hasRawSessionRow(
+			{
+				organizationId: "org-1",
+				sessionDate: new Date("2026-08-01T10:00:00.000Z"),
+				sessionId: "session-outside-bound",
+				table: "rudel.claude_sessions",
+				userId: "user-1",
+			},
+			{
+				query: async <T>(next: Parameters<ClickHouseExecutor["query"]>[0]) => {
+					statements.push(next);
+					return statements.length === 1 ? [] : [{ present: 1 } as T];
+				},
+			},
+		);
+
+		expect(present).toBe(true);
+		expect(statements).toHaveLength(2);
+		expect(statements[0]?.query).toContain("session_date BETWEEN");
+		expect(statements[0]?.query_params).toHaveProperty("sessionDate");
+		expect(statements[1]?.query).not.toContain("session_date BETWEEN");
+		expect(statements[1]?.query_params).not.toHaveProperty("sessionDate");
+	});
+
+	test("retries a bounded probe failure without the date bound", async () => {
+		let queryCount = 0;
+		const present = await hasRawSessionRow(
+			{
+				organizationId: "org-1",
+				sessionDate: new Date("2026-08-01T10:00:00.000Z"),
+				sessionId: "session-after-bounded-failure",
+				table: "rudel.codex_sessions",
+				userId: "user-1",
+			},
+			{
+				query: async <T>() => {
+					queryCount += 1;
+					if (queryCount === 1) throw new Error("bounded query failed");
+					return [{ present: 1 } as T];
+				},
+			},
+		);
+
+		expect(present).toBe(true);
+		expect(queryCount).toBe(2);
 	});
 
 	test("omits the date bound when legacy ownership has no date", async () => {
@@ -62,8 +114,35 @@ describe("hasRawSessionRow", () => {
 		});
 	});
 
-	test("continues ingest when date serialization or ClickHouse probing fails", async () => {
+	test("normalizes the timestamp string returned by Postgres", async () => {
+		let statement: Parameters<ClickHouseExecutor["query"]>[0] | undefined;
+		const present = await hasRawSessionRow(
+			{
+				organizationId: "org-1",
+				sessionDate: "2026-08-01 10:00:00+00",
+				sessionId: "postgres-timestamp-session",
+				table: "rudel.claude_sessions",
+				userId: "user-1",
+			},
+			{
+				query: async <T>(next: Parameters<ClickHouseExecutor["query"]>[0]) => {
+					statement = next;
+					return [{ present: 1 } as T];
+				},
+			},
+		);
+
+		expect(present).toBe(true);
+		expect(statement?.query).toContain("session_date BETWEEN");
+		expect(statement?.query_params).toHaveProperty(
+			"sessionDate",
+			"2026-08-01T10:00:00.000Z",
+		);
+	});
+
+	test("uses the unbounded fallback for an invalid session date", async () => {
 		let queryCount = 0;
+		let statement: Parameters<ClickHouseExecutor["query"]>[0] | undefined;
 		const invalidDateResult = await hasRawSessionRow(
 			{
 				organizationId: "org-1",
@@ -73,33 +152,44 @@ describe("hasRawSessionRow", () => {
 				userId: "user-1",
 			},
 			{
-				query: async () => {
+				query: async <T>(next: Parameters<ClickHouseExecutor["query"]>[0]) => {
 					queryCount += 1;
-					return [];
+					statement = next;
+					return [{ present: 1 } as T];
 				},
 			},
 		);
+
+		expect(invalidDateResult).toBe(true);
+		expect(queryCount).toBe(1);
+		expect(statement?.query).not.toContain("session_date BETWEEN");
+		expect(statement?.query_params).not.toHaveProperty("sessionDate");
+	});
+
+	test("continues ingest when both ClickHouse probes fail", async () => {
+		let queryCount = 0;
 		const clickhouseFailureResult = await hasRawSessionRow(
 			{
 				organizationId: "org-1",
-				sessionDate: null,
+				sessionDate: new Date("2026-08-01T10:00:00.000Z"),
 				sessionId: "clickhouse-failure",
 				table: "rudel.codex_sessions",
 				userId: "user-1",
 			},
 			{
 				query: async () => {
+					queryCount += 1;
 					throw new Error("ClickHouse unavailable");
 				},
 			},
 		);
 
-		expect(invalidDateResult).toBe(false);
-		expect(queryCount).toBe(0);
 		expect(clickhouseFailureResult).toBe(false);
+		expect(queryCount).toBe(2);
 	});
 
 	test("returns false after raw TTL expiry", async () => {
+		let queryCount = 0;
 		const present = await hasRawSessionRow(
 			{
 				organizationId: "org-1",
@@ -108,10 +198,16 @@ describe("hasRawSessionRow", () => {
 				table: "rudel.codex_sessions",
 				userId: "user-1",
 			},
-			{ query: async () => [] },
+			{
+				query: async () => {
+					queryCount += 1;
+					return [];
+				},
+			},
 		);
 
 		expect(present).toBe(false);
+		expect(queryCount).toBe(2);
 	});
 
 	test("rejects non-allowlisted table interpolation", async () => {

--- a/apps/api/src/services/raw-session.service.test.ts
+++ b/apps/api/src/services/raw-session.service.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import type { ClickHouseExecutor } from "../clickhouse.js";
+import { hasRawSessionRow } from "./raw-session.service.js";
+
+describe("hasRawSessionRow", () => {
+	test("queries the tenant, owner, session, and a one-day date tolerance", async () => {
+		let statement: Parameters<ClickHouseExecutor["query"]>[0] | undefined;
+		const present = await hasRawSessionRow(
+			{
+				organizationId: "org-1",
+				sessionDate: new Date("2026-08-01T10:00:00.000Z"),
+				sessionId: "session-1",
+				table: "rudel.claude_sessions",
+				userId: "user-1",
+			},
+			{
+				query: async <T>(next: Parameters<ClickHouseExecutor["query"]>[0]) => {
+					statement = next;
+					return [{ present: 1 } as T];
+				},
+			},
+		);
+
+		expect(present).toBe(true);
+		expect(statement?.query).toContain("FROM rudel.claude_sessions");
+		expect(statement?.query).toContain(
+			"session_date BETWEEN parseDateTime64BestEffort({sessionDate:String}, 3, 'UTC') - INTERVAL 1 DAY",
+		);
+		expect(statement?.query).toContain("+ INTERVAL 1 DAY");
+		expect(statement?.query_params).toEqual({
+			organizationId: "org-1",
+			sessionDate: "2026-08-01T10:00:00.000Z",
+			sessionId: "session-1",
+			userId: "user-1",
+		});
+	});
+
+	test("omits the date bound when legacy ownership has no date", async () => {
+		let statement: Parameters<ClickHouseExecutor["query"]>[0] | undefined;
+		const present = await hasRawSessionRow(
+			{
+				organizationId: "org-1",
+				sessionDate: null,
+				sessionId: "legacy-session",
+				table: "rudel.claude_sessions",
+				userId: "user-1",
+			},
+			{
+				query: async <T>(next: Parameters<ClickHouseExecutor["query"]>[0]) => {
+					statement = next;
+					return [{ present: 1 } as T];
+				},
+			},
+		);
+
+		expect(present).toBe(true);
+		expect(statement?.query).not.toContain("session_date BETWEEN");
+		expect(statement?.query_params).toEqual({
+			organizationId: "org-1",
+			sessionId: "legacy-session",
+			userId: "user-1",
+		});
+	});
+
+	test("continues ingest when date serialization or ClickHouse probing fails", async () => {
+		let queryCount = 0;
+		const invalidDateResult = await hasRawSessionRow(
+			{
+				organizationId: "org-1",
+				sessionDate: new Date(Number.NaN),
+				sessionId: "invalid-date",
+				table: "rudel.claude_sessions",
+				userId: "user-1",
+			},
+			{
+				query: async () => {
+					queryCount += 1;
+					return [];
+				},
+			},
+		);
+		const clickhouseFailureResult = await hasRawSessionRow(
+			{
+				organizationId: "org-1",
+				sessionDate: null,
+				sessionId: "clickhouse-failure",
+				table: "rudel.codex_sessions",
+				userId: "user-1",
+			},
+			{
+				query: async () => {
+					throw new Error("ClickHouse unavailable");
+				},
+			},
+		);
+
+		expect(invalidDateResult).toBe(false);
+		expect(queryCount).toBe(0);
+		expect(clickhouseFailureResult).toBe(false);
+	});
+
+	test("returns false after raw TTL expiry", async () => {
+		const present = await hasRawSessionRow(
+			{
+				organizationId: "org-1",
+				sessionDate: new Date("2026-08-01T10:00:00.000Z"),
+				sessionId: "expired-session",
+				table: "rudel.codex_sessions",
+				userId: "user-1",
+			},
+			{ query: async () => [] },
+		);
+
+		expect(present).toBe(false);
+	});
+
+	test("rejects non-allowlisted table interpolation", async () => {
+		expect(
+			hasRawSessionRow(
+				{
+					organizationId: "org-1",
+					sessionDate: new Date("2026-08-01T10:00:00.000Z"),
+					sessionId: "session-1",
+					table: "rudel.claude_sessions; DROP TABLE rudel.claude_sessions",
+					userId: "user-1",
+				},
+				{ query: async () => [] },
+			),
+		).rejects.toThrow("Unsupported ClickHouse table");
+	});
+});

--- a/apps/api/src/services/raw-session.service.ts
+++ b/apps/api/src/services/raw-session.service.ts
@@ -11,10 +11,50 @@ const logger = getLogger(["rudel", "api", "raw-session-service"]);
 
 interface RawSessionIdentity {
 	organizationId: string;
-	sessionDate: Date | null;
+	sessionDate: Date | string | null;
 	sessionId: string;
 	table: string;
 	userId: string;
+}
+
+async function queryRawSessionPresence(
+	identity: RawSessionIdentity,
+	table: string,
+	executor: RawSessionQueryExecutor,
+	sessionDate?: string,
+): Promise<boolean> {
+	const dateFilter = sessionDate
+		? "AND session_date BETWEEN parseDateTime64BestEffort({sessionDate:String}, 3, 'UTC') - INTERVAL 1 DAY AND parseDateTime64BestEffort({sessionDate:String}, 3, 'UTC') + INTERVAL 1 DAY"
+		: "";
+	const rows = await executor.query<{ present: number }>({
+		query: `
+			SELECT 1 AS present
+			FROM ${table}
+			WHERE organization_id = {organizationId:String}
+				${dateFilter}
+				AND session_id = {sessionId:String}
+				AND user_id = {userId:String}
+			LIMIT 1
+		`,
+		query_params: {
+			organizationId: identity.organizationId,
+			...(sessionDate ? { sessionDate } : {}),
+			sessionId: identity.sessionId,
+			userId: identity.userId,
+		},
+	});
+
+	return rows.length > 0;
+}
+
+function serializeSessionDate(
+	sessionDate: Date | string | null,
+): string | undefined {
+	if (!sessionDate) return undefined;
+	const parsedDate =
+		sessionDate instanceof Date ? sessionDate : new Date(sessionDate);
+	if (Number.isNaN(parsedDate.getTime())) return undefined;
+	return parsedDate.toISOString();
 }
 
 export async function hasRawSessionRow(
@@ -22,30 +62,29 @@ export async function hasRawSessionRow(
 	executor: RawSessionQueryExecutor = getClickhouse(),
 ): Promise<boolean> {
 	const table = getSafeClickHouseTable(identity.table);
+	const sessionDate = serializeSessionDate(identity.sessionDate);
+
+	if (sessionDate) {
+		try {
+			if (
+				await queryRawSessionPresence(identity, table, executor, sessionDate)
+			) {
+				return true;
+			}
+		} catch (error) {
+			logger.warn(
+				"Bounded raw-session duplicate probe failed; retrying without the date bound (organization_id={organizationId} session_id={sessionId} error={error})",
+				{
+					error: String(error),
+					organizationId: identity.organizationId,
+					sessionId: identity.sessionId,
+				},
+			);
+		}
+	}
 
 	try {
-		const sessionDate = identity.sessionDate?.toISOString();
-		const dateFilter = sessionDate
-			? "AND session_date BETWEEN parseDateTime64BestEffort({sessionDate:String}, 3, 'UTC') - INTERVAL 1 DAY AND parseDateTime64BestEffort({sessionDate:String}, 3, 'UTC') + INTERVAL 1 DAY"
-			: "";
-		const rows = await executor.query<{ present: number }>({
-			query: `
-				SELECT 1 AS present
-				FROM ${table}
-				WHERE organization_id = {organizationId:String}
-					AND user_id = {userId:String}
-					AND session_id = {sessionId:String}
-					${dateFilter}
-				LIMIT 1
-			`,
-			query_params: {
-				organizationId: identity.organizationId,
-				...(sessionDate ? { sessionDate } : {}),
-				sessionId: identity.sessionId,
-				userId: identity.userId,
-			},
-		});
-		return rows.length > 0;
+		return await queryRawSessionPresence(identity, table, executor);
 	} catch (error) {
 		logger.warn(
 			"Raw-session duplicate probe failed; continuing with ingest (organization_id={organizationId} session_id={sessionId} error={error})",

--- a/apps/api/src/services/raw-session.service.ts
+++ b/apps/api/src/services/raw-session.service.ts
@@ -1,0 +1,60 @@
+import { getLogger } from "@logtape/logtape";
+import {
+	type ClickHouseExecutor,
+	getClickhouse,
+	getSafeClickHouseTable,
+} from "../clickhouse.js";
+
+type RawSessionQueryExecutor = Pick<ClickHouseExecutor, "query">;
+
+const logger = getLogger(["rudel", "api", "raw-session-service"]);
+
+interface RawSessionIdentity {
+	organizationId: string;
+	sessionDate: Date | null;
+	sessionId: string;
+	table: string;
+	userId: string;
+}
+
+export async function hasRawSessionRow(
+	identity: RawSessionIdentity,
+	executor: RawSessionQueryExecutor = getClickhouse(),
+): Promise<boolean> {
+	const table = getSafeClickHouseTable(identity.table);
+
+	try {
+		const sessionDate = identity.sessionDate?.toISOString();
+		const dateFilter = sessionDate
+			? "AND session_date BETWEEN parseDateTime64BestEffort({sessionDate:String}, 3, 'UTC') - INTERVAL 1 DAY AND parseDateTime64BestEffort({sessionDate:String}, 3, 'UTC') + INTERVAL 1 DAY"
+			: "";
+		const rows = await executor.query<{ present: number }>({
+			query: `
+				SELECT 1 AS present
+				FROM ${table}
+				WHERE organization_id = {organizationId:String}
+					AND user_id = {userId:String}
+					AND session_id = {sessionId:String}
+					${dateFilter}
+				LIMIT 1
+			`,
+			query_params: {
+				organizationId: identity.organizationId,
+				...(sessionDate ? { sessionDate } : {}),
+				sessionId: identity.sessionId,
+				userId: identity.userId,
+			},
+		});
+		return rows.length > 0;
+	} catch (error) {
+		logger.warn(
+			"Raw-session duplicate probe failed; continuing with ingest (organization_id={organizationId} session_id={sessionId} error={error})",
+			{
+				error: String(error),
+				organizationId: identity.organizationId,
+				sessionId: identity.sessionId,
+			},
+		);
+		return false;
+	}
+}

--- a/apps/api/src/services/session-ownership.service.ts
+++ b/apps/api/src/services/session-ownership.service.ts
@@ -1,14 +1,28 @@
 import { getLogger } from "@logtape/logtape";
 import { sqlClient } from "../db.js";
+import type { IngestContentShape } from "../lib/ingest-content-shape.js";
 
 const logger = getLogger(["rudel", "api", "session-ownership"]);
 
 type SessionOwnershipClaim =
-	| { owned: true; lastContentSha256: string | null }
+	| {
+			owned: true;
+			lastAssistantLineCount: number | null;
+			lastContentBytes: number | null;
+			lastContentSha256: string | null;
+			lastContentShape: IngestContentShape | null;
+			lastFilterVersion: number | null;
+			lastSessionDate: Date | null;
+	  }
 	| { owned: false; ownerId: string };
 
 interface ReservedSessionOwner {
+	lastAssistantLineCount: number | null;
+	lastContentBytes: number | null;
 	lastContentSha256: string | null;
+	lastContentShape: IngestContentShape | null;
+	lastFilterVersion: number | null;
+	lastSessionDate: Date | null;
 	userId: string;
 }
 
@@ -29,6 +43,9 @@ export async function recordSessionIngestContent(
 	organizationId: string,
 	sessionId: string,
 	contentSha256: string,
+	contentShape: IngestContentShape,
+	filterVersion: number,
+	sessionDate: Date,
 	ingestedAt: Date,
 ): Promise<void> {
 	// This guard orders bookkeeping for successful writes with distinct
@@ -40,6 +57,11 @@ export async function recordSessionIngestContent(
 		UPDATE session_ownership
 		SET
 			last_content_sha256 = ${contentSha256},
+			last_content_bytes = ${contentShape.contentBytes},
+			last_assistant_line_count = ${contentShape.assistantLineCount},
+			last_content_shape_json = ${JSON.stringify(contentShape)},
+			last_filter_version = ${filterVersion},
+			last_session_date = ${sessionDate.toISOString()},
 			last_ingested_at = ${ingestedAtIso}
 		WHERE organization_id = ${organizationId}
 			AND session_id = ${sessionId}
@@ -71,7 +93,15 @@ async function reserveSessionOwner(
 ): Promise<ReservedSessionOwner> {
 	// The no-op update returns the winning row when a concurrent insert wins.
 	const [row] = await sqlClient<
-		Array<{ last_content_sha256: string | null; user_id: string }>
+		Array<{
+			last_assistant_line_count: number | null;
+			last_content_bytes: number | null;
+			last_content_sha256: string | null;
+			last_content_shape_json: string | null;
+			last_filter_version: number | null;
+			last_session_date: Date | null;
+			user_id: string;
+		}>
 	>`
 		INSERT INTO session_ownership AS ownership (
 			organization_id,
@@ -85,13 +115,25 @@ async function reserveSessionOwner(
 		)
 		ON CONFLICT (organization_id, session_id) DO UPDATE
 		SET user_id = ownership.user_id
-		RETURNING user_id, last_content_sha256
+		RETURNING
+			user_id,
+			last_content_sha256,
+			last_content_bytes,
+			last_assistant_line_count,
+			last_content_shape_json,
+			last_filter_version,
+			last_session_date
 	`;
 	if (!row) {
 		throw new Error("Session ownership reservation did not return an owner");
 	}
 	return {
+		lastAssistantLineCount: row.last_assistant_line_count,
+		lastContentBytes: row.last_content_bytes,
 		lastContentSha256: row.last_content_sha256,
+		lastContentShape: parseContentShape(row.last_content_shape_json),
+		lastFilterVersion: row.last_filter_version,
+		lastSessionDate: row.last_session_date,
 		userId: row.user_id,
 	};
 }
@@ -105,7 +147,12 @@ function getOwnershipClaim(
 	if (reservedOwner.userId === userId) {
 		return {
 			owned: true,
+			lastAssistantLineCount: reservedOwner.lastAssistantLineCount,
+			lastContentBytes: reservedOwner.lastContentBytes,
 			lastContentSha256: reservedOwner.lastContentSha256,
+			lastContentShape: reservedOwner.lastContentShape,
+			lastFilterVersion: reservedOwner.lastFilterVersion,
+			lastSessionDate: reservedOwner.lastSessionDate,
 		};
 	}
 
@@ -114,4 +161,36 @@ function getOwnershipClaim(
 		{ organizationId, sessionId, userId },
 	);
 	return { owned: false, ownerId: reservedOwner.userId };
+}
+
+function parseContentShape(value: string | null): IngestContentShape | null {
+	if (value === null) return null;
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (!isRecord(parsed) || parsed.version !== 1) return null;
+		if (!isContentComponent(parsed.main) || !isRecord(parsed.subagents)) {
+			return null;
+		}
+		for (const component of Object.values(parsed.subagents)) {
+			if (!isContentComponent(component)) return null;
+		}
+		if (!isContentComponent(parsed)) return null;
+		return parsed as unknown as IngestContentShape;
+	} catch {
+		return null;
+	}
+}
+
+function isContentComponent(value: unknown): boolean {
+	return (
+		isRecord(value) &&
+		Number.isSafeInteger(value.assistantLineCount) &&
+		Number(value.assistantLineCount) >= 0 &&
+		Number.isSafeInteger(value.contentBytes) &&
+		Number(value.contentBytes) >= 0
+	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/cli/src/__tests__/api-upload.integration.ts
+++ b/apps/cli/src/__tests__/api-upload.integration.ts
@@ -1000,6 +1000,7 @@ describe("CLI upload to local API", () => {
 				"Ingest request limit reached (2 requests per 60 min). Wait and retry with: rudel upload --retry",
 			attempts: 1,
 			rateLimited: true,
+			retryable: true,
 		});
 	}, 60_000);
 });

--- a/apps/cli/src/__tests__/batch-upload.test.ts
+++ b/apps/cli/src/__tests__/batch-upload.test.ts
@@ -1,13 +1,18 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { Logger } from "@logtape/logtape";
 import { MissingTranscriptTimestampError } from "@rudel/agent-adapters";
+import { SecretFilterJsonIntegrityError } from "@rudel/secret-filter";
 import { type BatchUploadItem, batchUpload } from "../lib/batch-upload.js";
 import {
+	type FailedUpload,
+	isRetryCandidate,
 	loadFailedUploads,
 	recordFailedUpload,
 } from "../lib/failed-uploads.js";
+import { reportHookUploadFailure } from "../lib/hook-upload-failure.js";
 
 describe("batchUpload", () => {
 	let configDir: string;
@@ -28,7 +33,7 @@ describe("batchUpload", () => {
 		await rm(configDir, { recursive: true, force: true });
 	});
 
-	test("skips timestamp-less sessions without poisoning the retry queue", async () => {
+	test("retains timestamp-less sessions as permanent failures", async () => {
 		const items: BatchUploadItem[] = [
 			{
 				sessionId: "client-validation",
@@ -88,6 +93,133 @@ describe("batchUpload", () => {
 				},
 			],
 		});
-		expect(await loadFailedUploads()).toEqual([]);
+		expect(await loadFailedUploads()).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					sessionId: "client-validation",
+					status: "permanent",
+				}),
+				expect.objectContaining({
+					sessionId: "server-validation",
+					status: "permanent",
+				}),
+			]),
+		);
+	});
+
+	test("retains typed JSON-integrity failures as permanent", async () => {
+		const item: BatchUploadItem = {
+			sessionId: "json-integrity",
+			label: "json-integrity",
+			transcriptPath: "/sessions/json-integrity.jsonl",
+			projectPath: "/project",
+			source: "claude_code",
+		};
+
+		const summary = await batchUpload({
+			items: [item],
+			upload: async () => {
+				throw new SecretFilterJsonIntegrityError();
+			},
+		});
+
+		expect(summary).toMatchObject({ failed: 0, skipped: 1, succeeded: 0 });
+		expect(
+			(await loadFailedUploads()).find(
+				(failure) => failure.sessionId === item.sessionId,
+			),
+		).toMatchObject({
+			failureKind: "json-integrity",
+			status: "permanent",
+		});
+	});
+
+	test("persists the hook failure kind used by retry promotion", async () => {
+		const logger = { error: () => undefined } as unknown as Logger;
+
+		await reportHookUploadFailure(
+			logger,
+			{
+				error: "replacement is smaller",
+				failureKind: "session-shrink-rejected",
+				retryable: false,
+				success: false,
+			},
+			{
+				projectPath: "/project",
+				sessionId: "hook-shrink",
+				transcriptPath: "/sessions/hook-shrink.jsonl",
+			},
+		);
+
+		expect(
+			(await loadFailedUploads()).find(
+				(failure) => failure.sessionId === "hook-shrink",
+			),
+		).toMatchObject({
+			failureKind: "session-shrink-rejected",
+			status: "permanent",
+		});
+	});
+
+	test("normalizes legacy failures as retryable and persists dispositions", async () => {
+		await writeFile(
+			join(configDir, "failed-uploads.json"),
+			JSON.stringify({
+				failures: [
+					{
+						error: "legacy transport failure",
+						failedAt: "2026-07-31T10:00:00.000Z",
+						projectPath: "/project",
+						sessionId: "legacy",
+						transcriptPath: "/sessions/legacy.jsonl",
+					},
+				],
+			}),
+		);
+
+		expect((await loadFailedUploads())[0]?.status).toBe("retryable");
+		await recordFailedUpload({
+			error: "invalid transcript",
+			projectPath: "/project",
+			sessionId: "permanent",
+			status: "permanent",
+			transcriptPath: "/sessions/permanent.jsonl",
+		});
+		expect(
+			(await loadFailedUploads()).find(
+				(failure) => failure.sessionId === "permanent",
+			)?.status,
+		).toBe("permanent");
+	});
+
+	test("force replacement promotes only permanent shrink failures", () => {
+		const base: FailedUpload = {
+			error: "permanent failure",
+			failedAt: "2026-08-03T00:00:00.000Z",
+			projectPath: "/project",
+			sessionId: "permanent",
+			status: "permanent",
+			transcriptPath: "/sessions/permanent.jsonl",
+		};
+
+		expect(
+			isRetryCandidate(
+				{ ...base, failureKind: "session-shrink-rejected" },
+				true,
+			),
+		).toBe(true);
+		expect(
+			isRetryCandidate({ ...base, error: "retry with --force-replace" }, true),
+		).toBe(true);
+		expect(
+			isRetryCandidate({ ...base, failureKind: "json-integrity" }, true),
+		).toBe(false);
+		expect(
+			isRetryCandidate(
+				{ ...base, failureKind: "session-shrink-rejected" },
+				false,
+			),
+		).toBe(false);
 	});
 });

--- a/apps/cli/src/__tests__/old-api-compat.test.ts
+++ b/apps/cli/src/__tests__/old-api-compat.test.ts
@@ -129,6 +129,7 @@ describe("uploadSession against an old-API ingest stub", () => {
 		readonly name: string;
 		readonly respond: (info: IngestStubRespondInfo) => Response;
 		readonly expectedErrorSubstring: string;
+		readonly expectedRetryable: boolean;
 	}
 
 	const DEGRADED_RESPONSE_CASES: readonly DegradedResponseCase[] = [
@@ -141,22 +142,44 @@ describe("uploadSession against an old-API ingest stub", () => {
 				}),
 			expectedErrorSubstring:
 				"unrecognized response instead of an ingest confirmation",
+			expectedRetryable: false,
 		},
 		{
 			name: "200 with non-oRPC JSON",
 			respond: () => Response.json({ ok: true }),
 			expectedErrorSubstring:
 				"unrecognized response instead of an ingest confirmation",
+			expectedRetryable: false,
+		},
+		{
+			name: "401 with a plain-text body",
+			respond: () => new Response("unauthorized", { status: 401 }),
+			expectedErrorSubstring: "401 Unauthorized",
+			expectedRetryable: false,
+		},
+		{
+			name: "403 with a plain-text body",
+			respond: () => new Response("forbidden", { status: 403 }),
+			expectedErrorSubstring: "403 Forbidden",
+			expectedRetryable: false,
 		},
 		{
 			name: "404 with a plain-text body",
 			respond: () => new Response("not found", { status: 404 }),
 			expectedErrorSubstring: "404 Not Found",
+			expectedRetryable: false,
+		},
+		{
+			name: "413 with a plain-text body",
+			respond: () => new Response("too large", { status: 413 }),
+			expectedErrorSubstring: "413 Payload Too Large",
+			expectedRetryable: false,
 		},
 		{
 			name: "422 with an unknown JSON shape",
 			respond: () => Response.json({ weird: true }, { status: 422 }),
 			expectedErrorSubstring: "422 Unprocessable Content",
+			expectedRetryable: false,
 		},
 		{
 			name: "500 with an HTML body",
@@ -166,6 +189,7 @@ describe("uploadSession against an old-API ingest stub", () => {
 					headers: { "content-type": "text/html" },
 				}),
 			expectedErrorSubstring: "500 Internal Server Error",
+			expectedRetryable: true,
 		},
 	];
 
@@ -179,12 +203,12 @@ describe("uploadSession against an old-API ingest stub", () => {
 				stubUploadConfig(stub),
 			);
 
-			// 200-but-unrecognized and 404/422/500 are all non-retryable
-			// (RETRYABLE_STATUS_CODES is {502, 503, 504}): exactly one attempt,
-			// a formatted error, and no throw.
+			// Deterministic responses remain permanent. A generic 500 is retained
+			// for a later retry even though only 502/503/504 retry inline.
 			expect(result).toMatchObject({
 				success: false,
 				attempts: 1,
+				retryable: degradedCase.expectedRetryable,
 			});
 			expect(result.error).toContain(degradedCase.expectedErrorSubstring);
 			expect(stub.requests).toHaveLength(1);

--- a/apps/cli/src/__tests__/release-pressure.integration.ts
+++ b/apps/cli/src/__tests__/release-pressure.integration.ts
@@ -90,6 +90,7 @@ let batchState:
 	| {
 			overBudgetSessionId: string;
 			overBudgetPath: string;
+			overBudgetFailedAtBefore: string;
 			missingSessionId: string;
 			missingFailedAtBefore: string;
 			fixedContent: string;
@@ -102,6 +103,7 @@ interface QueueEntry {
 	projectPath: string;
 	error: string;
 	failedAt: string;
+	status: "permanent" | "retryable";
 }
 
 type PressureBatchItem = BatchUploadItem & {
@@ -334,7 +336,8 @@ describe("release pressure: E2E integration", () => {
 		});
 
 		expect(summary.succeeded).toBe(4);
-		expect(summary.failed).toBe(2);
+		expect(summary.failed).toBe(1);
+		expect(summary.skipped).toBe(1);
 		expect(summary.total).toBe(6);
 		expect(summary.redacted).toEqual(expectedRedacted);
 		expect(summary.redactedBytes).toBe(expectedRedactedBytes);
@@ -345,17 +348,18 @@ describe("release pressure: E2E integration", () => {
 			4,
 		);
 
-		expect(summary.errors).toHaveLength(2);
-		const errorLabels = summary.errors.map((entry) => entry.label).sort();
-		expect(errorLabels).toEqual([missingId, overBudgetId].sort());
+		expect(summary.errors).toHaveLength(1);
+		expect(summary.errors[0]?.label).toBe(missingId);
 		for (const entry of summary.errors) {
 			expect(containsAnyCanary(entry.error, ALL_SECRETS)).toBe(false);
 		}
-		const overBudgetError = summary.errors.find(
+		expect(summary.skippedItems).toHaveLength(1);
+		const overBudgetSkip = summary.skippedItems.find(
 			(entry) => entry.label === overBudgetId,
 		);
-		assert(overBudgetError);
-		expect(overBudgetError.error).toContain(
+		assert(overBudgetSkip);
+		expect(containsAnyCanary(overBudgetSkip.reason, ALL_SECRETS)).toBe(false);
+		expect(overBudgetSkip.reason).toContain(
 			"Redaction safety check stopped upload",
 		);
 
@@ -371,10 +375,17 @@ describe("release pressure: E2E integration", () => {
 		);
 
 		const missingEntry = queue.find((entry) => entry.sessionId === missingId);
+		const overBudgetEntry = queue.find(
+			(entry) => entry.sessionId === overBudgetId,
+		);
 		assert(missingEntry);
+		assert(overBudgetEntry);
+		expect(missingEntry.status).toBe("retryable");
+		expect(overBudgetEntry.status).toBe("permanent");
 		batchState = {
 			overBudgetSessionId: overBudgetId,
 			overBudgetPath,
+			overBudgetFailedAtBefore: overBudgetEntry.failedAt,
 			missingSessionId: missingId,
 			missingFailedAtBefore: missingEntry.failedAt,
 			fixedContent: JSON.stringify({
@@ -420,8 +431,8 @@ describe("release pressure: E2E integration", () => {
 		expect(sharedRelay.getObservation().requestCount).toBe(requestCountBefore);
 	});
 
-	// ── Test 3 ── `upload --retry --yes` drains the fixed item, re-queues the rest.
-	test("upload --retry --yes drains the fixed queue item and refreshes the unfixed one", async () => {
+	// ── Test 3 ── `upload --retry --yes` attempts only retryable failures.
+	test("upload --retry --yes refreshes the retryable failure and retains the permanent one", async () => {
 		assert(batchState, "test 1 must have populated the failed-upload queue");
 		await writeFile(batchState.overBudgetPath, batchState.fixedContent);
 
@@ -430,32 +441,43 @@ describe("release pressure: E2E integration", () => {
 			{ configDir: batchConfigDir, home: batchHome },
 		);
 
-		// The missing-transcript item still fails, so the command exits 1 while
-		// the fixed item drains.
+		// The missing-transcript item still fails, so the command exits 1. The
+		// locally fixed permanent item remains visible but is not attempted.
 		expect(result.exitCode).toBe(1);
 		expect(containsAnyCanary(result.stdout, ALL_SECRETS)).toBe(false);
 		expect(containsAnyCanary(result.stderr, ALL_SECRETS)).toBe(false);
+		const retryOutput = `${result.stdout}\n${result.stderr}`;
+		expect(retryOutput).toContain(batchState.overBudgetSessionId);
+		expect(retryOutput).toContain(
+			"Permanent failures are retained for visibility and are not retried automatically.",
+		);
 
 		const queueRaw = await readFile(
 			join(batchConfigDir, "failed-uploads.json"),
 			"utf8",
 		);
 		const queue = (JSON.parse(queueRaw) as { failures: QueueEntry[] }).failures;
-		expect(queue).toHaveLength(1);
-		const remaining = queue[0];
-		assert(remaining);
-		expect(remaining.sessionId).toBe(batchState.missingSessionId);
-		expect(Date.parse(remaining.failedAt)).toBeGreaterThan(
+		expect(queue).toHaveLength(2);
+		const missingEntry = queue.find(
+			(entry) => entry.sessionId === batchState?.missingSessionId,
+		);
+		const overBudgetEntry = queue.find(
+			(entry) => entry.sessionId === batchState?.overBudgetSessionId,
+		);
+		assert(missingEntry);
+		assert(overBudgetEntry);
+		expect(missingEntry.status).toBe("retryable");
+		expect(Date.parse(missingEntry.failedAt)).toBeGreaterThan(
 			Date.parse(batchState.missingFailedAtBefore),
 		);
+		expect(overBudgetEntry.status).toBe("permanent");
+		expect(overBudgetEntry.failedAt).toBe(batchState.overBudgetFailedAtBefore);
 
 		const storedRow = await getStoredFilteredSession(
 			userId,
 			batchState.overBudgetSessionId,
 		);
-		assert(storedRow);
-		expect(storedRow.filter_version).toBe(FILTER_VERSION);
-		expect(hashText(storedRow.content)).toBe(hashText(batchState.fixedContent));
+		expect(storedRow).toBeNull();
 	}, 120_000);
 
 	// ── Test 4 ── rate-limited batch: 2 succeed, 1 real 429, 1 skipped, 3 wire requests.

--- a/apps/cli/src/__tests__/upload-destination.integration.test.ts
+++ b/apps/cli/src/__tests__/upload-destination.integration.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { readFile, rm } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
 	createCliFixture,
@@ -91,6 +91,30 @@ test("upload --endpoint permits loopback plaintext without an opt-in", async () 
 	}
 }, 30_000);
 
+test("upload --force-replace sends an explicit replacement instruction", async () => {
+	const stub = startIngestStub();
+	const fixture = await createCliFixture("claude_code");
+	try {
+		const result = await runCli(
+			[
+				"upload",
+				fixture.transcriptPath,
+				"--endpoint",
+				`${stub.loopbackBase}/rpc`,
+				"--force-replace",
+			],
+			fixture,
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("Upload successful!");
+		expect(stub.bodies[0]).toContain('"force_replace":true');
+	} finally {
+		await stub.server.stop(true);
+		await rm(fixture.home, { recursive: true, force: true });
+	}
+}, 30_000);
+
 test.each(
 	HOOK_CASES,
 )("$name refuses an unsafe RUDEL_API_BASE observably and queues the session", async (hookCase) => {
@@ -154,6 +178,96 @@ test.each(
 		]);
 	} finally {
 		await stub.server.stop(true);
+		await rm(fixture.home, { recursive: true, force: true });
+	}
+}, 30_000);
+
+test.each(
+	HOOK_CASES,
+)("$name exposes and retains permanent API failures", async (hookCase) => {
+	const message =
+		hookCase.source === "codex"
+			? "Codex transcript contains no valid timestamp"
+			: "Claude Code transcript contains no valid timestamp";
+	const stub = startIngestStub({
+		respond: () =>
+			Response.json(
+				{
+					json: {
+						defined: false,
+						code: "BAD_REQUEST",
+						status: 400,
+						message,
+					},
+				},
+				{ status: 400 },
+			),
+	});
+	const fixture = await createCliFixture(hookCase.source);
+	try {
+		const result = await runCli(hookCase.command, fixture, {
+			stdin: hookCase.buildInput(fixture),
+			env: { RUDEL_API_BASE: stub.loopbackBase },
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toContain("Rudel hook upload failed");
+		expect(result.stderr).toContain("[permanent]");
+		expect(result.stderr).toContain(message);
+
+		const failedUploads = JSON.parse(
+			await readFile(
+				join(fixture.home, ".rudel", "failed-uploads.json"),
+				"utf8",
+			),
+		) as { failures: Array<{ sessionId: string; status: string }> };
+		expect(failedUploads.failures).toContainEqual(
+			expect.objectContaining({
+				sessionId: fixture.sessionId,
+				status: "permanent",
+			}),
+		);
+	} finally {
+		await stub.server.stop(true);
+		await rm(fixture.home, { recursive: true, force: true });
+	}
+}, 30_000);
+
+test("whoami surfaces local retryable and permanent upload status", async () => {
+	const fixture = await createCliFixture("claude_code");
+	try {
+		await rm(join(fixture.home, ".rudel", "credentials.json"));
+		await writeFile(
+			join(fixture.home, ".rudel", "failed-uploads.json"),
+			JSON.stringify({
+				failures: [
+					{
+						error: "network",
+						failedAt: "2026-08-02T10:00:00.000Z",
+						projectPath: fixture.projectPath,
+						sessionId: "retryable",
+						status: "retryable",
+						transcriptPath: fixture.transcriptPath,
+					},
+					{
+						error: "invalid",
+						failedAt: "2026-08-02T10:00:00.000Z",
+						projectPath: fixture.projectPath,
+						sessionId: "permanent",
+						status: "permanent",
+						transcriptPath: fixture.transcriptPath,
+					},
+				],
+			}),
+		);
+
+		const result = await runCli(["whoami"], fixture);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain(
+			"Local upload status: 1 retryable failure(s), 1 permanent failure(s)",
+		);
+		expect(result.stdout).toContain("Not logged in");
+	} finally {
 		await rm(fixture.home, { recursive: true, force: true });
 	}
 }, 30_000);

--- a/apps/cli/src/__tests__/uploader-rate-limit.integration.ts
+++ b/apps/cli/src/__tests__/uploader-rate-limit.integration.ts
@@ -52,6 +52,7 @@ describe("CLI ingest rate-limit messages", () => {
 				"Ingest byte limit reached (0.00 MiB per 60 min). Wait and retry with: rudel upload --retry",
 			attempts: 1,
 			rateLimited: true,
+			retryable: true,
 		});
 	});
 });

--- a/apps/cli/src/__tests__/uploader.test.ts
+++ b/apps/cli/src/__tests__/uploader.test.ts
@@ -4,13 +4,19 @@ import {
 	INGEST_LIMIT_REASONS,
 	type IngestSessionInput,
 	REDACTION_DID_NOT_CONVERGE_CODE,
+	SECRET_FILTER_JSON_INTEGRITY_CODE,
 	SESSION_OWNERSHIP_CONFLICT_CODE,
+	SESSION_UPLOAD_SHRINK_REJECTED_CODE,
 } from "@rudel/api-routes";
-import { SecretFilterConvergenceError } from "@rudel/secret-filter";
+import {
+	SecretFilterConvergenceError,
+	SecretFilterJsonIntegrityError,
+} from "@rudel/secret-filter";
 import {
 	formatRedactionSummary,
 	formatUploadError,
 	getSecretFilterUploadFailure,
+	isRetryableUploadError,
 	uploadSession,
 } from "../lib/uploader.js";
 import {
@@ -92,6 +98,22 @@ describe("formatUploadError", () => {
 		);
 	});
 
+	test("makes the intentional smaller-session override explicit", () => {
+		const error = new ORPCError(SESSION_UPLOAD_SHRINK_REJECTED_CODE, {
+			status: 409,
+			data: {
+				currentAssistantLineCount: 2,
+				currentContentBytes: 50_000,
+				previousAssistantLineCount: 4,
+				previousContentBytes: 100_000,
+			},
+		});
+
+		expect(formatUploadError(error)).toContain(
+			"rudel upload <session> --force-replace",
+		);
+	});
+
 	test("explains server-side convergence rejection without exposing content", () => {
 		const error = new ORPCError(REDACTION_DID_NOT_CONVERGE_CODE, {
 			status: 422,
@@ -157,6 +179,21 @@ describe("formatUploadError", () => {
 	});
 });
 
+describe("isRetryableUploadError", () => {
+	test("treats Bun FailedToOpenSocket failures as retryable without a code allowlist", () => {
+		const error = Object.assign(new Error("failed to open socket"), {
+			code: "FailedToOpenSocket",
+		});
+
+		expect(isRetryableUploadError(error)).toBe(true);
+	});
+
+	test("keeps permanent RPC responses non-retryable", () => {
+		expect(isRetryableUploadError(new ORPCError("BAD_REQUEST"))).toBe(false);
+		expect(isRetryableUploadError(new ORPCError("BAD_GATEWAY"))).toBe(true);
+	});
+});
+
 describe("uploadSession aggregate size guard", () => {
 	test("rejects an oversized aggregate before making a network attempt", async () => {
 		const result = await uploadSession(
@@ -180,8 +217,63 @@ describe("uploadSession aggregate size guard", () => {
 			error:
 				"Session transcript payload is 2.00 MiB, above the 1.00 MiB per-session limit. Reduce the transcript/subagent payload before retrying.",
 			attempts: 0,
+			retryable: false,
 		});
 	});
+});
+
+describe("uploadSession transient transport handling", () => {
+	test("retries a 408 response and succeeds on the next attempt", async () => {
+		const stub = startIngestStub({ failFirstN: { n: 1, status: 408 } });
+		const retries: number[] = [];
+		try {
+			const result = await uploadSession(
+				{
+					source: "claude_code",
+					sessionId: "request-timeout-retry",
+					projectPath: "/test/project",
+					content: '{"type":"user","timestamp":"2026-08-03T10:00:00.000Z"}',
+				},
+				{
+					endpoint: `${stub.loopbackBase}/rpc`,
+					token: INGEST_STUB_TEST_TOKEN,
+					allowInsecureEndpoint: false,
+					onRetry: (attempt) => retries.push(attempt),
+				},
+			);
+
+			expect(result).toMatchObject({ success: true, attempts: 2 });
+			expect(retries).toEqual([1]);
+		} finally {
+			await stub.server.stop(true);
+		}
+	}, 10_000);
+
+	test("retains Bun connection-refused failures for retry", async () => {
+		const retries: number[] = [];
+		const result = await uploadSession(
+			{
+				source: "claude_code",
+				sessionId: "bun-connection-refused",
+				projectPath: "/test/project",
+				content: '{"type":"user","timestamp":"2026-08-03T10:00:00.000Z"}',
+			},
+			{
+				endpoint: "http://127.0.0.1:1/rpc",
+				token: INGEST_STUB_TEST_TOKEN,
+				allowInsecureEndpoint: false,
+				onRetry: (attempt) => retries.push(attempt),
+			},
+		);
+
+		expect(result).toMatchObject({
+			success: false,
+			attempts: 3,
+			retryable: true,
+		});
+		expect(result.error).toContain("Network error while contacting Rudel API");
+		expect(retries).toEqual([1, 2]);
+	}, 10_000);
 });
 
 describe("uploadSession timestamp validation", () => {
@@ -240,6 +332,51 @@ describe("uploadSession timestamp validation", () => {
 	});
 });
 
+describe("uploadSession typed filtering failures", () => {
+	test("maps a server JSON-integrity rejection to a permanent result", async () => {
+		const stub = startIngestStub({
+			respond: () =>
+				Response.json(
+					{
+						json: {
+							defined: false,
+							code: SECRET_FILTER_JSON_INTEGRITY_CODE,
+							status: 422,
+							message:
+								"Secret filtering could not preserve transcript JSON integrity.",
+						},
+					},
+					{ status: 422 },
+				),
+		});
+
+		try {
+			const result = await uploadSession(
+				{
+					source: "claude_code",
+					sessionId: "server-json-integrity",
+					projectPath: "/test/project",
+					content: '{"type":"user","timestamp":"2026-07-31T10:00:00.000Z"}',
+				},
+				{
+					endpoint: `${stub.loopbackBase}/rpc`,
+					token: INGEST_STUB_TEST_TOKEN,
+					allowInsecureEndpoint: false,
+				},
+			);
+
+			expect(result).toMatchObject({
+				success: false,
+				attempts: 1,
+				failureKind: "json-integrity",
+				retryable: false,
+			});
+		} finally {
+			await stub.server.stop(true);
+		}
+	});
+});
+
 describe("formatRedactionSummary", () => {
 	test("summarizes counts without including matched values", () => {
 		expect(
@@ -285,6 +422,7 @@ describe("uploadSession redaction safety budget", () => {
 				"Redaction safety check stopped upload: known-pattern redaction would replace 21 B of 100 B (21.0%), above the 20% transcript budget (stripe-access-token). The unfiltered transcript was not uploaded.",
 			attempts: 0,
 			redactionBudgetExceeded: true,
+			retryable: false,
 		});
 	});
 
@@ -355,8 +493,22 @@ describe("uploadSession redaction convergence", () => {
 				"Redaction safety check stopped upload because known-pattern filtering did not converge. The unfiltered transcript was not uploaded.",
 			attempts: 0,
 			redactionConvergenceExceeded: true,
+			retryable: false,
 		});
 		expect(getSecretFilterUploadFailure(new Error("worker failed"))).toBeNull();
+	});
+
+	test("maps JSON-integrity failures to a permanent ledger disposition", () => {
+		expect(
+			getSecretFilterUploadFailure(new SecretFilterJsonIntegrityError()),
+		).toEqual({
+			success: false,
+			error:
+				"Redaction safety check stopped upload because filtering could not preserve transcript JSON integrity. The filtered transcript was not uploaded.",
+			attempts: 0,
+			failureKind: "json-integrity",
+			retryable: false,
+		});
 	});
 });
 
@@ -381,6 +533,7 @@ describe("uploadSession endpoint safety", () => {
 				'Upload endpoint refused: refusing to send credentials over plaintext http: to "evil.example". Pass --allow-insecure-endpoint (or set RUDEL_ALLOW_INSECURE_ENDPOINT=1) if this upload destination really is plaintext. This does not opt login or other API-base traffic into --allow-insecure-api-base.',
 			attempts: 0,
 			endpointRejected: true,
+			retryable: false,
 		});
 		expect(result.error).not.toContain("must-not-leak");
 	});

--- a/apps/cli/src/commands/hooks/claude/session-end.ts
+++ b/apps/cli/src/commands/hooks/claude/session-end.ts
@@ -39,7 +39,12 @@ async function runSessionEnd(): Promise<undefined | Error> {
 		if (!input.session_id || !input.transcript_path) return;
 
 		const credentials = loadCredentials();
-		if (!credentials) return;
+		if (!credentials) {
+			process.stderr.write(
+				`Rudel hook upload skipped for session ${input.session_id}: not authenticated; run \`rudel login\`.\n`,
+			);
+			return;
+		}
 
 		logger.info("Uploading session {sessionId}", {
 			sessionId: input.session_id,
@@ -100,6 +105,9 @@ async function runSessionEnd(): Promise<undefined | Error> {
 		}
 	} catch (error) {
 		logger.error("Session end hook failed: {error}", { error });
+		process.stderr.write(
+			`Rudel Claude Code hook failed: ${error instanceof Error ? error.message : String(error)}\n`,
+		);
 	} finally {
 		await disposeLogging();
 	}

--- a/apps/cli/src/commands/hooks/codex/turn-complete.ts
+++ b/apps/cli/src/commands/hooks/codex/turn-complete.ts
@@ -45,11 +45,21 @@ async function runTurnComplete(): Promise<undefined | Error> {
 		if (!input.thread_id || !input.cwd) return;
 
 		const credentials = loadCredentials();
-		if (!credentials) return;
+		if (!credentials) {
+			process.stderr.write(
+				`Rudel hook upload skipped for session ${input.thread_id}: not authenticated; run \`rudel login\`.\n`,
+			);
+			return;
+		}
 
 		const transcriptPath =
 			input.transcript_path ?? (await findActiveRolloutFile(input.thread_id));
-		if (!transcriptPath) return;
+		if (!transcriptPath) {
+			process.stderr.write(
+				`Rudel hook upload skipped for session ${input.thread_id}: transcript file was not found.\n`,
+			);
+			return;
+		}
 
 		const sessionFile: SessionFile = {
 			sessionId: input.thread_id,
@@ -96,6 +106,9 @@ async function runTurnComplete(): Promise<undefined | Error> {
 		}
 	} catch (error) {
 		logger.error("Codex turn-complete hook failed: {error}", { error });
+		process.stderr.write(
+			`Rudel Codex hook failed: ${error instanceof Error ? error.message : String(error)}\n`,
+		);
 	} finally {
 		await disposeLogging();
 	}

--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -12,7 +12,11 @@ import type { BatchUploadItem } from "../lib/batch-upload.js";
 import { renderBatchSummary, runBatchUpload } from "../lib/batch-upload-ui.js";
 import { classifySession } from "../lib/classifier.js";
 import { loadCredentials } from "../lib/credentials.js";
-import { loadFailedUploads } from "../lib/failed-uploads.js";
+import {
+	isRetryCandidate,
+	loadFailedUploads,
+	removeFailedUpload,
+} from "../lib/failed-uploads.js";
 import { getGitInfo } from "../lib/git-info.js";
 import { getProjectOrgId } from "../lib/project-config.js";
 import { scanAndGroupProjects } from "../lib/project-grouping.js";
@@ -39,6 +43,7 @@ interface UploadFlags {
 	retry: boolean;
 	yes: boolean;
 	concurrency: number;
+	forceReplace: boolean;
 }
 
 async function runInteractiveUpload(
@@ -160,6 +165,7 @@ async function runInteractiveUpload(
 				organizationId: item.organizationId,
 				uploadMode: "manual",
 			});
+			if (flags.forceReplace) request.force_replace = true;
 
 			if (!flags.tag && flags.classify) {
 				const classified = await classifySession(request.content);
@@ -269,6 +275,7 @@ async function runSingleUpload(
 			write(`Classified as: ${classified}`);
 		}
 	}
+	if (flags.forceReplace) request.force_replace = true;
 
 	if (flags.dryRun) {
 		const preview = {
@@ -295,6 +302,7 @@ async function runSingleUpload(
 
 	if (result.success) {
 		write("Upload successful!");
+		await removeFailedUpload(request.sessionId);
 		const redactionSummary = formatRedactionSummary(
 			result.redacted,
 			result.redactedBytes,
@@ -324,17 +332,36 @@ async function runRetryUpload(
 		return;
 	}
 
-	p.log.info(`Found ${failures.length} failed upload(s):`);
+	const retryableFailures = failures.filter((failure) =>
+		isRetryCandidate(failure, flags.forceReplace),
+	);
+	const permanentFailures = failures.filter(
+		(failure) => failure.status === "permanent",
+	);
+	p.log.info(
+		`Found ${failures.length} failed upload(s): ${retryableFailures.length} retryable, ${permanentFailures.length} permanent`,
+	);
 	for (const f of failures.slice(0, 10)) {
-		p.log.warn(`  ${f.sessionId}: ${f.error} (${f.failedAt})`);
+		p.log.warn(`  [${f.status}] ${f.sessionId}: ${f.error} (${f.failedAt})`);
 	}
 	if (failures.length > 10) {
 		p.log.warn(`  ...and ${failures.length - 10} more`);
 	}
+	if (permanentFailures.length > 0) {
+		p.log.warn(
+			flags.forceReplace
+				? "Permanent shrink rejections are promoted by --force-replace; other permanent failures remain recorded."
+				: "Permanent failures are retained for visibility and are not retried automatically.",
+		);
+	}
+	if (retryableFailures.length === 0) {
+		p.outro("No retryable uploads. Permanent failures remain recorded.");
+		return;
+	}
 
 	if (!flags.yes) {
 		const shouldRetry = await p.confirm({
-			message: `Retry all ${failures.length} failed upload(s)?`,
+			message: `Retry ${retryableFailures.length} retryable upload(s)?`,
 			initialValue: true,
 		});
 
@@ -350,7 +377,7 @@ async function runRetryUpload(
 		failure: (typeof failures)[number];
 	};
 
-	const items: RetryItem[] = failures.map((f) => ({
+	const items: RetryItem[] = retryableFailures.map((f) => ({
 		sessionId: f.sessionId,
 		label: f.sessionId,
 		transcriptPath: f.transcriptPath,
@@ -385,6 +412,7 @@ async function runRetryUpload(
 				organizationId,
 				uploadMode: "retry",
 			});
+			if (flags.forceReplace) request.force_replace = true;
 
 			return uploadSession(request, {
 				endpoint,
@@ -481,6 +509,11 @@ export const uploadCommand = buildCommand({
 				parse: Number,
 				brief: "Max concurrent uploads",
 				default: "5",
+			},
+			forceReplace: {
+				kind: "boolean",
+				brief: "Intentionally replace a stored session with smaller content",
+				default: false,
 			},
 		},
 		aliases: {

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -2,8 +2,20 @@ import * as p from "@clack/prompts";
 import { buildCommand } from "@stricli/core";
 import { describeSavedCredentialsApiBaseRisk } from "../lib/api-base.js";
 import { verifyAuth } from "../lib/auth.js";
+import { loadFailedUploads } from "../lib/failed-uploads.js";
 
 async function runWhoami(): Promise<undefined | Error> {
+	const failedUploads = await loadFailedUploads();
+	if (failedUploads.length > 0) {
+		const retryable = failedUploads.filter(
+			(failure) => failure.status === "retryable",
+		).length;
+		const permanent = failedUploads.length - retryable;
+		p.log.warn(
+			`Local upload status: ${retryable} retryable failure(s), ${permanent} permanent failure(s). Run \`rudel upload --retry\` for details.`,
+		);
+	}
+
 	// Before verifyAuth, which sends the stored token to the stored base.
 	const storedApiBaseRisk = describeSavedCredentialsApiBaseRisk();
 	if (storedApiBaseRisk) {

--- a/apps/cli/src/lib/batch-upload.ts
+++ b/apps/cli/src/lib/batch-upload.ts
@@ -3,6 +3,7 @@ import type { Source } from "@rudel/api-routes";
 import {
 	mergeRedactionCounts,
 	type RedactionCounts,
+	SecretFilterJsonIntegrityError,
 } from "@rudel/secret-filter";
 import pMap from "p-map";
 import { recordFailedUpload, removeFailedUpload } from "./failed-uploads.js";
@@ -57,7 +58,6 @@ export async function batchUpload<T extends BatchUploadItem>(
 	let rateLimited = false;
 	const errors: Array<{ label: string; error: string }> = [];
 	const skippedItems: Array<{ label: string; reason: string }> = [];
-	const skippedSessionIds = new Set<string>();
 	let redacted: RedactionCounts = {};
 	let redactedBytes = 0;
 
@@ -75,6 +75,7 @@ export async function batchUpload<T extends BatchUploadItem>(
 					source: item.source,
 					organizationId: item.organizationId,
 					error,
+					status: "retryable",
 				});
 				completed++;
 				onItemComplete?.(completed, total);
@@ -102,7 +103,16 @@ export async function batchUpload<T extends BatchUploadItem>(
 						label: item.label,
 						reason: result.error ?? "Upload cannot be retried",
 					});
-					skippedSessionIds.add(item.sessionId);
+					await recordFailedUpload({
+						sessionId: item.sessionId,
+						transcriptPath: item.transcriptPath,
+						projectPath: item.projectPath,
+						source: item.source,
+						organizationId: item.organizationId,
+						error: result.error ?? "Upload cannot be retried",
+						failureKind: result.failureKind,
+						status: "permanent",
+					});
 				} else {
 					failed++;
 					const error = result.error ?? "Unknown error";
@@ -117,14 +127,31 @@ export async function batchUpload<T extends BatchUploadItem>(
 						source: item.source,
 						organizationId: item.organizationId,
 						error,
+						failureKind: result.failureKind,
+						status: "retryable",
 					});
 				}
 			} catch (err) {
 				const error = err instanceof Error ? err.message : String(err);
-				if (err instanceof MissingTranscriptTimestampError) {
+				if (
+					err instanceof MissingTranscriptTimestampError ||
+					err instanceof SecretFilterJsonIntegrityError
+				) {
 					skipped++;
 					skippedItems.push({ label: item.label, reason: error });
-					skippedSessionIds.add(item.sessionId);
+					await recordFailedUpload({
+						sessionId: item.sessionId,
+						transcriptPath: item.transcriptPath,
+						projectPath: item.projectPath,
+						source: item.source,
+						organizationId: item.organizationId,
+						error,
+						failureKind:
+							err instanceof SecretFilterJsonIntegrityError
+								? "json-integrity"
+								: undefined,
+						status: "permanent",
+					});
 				} else {
 					failed++;
 					errors.push({ label: item.label, error });
@@ -135,6 +162,7 @@ export async function batchUpload<T extends BatchUploadItem>(
 						source: item.source,
 						organizationId: item.organizationId,
 						error,
+						status: "retryable",
 					});
 				}
 			} finally {
@@ -144,10 +172,6 @@ export async function batchUpload<T extends BatchUploadItem>(
 		},
 		{ concurrency, stopOnError: false },
 	);
-
-	for (const sessionId of skippedSessionIds) {
-		await removeFailedUpload(sessionId);
-	}
 
 	if (rateLimited && deferred > 0) {
 		errors.push({

--- a/apps/cli/src/lib/failed-uploads.ts
+++ b/apps/cli/src/lib/failed-uploads.ts
@@ -23,11 +23,15 @@ export interface FailedUpload {
 	organizationId?: string;
 	error: string;
 	failedAt: string;
+	status: "permanent" | "retryable";
+	failureKind?: "json-integrity" | "session-shrink-rejected";
 }
 
 interface FailedUploadsData {
 	failures: FailedUpload[];
 }
+
+let mutationQueue: Promise<void> = Promise.resolve();
 
 function normalizeSource(raw: unknown): Source | undefined {
 	if (typeof raw !== "string") return undefined;
@@ -45,6 +49,7 @@ export async function loadFailedUploads(): Promise<FailedUpload[]> {
 		return data.failures.map((f) => ({
 			...f,
 			source: normalizeSource(f.source),
+			status: f.status === "permanent" ? "permanent" : "retryable",
 		}));
 	} catch {
 		return [];
@@ -66,26 +71,53 @@ async function saveFailedUploads(failures: FailedUpload[]): Promise<void> {
 }
 
 export async function recordFailedUpload(
-	failure: Omit<FailedUpload, "failedAt">,
+	failure: Omit<FailedUpload, "failedAt" | "status"> & {
+		status?: FailedUpload["status"];
+	},
 ): Promise<void> {
-	const failures = await loadFailedUploads();
-	const existing = failures.findIndex((f) => f.sessionId === failure.sessionId);
-	const entry: FailedUpload = {
-		...failure,
-		failedAt: new Date().toISOString(),
-	};
-	if (existing >= 0) {
-		failures[existing] = entry;
-	} else {
-		failures.push(entry);
-	}
-	await saveFailedUploads(failures);
+	await enqueueMutation(async () => {
+		const failures = await loadFailedUploads();
+		const existing = failures.findIndex(
+			(f) => f.sessionId === failure.sessionId,
+		);
+		const entry: FailedUpload = {
+			...failure,
+			failedAt: new Date().toISOString(),
+			status: failure.status ?? "retryable",
+		};
+		if (existing >= 0) {
+			failures[existing] = entry;
+		} else {
+			failures.push(entry);
+		}
+		await saveFailedUploads(failures);
+	});
 }
 
 export async function removeFailedUpload(sessionId: string): Promise<void> {
-	const failures = await loadFailedUploads();
-	const filtered = failures.filter((f) => f.sessionId !== sessionId);
-	if (filtered.length !== failures.length) {
-		await saveFailedUploads(filtered);
-	}
+	await enqueueMutation(async () => {
+		const failures = await loadFailedUploads();
+		const filtered = failures.filter((f) => f.sessionId !== sessionId);
+		if (filtered.length !== failures.length) {
+			await saveFailedUploads(filtered);
+		}
+	});
+}
+
+async function enqueueMutation(operation: () => Promise<void>): Promise<void> {
+	const queued = mutationQueue.then(operation, operation);
+	mutationQueue = queued.catch(() => {});
+	await queued;
+}
+
+export function isRetryCandidate(
+	failure: FailedUpload,
+	forceReplace: boolean,
+): boolean {
+	if (failure.status === "retryable") return true;
+	if (!forceReplace) return false;
+	return (
+		failure.failureKind === "session-shrink-rejected" ||
+		failure.error.includes("--force-replace")
+	);
 }

--- a/apps/cli/src/lib/hook-upload-failure.ts
+++ b/apps/cli/src/lib/hook-upload-failure.ts
@@ -1,9 +1,5 @@
 import type { Logger } from "@logtape/logtape";
-import {
-	type FailedUpload,
-	recordFailedUpload,
-	removeFailedUpload,
-} from "./failed-uploads.js";
+import { type FailedUpload, recordFailedUpload } from "./failed-uploads.js";
 import type { UploadResult } from "./types.js";
 
 /**
@@ -13,7 +9,7 @@ import type { UploadResult } from "./types.js";
 export async function reportHookUploadFailure(
 	logger: Logger,
 	result: UploadResult,
-	failure: Omit<FailedUpload, "error" | "failedAt">,
+	failure: Omit<FailedUpload, "error" | "failedAt" | "status">,
 ): Promise<undefined | Error> {
 	const uploadError = result.error ?? "Unknown error";
 	logger.error("Upload failed for session {sessionId}: {error}", {
@@ -21,20 +17,17 @@ export async function reportHookUploadFailure(
 		error: uploadError,
 	});
 
-	if (result.retryable === false) {
-		await removeFailedUpload(failure.sessionId);
-		return;
-	}
-
-	if (result.endpointRejected) {
-		process.stderr.write(
-			`Rudel hook upload refused for session ${failure.sessionId}: ${uploadError}\n`,
-		);
-	}
+	const disposition = result.retryable === false ? "permanent" : "retryable";
+	const verb = result.endpointRejected ? "refused" : "failed";
+	process.stderr.write(
+		`Rudel hook upload ${verb} for session ${failure.sessionId} [${disposition}]: ${uploadError}\n`,
+	);
 
 	await recordFailedUpload({
 		...failure,
 		error: uploadError,
+		failureKind: result.failureKind,
+		status: disposition,
 	});
 
 	if (result.endpointRejected) {

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -27,6 +27,7 @@ export interface UploadResult {
 	rateLimited?: boolean;
 	/** Whether a failed upload belongs in the durable retry queue. */
 	retryable?: boolean;
+	failureKind?: "json-integrity" | "session-shrink-rejected";
 	redacted?: RedactionCounts;
 	redactedBytes?: number;
 	redactionBudgetExceeded?: boolean;

--- a/apps/cli/src/lib/uploader.ts
+++ b/apps/cli/src/lib/uploader.ts
@@ -10,7 +10,9 @@ import {
 	parseSafeApiEndpoint,
 	REDACTION_BUDGET_EXCEEDED_CODE,
 	REDACTION_DID_NOT_CONVERGE_CODE,
+	SECRET_FILTER_JSON_INTEGRITY_CODE,
 	SESSION_OWNERSHIP_CONFLICT_CODE,
+	SESSION_UPLOAD_SHRINK_REJECTED_CODE,
 } from "@rudel/api-routes";
 import {
 	FILTER_VERSION,
@@ -21,6 +23,7 @@ import {
 	type RedactionBudgetAnomaly,
 	type RedactionCounts,
 	SecretFilterConvergenceError,
+	SecretFilterJsonIntegrityError,
 	type SessionTextFilterResult,
 } from "@rudel/secret-filter";
 import type { UploadResult } from "./types.js";
@@ -35,7 +38,7 @@ export interface UploadConfig {
 	onRetry?: (attempt: number, maxAttempts: number, error: string) => void;
 }
 
-const RETRYABLE_STATUS_CODES = new Set([502, 503, 504]);
+const RETRYABLE_STATUS_CODES = new Set([408, 502, 503, 504]);
 const MAX_ATTEMPTS = 3;
 const BASE_DELAY_MS = 1_000;
 
@@ -52,14 +55,11 @@ interface ErrorData {
 
 type UploadSubagent = NonNullable<IngestSessionInput["subagents"]>[number];
 
-function isRetryable(error: unknown): boolean {
+export function isRetryableUploadError(error: unknown): boolean {
 	if (error instanceof ORPCError) {
 		return RETRYABLE_STATUS_CODES.has(error.status);
 	}
-	if (error instanceof TypeError) {
-		return true; // network errors (fetch failures)
-	}
-	return false;
+	return true;
 }
 
 function isRateLimited(error: unknown): error is ORPCError<string, unknown> {
@@ -96,16 +96,27 @@ function isApiKeyRateLimited(
 export function getSecretFilterUploadFailure(
 	error: unknown,
 ): UploadResult | null {
-	if (!(error instanceof SecretFilterConvergenceError)) {
-		return null;
+	if (error instanceof SecretFilterJsonIntegrityError) {
+		return {
+			success: false,
+			error:
+				"Redaction safety check stopped upload because filtering could not preserve transcript JSON integrity. The filtered transcript was not uploaded.",
+			attempts: 0,
+			failureKind: "json-integrity",
+			retryable: false,
+		};
 	}
-	return {
-		success: false,
-		error:
-			"Redaction safety check stopped upload because known-pattern filtering did not converge. The unfiltered transcript was not uploaded.",
-		attempts: 0,
-		redactionConvergenceExceeded: true,
-	};
+	if (error instanceof SecretFilterConvergenceError) {
+		return {
+			success: false,
+			error:
+				"Redaction safety check stopped upload because known-pattern filtering did not converge. The unfiltered transcript was not uploaded.",
+			attempts: 0,
+			redactionConvergenceExceeded: true,
+			retryable: false,
+		};
+	}
+	return null;
 }
 
 export function formatUploadError(error: unknown): string {
@@ -148,6 +159,12 @@ export function formatUploadError(error: unknown): string {
 	}
 	if (
 		error instanceof ORPCError &&
+		error.code === SESSION_UPLOAD_SHRINK_REJECTED_CODE
+	) {
+		return "Rudel refused this upload because it is smaller than the stored session. Check that the transcript is complete, then run `rudel upload <session> --force-replace` only if the replacement is intentional. If this CLI does not recognize the flag, upgrade rudel first.";
+	}
+	if (
+		error instanceof ORPCError &&
 		error.code === REDACTION_BUDGET_EXCEEDED_CODE
 	) {
 		const data = getRedactionBudgetErrorData(error);
@@ -160,6 +177,12 @@ export function formatUploadError(error: unknown): string {
 		error.code === REDACTION_DID_NOT_CONVERGE_CODE
 	) {
 		return "Redaction safety check stopped upload because known-pattern filtering did not converge. The unfiltered transcript was not uploaded.";
+	}
+	if (
+		error instanceof ORPCError &&
+		error.code === SECRET_FILTER_JSON_INTEGRITY_CODE
+	) {
+		return "Redaction safety check stopped upload because filtering could not preserve transcript JSON integrity. The filtered transcript was not uploaded.";
 	}
 	if (isPayloadTooLarge(error)) {
 		const data = getErrorData(error);
@@ -174,13 +197,8 @@ export function formatUploadError(error: unknown): string {
 	if (error instanceof ORPCError) {
 		return `${error.status} ${error.message}`;
 	}
-	if (error instanceof TypeError) {
-		return `Network error while contacting Rudel API: ${error.message}. Check your connection and retry with: rudel upload --retry`;
-	}
-	if (error instanceof Error) {
-		return error.message;
-	}
-	return String(error);
+	const message = error instanceof Error ? error.message : "connection failed";
+	return `Network error while contacting Rudel API: ${message}. Check your connection and retry with: rudel upload --retry`;
 }
 
 function formatPayloadTooLargeError(error: ORPCError<string, unknown>): string {
@@ -271,7 +289,8 @@ function formatWait(milliseconds: number) {
 
 /**
  * Upload a session transcript to the backend via oRPC.
- * Retries on transient errors (502, 503, 504) with exponential backoff.
+ * Retries on transport errors and transient statuses (408, 502, 503, 504)
+ * with exponential backoff.
  * Rate limit errors (429) are not retried — the window is too long.
  */
 export async function uploadSession(
@@ -303,6 +322,7 @@ export async function uploadSession(
 			error: formatRedactionBudgetError(redactionBudgetAnomaly),
 			attempts: 0,
 			redactionBudgetExceeded: true,
+			retryable: false,
 		};
 	}
 	const filteredRequest: IngestSessionInput = {
@@ -319,6 +339,7 @@ export async function uploadSession(
 			success: false,
 			error: formatTranscriptTooLargeError(aggregateBytes, maxAggregateBytes),
 			attempts: 0,
+			retryable: false,
 		};
 	}
 
@@ -331,6 +352,7 @@ export async function uploadSession(
 			error: `Upload endpoint refused: ${describeUploadEndpointRejection(endpoint)}`,
 			attempts: 0,
 			endpointRejected: true,
+			retryable: false,
 		};
 	}
 
@@ -355,6 +377,7 @@ export async function uploadSession(
 					success: false,
 					error: formatUnrecognizedResponseError(),
 					attempts: attempt,
+					retryable: false,
 				};
 			}
 			return {
@@ -381,6 +404,30 @@ export async function uploadSession(
 					retryable: false,
 				};
 			}
+			if (
+				error instanceof ORPCError &&
+				error.code === SESSION_UPLOAD_SHRINK_REJECTED_CODE
+			) {
+				return {
+					success: false,
+					error: formatUploadError(error),
+					attempts: attempt,
+					failureKind: "session-shrink-rejected",
+					retryable: false,
+				};
+			}
+			if (
+				error instanceof ORPCError &&
+				error.code === SECRET_FILTER_JSON_INTEGRITY_CODE
+			) {
+				return {
+					success: false,
+					error: formatUploadError(error),
+					attempts: attempt,
+					failureKind: "json-integrity",
+					retryable: false,
+				};
+			}
 
 			const errorMessage = formatUploadError(error);
 
@@ -390,10 +437,11 @@ export async function uploadSession(
 					error: errorMessage,
 					attempts: attempt,
 					rateLimited: true,
+					retryable: true,
 				};
 			}
 
-			if (isRetryable(error) && attempt < MAX_ATTEMPTS) {
+			if (isRetryableUploadError(error) && attempt < MAX_ATTEMPTS) {
 				config.onRetry?.(attempt, MAX_ATTEMPTS, errorMessage);
 				const delay = BASE_DELAY_MS * 2 ** (attempt - 1);
 				await new Promise((resolve) => setTimeout(resolve, delay));
@@ -404,6 +452,7 @@ export async function uploadSession(
 				success: false,
 				error: errorMessage,
 				attempts: attempt,
+				retryable: isRetryableUploadError(error) || isServerError(error),
 			};
 		}
 	}
@@ -412,6 +461,7 @@ export async function uploadSession(
 		success: false,
 		error: "Max retries exceeded",
 		attempts: MAX_ATTEMPTS,
+		retryable: true,
 	};
 }
 

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -199,6 +199,7 @@ export const IngestSessionInputSchema = z.object({
 	cli_version: z.string().max(200).optional(),
 	platform_os: ProductAnalyticsPlatformOsSchema.optional(),
 	filter_version: z.number().int().min(0).max(65_535).optional(),
+	force_replace: z.boolean().optional(),
 });
 
 export const IngestSessionOutputSchema = z.object({
@@ -214,9 +215,16 @@ export const REDACTION_BUDGET_EXCEEDED_MESSAGE =
 export const REDACTION_DID_NOT_CONVERGE_CODE = "REDACTION_DID_NOT_CONVERGE";
 export const REDACTION_DID_NOT_CONVERGE_MESSAGE =
 	"Known-pattern redaction did not converge within the safety limit.";
+export const SECRET_FILTER_JSON_INTEGRITY_CODE = "SECRET_FILTER_JSON_INTEGRITY";
+export const SECRET_FILTER_JSON_INTEGRITY_MESSAGE =
+	"Secret filtering could not preserve transcript JSON integrity.";
 export const SESSION_OWNERSHIP_CONFLICT_CODE = "SESSION_OWNERSHIP_CONFLICT";
 export const SESSION_OWNERSHIP_CONFLICT_MESSAGE =
 	"This session belongs to another organization member and cannot be replaced.";
+export const SESSION_UPLOAD_SHRINK_REJECTED_CODE =
+	"SESSION_UPLOAD_SHRINK_REJECTED";
+export const SESSION_UPLOAD_SHRINK_REJECTED_MESSAGE =
+	"This upload is smaller than the stored session and was refused to protect existing data. Inspect the transcript, then use `rudel upload --force-replace` only if the replacement is intentional. If your CLI does not recognize the flag, upgrade rudel first.";
 
 export type IngestSessionInput = z.infer<typeof IngestSessionInputSchema>;
 
@@ -272,9 +280,23 @@ export const contract = {
 					maxPasses: z.number().int().positive(),
 				}),
 			},
+			[SECRET_FILTER_JSON_INTEGRITY_CODE]: {
+				status: 422,
+				message: SECRET_FILTER_JSON_INTEGRITY_MESSAGE,
+			},
 			[SESSION_OWNERSHIP_CONFLICT_CODE]: {
 				status: 409,
 				message: SESSION_OWNERSHIP_CONFLICT_MESSAGE,
+			},
+			[SESSION_UPLOAD_SHRINK_REJECTED_CODE]: {
+				status: 409,
+				message: SESSION_UPLOAD_SHRINK_REJECTED_MESSAGE,
+				data: z.object({
+					currentAssistantLineCount: z.number().int().nonnegative(),
+					currentContentBytes: z.number().int().nonnegative(),
+					previousAssistantLineCount: z.number().int().nonnegative(),
+					previousContentBytes: z.number().int().nonnegative(),
+				}),
 			},
 		}),
 	getOrganizationSessionCount: oc

--- a/packages/secret-filter/src/__tests__/json-integrity.test.ts
+++ b/packages/secret-filter/src/__tests__/json-integrity.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import {
+	assertFilteredJsonValidity,
+	filterSessionTextFields,
+	SecretFilterJsonIntegrityError,
+} from "../index.js";
+
+describe("post-filter JSON validity", () => {
+	test("keeps valid JSONL parseable after redaction", () => {
+		const anthropicApiKey = `sk-ant-api03-${"CANARY".padEnd(93, "A")}AA`;
+		const content = [
+			JSON.stringify({ token: anthropicApiKey }),
+			JSON.stringify({ message: "still valid" }),
+		].join("\n");
+		const result = filterSessionTextFields({ content, subagents: undefined });
+
+		expect(result.content).toContain("[REDACTED:");
+		for (const line of result.content.split("\n")) {
+			expect(() => JSON.parse(line)).not.toThrow();
+		}
+	});
+
+	test("fails closed if a future rule damages valid transcript JSON", () => {
+		expect(() =>
+			assertFilteredJsonValidity('{"message":"safe"}', '{"message":'),
+		).toThrow(SecretFilterJsonIntegrityError);
+	});
+
+	test("does not impose JSON parsing on plain text fields", () => {
+		expect(() =>
+			assertFilteredJsonValidity("plain transcript text", "plain [REDACTED]"),
+		).not.toThrow();
+	});
+});

--- a/packages/secret-filter/src/filter.ts
+++ b/packages/secret-filter/src/filter.ts
@@ -39,6 +39,15 @@ export class SecretFilterConvergenceError extends Error {
 	}
 }
 
+export class SecretFilterJsonIntegrityError extends Error {
+	constructor() {
+		super(
+			"Secret filtering changed valid JSON transcript text into invalid JSON.",
+		);
+		this.name = "SecretFilterJsonIntegrityError";
+	}
+}
+
 export function filterKnownSecrets(text: string): SecretFilterResult {
 	return filterKnownSecretsWithCompiledRules(text, COMPILED_SECRET_RULES);
 }
@@ -95,11 +104,11 @@ export function filterSessionTextFields<
 	readonly content: string;
 	readonly subagents: readonly TSubagent[] | undefined;
 }): SessionTextFilterResult<TSubagent> {
-	const contentResult = filterKnownSecrets(fields.content);
+	const contentResult = filterKnownSecretsPreservingJson(fields.content);
 	let counts = contentResult.counts;
 	let redactedBytes = contentResult.redactedBytes;
 	const subagents = fields.subagents?.map((subagent) => {
-		const result = filterKnownSecrets(subagent.content);
+		const result = filterKnownSecretsPreservingJson(subagent.content);
 		counts = mergeRedactionCounts(counts, result.counts);
 		redactedBytes += result.redactedBytes;
 		return { ...subagent, content: result.text };
@@ -111,6 +120,60 @@ export function filterSessionTextFields<
 		counts,
 		redactedBytes,
 	};
+}
+
+function filterKnownSecretsPreservingJson(text: string) {
+	const result = filterKnownSecrets(text);
+	assertFilteredJsonValidity(text, result.text);
+	return result;
+}
+
+export function assertFilteredJsonValidity(input: string, output: string) {
+	const inputMode = getJsonValidationMode(input);
+
+	if (inputMode === "unchecked") {
+		return;
+	}
+
+	if (inputMode === "document") {
+		if (!isValidJson(output)) {
+			throw new SecretFilterJsonIntegrityError();
+		}
+		return;
+	}
+
+	const inputLines = getNonEmptyLines(input);
+	const outputLines = getNonEmptyLines(output);
+	if (
+		inputLines.length !== outputLines.length ||
+		outputLines.some((line) => !isValidJson(line))
+	) {
+		throw new SecretFilterJsonIntegrityError();
+	}
+}
+
+function getJsonValidationMode(
+	text: string,
+): "document" | "jsonl" | "unchecked" {
+	if (isValidJson(text)) {
+		return "document";
+	}
+
+	const lines = getNonEmptyLines(text);
+	return lines.length > 0 && lines.every(isValidJson) ? "jsonl" : "unchecked";
+}
+
+function getNonEmptyLines(text: string) {
+	return text.split("\n").filter((line) => line.trim().length > 0);
+}
+
+function isValidJson(text: string) {
+	try {
+		JSON.parse(text);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 export function mergeRedactionCounts(

--- a/packages/secret-filter/src/index.ts
+++ b/packages/secret-filter/src/index.ts
@@ -1,4 +1,5 @@
 export {
+	assertFilteredJsonValidity,
 	FILTER_VERSION,
 	FILTERED_TRANSCRIPT_PATHS,
 	filterKnownSecrets,
@@ -13,6 +14,7 @@ export {
 	OVERLONG_REDACTION_RULE_ID,
 	SECRET_FILTER_CONVERGENCE_MESSAGE,
 	SecretFilterConvergenceError,
+	SecretFilterJsonIntegrityError,
 } from "./filter.js";
 export { GITLEAKS_VERSION } from "./generated-rules.js";
 export type {

--- a/packages/sql-schema/db/migrations/0021_session_ownership_ingest_shape.sql
+++ b/packages/sql-schema/db/migrations/0021_session_ownership_ingest_shape.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "session_ownership"
+	ADD COLUMN "last_content_bytes" integer,
+	ADD COLUMN "last_assistant_line_count" integer;

--- a/packages/sql-schema/db/migrations/0022_session_ownership_component_shape.sql
+++ b/packages/sql-schema/db/migrations/0022_session_ownership_component_shape.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "session_ownership"
+	ADD COLUMN "last_content_shape_json" text,
+	ADD COLUMN "last_filter_version" integer,
+	ADD COLUMN "last_session_date" timestamp with time zone;

--- a/packages/sql-schema/db/migrations/meta/_journal.json
+++ b/packages/sql-schema/db/migrations/meta/_journal.json
@@ -148,6 +148,20 @@
 			"when": 1785480272000,
 			"tag": "0020_durable_clickhouse_purge",
 			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1785686400000,
+			"tag": "0021_session_ownership_ingest_shape",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1785772800000,
+			"tag": "0022_session_ownership_component_shape",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/sql-schema/src/__tests__/incremental-migration.integration.ts
+++ b/packages/sql-schema/src/__tests__/incremental-migration.integration.ts
@@ -14,12 +14,12 @@ import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
 
 const MIGRATION_0019_TIMESTAMP = "1785426102000";
-const MIGRATION_0020_TIMESTAMP = "1785480272000";
+const MIGRATION_0022_TIMESTAMP = "1785772800000";
 const migrationsFolder = join(import.meta.dir, "..", "..", "db", "migrations");
 
 setDefaultTimeout(120_000);
 
-test("applies migration 0020 to a database already migrated through 0019", async () => {
+test("applies migrations 0020-0022 to a database already migrated through 0019", async () => {
 	const connectionString = getPostgresConnectionString();
 	const databaseName = `rudel_migration_${Date.now()}_${crypto.randomUUID().replaceAll("-", "")}`;
 	const migrationsThrough0019 = await createMigrationsThrough0019();
@@ -52,7 +52,7 @@ test("applies migration 0020 to a database already migrated through 0019", async
 
 			await migrate(database, { migrationsFolder });
 
-			const [after0020] = await migrationSql<MigrationState[]>`
+			const [after0022] = await migrationSql<MigrationState[]>`
 				SELECT
 					COUNT(*)::int AS count,
 					MAX(created_at)::text AS "latestTimestamp"
@@ -61,11 +61,32 @@ test("applies migration 0020 to a database already migrated through 0019", async
 			const [tableAfter0020] = await migrationSql<TableState[]>`
 				SELECT to_regclass('public.clickhouse_purge_job')::text AS name
 			`;
-			expect(after0020).toEqual({
-				count: 21,
-				latestTimestamp: MIGRATION_0020_TIMESTAMP,
+			expect(after0022).toEqual({
+				count: 23,
+				latestTimestamp: MIGRATION_0022_TIMESTAMP,
 			});
 			expect(tableAfter0020?.name).toBe("clickhouse_purge_job");
+			const shapeColumns = await migrationSql<Array<{ name: string }>>`
+				SELECT column_name AS name
+				FROM information_schema.columns
+				WHERE table_schema = 'public'
+					AND table_name = 'session_ownership'
+					AND column_name IN (
+						'last_content_bytes',
+						'last_assistant_line_count',
+						'last_content_shape_json',
+						'last_filter_version',
+						'last_session_date'
+					)
+				ORDER BY column_name
+			`;
+			expect([...shapeColumns]).toEqual([
+				{ name: "last_assistant_line_count" },
+				{ name: "last_content_bytes" },
+				{ name: "last_content_shape_json" },
+				{ name: "last_filter_version" },
+				{ name: "last_session_date" },
+			]);
 		} finally {
 			await migrationSql.end();
 		}

--- a/packages/sql-schema/src/migrate.ts
+++ b/packages/sql-schema/src/migrate.ts
@@ -18,6 +18,11 @@ const REQUIRED_OWNERSHIP_MIGRATIONS = [
 	{ createdAt: "1784824445931", tag: "0014_session_ownership" },
 	{ createdAt: "1784824638910", tag: "0015_session_ownership_user_index" },
 	{ createdAt: "1784832000000", tag: "0016_session_ownership_backfill_state" },
+	{ createdAt: "1784901786000", tag: "0017_session_ownership_content_hash" },
+	{
+		createdAt: "1785686400000",
+		tag: "0021_session_ownership_ingest_shape",
+	},
 ] as const;
 
 try {
@@ -35,6 +40,8 @@ async function assertOwnershipSchemaDoesNotLeadMigrationHistory(): Promise<void>
 	const recordedMigrations = await getRecordedMigrationTimestamps();
 	const [artifacts] = await sql<
 		Array<{
+			ownership_content_hash_column: boolean;
+			ownership_content_shape_columns: boolean;
 			ownership_backfill_state_table: boolean;
 			ownership_table: boolean;
 			ownership_user_index: boolean;
@@ -48,6 +55,23 @@ async function assertOwnershipSchemaDoesNotLeadMigrationHistory(): Promise<void>
 				AS ownership_user_index,
 			to_regclass('public.session_ownership_backfill_state') IS NOT NULL
 				AS ownership_backfill_state_table,
+			EXISTS (
+				SELECT 1
+				FROM information_schema.columns
+				WHERE table_schema = 'public'
+					AND table_name = 'session_ownership'
+					AND column_name = 'last_content_sha256'
+			) AS ownership_content_hash_column,
+			(
+				SELECT COUNT(*) = 2
+				FROM information_schema.columns
+				WHERE table_schema = 'public'
+					AND table_name = 'session_ownership'
+					AND column_name IN (
+						'last_content_bytes',
+						'last_assistant_line_count'
+					)
+			) AS ownership_content_shape_columns,
 			EXISTS (
 				SELECT 1
 				FROM information_schema.columns
@@ -76,6 +100,14 @@ async function assertOwnershipSchemaDoesNotLeadMigrationHistory(): Promise<void>
 		{
 			artifactExists: artifacts.ownership_backfill_state_table,
 			migration: REQUIRED_OWNERSHIP_MIGRATIONS[4],
+		},
+		{
+			artifactExists: artifacts.ownership_content_hash_column,
+			migration: REQUIRED_OWNERSHIP_MIGRATIONS[5],
+		},
+		{
+			artifactExists: artifacts.ownership_content_shape_columns,
+			migration: REQUIRED_OWNERSHIP_MIGRATIONS[6],
 		},
 	];
 

--- a/packages/sql-schema/src/session-ownership-schema.ts
+++ b/packages/sql-schema/src/session-ownership-schema.ts
@@ -1,5 +1,6 @@
 import {
 	index,
+	integer,
 	pgTable,
 	primaryKey,
 	text,
@@ -18,6 +19,14 @@ export const sessionOwnership = pgTable(
 			.notNull()
 			.references(() => user.id, { onDelete: "cascade" }),
 		lastContentSha256: text("last_content_sha256"),
+		lastContentBytes: integer("last_content_bytes"),
+		lastAssistantLineCount: integer("last_assistant_line_count"),
+		lastContentShapeJson: text("last_content_shape_json"),
+		lastFilterVersion: integer("last_filter_version"),
+		lastSessionDate: timestamp("last_session_date", {
+			withTimezone: true,
+			mode: "date",
+		}),
 		lastIngestedAt: timestamp("last_ingested_at", {
 			withTimezone: true,
 			mode: "date",


### PR DESCRIPTION
## Summary

- Reject accidental transcript shrink by component, persist versioned content-shape state, allow explicit force replacement, and permit re-ingest after raw-data TTL expiry.
- Preserve secret-filter JSONL integrity and make hook/batch upload failures visible through typed, retryable/permanent CLI dispositions.
- Add the ingest quiesce switch plus Postgres migrations 0021/0022 and migration-drift checks.

## Extraction boundary

This is the lean PR-1 slice extracted from `feat/token-cost-closure` onto current `main`. It closes R3, R25–R28, S10, S15, T4, and T7. The archive branches remain untouched.

Excluded by construction: `usage_events`, the abandoned ClickHouse migration and rewritten session MVs, readiness probes, pricing/web changes, and every `is_capped`, `stale_extraction`, or cache-split-column dependency.

## Deploy safety

Production Postgres migrations are automatic: `.github/workflows/ci.yml` runs `bun run --cwd packages/sql-schema migrate` before `flyctl deploy`, so 0021/0022 land before runtime code uses their columns. This PR contains no ClickHouse schema migration.

## Verification

- `bun run verify` — green; 1,372 tests passed, 0 failed.
- Focused API ingest, CLI disposition, and JSON-integrity suite — 98 passed, 0 failed.
- `git diff --check origin/main...HEAD` and disclosure check — green.
- Local Postgres integration execution was unavailable because this workspace has no `PG_CONNECTION_STRING`; CI will execute the incremental 0020→0022 migration and ingest integration paths. The extracted stale 0021-only assertion was corrected to require 0022 and all five ownership columns.