### PR TITLE
fix(deploy): include usage-events workspace in image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 node_modules
+**/node_modules
 .git
 .turbo
 .context

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY packages/ch-schema/package.json packages/ch-schema/package.json
 COPY packages/secret-filter/package.json packages/secret-filter/package.json
 COPY packages/sql-schema/package.json packages/sql-schema/package.json
 COPY packages/typescript-config/package.json packages/typescript-config/package.json
+COPY packages/usage-events/package.json packages/usage-events/package.json
 RUN bun install --frozen-lockfile
 
 # Copy source


### PR DESCRIPTION
## Summary
- copy the `@rudel/usage-events` workspace manifest before the frozen Bun install
- exclude nested workspace `node_modules` symlinks from the Docker build context
- restore the production image build blocked after #433

## Test plan
- [x] `bun run verify`
- [x] `flyctl deploy --remote-only --build-only`
- [x] confirmed the complete image exported successfully without deploying

No production deployment was performed by the build-only verification.