### PR TITLE
feat(usage): add bounded usage-event backfill

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,6 +4,8 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
+		"backfill:usage-events": "bun src/scripts/backfill-usage-events.ts",
+		"compare:usage-events": "bun src/scripts/compare-usage-events.ts",
 		"dev": "bun --watch src/index.ts",
 		"cleanup:session-ownership": "bun src/scripts/cleanup-session-ownership.ts",
 		"cutover:session-ownership": "bun src/scripts/backfill-session-ownership.ts",
@@ -11,7 +13,7 @@
 		"check-types": "tsc --noEmit",
 		"test": "bun test",
 		"test:clickhouse": "bun test --preload ./src/__tests__/helpers/local-integration-guard.ts ./src/__tests__/clickhouse.integration.ts",
-		"test:integration": "bun test --preload ./src/__tests__/helpers/local-integration-guard.ts --max-concurrency=1 ./src/__tests__/http-response-policy.integration.ts ./src/__tests__/rpc-request-id.integration.ts ./src/__tests__/ingest-clickhouse.integration.ts ./src/__tests__/usage-event-ingest.integration.ts ./src/__tests__/ingest-rate-limit.integration.ts ./src/__tests__/ingest-filter-queue.integration.ts ./src/__tests__/session-ingest-content.integration.ts ./src/__tests__/clickhouse.integration.ts ./src/__tests__/clickhouse-credentials.integration.ts ./src/__tests__/clickhouse-purge.integration.ts ./src/__tests__/delete-sessions.integration.ts ./src/__tests__/deletion-data-loss.integration.ts ./src/__tests__/session-sharing.integration.ts ./src/__tests__/session-ownership-cleanup.integration.ts ./src/__tests__/session-analytics-values.integration.ts ./src/__tests__/team-invite-link.integration.ts ./src/__tests__/wrapped-share-rate-limit.integration.ts ./src/__tests__/wrapped-share-resource-budget.integration.ts",
+		"test:integration": "bun test --preload ./src/__tests__/helpers/local-integration-guard.ts --max-concurrency=1 ./src/__tests__/http-response-policy.integration.ts ./src/__tests__/rpc-request-id.integration.ts ./src/__tests__/ingest-clickhouse.integration.ts ./src/__tests__/usage-event-ingest.integration.ts ./src/__tests__/usage-event-backfill.integration.ts ./src/__tests__/ingest-rate-limit.integration.ts ./src/__tests__/ingest-filter-queue.integration.ts ./src/__tests__/session-ingest-content.integration.ts ./src/__tests__/clickhouse.integration.ts ./src/__tests__/clickhouse-credentials.integration.ts ./src/__tests__/clickhouse-purge.integration.ts ./src/__tests__/delete-sessions.integration.ts ./src/__tests__/deletion-data-loss.integration.ts ./src/__tests__/session-sharing.integration.ts ./src/__tests__/session-ownership-cleanup.integration.ts ./src/__tests__/session-analytics-values.integration.ts ./src/__tests__/team-invite-link.integration.ts ./src/__tests__/wrapped-share-rate-limit.integration.ts ./src/__tests__/wrapped-share-resource-budget.integration.ts",
 		"test:analytics": "bun test src/__tests__/session-analytics-values.integration.ts",
 		"test:migrate": "bun test src/__tests__/migrate-sessions.integration.ts",
 		"test:delete-sessions": "bun test --preload ./src/__tests__/helpers/local-integration-guard.ts ./src/__tests__/delete-sessions.integration.ts"

--- a/apps/api/src/__tests__/session-ingest-content.integration.ts
+++ b/apps/api/src/__tests__/session-ingest-content.integration.ts
@@ -22,6 +22,7 @@ import { getIngestContentShape } from "../lib/ingest-content-shape.js";
 import {
 	claimSessionIngestOwnership,
 	recordSessionIngestContent,
+	reserveUsageBackfillGeneration,
 	reserveUsageExtractionGeneration,
 	UsageExtractionSupersededError,
 } from "../services/session-ownership.service.js";
@@ -43,6 +44,7 @@ const FORCE_REPLACE_SESSION_ID = `${TEST_RUN_ID}_force_replace`;
 const RAW_FIRST_FAILURE_SESSION_ID = `${TEST_RUN_ID}_raw_first_failure`;
 const EXTRACTION_BYPASS_SESSION_ID = `${TEST_RUN_ID}_extraction_bypass`;
 const GENERATION_HEDGE_SESSION_ID = `${TEST_RUN_ID}_generation_hedge`;
+const BACKFILL_GENERATION_SESSION_ID = `${TEST_RUN_ID}_backfill_generation`;
 
 let server: ApiTestServer;
 let userId: string;
