### PR TITLE
fix(analytics): preserve known cost subtotals

### DIFF
--- a/apps/api/src/__tests__/usage-event-analytics.integration.ts
+++ b/apps/api/src/__tests__/usage-event-analytics.integration.ts
@@ -13,7 +13,10 @@ import {
 	type RudelUsageEventsRow,
 } from "@rudel/ch-schema/generated";
 import { createClickHouseExecutor } from "../clickhouse.js";
-import { buildUsageEventAnalyticsCte } from "../services/usage-event-analytics.service.js";
+import {
+	buildUsageCostSubtotalSql,
+	buildUsageEventAnalyticsCte,
+} from "../services/usage-event-analytics.service.js";
 
 setDefaultTimeout(30_000);
 
@@ -216,7 +219,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 			},
 			{
 				cost_is_complete: 0,
-				estimated_cost: null,
+				estimated_cost: 0,
 				input_tokens: "4000000",
 				model_used: "claude-opus-4-1",
 				output_tokens: "1000000",
@@ -270,7 +273,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 			},
 			{
 				cost_is_complete: 0,
-				estimated_cost: null,
+				estimated_cost: 0,
 				input_tokens: "4000000",
 				model_used: "claude-opus-4-1",
 				output_tokens: "1000000",
@@ -279,7 +282,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 			},
 			{
 				cost_is_complete: 0,
-				estimated_cost: null,
+				estimated_cost: 0,
 				input_tokens: "4000000",
 				model_used: "claude-opus-4-1",
 				output_tokens: "1000000",
@@ -299,6 +302,24 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				false,
 			);
 		}