@@ -267,6 +269,44 @@ describe("session ingest content bookkeeping", () => {
 		expect(first).toBeGreaterThanOrEqual(BigInt(beforeReservation.epoch_ms));
 		expect(first).toBeLessThanOrEqual(BigInt(afterReservation.epoch_ms));
 		expect(second).toBeGreaterThan(first);
+	});
+
+	test("backfill generation reservation loses to a newer live snapshot", async () => {
+		const claim = await claimSessionIngestOwnership(
+			userId,
+			BACKFILL_GENERATION_SESSION_ID,
+			userId,
+		);
+		assert(claim.owned);
+		const currentHash = "f".repeat(64);
+		await recordSessionIngestContent(
+			userId,
+			BACKFILL_GENERATION_SESSION_ID,
+			currentHash,
+			contentShape(4_000, 4),
+			5,
+			new Date("2026-08-03T10:00:00.000Z"),
+			new Date("2026-08-03T10:01:00.000Z"),
+		);
+
+		expect(
+			await reserveUsageBackfillGeneration(
+				userId,
+				BACKFILL_GENERATION_SESSION_ID,
+				userId,
+				"e".repeat(64),
+				new Date("2026-08-03T10:00:00.000Z"),
+			),
+		).toBeNull();
+		expect(
+			await reserveUsageBackfillGeneration(
+				userId,
+				BACKFILL_GENERATION_SESSION_ID,
+				userId,
+				currentHash,
+				new Date("2026-08-03T10:02:00.000Z"),
+			),
+		).not.toBeNull();
 	});
 
 	test("drives the legacy fallback through total-vs-total pass and shrink rejection", async () => {

--- a/apps/api/src/__tests__/usage-event-backfill.integration.ts
+++ b/apps/api/src/__tests__/usage-event-backfill.integration.ts
@@ -1,0 +1,317 @@
+import {
+	afterAll,
+	beforeAll,
+	describe,
+	expect,
+	setDefaultTimeout,
+	test,
+} from "bun:test";
+import { randomUUID } from "node:crypto";
+import {
+	ingestRudelClaudeSessions,
+	type RudelClaudeSessionsRow,
+} from "@rudel/ch-schema/generated";
+import {
+	USAGE_EVENT_EXTRACTION_VERSION,
+	USAGE_EVENT_IDENTITY_VERSION,
+	USAGE_EVENT_MODEL_RATE_CARD_VERSION,
+} from "@rudel/usage-events";
+import { createClickHouseExecutor } from "../clickhouse.js";
+import { sqlClient } from "../db.js";
+import { claimSessionIngestOwnership } from "../services/session-ownership.service.js";
+import {
+	backfillUsageEvents,
+	previewUsageEventsBackfill,
+} from "../services/usage-event-backfill.service.js";
+import { compareUsageEventTotals } from "../services/usage-event-comparison.service.js";
+
+setDefaultTimeout(30_000);
+
+const runId = randomUUID();
+const organizationId = `usage_backfill_org_${runId}`;
+const userId = `usage_backfill_user_${runId}`;
+const sessionId = `usage_backfill_session_${runId}`;
+const noUsageSessionId = `usage_backfill_no_usage_${runId}`;
+const sessionDate = "2026-08-04 08:00:00.000";
+const cutoff = new Date("2026-08-04T09:00:00.000Z");
+const executor = createClickHouseExecutor({
+	database: "default",
+	password: process.env.CLICKHOUSE_PASSWORD || "",
+	url: process.env.CLICKHOUSE_URL || "http://localhost:8123",
+	username:
+		process.env.CLICKHOUSE_USERNAME || process.env.CLICKHOUSE_USER || "default",
+});
+
+beforeAll(async () => {
+	await sqlClient`
+		INSERT INTO "user" (id, name, email)
+		VALUES (${userId}, 'Usage Backfill User', ${`${runId}@example.com`})
+	`;
+	await sqlClient`
+		INSERT INTO organization (id, name, slug)
+		VALUES (${organizationId}, 'Usage Backfill Organization', ${`usage-backfill-${runId}`})
+	`;
+	await sqlClient`
+		INSERT INTO member (id, organization_id, user_id, role)
+		VALUES (${randomUUID()}, ${organizationId}, ${userId}, 'owner')
+	`;
+	const ownership = await claimSessionIngestOwnership(
+		organizationId,
+		sessionId,
+		userId,
+	);
+	if (!ownership.owned) {
+		throw new Error("Expected the integration user to own the test session");
+	}
+	const noUsageOwnership = await claimSessionIngestOwnership(
+		organizationId,
+		noUsageSessionId,
+		userId,
+	);
+	if (!noUsageOwnership.owned) {
+		throw new Error(
+			"Expected the integration user to own the no-usage session",
+		);
+	}
+	await ingestRudelClaudeSessions(
+		executor,
+		[rawSessionRow(), rawSessionRowWithoutUsage()],
+		{
+			validate: true,
+		},
+	);
+});
+
+afterAll(async () => {
+	await executor.execute({
+		query: `DELETE FROM rudel.usage_events WHERE organization_id = {organizationId:String} SETTINGS lightweight_deletes_sync = 3`,
+		query_params: { organizationId },
+	});
+	await executor.execute({
+		query: `DELETE FROM rudel.claude_sessions WHERE organization_id = {organizationId:String} SETTINGS lightweight_deletes_sync = 3`,
+		query_params: { organizationId },
+	});
+	await sqlClient`
+		DELETE FROM organization
+		WHERE id = ${organizationId}
+	`;
+	await sqlClient`
+		DELETE FROM "user"
+		WHERE id = ${userId}
+	`;
+	await executor.close();
+});
+
+describe("usage event backfill", () => {
+	test("previews without writing, executes once, and skips the completed receipt on replay", async () => {
+		const preview = await previewUsageEventsBackfill(executor, {
+			cutoff,
+			maxSessions: 10,
+			organizationId,
+		});
+		expect(preview).toMatchObject({
+			candidateCount: 1,
+			completeCount: 1,
+			failedCount: 0,
+			rawSessionCount: 2,
+			skippedNoUsageCount: 1,
+			status: "preview",
+			wouldWriteCount: 1,
+		});
+		expect(await countPhysicalUsageRows()).toBe(0);
+
+		const completed = await backfillUsageEvents(executor, {
+			cutoff,
+			maxSessions: 10,
+			organizationId,
+		});
+		expect(completed).toMatchObject({
+			candidateCount: 1,
+			completedCount: 1,
+			failedCount: 0,
+			status: "completed",
+		});
+		const rowsAfterFirstRun = await readActiveUsageRows();
+		expect(rowsAfterFirstRun).toEqual([
+			{
+				event_count: 1,
+				receipt_count: 1,
+				receipt_event_count: 1,
+				receipt_is_complete: 1,
+			},
+		]);
+		const physicalRowsAfterFirstRun = await countPhysicalUsageRows();
+		expect(physicalRowsAfterFirstRun).toBe(2);
+
+		const replay = await backfillUsageEvents(executor, {
+			cutoff,
+			maxSessions: 10,
+			organizationId,
+		});
+		expect(replay).toMatchObject({
+			alreadyCompleteCount: 1,
+			candidateCount: 1,
+			completedCount: 0,
+			failedCount: 0,
+			status: "completed",
+		});
+		expect(await countPhysicalUsageRows()).toBe(physicalRowsAfterFirstRun);
+
+		const comparison = await compareUsageEventTotals(executor, {
+			maxSessions: 10,
+			organizationId,
+			topSessions: 5,
+		});
+		expect(comparison.sources).toEqual([
+			{
+				completeReceiptSessionCount: 1,
+				legacyOnlySessionCount: 0,
+				legacySessionCount: 1,
+				matchedSessionCount: 1,
+				newCacheReadInputTokens: "5",
+				newCacheWriteInputTokens: "3",
+				newOutputTokens: "2",
+				newReasoningOutputTokens: "0",
+				newUncachedInputTokens: "10",
+				oldCacheReadInputTokens: "5",
+				oldCacheWriteInputTokens: "3",
+				oldOutputTokens: "2",
+				oldUncachedInputTokens: "10",
+				orphanEventSessionCount: 0,
+				receiptOnlySessionCount: 0,
+				receiptSessionCount: 1,
+				source: "claude_code",
+			},
+		]);
+		expect(comparison.topDivergences).toEqual([
+			{
+				absoluteTokenDelta: "0",
+				newTotalTokens: "20",
+				oldTotalTokens: "20",
+				organizationId,
+				sessionId,
+				source: "claude_code",
+			},
+		]);
+
+		const [ownership] = await sqlClient<
+			Array<{
+				last_usage_checksum: string | null;
+				last_usage_extraction_version: number | null;
+				last_usage_event_identity_version: number | null;
+				last_usage_model_rate_card_version: string | null;
+			}>
+		>`
+			SELECT
+				last_usage_checksum,
+				last_usage_extraction_version,
+				last_usage_event_identity_version,
+				last_usage_model_rate_card_version
+			FROM session_ownership
+			WHERE organization_id = ${organizationId}
+				AND session_id = ${sessionId}
+		`;
+		expect(ownership?.last_usage_checksum).toHaveLength(64);
+		expect(ownership?.last_usage_extraction_version).toBe(
+			USAGE_EVENT_EXTRACTION_VERSION,
+		);
+		expect(ownership?.last_usage_event_identity_version).toBe(
+			USAGE_EVENT_IDENTITY_VERSION,
+		);
+		expect(ownership?.last_usage_model_rate_card_version).toBe(
+			USAGE_EVENT_MODEL_RATE_CARD_VERSION,
+		);
+	});
+});
+
+function rawSessionRow(): RudelClaudeSessionsRow {
+	return {
+		content: JSON.stringify({
+			message: {
+				id: "message-1",
+				model: "claude-sonnet-4-5",
+				role: "assistant",
+				usage: {
+					cache_creation_input_tokens: 3,
+					cache_read_input_tokens: 5,
+					input_tokens: 10,
+					output_tokens: 2,
+				},
+			},
+			requestId: "request-1",
+			timestamp: "2026-08-04T08:00:00.000Z",
+			type: "assistant",
+		}),
+		filter_version: 5,
+		git_branch: null,
+		git_remote: "",
+		git_sha: null,
+		ingested_at: "2026-08-04 08:30:00.000",
+		last_interaction_date: sessionDate,
+		organization_id: organizationId,
+		package_name: "",
+		package_type: "",
+		project_path: "/tmp/usage-backfill",
+		session_date: sessionDate,
+		session_id: sessionId,
+		subagents: {},
+		tag: null,
+		user_id: userId,
+	};
+}
+
+function rawSessionRowWithoutUsage(): RudelClaudeSessionsRow {
+	return {
+		...rawSessionRow(),
+		content: JSON.stringify({
+			message: { role: "user" },
+			timestamp: "2026-08-04T08:00:00.000Z",
+			type: "user",
+		}),
+		session_id: noUsageSessionId,
+	};
+}
+
+async function countPhysicalUsageRows(): Promise<number> {
+	const [row] = await executor.query<{ row_count: number }>({
+		query: `
+			SELECT count() AS row_count
+			FROM rudel.usage_events
+			WHERE organization_id = {organizationId:String}
+				AND user_id = {userId:String}
+				AND source = 'claude_code'
+				AND session_id = {sessionId:String}
+		`,
+		query_params: { organizationId, sessionId, userId },
+	});
+	return row?.row_count ?? 0;
+}
+
+async function readActiveUsageRows() {
+	return executor.query<{
+		event_count: number;
+		receipt_count: number;
+		receipt_event_count: number;
+		receipt_is_complete: number;
+	}>({
+		query: `
+			SELECT
+				countIf(record_kind = 'event') AS event_count,
+				countIf(record_kind = 'receipt') AS receipt_count,
+				anyIf(receipt_event_count, record_kind = 'receipt') AS receipt_event_count,
+				anyIf(receipt_is_complete, record_kind = 'receipt') AS receipt_is_complete
+			FROM (
+				SELECT *
+				FROM rudel.usage_events
+				WHERE organization_id = {organizationId:String}
+					AND user_id = {userId:String}
+					AND source = 'claude_code'
+					AND session_id = {sessionId:String}
+				ORDER BY event_version DESC
+				LIMIT 1 BY organization_id, user_id, source, session_id, event_id
+			)
+			WHERE is_deleted = 0
+		`,
+		query_params: { organizationId, sessionId, userId },
+	});
+}

--- a/apps/api/src/scripts/backfill-usage-events.ts
+++ b/apps/api/src/scripts/backfill-usage-events.ts
@@ -1,0 +1,78 @@
+import { parseArgs } from "node:util";
+import { getClickhouse } from "../clickhouse.js";
+import { sqlClient } from "../db.js";
+import {
+	backfillUsageEvents,
+	previewUsageEventsBackfill,
+	type UsageEventsBackfillOptions,
+} from "../services/usage-event-backfill.service.js";
+
+const DEFAULT_MAX_SESSIONS = 2_000;
+const DEFAULT_MAX_SESSION_MIB = 512;
+const { values } = parseArgs({
+	args: Bun.argv.slice(2),
+	options: {
+		cutoff: { type: "string" },
+		execute: { default: false, type: "boolean" },
+		"max-session-mib": { type: "string" },
+		"max-sessions": { type: "string" },
+		"organization-id": { type: "string" },
+	},
+	strict: true,
+});
+
+if (values.execute && !values.cutoff) {
+	throw new Error(
+		"Execution requires the exact --cutoff value printed by a prior preview.",
+	);
+}
+
+const cutoff = values.cutoff ? new Date(values.cutoff) : new Date();
+const maxSessions = parsePositiveInteger(
+	values["max-sessions"],
+	DEFAULT_MAX_SESSIONS,
+	"--max-sessions",
+);
+const maxSessionMib = parsePositiveInteger(
+	values["max-session-mib"],
+	DEFAULT_MAX_SESSION_MIB,
+	"--max-session-mib",
+);
+const executor = getClickhouse();
+const startedAt = Date.now();
+
+try {
+	const options: UsageEventsBackfillOptions = {
+		cutoff,
+		maxSessionBytes: maxSessionMib * 1024 * 1024,
+		maxSessions,
+		onProgress(progress) {
+			console.error(
+				`usage-event backfill progress: ${progress.processedCandidateCount}/${progress.totalCandidateCount} sessions (${progress.completedBatchCount}/${progress.batchCount} batches, ${Math.round((Date.now() - startedAt) / 1000)}s elapsed)`,
+			);
+		},
+		organizationId: values["organization-id"],
+	};
+	const result = values.execute
+		? await backfillUsageEvents(executor, options)
+		: await previewUsageEventsBackfill(executor, options);
+	console.log(JSON.stringify(result, null, 2));
+	if (result.failedCount > 0 || result.supersededCount > 0) {
+		process.exitCode = 2;
+	}
+} finally {
+	await Promise.all([executor.close(), sqlClient.end({ timeout: 5 })]);
+}
+
+function parsePositiveInteger(
+	value: string | undefined,
+	fallback: number,
+	flag: string,
+): number {
+	if (value === undefined) return fallback;
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+		throw new Error(`${flag} must be a positive integer.`);
+	}
+	return parsed;
+}

--- a/apps/api/src/scripts/compare-usage-events.ts
+++ b/apps/api/src/scripts/compare-usage-events.ts
@@ -1,0 +1,69 @@
+import { parseArgs } from "node:util";
+import { getClickhouse } from "../clickhouse.js";
+import {
+	compareUsageEventTotals,
+	hasUsageEventCoverageGap,
+} from "../services/usage-event-comparison.service.js";
+
+const DEFAULT_MAX_SESSIONS = 2_000;
+const DEFAULT_TOP_SESSIONS = 20;
+const { values } = parseArgs({
+	args: Bun.argv.slice(2),
+	options: {
+		"max-sessions": { type: "string" },
+		"organization-id": { type: "string" },
+		"require-complete": { default: false, type: "boolean" },
+		"top-sessions": { type: "string" },
+	},
+	strict: true,
+});
+const maxSessions = parsePositiveInteger(
+	values["max-sessions"],
+	DEFAULT_MAX_SESSIONS,
+	"--max-sessions",
+);
+const topSessions = parsePositiveInteger(
+	values["top-sessions"],
+	DEFAULT_TOP_SESSIONS,
+	"--top-sessions",
+);
+const executor = getClickhouse();
+
+try {
+	const comparison = await compareUsageEventTotals(executor, {
+		maxSessions,
+		organizationId: values["organization-id"],
+		topSessions,
+	});
+	console.log(
+		JSON.stringify(
+			{
+				authority: "regression_only_not_billing_truth",
+				...comparison,
+			},
+			null,
+			2,
+		),
+	);
+	if (
+		values["require-complete"] &&
+		hasUsageEventCoverageGap(comparison.sources)
+	) {
+		process.exitCode = 2;
+	}
+} finally {
+	await executor.close();
+}
+
+function parsePositiveInteger(
+	value: string | undefined,
+	fallback: number,
+	flag: string,
+): number {
+	if (value === undefined) return fallback;
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+		throw new Error(`${flag} must be a positive integer.`);
+	}
+	return parsed;
+}