+	});
+
+	test("returns the known aggregate subtotal without discarding completeness", async () => {
+		const rows = await executor.query<{
+			cost: number;
+			incomplete_sessions: number;
+		}>({
+			query: `
+				WITH ${buildUsageEventAnalyticsCte()}
+				SELECT
+					${buildUsageCostSubtotalSql("estimated_cost", 4)} AS cost,
+					countIf(cost_is_complete = 0) AS incomplete_sessions
+				FROM usage_analytics_sessions
+			`,
+			query_params: { orgId: organizationId },
+		});
+
+		expect(rows).toEqual([{ cost: 245.55, incomplete_sessions: 4 }]);
 	});
 
 	test("keeps bounded key prefixes visible across the shared query families", async () => {

--- a/apps/api/src/__tests__/usage-event-analytics.integration.ts
+++ b/apps/api/src/__tests__/usage-event-analytics.integration.ts
@@ -30,6 +30,7 @@ const unresolvedSessionId = `usage_analytics_unresolved_${runId}`;
 const unsupportedTierSessionId = `usage_analytics_unsupported_tier_${runId}`;
 const openAiFastSessionId = `usage_analytics_openai_fast_${runId}`;
 const claudeFastUsSessionId = `usage_analytics_claude_fast_us_${runId}`;
+const unavailableGeoSessionId = `usage_analytics_unavailable_geo_${runId}`;
 const longContextSessionId = `usage_analytics_long_${runId}`;
 const mismatchedSessionId = `usage_analytics_mismatch_${runId}`;
 const partialSessionId = `usage_analytics_partial_${runId}`;
@@ -58,6 +59,7 @@ beforeAll(async () => {
 				unsupportedTierSessionId,
 				openAiFastSessionId,
 				claudeFastUsSessionId,
+				unavailableGeoSessionId,
 				longContextSessionId,
 				mismatchedSessionId,
 				partialSessionId,
@@ -123,6 +125,14 @@ beforeAll(async () => {
 				service_tier: "priority",
 			}),
 			buildReceiptRow(claudeFastUsSessionId, "1", 1, true),
+			buildEventRow(unavailableGeoSessionId, "1", {
+				inference_geo: "",
+				model_provider: "anthropic",
+				quality_flags: ["inference_geo_not_available"],
+				raw_model: "claude-opus-4-8",
+				resolved_model: "claude-opus-4-8",
+			}),
+			buildReceiptRow(unavailableGeoSessionId, "1", 1, true),
 			buildEventRow(longContextSessionId, "1", {
 				cache_read_input_tokens: "0",
 				cache_write_1h_input_tokens: "0",
@@ -273,6 +283,15 @@ describe("usage-event analytics ClickHouse rollups", () => {
 			},
 			{
 				cost_is_complete: 0,
+				estimated_cost: 46.75,
+				input_tokens: "4000000",
+				model_used: "claude-opus-4-1",
+				output_tokens: "1000000",
+				session_id: unavailableGeoSessionId,
+				total_tokens: "5000000",
+			},
+			{
+				cost_is_complete: 0,
 				estimated_cost: 0,
 				input_tokens: "4000000",
 				model_used: "claude-opus-4-1",
@@ -319,7 +338,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 			query_params: { orgId: organizationId },
 		});
 
-		expect(rows).toEqual([{ cost: 245.55, incomplete_sessions: 4 }]);
+		expect(rows).toEqual([{ cost: 292.3, incomplete_sessions: 5 }]);
 	});
 
 	test("keeps bounded key prefixes visible across the shared query families", async () => {

--- a/apps/api/src/services/developer.service.ts
+++ b/apps/api/src/services/developer.service.ts
@@ -21,7 +21,10 @@ import {
 	queryClickhouse,
 } from "../clickhouse.js";
 import { sqlClient } from "../db.js";
-import { getUsageAnalyticsQueryContext } from "./usage-event-analytics.service.js";
+import {
+	buildUsageCostSubtotalSql,
+	getUsageAnalyticsQueryContext,
+} from "./usage-event-analytics.service.js";
 
 export interface DeveloperSummary extends DeveloperSummaryBase {
 	username?: string;
@@ -195,7 +198,7 @@ export async function getDeveloperList(
         round(AVG(actual_duration_min), 2) as avg_session_duration_min,
         toString(max(session_date)) as last_active_date,
         round(AVG(success_score), 2) as success_rate,
-		if(countIf(cost_is_complete = 0) = 0, toNullable(round(SUM(ifNull(estimated_cost, 0)), 4)), CAST(NULL, 'Nullable(Float64)')) as total_cost
+		${buildUsageCostSubtotalSql("estimated_cost", 4)} as total_cost
       FROM ${usage.sessionsRelation}
       WHERE ${buildDateFilter("currentDays")}
         AND organization_id = {orgId:String}
@@ -266,7 +269,7 @@ export async function getDeveloperTeamCards(
       SUM(ifNull(input_tokens, 0)) as total_input_tokens,
       SUM(ifNull(output_tokens, 0)) as total_output_tokens,
       SUM(ifNull(input_tokens, 0) + ifNull(output_tokens, 0)) as total_tokens,
-	  if(countIf(cost_is_complete = 0) = 0, toNullable(round(SUM(ifNull(estimated_cost, 0)), 4)), CAST(NULL, 'Nullable(Float64)')) as cost,
+	  ${buildUsageCostSubtotalSql("estimated_cost", 4)} as cost,
       toString(max(session_date)) as last_active_date
     FROM ${usage.sessionsRelation}
     WHERE ${buildDateFilter("days")}
@@ -419,7 +422,7 @@ export async function getDeveloperDetails(
         round(AVG(success_score), 2) as success_rate,
         COUNT(DISTINCT project_path) as distinct_projects,
         SUM(error_count) as error_count,
-		if(countIf(cost_is_complete = 0) = 0, toNullable(round(SUM(ifNull(estimated_cost, 0)), 4)), CAST(NULL, 'Nullable(Float64)')) as total_cost
+		${buildUsageCostSubtotalSql("estimated_cost", 4)} as total_cost
       FROM ${usage.sessionsRelation}
       WHERE user_id = {userId:String}
         AND ${buildDateFilter("currentDays")}

--- a/apps/api/src/services/overview.service.ts
+++ b/apps/api/src/services/overview.service.ts
@@ -13,7 +13,10 @@ import {
 } from "../clickhouse.js";
 import { sqlClient } from "../db.js";
 import { buildEstimatedCostSql } from "./pricing.service.js";
-import { getUsageAnalyticsQueryContext } from "./usage-event-analytics.service.js";
+import {
+	buildUsageCostSubtotalSql,
+	getUsageAnalyticsQueryContext,
+} from "./usage-event-analytics.service.js";
 
 export interface Insight {
 	type: "trend" | "performer" | "alert" | "info";
@@ -113,11 +116,7 @@ export async function getModelTokensTrend(
 	const usage = await getUsageAnalyticsQueryContext(orgId);
 	const estimatedCostSql =
 		usage.mode === "events"
-			? `if(
-				countIf(cost_is_complete = 0) = 0,
-				toNullable(round(sum(ifNull(estimated_cost, 0)), 4)),
-				CAST(NULL, 'Nullable(Float64)')
-			)`
+			? buildUsageCostSubtotalSql("estimated_cost", 4)
 			: `ifNull(${buildEstimatedCostSql({
 					dateExpr: "sa.usage_date",
 					inputExpr: "sum(sa.input_tokens)",
@@ -205,11 +204,7 @@ export async function getUsersTokenUsage(
       sum(ifNull(sa.total_tokens, 0)) as total_tokens,
       sum(ifNull(sa.input_tokens, 0)) as input_tokens,
       sum(ifNull(sa.output_tokens, 0)) as output_tokens,
-      if(
-		countIf(sa.cost_is_complete = 0) = 0,
-		toNullable(round(sum(ifNull(sa.estimated_cost, 0)), 4)),
-		CAST(NULL, 'Nullable(Float64)')
-	  ) as cost,
+		${buildUsageCostSubtotalSql("sa.estimated_cost", 4)} as cost,
       count() as total_sessions,
       round(sum(sa.actual_duration_min), 2) as total_duration_min,
       round(avg(sa.success_score), 2) as success_rate,

--- a/apps/api/src/services/project.service.ts
+++ b/apps/api/src/services/project.service.ts
@@ -13,7 +13,10 @@ import {
 	buildDateFilter,
 	queryClickhouse,
 } from "../clickhouse.js";
-import { getUsageAnalyticsQueryContext } from "./usage-event-analytics.service.js";
+import {
+	buildUsageCostSubtotalSql,
+	getUsageAnalyticsQueryContext,
+} from "./usage-event-analytics.service.js";
 
 const logger = getLogger(["rudel", "api", "project-service"]);
 
@@ -169,7 +172,7 @@ export async function getProjectInvestment(
         round(SUM(actual_duration_min), 2) as total_duration_min,
         round(AVG(actual_duration_min), 2) as avg_session_duration_min,
 		round(AVG(success_score), 2) as success_rate,
-		if(countIf(cost_is_complete = 0) = 0, toNullable(round(SUM(ifNull(estimated_cost, 0)), 4)), CAST(NULL, 'Nullable(Float64)')) as total_cost
+		${buildUsageCostSubtotalSql("estimated_cost", 4)} as total_cost
       FROM ${usage.sessionsRelation}
       WHERE ${buildDateFilter("currentDays")}
         AND organization_id = {orgId:String}
@@ -403,7 +406,7 @@ export async function getProjectDetails(
       ifNull(round(avgOrNull(actual_duration_min), 2), 0) as avg_session_duration_min,
       ifNull(round(avgOrNull(success_score), 2), 0) as success_rate,
 	  round(SUM(actual_duration_min), 2) as total_duration_min,
-	  if(countIf(cost_is_complete = 0) = 0, toNullable(round(SUM(ifNull(estimated_cost, 0)), 4)), CAST(NULL, 'Nullable(Float64)')) as event_cost
+	  ${buildUsageCostSubtotalSql("estimated_cost", 4)} as event_cost
     FROM ${usage.sessionsRelation}
     WHERE ${PROJECT_DISPLAY_EXPR} = ${projectDisplaySubquery}
       AND ${buildDateFilter("days")}

--- a/apps/api/src/services/roi.service.ts
+++ b/apps/api/src/services/roi.service.ts
@@ -14,7 +14,10 @@ import {
 	ESTIMATED_PRICING_MODE,
 	getModelPricingCatalog,
 } from "./pricing.service.js";
-import { getUsageAnalyticsQueryContext } from "./usage-event-analytics.service.js";
+import {
+	buildUsageCostSubtotalSql,
+	getUsageAnalyticsQueryContext,
+} from "./usage-event-analytics.service.js";
 
 // Preserve the legacy ROI formulas while cutover mode is off. Event mode prices
 // each request through the typed rate card in usage-event-analytics.service.
@@ -140,17 +143,13 @@ function calculateChangePct(
 	return roundTo(((current - previous) / previous) * 100);
 }
 
-function buildCompleteCostAggregateSql(
+function buildCostSubtotalSql(
 	mode: "events" | "legacy",
 	precision: number,
 	legacyExpression: string,
 ): string {
 	if (mode === "legacy") return legacyExpression;
-	return `if(
-		countIf(cost_is_complete = 0) = 0,
-		toNullable(round(sum(ifNull(estimated_cost, 0)), ${precision})),
-		CAST(NULL, 'Nullable(Float64)')
-	)`;
+	return buildUsageCostSubtotalSql("estimated_cost", precision);
 }
 
 function shiftIsoDate(isoDate: string, days: number) {
@@ -261,7 +260,7 @@ export async function getROIMetrics(
 		+ (SUM(input_tokens) / 1000000.0) * ${INPUT_PRICE_PER_MILLION},
 		2
 	)`;
-	const costSql = buildCompleteCostAggregateSql(usage.mode, 2, legacyCostSql);
+	const costSql = buildCostSubtotalSql(usage.mode, 2, legacyCostSql);
 
 	const query = `
 	WITH ${usage.cteDefinitions},
@@ -487,7 +486,7 @@ export async function getROITrends(
 ): Promise<ROITrend[]> {
 	const d = Number(days);
 	const usage = await getUsageAnalyticsQueryContext(orgId);
-	const costSql = buildCompleteCostAggregateSql(
+	const costSql = buildCostSubtotalSql(
 		usage.mode,
 		2,
 		`round((SUM(output_tokens) / 1000000.0) * ${OUTPUT_PRICE_PER_MILLION} + (SUM(input_tokens) / 1000000.0) * ${INPUT_PRICE_PER_MILLION}, 2)`,
@@ -554,7 +553,7 @@ export async function getDeveloperCostBreakdown(
 ): Promise<DeveloperCostBreakdown[]> {
 	const d = Number(days);
 	const usage = await getUsageAnalyticsQueryContext(orgId);
-	const costSql = buildCompleteCostAggregateSql(
+	const costSql = buildCostSubtotalSql(
 		usage.mode,
 		2,
 		`round((SUM(output_tokens) / 1000000.0) * ${OUTPUT_PRICE_PER_MILLION} + (SUM(input_tokens) / 1000000.0) * ${INPUT_PRICE_PER_MILLION}, 2)`,
@@ -619,7 +618,7 @@ export async function getProjectCostBreakdown(
 ): Promise<ProjectCostBreakdown[]> {
 	const d = Number(days);
 	const usage = await getUsageAnalyticsQueryContext(orgId);
-	const costSql = buildCompleteCostAggregateSql(
+	const costSql = buildCostSubtotalSql(
 		usage.mode,
 		2,
 		`round((SUM(output_tokens) / 1000000.0) * ${OUTPUT_PRICE_PER_MILLION} + (SUM(input_tokens) / 1000000.0) * ${INPUT_PRICE_PER_MILLION}, 2)`,
@@ -682,7 +681,7 @@ async function getRangeSnapshot(
 	endDate: string,
 ): Promise<RangeSnapshotRow | undefined> {
 	const usage = await getUsageAnalyticsQueryContext(orgId);
-	const costSql = buildCompleteCostAggregateSql(
+	const costSql = buildCostSubtotalSql(
 		usage.mode,
 		4,
 		"round(SUM(ifNull(estimated_cost, 0)), 4)",
@@ -722,7 +721,7 @@ async function getDeveloperCostBreakdownForRange(
 	endDate: string,
 ): Promise<DeveloperCostBreakdown[]> {
 	const usage = await getUsageAnalyticsQueryContext(orgId);
-	const costSql = buildCompleteCostAggregateSql(
+	const costSql = buildCostSubtotalSql(
 		usage.mode,
 		4,
 		"round(SUM(ifNull(estimated_cost, 0)), 4)",
@@ -781,7 +780,7 @@ async function getProjectCostBreakdownForRange(
 	endDate: string,
 ): Promise<ProjectCostBreakdown[]> {
 	const usage = await getUsageAnalyticsQueryContext(orgId);
-	const costSql = buildCompleteCostAggregateSql(
+	const costSql = buildCostSubtotalSql(
 		usage.mode,
 		4,
 		"round(SUM(ifNull(estimated_cost, 0)), 4)",
@@ -857,7 +856,7 @@ export async function getROIDashboard(
 				? "toMonday(session_date)"
 				: "toStartOfMonth(session_date)";
 	const usage = await getUsageAnalyticsQueryContext(orgId);
-	const trendCostSql = buildCompleteCostAggregateSql(
+	const trendCostSql = buildCostSubtotalSql(
 		usage.mode,
 		4,
 		"round(SUM(ifNull(estimated_cost, 0)), 4)",

--- a/apps/api/src/services/session-analytics.service.ts
+++ b/apps/api/src/services/session-analytics.service.ts
@@ -164,7 +164,7 @@ export async function getSessionAnalytics(
 	});
 	const estimatedCostSql =
 		usage.mode === "events"
-			? "if(sa.cost_is_complete = 1, sa.estimated_cost, CAST(NULL, 'Nullable(Float64)'))"
+			? "sa.estimated_cost"
 			: LEGACY_SESSION_DISPLAY_COST_WITH_FALLBACK_SQL;
 
 	const query = `
@@ -729,7 +729,7 @@ export async function getSessionDetail(
 	});
 	const estimatedCostSql =
 		usage.mode === "events"
-			? "if(sa.cost_is_complete = 1, sa.estimated_cost, CAST(NULL, 'Nullable(Float64)'))"
+			? "sa.estimated_cost"
 			: LEGACY_SESSION_DISPLAY_COST_WITH_FALLBACK_SQL;
 	const query = `
 	WITH ${usage.cteDefinitions},

--- a/apps/api/src/services/usage-event-analytics.service.test.ts
+++ b/apps/api/src/services/usage-event-analytics.service.test.ts
@@ -85,7 +85,7 @@ describe("usage-event analytics query contract", () => {
 			"toNullable(sum(ifNull(p.estimated_cost, 0))) AS estimated_cost",
 		);
 		expect(sql).toContain(
-			"toUInt8(countIf(isNull(p.estimated_cost)) = 0) AS cost_is_complete",
+			"OR has(p.quality_flags, 'inference_geo_not_available')",
 		);
 		expect(buildUsageCostSubtotalSql("sa.estimated_cost", 4)).toBe(
 			"toNullable(round(sum(ifNull(sa.estimated_cost, 0)), 4))",

--- a/apps/api/src/services/usage-event-analytics.service.test.ts
+++ b/apps/api/src/services/usage-event-analytics.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	buildLegacyUsageAnalyticsCte,
+	buildUsageCostSubtotalSql,
 	buildUsageEventAnalyticsCte,
 	getUsageAnalyticsQueryContext,
 	UsageEventAnalyticsReadinessGate,
@@ -75,6 +76,20 @@ describe("usage-event analytics query contract", () => {
 		expect(sql).toContain("unrecognized_service_tier");
 		expect(sql).toContain("provider_model_mismatch");
 		expect(sql).toContain("e.has_valid_timestamp = 1");
+	});
+
+	test("keeps the known cost subtotal while completeness remains internal", () => {
+		const sql = buildUsageEventAnalyticsCte();
+
+		expect(sql).toContain(
+			"toNullable(sum(ifNull(p.estimated_cost, 0))) AS estimated_cost",
+		);
+		expect(sql).toContain(
+			"toUInt8(countIf(isNull(p.estimated_cost)) = 0) AS cost_is_complete",
+		);
+		expect(buildUsageCostSubtotalSql("sa.estimated_cost", 4)).toBe(
+			"toNullable(round(sum(ifNull(sa.estimated_cost, 0)), 4))",
+		);
 	});
 
 	test("keeps the legacy branch source-compatible", () => {

--- a/apps/api/src/services/usage-event-analytics.service.ts
+++ b/apps/api/src/services/usage-event-analytics.service.ts
@@ -116,6 +116,13 @@ interface UsageEventAnalyticsReadinessGateOptions {
 	readonly timeoutMs: number;
 }
 
+export function buildUsageCostSubtotalSql(
+	estimatedCostExpression: string,
+	precision: number,
+): string {
+	return `toNullable(round(sum(ifNull(${estimatedCostExpression}, 0)), ${precision}))`;
+}
+
 export class UsageEventAnalyticsReadinessGate {
 	private readonly degradedTtlMs: number;
 	private inFlight: Promise<ReadinessState> | null = null;
@@ -293,7 +300,7 @@ export function buildUsageEventAnalyticsCte(
 				sum(p.cache_read_input_tokens) AS cache_read_input_tokens,
 				sum(p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens) AS cache_creation_input_tokens,
 				sum(p.uncached_input_tokens + p.cache_read_input_tokens + p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens + p.output_tokens) AS total_tokens,
-				if(countIf(isNotNull(p.estimated_cost)) > 0, toNullable(sum(ifNull(p.estimated_cost, 0))), CAST(NULL, 'Nullable(Float64)')) AS estimated_cost,
+				toNullable(sum(ifNull(p.estimated_cost, 0))) AS estimated_cost,
 				toUInt8(countIf(isNull(p.estimated_cost)) = 0) AS cost_is_complete
 			FROM priced_usage_events AS p
 			GROUP BY p.organization_id, p.user_id, p.source, p.session_id
@@ -310,7 +317,7 @@ export function buildUsageEventAnalyticsCte(
 				sum(p.cache_read_input_tokens) AS cache_read_input_tokens,
 				sum(p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens) AS cache_creation_input_tokens,
 				sum(p.uncached_input_tokens + p.cache_read_input_tokens + p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens + p.output_tokens) AS total_tokens,
-				if(countIf(isNotNull(p.estimated_cost)) > 0, toNullable(sum(ifNull(p.estimated_cost, 0))), CAST(NULL, 'Nullable(Float64)')) AS estimated_cost,
+				toNullable(sum(ifNull(p.estimated_cost, 0))) AS estimated_cost,
 				toUInt8(countIf(isNull(p.estimated_cost)) = 0) AS cost_is_complete
 			FROM priced_usage_events AS p
 			GROUP BY p.organization_id, p.user_id, p.source, p.session_id, p.usage_date

--- a/apps/api/src/services/usage-event-analytics.service.ts
+++ b/apps/api/src/services/usage-event-analytics.service.ts
@@ -301,7 +301,10 @@ export function buildUsageEventAnalyticsCte(
 				sum(p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens) AS cache_creation_input_tokens,
 				sum(p.uncached_input_tokens + p.cache_read_input_tokens + p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens + p.output_tokens) AS total_tokens,
 				toNullable(sum(ifNull(p.estimated_cost, 0))) AS estimated_cost,
-				toUInt8(countIf(isNull(p.estimated_cost)) = 0) AS cost_is_complete
+				toUInt8(countIf(
+					isNull(p.estimated_cost)
+					OR has(p.quality_flags, 'inference_geo_not_available')
+				) = 0) AS cost_is_complete
 			FROM priced_usage_events AS p
 			GROUP BY p.organization_id, p.user_id, p.source, p.session_id
 		),
@@ -318,7 +321,10 @@ export function buildUsageEventAnalyticsCte(
 				sum(p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens) AS cache_creation_input_tokens,
 				sum(p.uncached_input_tokens + p.cache_read_input_tokens + p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens + p.output_tokens) AS total_tokens,
 				toNullable(sum(ifNull(p.estimated_cost, 0))) AS estimated_cost,
-				toUInt8(countIf(isNull(p.estimated_cost)) = 0) AS cost_is_complete
+				toUInt8(countIf(
+					isNull(p.estimated_cost)
+					OR has(p.quality_flags, 'inference_geo_not_available')
+				) = 0) AS cost_is_complete
 			FROM priced_usage_events AS p
 			GROUP BY p.organization_id, p.user_id, p.source, p.session_id, p.usage_date
 		),

--- a/apps/api/src/services/wrapped.service.ts
+++ b/apps/api/src/services/wrapped.service.ts
@@ -12,7 +12,10 @@ import {
 } from "@rudel/ch-schema/wrapped-archetype-constants";
 import { buildWrappedArchetypeCentroidUnionAll } from "@rudel/ch-schema/wrapped-archetype-rebuild";
 import { queryClickhouse } from "../clickhouse.js";
-import { getUsageAnalyticsQueryContext } from "./usage-event-analytics.service.js";
+import {
+	buildUsageCostSubtotalSql,
+	getUsageAnalyticsQueryContext,
+} from "./usage-event-analytics.service.js";
 import { buildWrappedArchetypeGate } from "./wrapped-archetype-gate.js";
 import { enqueueWrappedArchetypeSnapshotRebuild } from "./wrapped-archetype-rebuild.service.js";
 
@@ -154,11 +157,7 @@ async function getWrappedSummary(
 					formatDateTime(max(session_date), '%Y-%m-%dT%H:%i:%SZ')
 				) AS last_session_at,
 				ifNull(sum(ifNull(input_tokens, 0) + ifNull(output_tokens, 0)), 0) AS total_tokens,
-				if(
-					countIf(cost_is_complete = 0) = 0,
-					toNullable(round(sum(ifNull(estimated_cost, 0)), 4)),
-					CAST(NULL, 'Nullable(Float64)')
-				) AS estimated_spend_usd,
+				${buildUsageCostSubtotalSql("estimated_cost", 4)} AS estimated_spend_usd,
 				ifNull(maxOrNull(actual_duration_min), 0) AS longest_session_min,
 				countIf(source = 'claude_code') AS claude_session_count,
 				countIf(source = 'codex') AS codex_session_count

--- a/packages/usage-events/src/extract.test.ts
+++ b/packages/usage-events/src/extract.test.ts
@@ -11,8 +11,8 @@ import {
 } from "./index.js";
 
 describe("usage identity versioning", () => {
-	test("pins pricing-provenance extraction semantics to v3", () => {
-		expect(USAGE_EVENT_EXTRACTION_VERSION).toBe(3);
+	test("pins pricing-provenance extraction semantics to v4", () => {
+		expect(USAGE_EVENT_EXTRACTION_VERSION).toBe(4);
 	});
 
 	test("pins every event and lineage prefix to the identity-version knob", () => {
@@ -716,6 +716,48 @@ describe("Claude usage-event extraction", () => {
 			inferenceSpeed: "fast",
 			rawModel: "claude-opus-4-8 [1m]",
 			resolvedModel: "claude-opus-4-8",
+		});
+	});
+
+	test("treats Anthropic's not_available geography sentinel as base-compatible but disclosed", () => {
+		const result = complete(
+			extractClaude(
+				claudeLine({
+					messageId: "claude-routing-unavailable",
+					requestId: "claude-routing-unavailable-request",
+					input: 10,
+					output: 2,
+					inferenceGeo: "not_available",
+					model: "claude-opus-4-6",
+				}),
+			),
+		);
+
+		expect(onlyEvent(result)).toMatchObject({
+			inferenceGeo: "",
+			qualityFlags: ["inference_geo_not_available"],
+		});
+		expect(result.diagnostics).toContainEqual({
+			code: "claude_code_inference_geo_not_available",
+			count: 1,
+			fatal: false,
+		});
+
+		const unsupported = onlyEvent(
+			extractClaude(
+				claudeLine({
+					messageId: "claude-routing-unsupported",
+					requestId: "claude-routing-unsupported-request",
+					input: 10,
+					output: 2,
+					inferenceGeo: "moon",
+					model: "claude-opus-4-6",
+				}),
+			),
+		);
+		expect(unsupported).toMatchObject({
+			inferenceGeo: "",
+			qualityFlags: ["unrecognized_inference_geo"],
 		});
 	});
 

--- a/packages/usage-events/src/extract.ts
+++ b/packages/usage-events/src/extract.ts
@@ -416,11 +416,8 @@ function readClaudeCandidate(
 		identityKind,
 		identityValue,
 		isMain: isMainTranscript && !isSidechain,
-		inferenceGeo: normalizeBillingDimension(
+		inferenceGeo: normalizeClaudeInferenceGeo(
 			usage.inference_geo,
-			new Set(["global", "us"]),
-			"claude_code_unrecognized_inference_geo",
-			"unrecognized_inference_geo",
 			qualityFlags,
 			diagnostics,
 		),
@@ -1715,6 +1712,33 @@ function normalizeBillingDimension(
 	qualityFlags.push(qualityFlag);
 	addDiagnostic(diagnostics, diagnosticCode, false, normalized);
 	return "";
+}
+
+function normalizeClaudeInferenceGeo(
+	value: unknown,
+	qualityFlags: string[],
+	diagnostics: Map<string, MutableDiagnostic>,
+): string {
+	const normalized = readNonEmptyString(value)?.toLowerCase() ?? "";
+	if (normalized === "not_available") {
+		// Anthropic emits this documented sentinel when the routing dimension is
+		// unavailable. Use the comparable base rate, but retain internal disclosure.
+		qualityFlags.push("inference_geo_not_available");
+		addDiagnostic(
+			diagnostics,
+			"claude_code_inference_geo_not_available",
+			false,
+		);
+		return "";
+	}
+	return normalizeBillingDimension(
+		normalized,
+		new Set(["global", "us"]),
+		"claude_code_unrecognized_inference_geo",
+		"unrecognized_inference_geo",
+		qualityFlags,
+		diagnostics,
+	);
 }
 
 function readRequiredToken(

--- a/packages/usage-events/src/types.ts
+++ b/packages/usage-events/src/types.ts
@@ -1,7 +1,7 @@
 import { MODEL_RATE_CARD_VERSION } from "@rudel/api-routes/model-pricing";
 
 export const USAGE_EVENT_IDENTITY_VERSION = 1;
-export const USAGE_EVENT_EXTRACTION_VERSION = 3;
+export const USAGE_EVENT_EXTRACTION_VERSION = 4;
 export const USAGE_EVENT_MODEL_RATE_CARD_VERSION = MODEL_RATE_CARD_VERSION;
 
 export type UsageEventSource = "claude_code" | "codex";


### PR DESCRIPTION
## Summary
- keep request-level cost completeness as an internal diagnostic without nulling known subtotals
- return known subtotals consistently across Dashboard, Team, Sessions, Projects, ROI, and Wrapped
- recognize Anthropic’s documented `inference_geo: "not_available"` sentinel as a base-rate estimate while retaining an internal incompleteness flag; genuinely unknown geographies still fail closed
- bump extraction semantics to v4 so retained raw sessions can be replayed deterministically
- add authored extractor, unit, and ClickHouse integration coverage for partial, fully unpriced, and unavailable-geography sessions

## Test plan
- [x] `bun run verify`
- [x] GitHub `integration` job against disposable Postgres and ClickHouse

## Production operation
- the owner-organization v3 backfill completed 1,502 usage-bearing sessions at cutoff `2026-08-05T08:23:18.987Z`; six transient consistency checks were repaired idempotently and certified at v3
- after this PR deploys, preview and execute the same bounded owner-org replay at v4; do not write v4 before deploy because live v3 ingest could supersede it
- no schema migration is included in this PR