--- a/apps/api/src/services/session-ownership.service.ts
+++ b/apps/api/src/services/session-ownership.service.ts
@@ -46,6 +46,36 @@ interface UsageExtractionReceiptRecord {
 	modelRateCardVersion: string;
 }
 
+export interface UsageBackfillOwnershipState {
+	lastContentSha256: string | null;
+	lastIngestedAt: Date | null;
+	lastUsageContentSha256: string | null;
+	lastUsageChecksum: string | null;
+	lastUsageExtractionVersion: number | null;
+	lastUsageEventIdentityVersion: number | null;
+	lastUsageModelRateCardVersion: string | null;
+	userId: string;
+}
+
+export interface UsageBackfillOwnershipStateRow
+	extends UsageBackfillOwnershipState {
+	organizationId: string;
+	sessionId: string;
+}
+
+interface UsageBackfillOwnershipDatabaseRow {
+	last_content_sha256: string | null;
+	last_ingested_at: Date | null;
+	last_usage_checksum: string | null;
+	last_usage_content_sha256: string | null;
+	last_usage_extraction_version: number | null;
+	last_usage_event_identity_version: number | null;
+	last_usage_model_rate_card_version: string | null;
+	organization_id: string;
+	session_id: string;
+	user_id: string;
+}
+
 export class UsageExtractionSupersededError extends Error {
 	constructor() {
 		super(
@@ -172,6 +202,120 @@ export async function reserveUsageExtractionGeneration(
 		throw new Error("Usage extraction generation reservation failed");
 	}
 	return row.generation;
+}
+
+/**
+ * Reserve a backfill generation only while the raw snapshot is still current.
+ * A live upload that records newer content wins without requiring ingest to be
+ * quiesced; a live extraction reserved after this call receives a higher
+ * generation and supersedes the backfill rows.
+ */
+export async function reserveUsageBackfillGeneration(
+	organizationId: string,
+	sessionId: string,
+	userId: string,
+	expectedContentSha256: string,
+	cutoff: Date,
+): Promise<string | null> {
+	const [row] = await sqlClient<Array<{ generation: string }>>`
+		UPDATE session_ownership
+		SET usage_extraction_generation = GREATEST(
+			usage_extraction_generation + 1,
+			FLOOR(EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint
+		)
+		WHERE organization_id = ${organizationId}
+			AND session_id = ${sessionId}
+			AND user_id = ${userId}
+			AND (
+				last_content_sha256 IS NULL
+				OR last_content_sha256 = ${expectedContentSha256}
+			)
+			AND (
+				last_ingested_at IS NULL
+				OR last_ingested_at <= ${cutoff.toISOString()}
+			)
+		RETURNING usage_extraction_generation::text AS generation
+	`;
+	return row?.generation ?? null;
+}
+
+export async function listUsageBackfillOwnershipStates(options: {
+	maxRows: number;
+	organizationId?: string;
+}): Promise<readonly UsageBackfillOwnershipStateRow[]> {
+	const organizationPredicate = options.organizationId
+		? "WHERE organization_id = $1"
+		: "";
+	const limitParameter = options.organizationId ? "$2" : "$1";
+	const parameters = options.organizationId
+		? [options.organizationId, options.maxRows]
+		: [options.maxRows];
+	const rows = await sqlClient.unsafe<UsageBackfillOwnershipDatabaseRow[]>(
+		`
+			SELECT
+				organization_id,
+				session_id,
+				user_id,
+				last_content_sha256,
+				last_ingested_at,
+				last_usage_content_sha256,
+				last_usage_checksum,
+				last_usage_extraction_version,
+				last_usage_event_identity_version,
+				last_usage_model_rate_card_version
+			FROM session_ownership
+			${organizationPredicate}
+			ORDER BY organization_id, session_id
+			LIMIT ${limitParameter}
+		`,
+		parameters,
+	);
+	return rows.map(mapUsageBackfillOwnershipState);
+}
+
+function mapUsageBackfillOwnershipState(
+	row: UsageBackfillOwnershipDatabaseRow,
+): UsageBackfillOwnershipStateRow {
+	return {
+		lastContentSha256: row.last_content_sha256,
+		lastIngestedAt: row.last_ingested_at,
+		lastUsageChecksum: row.last_usage_checksum,
+		lastUsageContentSha256: row.last_usage_content_sha256,
+		lastUsageExtractionVersion: row.last_usage_extraction_version,
+		lastUsageEventIdentityVersion: row.last_usage_event_identity_version,
+		lastUsageModelRateCardVersion: row.last_usage_model_rate_card_version,
+		organizationId: row.organization_id,
+		sessionId: row.session_id,
+		userId: row.user_id,
+	};
+}
+
+export async function recordUsageBackfillReceipt(
+	organizationId: string,
+	sessionId: string,
+	contentSha256: string,
+	receipt: UsageExtractionReceiptRecord,
+): Promise<void> {
+	const completed = await sqlClient<Array<{ generation: string }>>`
+		UPDATE session_ownership
+		SET
+			last_usage_content_sha256 = ${contentSha256},
+			last_usage_extraction_version = ${receipt.extractionVersion},
+			last_usage_event_identity_version = ${receipt.eventIdentityVersion},
+			last_usage_model_rate_card_version = ${receipt.modelRateCardVersion},
+			last_usage_event_count = ${receipt.eventCount},
+			last_usage_checksum = ${receipt.checksum},
+			last_usage_diagnostics_json = ${receipt.diagnostics},
+			last_usage_completed_generation = ${receipt.generation},
+			last_usage_completed_at = NOW()
+		WHERE organization_id = ${organizationId}
+			AND session_id = ${sessionId}
+			AND usage_extraction_generation = ${receipt.generation}
+		RETURNING usage_extraction_generation::text AS generation
+	`;
+	if (completed.length !== 1) {
+		throw new UsageExtractionSupersededError();
+	}
 }
 
 export async function getSessionOwner(

--- a/apps/api/src/services/usage-event-backfill.service.ts
+++ b/apps/api/src/services/usage-event-backfill.service.ts
@@ -1,0 +1,835 @@
+import {
+	type IngestSessionInput,
+	IngestSessionInputSchema,
+} from "@rudel/api-routes";
+import {
+	extractUsageEvents,
+	type UsageEventSource,
+	type UsageExtractionDiagnostic,
+} from "@rudel/usage-events";
+import {
+	type ClickHouseExecutor,
+	getSafeClickHouseTable,
+} from "../clickhouse.js";
+import { computeIngestContentHash } from "../lib/ingest-content-hash.js";
+import {
+	listUsageBackfillOwnershipStates,
+	recordUsageBackfillReceipt,
+	reserveUsageBackfillGeneration,
+	type UsageBackfillOwnershipState,
+	UsageExtractionSupersededError,
+} from "./session-ownership.service.js";
+import {
+	hasMatchingUsageExtractionReceipt,
+	writeUsageExtraction,
+} from "./usage-event-ingest.service.js";
+
+const DEFAULT_MAX_SESSION_BYTES = 512 * 1024 * 1024;
+const MAX_CONFIGURED_SESSION_BYTES = 8 * 1024 * 1024 * 1024;
+const MAX_ISSUES = 100;
+const RAW_BATCH_TARGET_BYTES = 128 * 1024 * 1024;
+const RAW_BATCH_MAX_ROWS = 64;
+const SOURCE_SCAN_SETTINGS = {
+	max_bytes_to_read: String(16 * 1024 * 1024 * 1024),
+	max_execution_time: 300,
+	max_rows_to_read: "5000000",
+	result_overflow_mode: "throw",
+} as const;
+
+export interface UsageEventsBackfillOptions {
+	cutoff: Date;
+	maxSessionBytes?: number;
+	maxSessions: number;
+	onProgress?: (progress: UsageEventsBackfillProgress) => void;
+	organizationId?: string;
+}
+
+export interface UsageEventsBackfillProgress {
+	batchCount: number;
+	completedBatchCount: number;
+	processedCandidateCount: number;
+	totalCandidateCount: number;
+}
+
+export type UsageEventsBackfillIssueCode =
+	| "consistency_repair_required"
+	| "extraction_incomplete"
+	| "missing_ownership"
+	| "missing_raw_snapshot"
+	| "ownership_conflict"
+	| "oversized_snapshot"
+	| "snapshot_superseded"
+	| "unexpected_error";
+
+export interface UsageEventsBackfillIssue {
+	code: UsageEventsBackfillIssueCode;
+	diagnostics: readonly string[];
+	sessionId: string;
+	source: UsageEventSource;
+}
+
+export interface UsageEventsBackfillResult {
+	alreadyCompleteCount: number;
+	candidateCount: number;
+	completeCount: number;
+	completedCount: number;
+	cutoff: string;
+	failedCount: number;
+	incompleteCount: number;
+	issues: readonly UsageEventsBackfillIssue[];
+	oversizedCount: number;
+	rawSessionCount: number;
+	skippedNoUsageCount: number;
+	status: "completed" | "preview";
+	supersededCount: number;
+	wouldWriteCount: number;
+}
+
+interface RawSessionCandidate {
+	contentBytes: number;
+	ingestedAt: string;
+	organizationId: string;
+	sessionDate: string;
+	sessionId: string;
+	source: UsageEventSource;
+	userId: string;
+}
+
+interface RawSessionCandidateRow {
+	latest_content_bytes: number;
+	latest_ingested_at: string;
+	latest_session_date: string;
+	latest_user_id: string;
+	organization_id: string;
+	raw_session_count: number;
+	session_id: string;
+}
+
+interface RawSessionCandidateCensus {
+	candidates: readonly RawSessionCandidate[];
+	rawSessionCount: number;
+}
+
+interface RawSessionRow {
+	content: string;
+	filter_version: number;
+	git_branch: string | null;
+	git_remote: string;
+	git_sha: string | null;
+	raw_ingested_at: string;
+	organization_id: string;
+	package_name: string;
+	package_type: string;
+	project_path: string;
+	raw_session_date: string;
+	session_id: string;
+	subagents: Record<string, string>;
+	tag: string | null;
+	user_id: string;
+}
+
+interface RawSessionBatch {
+	candidates: readonly RawSessionCandidate[];
+	contentBytes: number;
+	monthEnd: string;
+	monthStart: string;
+}
+
+type CandidateResult =
+	| { status: "already_complete" }
+	| { status: "completed" }
+	| { status: "would_write" }
+	| { status: "superseded"; issue: UsageEventsBackfillIssue }
+	| { status: "failed"; issue: UsageEventsBackfillIssue };
+
+export async function previewUsageEventsBackfill(
+	executor: ClickHouseExecutor,
+	options: UsageEventsBackfillOptions,
+): Promise<UsageEventsBackfillResult> {
+	return runUsageEventsBackfill(executor, options, false);
+}
+
+export async function backfillUsageEvents(
+	executor: ClickHouseExecutor,
+	options: UsageEventsBackfillOptions,
+): Promise<UsageEventsBackfillResult> {
+	return runUsageEventsBackfill(executor, options, true);
+}
+
+async function runUsageEventsBackfill(
+	executor: ClickHouseExecutor,
+	options: UsageEventsBackfillOptions,
+	execute: boolean,
+): Promise<UsageEventsBackfillResult> {
+	validateOptions(options);
+	const census = await listRawSessionCandidates(executor, options);
+	const candidates = census.candidates;
+	const ownershipBySession = await loadOwnershipStates(
+		candidates,
+		options.maxSessions,
+	);
+	const result: UsageEventsBackfillResult = {
+		alreadyCompleteCount: 0,
+		candidateCount: candidates.length,
+		completeCount: 0,
+		completedCount: 0,
+		cutoff: options.cutoff.toISOString(),
+		failedCount: 0,
+		incompleteCount: 0,
+		issues: [],
+		oversizedCount: 0,
+		rawSessionCount: census.rawSessionCount,
+		skippedNoUsageCount: census.rawSessionCount - candidates.length,
+		status: execute ? "completed" : "preview",
+		supersededCount: 0,
+		wouldWriteCount: 0,
+	};
+
+	const readableCandidates: RawSessionCandidate[] = [];
+	const maxSessionBytes = options.maxSessionBytes ?? DEFAULT_MAX_SESSION_BYTES;
+	for (const candidate of candidates) {
+		const ownership = ownershipBySession.get(candidateKey(candidate));
+		if (candidate.contentBytes > maxSessionBytes) {
+			applyCandidateResult(result, {
+				status: "failed",
+				issue: issue(candidate, "oversized_snapshot", [
+					`${candidate.contentBytes} > ${maxSessionBytes}`,
+				]),
+			});
+			continue;
+		}
+		if (!ownership) {
+			applyCandidateResult(result, {
+				status: "failed",
+				issue: issue(candidate, "missing_ownership"),
+			});
+			continue;
+		}
+		if (ownership.userId !== candidate.userId) {
+			applyCandidateResult(result, {
+				status: "failed",
+				issue: issue(candidate, "ownership_conflict"),
+			});
+			continue;
+		}
+		readableCandidates.push(candidate);
+	}
+
+	const batches = createRawSessionBatches(readableCandidates);
+	let processedCandidateCount = candidates.length - readableCandidates.length;
+	for (const [batchIndex, batch] of batches.entries()) {
+		const rawRows = await readRawSessions(
+			executor,
+			batch,
+			options.cutoff,
+			maxSessionBytes,
+		);
+		const rawBySession = new Map(
+			rawRows.map((raw) => [rawSessionKey(raw), raw]),
+		);
+		for (const candidate of batch.candidates) {
+			const candidateResult = await processCandidate(
+				executor,
+				candidate,
+				rawBySession.get(candidateKey(candidate)),
+				ownershipBySession.get(candidateKey(candidate)),
+				options,
+				execute,
+			).catch(
+				(error: unknown): CandidateResult => ({
+					status: "failed",
+					issue: issue(candidate, "unexpected_error", [describeError(error)]),
+				}),
+			);
+			applyCandidateResult(result, candidateResult);
+		}
+		processedCandidateCount += batch.candidates.length;
+		options.onProgress?.({
+			batchCount: batches.length,
+			completedBatchCount: batchIndex + 1,
+			processedCandidateCount,
+			totalCandidateCount: candidates.length,
+		});
+	}
+
+	return result;
+}
+
+async function processCandidate(
+	executor: ClickHouseExecutor,
+	candidate: RawSessionCandidate,
+	raw: RawSessionRow | undefined,
+	ownership: UsageBackfillOwnershipState | undefined,
+	options: UsageEventsBackfillOptions,
+	execute: boolean,
+): Promise<CandidateResult> {
+	if (!raw) {
+		return {
+			status: "failed",
+			issue: issue(candidate, "missing_raw_snapshot"),
+		};
+	}
+	const input = buildIngestInput(candidate.source, raw);
+	const contentSha256 = computeIngestContentHash(input);
+	if (!ownership) {
+		return {
+			status: "failed",
+			issue: issue(candidate, "missing_ownership"),
+		};
+	}
+	if (ownership.userId !== candidate.userId) {
+		return {
+			status: "failed",
+			issue: issue(candidate, "ownership_conflict"),
+		};
+	}
+	if (
+		ownership.lastContentSha256 !== null &&
+		ownership.lastContentSha256 !== contentSha256
+	) {
+		return {
+			status: "superseded",
+			issue: issue(candidate, "snapshot_superseded"),
+		};
+	}
+	if (hasMatchingUsageExtractionReceipt(ownership, contentSha256)) {
+		return { status: "already_complete" };
+	}
+
+	const extraction = extractUsageEvents({
+		content: input.content,
+		organizationId: candidate.organizationId,
+		sessionId: candidate.sessionId,
+		source: candidate.source,
+		subagents: Object.fromEntries(
+			(input.subagents ?? []).map((subagent) => [
+				subagent.agentId,
+				subagent.content,
+			]),
+		),
+		userId: candidate.userId,
+	});
+	if (!execute) {
+		if (extraction.status === "incomplete") {
+			return {
+				status: "failed",
+				issue: issue(
+					candidate,
+					"extraction_incomplete",
+					diagnosticCodes(extraction.diagnostics),
+				),
+			};
+		}
+		return { status: "would_write" };
+	}
+
+	const generation = await reserveUsageBackfillGeneration(
+		candidate.organizationId,
+		candidate.sessionId,
+		candidate.userId,
+		contentSha256,
+		options.cutoff,
+	);
+	if (generation === null) {
+		return {
+			status: "superseded",
+			issue: issue(candidate, "snapshot_superseded"),
+		};
+	}
+	const write = await writeUsageExtraction(executor, {
+		contentSha256,
+		extraction,
+		filterVersion: input.filter_version ?? 0,
+		generation,
+		ingestedAt: parseClickHouseUtc(raw.raw_ingested_at),
+		organizationId: candidate.organizationId,
+		replaceAbsentEvents: extraction.status === "complete",
+		sessionDate: parseClickHouseUtc(raw.raw_session_date),
+		sessionId: candidate.sessionId,
+		source: candidate.source,
+		userId: candidate.userId,
+	});
+	if (write.consistency.status === "repair_required") {
+		return {
+			status: "failed",
+			issue: issue(candidate, "consistency_repair_required"),
+		};
+	}
+	if (extraction.status === "incomplete") {
+		return {
+			status: "failed",
+			issue: issue(
+				candidate,
+				"extraction_incomplete",
+				diagnosticCodes(extraction.diagnostics),
+			),
+		};
+	}
+	try {
+		await recordUsageBackfillReceipt(
+			candidate.organizationId,
+			candidate.sessionId,
+			contentSha256,
+			{
+				checksum: extraction.receipt.checksum,
+				diagnostics: JSON.stringify(extraction.diagnostics),
+				eventCount: extraction.receipt.eventCount,
+				extractionVersion: extraction.receipt.extractionVersion,
+				eventIdentityVersion: extraction.receipt.eventIdentityVersion,
+				generation,
+				modelRateCardVersion: extraction.receipt.modelRateCardVersion,
+			},
+		);
+	} catch (error) {
+		if (error instanceof UsageExtractionSupersededError) {
+			return {
+				status: "superseded",
+				issue: issue(candidate, "snapshot_superseded"),
+			};
+		}
+		throw error;
+	}
+	return { status: "completed" };
+}
+
+async function listRawSessionCandidates(
+	executor: ClickHouseExecutor,
+	options: UsageEventsBackfillOptions,
+): Promise<RawSessionCandidateCensus> {
+	const [claude, codex] = await Promise.all([
+		listSourceCandidates(executor, "claude_code", options),
+		listSourceCandidates(executor, "codex", options),
+	]);
+	const candidates = [...claude.candidates, ...codex.candidates].sort(
+		compareCandidates,
+	);
+	if (candidates.length > options.maxSessions) {
+		throw new Error(
+			`Usage-event backfill found more than --max-sessions=${options.maxSessions}. Increase the explicit bound after reviewing the candidate count.`,
+		);
+	}
+	const rawSessionCount = claude.rawSessionCount + codex.rawSessionCount;
+	if (rawSessionCount > options.maxSessions) {
+		throw new Error(
+			`Usage-event backfill raw census exceeds --max-sessions=${options.maxSessions} (${rawSessionCount} sessions). Increase the explicit bound after reviewing table growth.`,
+		);
+	}
+	return {
+		candidates,
+		rawSessionCount,
+	};
+}
+
+async function listSourceCandidates(
+	executor: ClickHouseExecutor,
+	source: UsageEventSource,
+	options: UsageEventsBackfillOptions,
+): Promise<RawSessionCandidateCensus> {
+	const table = getRawTable(source);
+	const organizationFilter = options.organizationId
+		? "AND organization_id = {organizationId:String}"
+		: "";
+	const subagentBytes =
+		source === "claude_code"
+			? "+ arraySum(arrayMap(value -> length(value), mapValues(subagents)))"
+			: "";
+	const hasUsage =
+		source === "claude_code"
+			? `position(content, '"usage"') > 0
+				OR arrayExists(value -> position(value, '"usage"') > 0, mapValues(subagents))`
+			: `position(content, '"last_token_usage"') > 0
+				OR position(content, '"token_count"') > 0`;
+	const rows = await executor.query<RawSessionCandidateRow>({
+		clickhouse_settings: {
+			...SOURCE_SCAN_SETTINGS,
+			max_result_rows: String(options.maxSessions + 1),
+		},
+		query: `
+			SELECT
+				organization_id,
+				session_id,
+				latest_user_id,
+				latest_session_date,
+				latest_ingested_at,
+				latest_content_bytes,
+				raw_session_count
+			FROM (
+				SELECT *, count() OVER () AS raw_session_count
+				FROM (
+					SELECT
+						organization_id,
+						session_id,
+						argMax(user_id, ingested_at) AS latest_user_id,
+						toString(argMax(session_date, ingested_at)) AS latest_session_date,
+						toString(max(ingested_at)) AS latest_ingested_at,
+						argMax(length(content) ${subagentBytes}, ingested_at) AS latest_content_bytes,
+						argMax(toUInt8(${hasUsage}), ingested_at) AS has_usage
+					FROM ${table}
+					WHERE ingested_at <= {cutoff:DateTime64(3, 'UTC')}
+						${organizationFilter}
+					GROUP BY organization_id, session_id
+				)
+			)
+			WHERE has_usage = 1
+			ORDER BY organization_id, session_id
+			LIMIT {candidateLimit:UInt32}
+		`,
+		query_params: {
+			candidateLimit: options.maxSessions + 1,
+			cutoff: toClickHouseTimestamp(options.cutoff),
+			organizationId: options.organizationId ?? "",
+		},
+	});
+	const candidates = rows.map((row) => ({
+		contentBytes: Number(row.latest_content_bytes),
+		ingestedAt: row.latest_ingested_at,
+		organizationId: row.organization_id,
+		sessionDate: row.latest_session_date,
+		sessionId: row.session_id,
+		source,
+		userId: row.latest_user_id,
+	}));
+	return {
+		candidates,
+		rawSessionCount:
+			rows[0]?.raw_session_count ??
+			(await countSourceSessions(executor, source, options)),
+	};
+}
+
+async function countSourceSessions(
+	executor: ClickHouseExecutor,
+	source: UsageEventSource,
+	options: UsageEventsBackfillOptions,
+): Promise<number> {
+	const table = getRawTable(source);
+	const organizationFilter = options.organizationId
+		? "AND organization_id = {organizationId:String}"
+		: "";
+	const [row] = await executor.query<{ session_count: number }>({
+		clickhouse_settings: {
+			...SOURCE_SCAN_SETTINGS,
+			max_result_rows: "1",
+		},
+		query: `
+			SELECT count() AS session_count
+			FROM (
+				SELECT organization_id, session_id
+				FROM ${table}
+				WHERE ingested_at <= {cutoff:DateTime64(3, 'UTC')}
+					${organizationFilter}
+				GROUP BY organization_id, session_id
+			)
+		`,
+		query_params: {
+			cutoff: toClickHouseTimestamp(options.cutoff),
+			organizationId: options.organizationId ?? "",
+		},
+	});
+	return row?.session_count ?? 0;
+}
+
+async function loadOwnershipStates(
+	candidates: readonly RawSessionCandidate[],
+	maxSessions: number,
+): Promise<Map<string, UsageBackfillOwnershipState>> {
+	const organizationIds = [
+		...new Set(candidates.map((candidate) => candidate.organizationId)),
+	].sort();
+	const ownershipBySession = new Map<string, UsageBackfillOwnershipState>();
+	for (const organizationId of organizationIds) {
+		const states = await listUsageBackfillOwnershipStates({
+			maxRows: maxSessions + 1,
+			organizationId,
+		});
+		if (states.length > maxSessions) {
+			throw new Error(
+				`Organization ${organizationId} has more than --max-sessions=${maxSessions} ownership rows. Increase the explicit bound after reviewing table growth.`,
+			);
+		}
+		for (const state of states) {
+			ownershipBySession.set(
+				`${state.organizationId}\u0000${state.sessionId}`,
+				state,
+			);
+		}
+	}
+	return ownershipBySession;
+}
+
+function createRawSessionBatches(
+	candidates: readonly RawSessionCandidate[],
+): readonly RawSessionBatch[] {
+	const batches: RawSessionBatch[] = [];
+	let currentCandidates: RawSessionCandidate[] = [];
+	let currentBytes = 0;
+	let currentMonth = "";
+
+	for (const candidate of candidates) {
+		const first = currentCandidates[0];
+		const groupChanged =
+			first !== undefined &&
+			(first.source !== candidate.source ||
+				first.organizationId !== candidate.organizationId ||
+				currentMonth !== candidate.sessionDate.slice(0, 7));
+		const batchFull =
+			currentCandidates.length >= RAW_BATCH_MAX_ROWS ||
+			(currentCandidates.length > 0 &&
+				currentBytes + candidate.contentBytes > RAW_BATCH_TARGET_BYTES);
+		if (groupChanged || batchFull) {
+			batches.push({
+				candidates: currentCandidates,
+				contentBytes: currentBytes,
+				...monthBounds(currentMonth),
+			});
+			currentCandidates = [];
+			currentBytes = 0;
+		}
+		if (currentCandidates.length === 0) {
+			currentMonth = candidate.sessionDate.slice(0, 7);
+		}
+		currentCandidates.push(candidate);
+		currentBytes += candidate.contentBytes;
+	}
+
+	if (currentCandidates.length > 0) {
+		batches.push({
+			candidates: currentCandidates,
+			contentBytes: currentBytes,
+			...monthBounds(currentMonth),
+		});
+	}
+	return batches;
+}
+
+async function readRawSessions(
+	executor: ClickHouseExecutor,
+	batch: RawSessionBatch,
+	cutoff: Date,
+	maxSessionBytes: number,
+): Promise<readonly RawSessionRow[]> {
+	const first = batch.candidates[0];
+	if (!first) return [];
+	const table = getRawTable(first.source);
+	const subagents =
+		first.source === "claude_code"
+			? "subagents"
+			: "CAST(map(), 'Map(String, String)') AS subagents";
+	const resultByteLimit = Math.max(
+		16 * 1024 * 1024,
+		Math.min(maxSessionBytes * 2, batch.contentBytes * 2),
+	);
+	return executor.query<RawSessionRow>({
+		clickhouse_settings: {
+			max_bytes_to_read: SOURCE_SCAN_SETTINGS.max_bytes_to_read,
+			max_execution_time: 180,
+			max_result_bytes: String(resultByteLimit),
+			max_result_rows: String(batch.candidates.length),
+			max_rows_to_read: SOURCE_SCAN_SETTINGS.max_rows_to_read,
+			result_overflow_mode: "throw",
+		},
+		query: `
+			SELECT
+				organization_id,
+				user_id,
+				session_id,
+				toString(session_date) AS raw_session_date,
+				project_path,
+				git_remote,
+				package_name,
+				package_type,
+				content,
+				filter_version,
+				toString(ingested_at) AS raw_ingested_at,
+				git_branch,
+				git_sha,
+				tag,
+				${subagents}
+			FROM ${table}
+			WHERE organization_id = {organizationId:String}
+				AND session_date >= {monthStart:DateTime64(3, 'UTC')}
+				AND session_date < {monthEnd:DateTime64(3, 'UTC')}
+				AND session_id IN {sessionIds:Array(String)}
+				AND ingested_at <= {cutoff:DateTime64(3, 'UTC')}
+			ORDER BY organization_id, session_id, ingested_at DESC
+			LIMIT 1 BY organization_id, session_id
+			LIMIT {batchLimit:UInt32}
+		`,
+		query_params: {
+			batchLimit: batch.candidates.length,
+			cutoff: toClickHouseTimestamp(cutoff),
+			monthEnd: batch.monthEnd,
+			monthStart: batch.monthStart,
+			organizationId: first.organizationId,
+			sessionIds: batch.candidates.map((candidate) => candidate.sessionId),
+		},
+	});
+}
+
+function buildIngestInput(
+	source: UsageEventSource,
+	raw: RawSessionRow,
+): IngestSessionInput {
+	return IngestSessionInputSchema.parse({
+		content: raw.content,
+		filter_version: raw.filter_version,
+		gitBranch: raw.git_branch ?? undefined,
+		gitRemote: raw.git_remote || undefined,
+		gitSha: raw.git_sha ?? undefined,
+		packageName: raw.package_name || undefined,
+		packageType: raw.package_type || undefined,
+		projectPath: raw.project_path,
+		sessionId: raw.session_id,
+		source,
+		subagents:
+			source === "claude_code"
+				? Object.entries(raw.subagents).map(([agentId, content]) => ({
+						agentId,
+						content,
+					}))
+				: undefined,
+		tag: raw.tag ?? undefined,
+	});
+}
+
+function applyCandidateResult(
+	result: UsageEventsBackfillResult,
+	candidateResult: CandidateResult,
+): void {
+	switch (candidateResult.status) {
+		case "already_complete":
+			result.alreadyCompleteCount += 1;
+			result.completeCount += 1;
+			return;
+		case "completed":
+			result.completeCount += 1;
+			result.completedCount += 1;
+			return;
+		case "would_write":
+			result.completeCount += 1;
+			result.wouldWriteCount += 1;
+			return;
+		case "superseded":
+			result.supersededCount += 1;
+			appendIssue(result, candidateResult.issue);
+			return;
+		case "failed":
+			result.failedCount += 1;
+			if (candidateResult.issue.code === "extraction_incomplete") {
+				result.incompleteCount += 1;
+			}
+			if (candidateResult.issue.code === "oversized_snapshot") {
+				result.oversizedCount += 1;
+			}
+			appendIssue(result, candidateResult.issue);
+	}
+}
+
+function appendIssue(
+	result: UsageEventsBackfillResult,
+	backfillIssue: UsageEventsBackfillIssue,
+): void {
+	if (result.issues.length < MAX_ISSUES) {
+		result.issues = [...result.issues, backfillIssue];
+	}
+}
+
+function issue(
+	candidate: RawSessionCandidate,
+	code: UsageEventsBackfillIssueCode,
+	diagnostics: readonly string[] = [],
+): UsageEventsBackfillIssue {
+	return {
+		code,
+		diagnostics,
+		sessionId: candidate.sessionId,
+		source: candidate.source,
+	};
+}
+
+function diagnosticCodes(
+	diagnostics: readonly UsageExtractionDiagnostic[],
+): readonly string[] {
+	return diagnostics.map((diagnostic) => diagnostic.code);
+}
+
+function compareCandidates(
+	left: RawSessionCandidate,
+	right: RawSessionCandidate,
+): number {
+	return (
+		left.source.localeCompare(right.source) ||
+		left.organizationId.localeCompare(right.organizationId) ||
+		left.sessionDate.localeCompare(right.sessionDate) ||
+		left.sessionId.localeCompare(right.sessionId)
+	);
+}
+
+function candidateKey(candidate: RawSessionCandidate): string {
+	return `${candidate.organizationId}\u0000${candidate.sessionId}`;
+}
+
+function rawSessionKey(raw: RawSessionRow): string {
+	return `${raw.organization_id}\u0000${raw.session_id}`;
+}
+
+function monthBounds(month: string): { monthEnd: string; monthStart: string } {
+	if (!/^\d{4}-\d{2}$/u.test(month)) {
+		throw new Error(`Invalid ClickHouse session month: ${month}`);
+	}
+	const start = new Date(`${month}-01T00:00:00.000Z`);
+	if (Number.isNaN(start.getTime())) {
+		throw new Error(`Invalid ClickHouse session month: ${month}`);
+	}
+	const end = new Date(
+		Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + 1, 1),
+	);
+	return {
+		monthEnd: toClickHouseTimestamp(end),
+		monthStart: toClickHouseTimestamp(start),
+	};
+}
+
+function getRawTable(source: UsageEventSource): string {
+	return getSafeClickHouseTable(
+		source === "claude_code" ? "rudel.claude_sessions" : "rudel.codex_sessions",
+	);
+}
+
+function parseClickHouseUtc(value: string): Date {
+	const normalized = /(?:Z|[+-]\d\d:\d\d)$/u.test(value)
+		? value
+		: `${value.replace(" ", "T")}Z`;
+	const parsed = new Date(normalized);
+	if (Number.isNaN(parsed.getTime())) {
+		throw new Error(`ClickHouse returned an invalid UTC timestamp: ${value}`);
+	}
+	return parsed;
+}
+
+function toClickHouseTimestamp(value: Date): string {
+	return value.toISOString().replace("T", " ").replace("Z", "");
+}
+
+function describeError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function validateOptions(options: UsageEventsBackfillOptions): void {
+	if (Number.isNaN(options.cutoff.getTime())) {
+		throw new Error("Usage-event backfill cutoff must be a valid date");
+	}
+	if (options.cutoff.getTime() > Date.now()) {
+		throw new Error("Usage-event backfill cutoff cannot be in the future");
+	}
+	if (!Number.isSafeInteger(options.maxSessions) || options.maxSessions <= 0) {
+		throw new Error("Usage-event backfill maxSessions must be positive");
+	}
+	const maxSessionBytes = options.maxSessionBytes ?? DEFAULT_MAX_SESSION_BYTES;
+	if (!Number.isSafeInteger(maxSessionBytes) || maxSessionBytes <= 0) {
+		throw new Error("Usage-event backfill maxSessionBytes must be positive");
+	}
+	if (maxSessionBytes > MAX_CONFIGURED_SESSION_BYTES) {
+		throw new Error("Usage-event backfill maxSessionBytes cannot exceed 8 GiB");
+	}
+}

--- a/apps/api/src/services/usage-event-comparison.service.test.ts
+++ b/apps/api/src/services/usage-event-comparison.service.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import {
+	hasUsageEventCoverageGap,
+	summarizeUsageEventComparison,
+} from "./usage-event-comparison.service.js";
+
+describe("usage-event side-by-side summary", () => {
+	test("keeps token classes separate and ranks absolute per-session divergence", () => {
+		const result = summarizeUsageEventComparison(
+			[
+				{
+					has_events: 1,
+					has_legacy: 1,
+					has_receipt: 1,
+					new_cache_read_input_tokens: "30",
+					new_cache_write_input_tokens: "40",
+					new_output_tokens: "50",
+					new_reasoning_output_tokens: "5",
+					new_uncached_input_tokens: "20",
+					old_cache_read_input_tokens: "3",
+					old_cache_write_input_tokens: "4",
+					old_output_tokens: "5",
+					old_uncached_input_tokens: "2",
+					organization_id: "org-1",
+					receipt_is_complete: 1,
+					session_id: "large-diff",
+					source: "claude_code",
+				},
+				{
+					has_events: 0,
+					has_legacy: 1,
+					has_receipt: 0,
+					new_cache_read_input_tokens: "0",
+					new_cache_write_input_tokens: "0",
+					new_output_tokens: "0",
+					new_reasoning_output_tokens: "0",
+					new_uncached_input_tokens: "0",
+					old_cache_read_input_tokens: "2",
+					old_cache_write_input_tokens: "3",
+					old_output_tokens: "4",
+					old_uncached_input_tokens: "1",
+					organization_id: "org-1",
+					receipt_is_complete: 0,
+					session_id: "legacy-only",
+					source: "codex",
+				},
+				{
+					has_events: 1,
+					has_legacy: 0,
+					has_receipt: 1,
+					new_cache_read_input_tokens: "1",
+					new_cache_write_input_tokens: "1",
+					new_output_tokens: "1",
+					new_reasoning_output_tokens: "0",
+					new_uncached_input_tokens: "1",
+					old_cache_read_input_tokens: "0",
+					old_cache_write_input_tokens: "0",
+					old_output_tokens: "0",
+					old_uncached_input_tokens: "0",
+					organization_id: "org-2",
+					receipt_is_complete: 0,
+					session_id: "incomplete-new-only",
+					source: "codex",
+				},
+			],
+			2,
+		);
+
+		expect(result.sources).toEqual([
+			{
+				completeReceiptSessionCount: 1,
+				legacyOnlySessionCount: 0,
+				legacySessionCount: 1,
+				matchedSessionCount: 1,
+				newCacheReadInputTokens: "30",
+				newCacheWriteInputTokens: "40",
+				newOutputTokens: "50",
+				newReasoningOutputTokens: "5",
+				newUncachedInputTokens: "20",
+				orphanEventSessionCount: 0,
+				oldCacheReadInputTokens: "3",
+				oldCacheWriteInputTokens: "4",
+				oldOutputTokens: "5",
+				oldUncachedInputTokens: "2",
+				receiptOnlySessionCount: 0,
+				receiptSessionCount: 1,
+				source: "claude_code",
+			},
+			{
+				completeReceiptSessionCount: 0,
+				legacyOnlySessionCount: 1,
+				legacySessionCount: 1,
+				matchedSessionCount: 0,
+				newCacheReadInputTokens: "0",
+				newCacheWriteInputTokens: "0",
+				newOutputTokens: "0",
+				newReasoningOutputTokens: "0",
+				newUncachedInputTokens: "0",
+				orphanEventSessionCount: 0,
+				oldCacheReadInputTokens: "2",
+				oldCacheWriteInputTokens: "3",
+				oldOutputTokens: "4",
+				oldUncachedInputTokens: "1",
+				receiptOnlySessionCount: 1,
+				receiptSessionCount: 1,
+				source: "codex",
+			},
+		]);
+		expect(result.topDivergences).toEqual([
+			{
+				absoluteTokenDelta: "126",
+				newTotalTokens: "140",
+				oldTotalTokens: "14",
+				organizationId: "org-1",
+				sessionId: "large-diff",
+				source: "claude_code",
+			},
+			{
+				absoluteTokenDelta: "10",
+				newTotalTokens: "0",
+				oldTotalTokens: "10",
+				organizationId: "org-1",
+				sessionId: "legacy-only",
+				source: "codex",
+			},
+		]);
+	});
+
+	test("requires each legacy session to match a complete receipt", () => {
+		expect(
+			hasUsageEventCoverageGap([
+				{
+					legacySessionCount: 1,
+					matchedSessionCount: 0,
+					orphanEventSessionCount: 0,
+				},
+			]),
+		).toBe(true);
+		expect(
+			hasUsageEventCoverageGap([
+				{
+					legacySessionCount: 1,
+					matchedSessionCount: 1,
+					orphanEventSessionCount: 0,
+				},
+			]),
+		).toBe(false);
+	});
+});

--- a/apps/api/src/services/usage-event-comparison.service.ts
+++ b/apps/api/src/services/usage-event-comparison.service.ts
@@ -1,0 +1,389 @@
+import type { UsageEventSource } from "@rudel/usage-events";
+import type { ClickHouseExecutor } from "../clickhouse.js";
+
+const COMPARISON_SCAN_SETTINGS = {
+	max_bytes_to_read: String(16 * 1024 * 1024 * 1024),
+	max_execution_time: 300,
+	max_rows_to_read: "5000000",
+	result_overflow_mode: "throw",
+} as const;
+
+export interface UsageEventComparisonOptions {
+	maxSessions: number;
+	organizationId?: string;
+	topSessions: number;
+}
+
+export interface UsageEventComparisonRow {
+	has_events: number;
+	has_legacy: number;
+	has_receipt: number;
+	new_cache_read_input_tokens: string;
+	new_cache_write_input_tokens: string;
+	new_output_tokens: string;
+	new_reasoning_output_tokens: string;
+	new_uncached_input_tokens: string;
+	old_cache_read_input_tokens: string;
+	old_cache_write_input_tokens: string;
+	old_output_tokens: string;
+	old_uncached_input_tokens: string;
+	organization_id: string;
+	receipt_is_complete: number;
+	session_id: string;
+	source: string;
+}
+
+export interface UsageEventComparisonSourceSummary {
+	completeReceiptSessionCount: number;
+	legacyOnlySessionCount: number;
+	legacySessionCount: number;
+	matchedSessionCount: number;
+	newCacheReadInputTokens: string;
+	newCacheWriteInputTokens: string;
+	newOutputTokens: string;
+	newReasoningOutputTokens: string;
+	newUncachedInputTokens: string;
+	oldCacheReadInputTokens: string;
+	oldCacheWriteInputTokens: string;
+	oldOutputTokens: string;
+	oldUncachedInputTokens: string;
+	orphanEventSessionCount: number;
+	receiptOnlySessionCount: number;
+	receiptSessionCount: number;
+	source: UsageEventSource;
+}
+
+export interface UsageEventComparisonDivergence {
+	absoluteTokenDelta: string;
+	newTotalTokens: string;
+	oldTotalTokens: string;
+	organizationId: string;
+	sessionId: string;
+	source: UsageEventSource;
+}
+
+export interface UsageEventComparisonResult {
+	sources: readonly UsageEventComparisonSourceSummary[];
+	topDivergences: readonly UsageEventComparisonDivergence[];
+}
+
+export function hasUsageEventCoverageGap(
+	sources: readonly Pick<
+		UsageEventComparisonSourceSummary,
+		"legacySessionCount" | "matchedSessionCount" | "orphanEventSessionCount"
+	>[],
+): boolean {
+	return sources.some(
+		(source) =>
+			source.matchedSessionCount !== source.legacySessionCount ||
+			source.orphanEventSessionCount > 0,
+	);
+}
+
+interface MutableSourceSummary {
+	completeReceiptSessionCount: number;
+	legacyOnlySessionCount: number;
+	legacySessionCount: number;
+	matchedSessionCount: number;
+	newCacheReadInputTokens: bigint;
+	newCacheWriteInputTokens: bigint;
+	newOutputTokens: bigint;
+	newReasoningOutputTokens: bigint;
+	newUncachedInputTokens: bigint;
+	oldCacheReadInputTokens: bigint;
+	oldCacheWriteInputTokens: bigint;
+	oldOutputTokens: bigint;
+	oldUncachedInputTokens: bigint;
+	orphanEventSessionCount: number;
+	receiptOnlySessionCount: number;
+	receiptSessionCount: number;
+	source: UsageEventSource;
+}
+
+export async function compareUsageEventTotals(
+	executor: ClickHouseExecutor,
+	options: UsageEventComparisonOptions,
+): Promise<UsageEventComparisonResult> {
+	validateOptions(options);
+	const organizationFilter = options.organizationId
+		? "AND organization_id = {organizationId:String}"
+		: "";
+	const legacyOrganizationFilter = options.organizationId
+		? "AND organization_id = {organizationId:String}"
+		: "";
+	const rows = await executor.query<UsageEventComparisonRow>({
+		clickhouse_settings: {
+			...COMPARISON_SCAN_SETTINGS,
+			max_result_rows: String(options.maxSessions + 1),
+		},
+		query: `
+			WITH
+			latest_usage_records AS (
+				SELECT
+					organization_id,
+					user_id,
+					source,
+					session_id,
+					record_kind,
+					is_deleted,
+					receipt_is_complete,
+					uncached_input_tokens,
+					cache_read_input_tokens,
+					cache_write_5m_input_tokens,
+					cache_write_1h_input_tokens,
+					output_tokens,
+					reasoning_output_tokens
+				FROM rudel.usage_events FINAL
+				WHERE source IN ('claude_code', 'codex')
+					${organizationFilter}
+			),
+			receipts AS (
+				SELECT
+					organization_id,
+					user_id,
+					source,
+					session_id,
+					max(receipt_is_complete) AS receipt_is_complete,
+					toUInt8(1) AS has_receipt
+				FROM latest_usage_records
+				WHERE record_kind = 'receipt' AND is_deleted = 0
+				GROUP BY organization_id, user_id, source, session_id
+			),
+			event_rollups AS (
+				SELECT
+					organization_id,
+					user_id,
+					source,
+					session_id,
+					sum(uncached_input_tokens) AS uncached_input_tokens,
+					sum(cache_read_input_tokens) AS cache_read_input_tokens,
+					sum(cache_write_5m_input_tokens + cache_write_1h_input_tokens) AS cache_write_input_tokens,
+					sum(output_tokens) AS output_tokens,
+					sum(reasoning_output_tokens) AS reasoning_output_tokens,
+					toUInt8(1) AS has_events
+				FROM latest_usage_records
+				WHERE record_kind = 'event' AND is_deleted = 0
+				GROUP BY organization_id, user_id, source, session_id
+			),
+			usage_side AS (
+				SELECT
+					if(r.has_receipt = 1, r.organization_id, e.organization_id) AS organization_id,
+					if(r.has_receipt = 1, r.user_id, e.user_id) AS user_id,
+					if(r.has_receipt = 1, r.source, e.source) AS source,
+					if(r.has_receipt = 1, r.session_id, e.session_id) AS session_id,
+					ifNull(r.has_receipt, 0) AS has_receipt,
+					ifNull(e.has_events, 0) AS has_events,
+					ifNull(r.receipt_is_complete, 0) AS receipt_is_complete,
+					if(r.receipt_is_complete = 1, ifNull(e.uncached_input_tokens, 0), 0) AS uncached_input_tokens,
+					if(r.receipt_is_complete = 1, ifNull(e.cache_read_input_tokens, 0), 0) AS cache_read_input_tokens,
+					if(r.receipt_is_complete = 1, ifNull(e.cache_write_input_tokens, 0), 0) AS cache_write_input_tokens,
+					if(r.receipt_is_complete = 1, ifNull(e.output_tokens, 0), 0) AS output_tokens,
+					if(r.receipt_is_complete = 1, ifNull(e.reasoning_output_tokens, 0), 0) AS reasoning_output_tokens
+				FROM receipts AS r
+				FULL OUTER JOIN event_rollups AS e
+					USING (organization_id, user_id, source, session_id)
+			),
+			legacy AS (
+				SELECT
+					organization_id,
+					user_id,
+					source,
+					session_id,
+					greatest(input_tokens - cache_read_input_tokens - cache_creation_input_tokens, 0) AS uncached_input_tokens,
+					cache_read_input_tokens,
+					cache_creation_input_tokens AS cache_write_input_tokens,
+					output_tokens,
+					toUInt8(1) AS has_legacy
+				FROM rudel.session_analytics FINAL
+				WHERE source IN ('claude_code', 'codex')
+					AND input_tokens + output_tokens > 0
+					${legacyOrganizationFilter}
+			)
+			SELECT
+				if(l.has_legacy = 1, l.organization_id, u.organization_id) AS organization_id,
+				if(l.has_legacy = 1, l.source, u.source) AS source,
+				if(l.has_legacy = 1, l.session_id, u.session_id) AS session_id,
+				ifNull(l.has_legacy, 0) AS has_legacy,
+				ifNull(u.has_receipt, 0) AS has_receipt,
+				ifNull(u.has_events, 0) AS has_events,
+				ifNull(u.receipt_is_complete, 0) AS receipt_is_complete,
+				toString(ifNull(l.uncached_input_tokens, 0)) AS old_uncached_input_tokens,
+				toString(ifNull(l.cache_read_input_tokens, 0)) AS old_cache_read_input_tokens,
+				toString(ifNull(l.cache_write_input_tokens, 0)) AS old_cache_write_input_tokens,
+				toString(ifNull(l.output_tokens, 0)) AS old_output_tokens,
+				toString(ifNull(u.uncached_input_tokens, 0)) AS new_uncached_input_tokens,
+				toString(ifNull(u.cache_read_input_tokens, 0)) AS new_cache_read_input_tokens,
+				toString(ifNull(u.cache_write_input_tokens, 0)) AS new_cache_write_input_tokens,
+				toString(ifNull(u.output_tokens, 0)) AS new_output_tokens,
+				toString(ifNull(u.reasoning_output_tokens, 0)) AS new_reasoning_output_tokens
+			FROM legacy AS l
+			FULL OUTER JOIN usage_side AS u
+				USING (organization_id, user_id, source, session_id)
+			ORDER BY source, organization_id, session_id
+			LIMIT {sessionLimit:UInt32}
+		`,
+		query_params: {
+			organizationId: options.organizationId ?? "",
+			sessionLimit: options.maxSessions + 1,
+		},
+	});
+	if (rows.length > options.maxSessions) {
+		throw new Error(
+			`Usage-event comparison found more than --max-sessions=${options.maxSessions}. Increase the explicit bound after reviewing table growth.`,
+		);
+	}
+	return summarizeUsageEventComparison(rows, options.topSessions);
+}
+
+export function summarizeUsageEventComparison(
+	rows: readonly UsageEventComparisonRow[],
+	topSessions: number,
+): UsageEventComparisonResult {
+	const bySource = new Map<UsageEventSource, MutableSourceSummary>();
+	const divergences: UsageEventComparisonDivergence[] = [];
+
+	for (const row of rows) {
+		const source = parseSource(row.source);
+		const summary = bySource.get(source) ?? emptySummary(source);
+		const hasLegacy = row.has_legacy === 1;
+		const hasReceipt = row.has_receipt === 1;
+		const hasCompleteReceipt = hasReceipt && row.receipt_is_complete === 1;
+		const hasEvents = row.has_events === 1;
+
+		if (hasLegacy) summary.legacySessionCount += 1;
+		if (hasReceipt) summary.receiptSessionCount += 1;
+		if (hasCompleteReceipt) summary.completeReceiptSessionCount += 1;
+		if (hasLegacy && hasCompleteReceipt) summary.matchedSessionCount += 1;
+		if (hasLegacy && !hasReceipt) summary.legacyOnlySessionCount += 1;
+		if (!hasLegacy && hasReceipt) summary.receiptOnlySessionCount += 1;
+		if (hasEvents && !hasReceipt) summary.orphanEventSessionCount += 1;
+
+		const oldUncached = hasLegacy ? BigInt(row.old_uncached_input_tokens) : 0n;
+		const oldCacheRead = hasLegacy
+			? BigInt(row.old_cache_read_input_tokens)
+			: 0n;
+		const oldCacheWrite = hasLegacy
+			? BigInt(row.old_cache_write_input_tokens)
+			: 0n;
+		const oldOutput = hasLegacy ? BigInt(row.old_output_tokens) : 0n;
+		const newUncached = hasCompleteReceipt
+			? BigInt(row.new_uncached_input_tokens)
+			: 0n;
+		const newCacheRead = hasCompleteReceipt
+			? BigInt(row.new_cache_read_input_tokens)
+			: 0n;
+		const newCacheWrite = hasCompleteReceipt
+			? BigInt(row.new_cache_write_input_tokens)
+			: 0n;
+		const newOutput = hasCompleteReceipt ? BigInt(row.new_output_tokens) : 0n;
+		const newReasoning = hasCompleteReceipt
+			? BigInt(row.new_reasoning_output_tokens)
+			: 0n;
+
+		summary.oldUncachedInputTokens += oldUncached;
+		summary.oldCacheReadInputTokens += oldCacheRead;
+		summary.oldCacheWriteInputTokens += oldCacheWrite;
+		summary.oldOutputTokens += oldOutput;
+		summary.newUncachedInputTokens += newUncached;
+		summary.newCacheReadInputTokens += newCacheRead;
+		summary.newCacheWriteInputTokens += newCacheWrite;
+		summary.newOutputTokens += newOutput;
+		summary.newReasoningOutputTokens += newReasoning;
+		bySource.set(source, summary);
+
+		const oldTotal = oldUncached + oldCacheRead + oldCacheWrite + oldOutput;
+		const newTotal = newUncached + newCacheRead + newCacheWrite + newOutput;
+		const delta = newTotal - oldTotal;
+		divergences.push({
+			absoluteTokenDelta: (delta < 0n ? -delta : delta).toString(),
+			newTotalTokens: newTotal.toString(),
+			oldTotalTokens: oldTotal.toString(),
+			organizationId: row.organization_id,
+			sessionId: row.session_id,
+			source,
+		});
+	}
+
+	return {
+		sources: [...bySource.values()]
+			.sort((left, right) => left.source.localeCompare(right.source))
+			.map(toSourceSummary),
+		topDivergences: divergences
+			.sort((left, right) => {
+				const deltaOrder =
+					BigInt(right.absoluteTokenDelta) - BigInt(left.absoluteTokenDelta);
+				if (deltaOrder !== 0n) return deltaOrder > 0n ? 1 : -1;
+				return (
+					left.source.localeCompare(right.source) ||
+					left.organizationId.localeCompare(right.organizationId) ||
+					left.sessionId.localeCompare(right.sessionId)
+				);
+			})
+			.slice(0, topSessions),
+	};
+}
+
+function emptySummary(source: UsageEventSource): MutableSourceSummary {
+	return {
+		completeReceiptSessionCount: 0,
+		legacyOnlySessionCount: 0,
+		legacySessionCount: 0,
+		matchedSessionCount: 0,
+		newCacheReadInputTokens: 0n,
+		newCacheWriteInputTokens: 0n,
+		newOutputTokens: 0n,
+		newReasoningOutputTokens: 0n,
+		newUncachedInputTokens: 0n,
+		oldCacheReadInputTokens: 0n,
+		oldCacheWriteInputTokens: 0n,
+		oldOutputTokens: 0n,
+		oldUncachedInputTokens: 0n,
+		orphanEventSessionCount: 0,
+		receiptOnlySessionCount: 0,
+		receiptSessionCount: 0,
+		source,
+	};
+}
+
+function toSourceSummary(
+	summary: MutableSourceSummary,
+): UsageEventComparisonSourceSummary {
+	return {
+		completeReceiptSessionCount: summary.completeReceiptSessionCount,
+		legacyOnlySessionCount: summary.legacyOnlySessionCount,
+		legacySessionCount: summary.legacySessionCount,
+		matchedSessionCount: summary.matchedSessionCount,
+		newCacheReadInputTokens: summary.newCacheReadInputTokens.toString(),
+		newCacheWriteInputTokens: summary.newCacheWriteInputTokens.toString(),
+		newOutputTokens: summary.newOutputTokens.toString(),
+		newReasoningOutputTokens: summary.newReasoningOutputTokens.toString(),
+		newUncachedInputTokens: summary.newUncachedInputTokens.toString(),
+		oldCacheReadInputTokens: summary.oldCacheReadInputTokens.toString(),
+		oldCacheWriteInputTokens: summary.oldCacheWriteInputTokens.toString(),
+		oldOutputTokens: summary.oldOutputTokens.toString(),
+		oldUncachedInputTokens: summary.oldUncachedInputTokens.toString(),
+		orphanEventSessionCount: summary.orphanEventSessionCount,
+		receiptOnlySessionCount: summary.receiptOnlySessionCount,
+		receiptSessionCount: summary.receiptSessionCount,
+		source: summary.source,
+	};
+}
+
+function parseSource(source: string): UsageEventSource {
+	if (source === "claude_code" || source === "codex") return source;
+	throw new Error(`Unexpected usage-event comparison source: ${source}`);
+}
+
+function validateOptions(options: UsageEventComparisonOptions): void {
+	if (!Number.isSafeInteger(options.maxSessions) || options.maxSessions <= 0) {
+		throw new Error("Usage-event comparison maxSessions must be positive");
+	}
+	if (!Number.isSafeInteger(options.topSessions) || options.topSessions <= 0) {
+		throw new Error("Usage-event comparison topSessions must be positive");
+	}
+	if (options.topSessions > options.maxSessions) {
+		throw new Error(
+			"Usage-event comparison topSessions cannot exceed maxSessions",
+		);
+	}
+}

--- a/docs/operations/usage-events-backfill.md
+++ b/docs/operations/usage-events-backfill.md
@@ -30,8 +30,7 @@ Use the production operator environment. Set the organization filter when
 performing a staged run; omit it only for the final fleet-wide run.
 
 ```bash
-doppler run --project rudel --config prd_local -- \
-  bun run --cwd apps/api backfill:usage-events -- \
+bun run --cwd apps/api backfill:usage-events -- \
   --organization-id ORGANIZATION_ID \
   --max-sessions REVIEWED_UPPER_BOUND
 ```
@@ -54,8 +53,7 @@ raises its own bound.
 Pass the exact preview `cutoff` and the same organization and size bounds.
 
 ```bash
-doppler run --project rudel --config prd_local -- \
-  bun run --cwd apps/api backfill:usage-events -- \
+bun run --cwd apps/api backfill:usage-events -- \
   --execute \
   --cutoff 2026-01-01T00:00:00.000Z \
   --organization-id ORGANIZATION_ID \
@@ -74,8 +72,7 @@ sessions are idempotently skipped.
 ## 3. Side-by-side coverage and token classes
 
 ```bash
-doppler run --project rudel --config prd_local -- \
-  bun run --cwd apps/api compare:usage-events -- \
+bun run --cwd apps/api compare:usage-events -- \
   --organization-id ORGANIZATION_ID \
   --max-sessions REVIEWED_UPPER_BOUND \
   --top-sessions 20 \

--- a/docs/operations/usage-events-backfill.md
+++ b/docs/operations/usage-events-backfill.md
@@ -1,0 +1,92 @@
+# Usage-events backfill
+
+This runbook fills the request-level `rudel.usage_events` table from retained
+raw transcripts. It does not modify either raw-session table and does not
+require ingest quiescence.
+
+The side-by-side report is a regression and coverage check. It is not evidence
+of billing truth; provider anchors and client attestation remain the external
+authorities.
+
+## Safety model
+
+- Preview is read-only and prints the exact cutoff required for execution.
+- Only latest raw snapshots containing provider usage telemetry are extracted.
+  Sessions without usage telemetry cannot produce a token fact; the receipt
+  reports both the full raw-session census and the exact skipped count.
+- The full raw-session census is explicitly bounded by `--max-sessions`.
+- Raw reads are grouped by source, organization, and UTC month, then capped at
+  64 sessions and approximately 128 MiB per response.
+- The execution path reserves a Postgres generation only if the previewed raw
+  content is still current. A concurrent live upload either prevents the
+  reservation or receives a higher generation and wins.
+- A complete, consistency-checked ClickHouse receipt is recorded in Postgres
+  last. Re-running the same cutoff skips that content without adding physical
+  rows.
+
+## 1. Preview
+
+Use the production operator environment. Set the organization filter when
+performing a staged run; omit it only for the final fleet-wide run.
+
+```bash
+doppler run --project rudel --config prd_local -- \
+  bun run --cwd apps/api backfill:usage-events -- \
+  --organization-id ORGANIZATION_ID \
+  --max-sessions REVIEWED_UPPER_BOUND
+```
+
+Save the complete JSON receipt. The preview gate is:
+
+- `failedCount = 0`
+- `incompleteCount = 0`
+- `oversizedCount = 0`
+- `supersededCount = 0`
+- `completeCount = candidateCount`
+- `wouldWriteCount + alreadyCompleteCount = candidateCount`
+
+Review `rawSessionCount`, `candidateCount`, and `skippedNoUsageCount`. A higher
+raw census requires an explicit larger `--max-sessions`; the tool never
+raises its own bound.
+
+## 2. Execute the identical snapshot
+
+Pass the exact preview `cutoff` and the same organization and size bounds.
+
+```bash
+doppler run --project rudel --config prd_local -- \
+  bun run --cwd apps/api backfill:usage-events -- \
+  --execute \
+  --cutoff 2026-01-01T00:00:00.000Z \
+  --organization-id ORGANIZATION_ID \
+  --max-sessions REVIEWED_UPPER_BOUND
+```
+
+The execution gate is the preview gate plus:
+
+- `completedCount + alreadyCompleteCount = candidateCount`
+- process exit code `0`
+
+If execution exits nonzero, keep live ingest enabled, retain the JSON receipt,
+and rerun the same command after diagnosing the listed sessions. Completed
+sessions are idempotently skipped.
+
+## 3. Side-by-side coverage and token classes
+
+```bash
+doppler run --project rudel --config prd_local -- \
+  bun run --cwd apps/api compare:usage-events -- \
+  --organization-id ORGANIZATION_ID \
+  --max-sessions REVIEWED_UPPER_BOUND \
+  --top-sessions 20 \
+  --require-complete
+```
+
+`--require-complete` fails when a token-bearing legacy session lacks a complete
+usage receipt or when active event rows have no receipt. Expected token deltas
+remain visible by provider and in the top-session list; they are not required
+to be zero because the new extractor deliberately fixes attribution and dedupe
+semantics.
+
+Do not cut over pricing endpoints or make accuracy claims from this report
+alone. Continue with the provider-anchor and client-checksum gates.


### PR DESCRIPTION
## Summary
- add a preview-first, cutoff-pinned usage-event backfill with bounded raw reads and Postgres generation CAS protection against live-ingest races
- add an idempotent ClickHouse/Postgres integration test covering preview, execution, replay, receipts, and exact token-class parity
- add a read-only side-by-side coverage report that labels itself regression-only and fails closed on missing complete receipts or orphan events
- document the staged production procedure and external provider/client truth gates

## Evidence
- `bun run verify` (10/10 tasks; API 282/282)
- production preview only, no writes: cutoff `2026-08-04T09:59:48.044Z`, 48,737 raw sessions, 1,502 usage-bearing candidates, 1,502 complete, 1 already complete, 1,501 would write, 0 failed/incomplete/oversized/superseded

## Test plan
- [x] API typecheck and focused comparison tests
- [x] full `bun run verify`
- [ ] GitHub integration job executes the new test against disposable ClickHouse and Postgres
- [ ] after review/merge, run a fresh production preview and execute only its identical cutoff
- [ ] require side-by-side coverage green before provider anchors and any cutover