### PR TITLE
fix(analytics): prevent synthetic model labels

### DIFF
--- a/apps/api/src/__tests__/usage-event-analytics.integration.ts
+++ b/apps/api/src/__tests__/usage-event-analytics.integration.ts
@@ -39,6 +39,8 @@ const invalidTimestampSessionId = `usage_analytics_invalid_timestamp_${runId}`;
 const deletedReceiptSessionId = `usage_analytics_deleted_receipt_${runId}`;
 const tombstonedSessionId = `usage_analytics_tombstone_${runId}`;
 const missingMetadataSessionId = `usage_analytics_missing_metadata_${runId}`;
+const unknownMixedModelSessionId = `usage_analytics_unknown_mixed_${runId}`;
+const unknownSingleModelSessionId = `usage_analytics_unknown_single_${runId}`;
 const eventId = "a".repeat(64);
 const receiptId = "b".repeat(64);
 const executor = createClickHouseExecutor({
@@ -72,6 +74,16 @@ beforeAll(async () => {
 				...buildSessionAnalyticsRow(resolvedSessionId),
 				organization_id: isolatedOrganizationId,
 				user_id: isolatedUserId,
+			},
+			{
+				...buildSessionAnalyticsRow(unknownMixedModelSessionId),
+				model_used: "unknown",
+				source: "codex",
+			},
+			{
+				...buildSessionAnalyticsRow(unknownSingleModelSessionId),
+				model_used: "unknown",
+				source: "codex",
 			},
 		],
 		{ validate: true },
@@ -182,6 +194,23 @@ beforeAll(async () => {
 			buildReceiptRow(tombstonedSessionId, "2", 0, true),
 			buildEventRow(missingMetadataSessionId, "1"),
 			buildReceiptRow(missingMetadataSessionId, "1", 1, true),
+			buildCodexDisplayEvent(
+				unknownMixedModelSessionId,
+				eventId,
+				"gpt-5.6-sol",
+			),
+			buildCodexDisplayEvent(
+				unknownMixedModelSessionId,
+				"f".repeat(64),
+				"gpt-5.6-terra",
+			),
+			buildReceiptRow(unknownMixedModelSessionId, "1", 2, true, "codex"),
+			buildCodexDisplayEvent(
+				unknownSingleModelSessionId,
+				eventId,
+				"gpt-5.6-sol",
+			),
+			buildReceiptRow(unknownSingleModelSessionId, "1", 1, true, "codex"),
 			{
 				...buildEventRow(resolvedSessionId, "1"),
 				organization_id: isolatedOrganizationId,
@@ -291,6 +320,24 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				total_tokens: "5000000",
 			},
 			{
+				cost_is_complete: 1,
+				estimated_cost: 4.97,
+				input_tokens: "400000",
+				model_used: "unknown",
+				output_tokens: "200000",
+				session_id: unknownMixedModelSessionId,
+				total_tokens: "600000",
+			},
+			{
+				cost_is_complete: 1,
+				estimated_cost: 3.55,
+				input_tokens: "200000",
+				model_used: "gpt-5.6-sol",
+				output_tokens: "100000",
+				session_id: unknownSingleModelSessionId,
+				total_tokens: "300000",
+			},
+			{
 				cost_is_complete: 0,
 				estimated_cost: 0,
 				input_tokens: "4000000",
@@ -338,7 +385,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 			query_params: { orgId: organizationId },
 		});
 
-		expect(rows).toEqual([{ cost: 292.3, incomplete_sessions: 5 }]);
+		expect(rows).toEqual([{ cost: 300.82, incomplete_sessions: 5 }]);
 	});
 
 	test("keeps bounded key prefixes visible across the shared query families", async () => {
@@ -550,4 +597,25 @@ function buildReceiptRow(
 			uncached_input_tokens: "0",
 		}),
 	};
+}
+
+function buildCodexDisplayEvent(
+	sessionId: string,
+	rowEventId: string,
+	model: string,
+): RudelUsageEventsRow {
+	return buildEventRow(sessionId, "1", {
+		cache_read_input_tokens: "100000",
+		cache_write_1h_input_tokens: "0",
+		cache_write_5m_input_tokens: "0",
+		context_input_tokens: "200000",
+		event_id: rowEventId,
+		model_provider: "openai",
+		output_tokens: "100000",
+		raw_model: model,
+		resolved_model: model,
+		service_tier: "auto",
+		source: "codex",
+		uncached_input_tokens: "100000",
+	});
 }

--- a/apps/api/src/__tests__/usage-event-analytics.integration.ts
+++ b/apps/api/src/__tests__/usage-event-analytics.integration.ts
@@ -39,6 +39,8 @@ const invalidTimestampSessionId = `usage_analytics_invalid_timestamp_${runId}`;
 const deletedReceiptSessionId = `usage_analytics_deleted_receipt_${runId}`;
 const tombstonedSessionId = `usage_analytics_tombstone_${runId}`;
 const missingMetadataSessionId = `usage_analytics_missing_metadata_${runId}`;
+const syntheticTerminalSessionId = `usage_analytics_synthetic_terminal_${runId}`;
+const syntheticZeroSessionId = `usage_analytics_synthetic_zero_${runId}`;
 const unknownMixedModelSessionId = `usage_analytics_unknown_mixed_${runId}`;
 const unknownSingleModelSessionId = `usage_analytics_unknown_single_${runId}`;
 const eventId = "a".repeat(64);
@@ -84,6 +86,14 @@ beforeAll(async () => {
 				...buildSessionAnalyticsRow(unknownSingleModelSessionId),
 				model_used: "unknown",
 				source: "codex",
+			},
+			{
+				...buildSessionAnalyticsRow(syntheticTerminalSessionId),
+				model_used: "<synthetic>",
+			},
+			{
+				...buildSessionAnalyticsRow(syntheticZeroSessionId),
+				model_used: "<synthetic>",
 			},
 		],
 		{ validate: true },
@@ -194,15 +204,40 @@ beforeAll(async () => {
 			buildReceiptRow(tombstonedSessionId, "2", 0, true),
 			buildEventRow(missingMetadataSessionId, "1"),
 			buildReceiptRow(missingMetadataSessionId, "1", 1, true),
+			buildEventRow(syntheticTerminalSessionId, "1", {
+				event_id: "1".repeat(64),
+				first_observed_line: 10,
+				occurred_at: "2026-08-04 08:00:00.000",
+			}),
+			buildEventRow(syntheticTerminalSessionId, "1", {
+				agent_id: "worker",
+				event_id: "2".repeat(64),
+				first_observed_line: 20,
+				occurred_at: "2026-08-04 08:01:00.000",
+				raw_model: "claude-haiku-4-5",
+				resolved_model: "claude-haiku-4-5-20251001",
+			}),
+			buildSyntheticZeroEvent(syntheticTerminalSessionId, "3".repeat(64)),
+			buildReceiptRow(syntheticTerminalSessionId, "1", 3, true),
+			buildSyntheticZeroEvent(syntheticZeroSessionId, "4".repeat(64)),
+			buildReceiptRow(syntheticZeroSessionId, "1", 1, true),
 			buildCodexDisplayEvent(
 				unknownMixedModelSessionId,
 				eventId,
 				"gpt-5.6-sol",
+				{
+					first_observed_line: 10,
+					occurred_at: "2026-08-04 08:00:00.000",
+				},
 			),
 			buildCodexDisplayEvent(
 				unknownMixedModelSessionId,
 				"f".repeat(64),
 				"gpt-5.6-terra",
+				{
+					first_observed_line: 20,
+					occurred_at: "2026-08-04 08:01:00.000",
+				},
 			),
 			buildReceiptRow(unknownMixedModelSessionId, "1", 2, true, "codex"),
 			buildCodexDisplayEvent(
@@ -251,7 +286,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 1,
 				estimated_cost: 102.85,
 				input_tokens: "4000000",
-				model_used: "claude-opus-4-1",
+				model_used: "claude-opus-4-8",
 				output_tokens: "1000000",
 				session_id: claudeFastUsSessionId,
 				total_tokens: "5000000",
@@ -260,7 +295,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 0,
 				estimated_cost: 0,
 				input_tokens: "4000000",
-				model_used: "claude-opus-4-1",
+				model_used: "claude-sonnet-4-5",
 				output_tokens: "1000000",
 				session_id: invalidTimestampSessionId,
 				total_tokens: "5000000",
@@ -269,7 +304,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 1,
 				estimated_cost: 55,
 				input_tokens: "1000000",
-				model_used: "claude-opus-4-1",
+				model_used: "gpt-5.6-sol",
 				output_tokens: "1000000",
 				session_id: longContextSessionId,
 				total_tokens: "2000000",
@@ -278,7 +313,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 1,
 				estimated_cost: 3.55,
 				input_tokens: "200000",
-				model_used: "claude-opus-4-1",
+				model_used: "gpt-5.4",
 				output_tokens: "100000",
 				session_id: openAiFastSessionId,
 				total_tokens: "300000",
@@ -287,7 +322,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 0,
 				estimated_cost: 28.05,
 				input_tokens: "8000000",
-				model_used: "claude-opus-4-1",
+				model_used: "claude-sonnet-4-5",
 				output_tokens: "2000000",
 				session_id: partialSessionId,
 				total_tokens: "10000000",
@@ -296,16 +331,34 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 1,
 				estimated_cost: 56.1,
 				input_tokens: "8000000",
-				model_used: "claude-opus-4-1",
+				model_used: "claude-sonnet-4-5",
 				output_tokens: "2000000",
 				session_id: resolvedSessionId,
 				total_tokens: "10000000",
 			},
 			{
 				cost_is_complete: 1,
+				estimated_cost: 37.4,
+				input_tokens: "8000000",
+				model_used: "claude-sonnet-4-5",
+				output_tokens: "2000000",
+				session_id: syntheticTerminalSessionId,
+				total_tokens: "10000000",
+			},
+			{
+				cost_is_complete: 1,
 				estimated_cost: 0,
 				input_tokens: "0",
-				model_used: "claude-opus-4-1",
+				model_used: "",
+				output_tokens: "0",
+				session_id: syntheticZeroSessionId,
+				total_tokens: "0",
+			},
+			{
+				cost_is_complete: 1,
+				estimated_cost: 0,
+				input_tokens: "0",
+				model_used: "",
 				output_tokens: "0",
 				session_id: tombstonedSessionId,
 				total_tokens: "0",
@@ -314,7 +367,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 0,
 				estimated_cost: 46.75,
 				input_tokens: "4000000",
-				model_used: "claude-opus-4-1",
+				model_used: "claude-opus-4-8",
 				output_tokens: "1000000",
 				session_id: unavailableGeoSessionId,
 				total_tokens: "5000000",
@@ -323,7 +376,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 1,
 				estimated_cost: 4.97,
 				input_tokens: "400000",
-				model_used: "unknown",
+				model_used: "gpt-5.6-terra",
 				output_tokens: "200000",
 				session_id: unknownMixedModelSessionId,
 				total_tokens: "600000",
@@ -341,7 +394,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 0,
 				estimated_cost: 0,
 				input_tokens: "4000000",
-				model_used: "claude-opus-4-1",
+				model_used: "",
 				output_tokens: "1000000",
 				session_id: unresolvedSessionId,
 				total_tokens: "5000000",
@@ -350,12 +403,18 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 0,
 				estimated_cost: 0,
 				input_tokens: "4000000",
-				model_used: "claude-opus-4-1",
+				model_used: "claude-sonnet-4-5",
 				output_tokens: "1000000",
 				session_id: unsupportedTierSessionId,
 				total_tokens: "5000000",
 			},
 		]);
+		expect(
+			rows.every(
+				(row) =>
+					row.model_used !== "unknown" && row.model_used !== "<synthetic>",
+			),
+		).toBe(true);
 		expect(
 			rows.some((row) => row.session_id === missingMetadataSessionId),
 		).toBe(false);
@@ -385,7 +444,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 			query_params: { orgId: organizationId },
 		});
 
-		expect(rows).toEqual([{ cost: 300.82, incomplete_sessions: 5 }]);
+		expect(rows).toEqual([{ cost: 338.22, incomplete_sessions: 5 }]);
 	});
 
 	test("keeps bounded key prefixes visible across the shared query families", async () => {
@@ -603,6 +662,7 @@ function buildCodexDisplayEvent(
 	sessionId: string,
 	rowEventId: string,
 	model: string,
+	overrides: Partial<RudelUsageEventsRow> = {},
 ): RudelUsageEventsRow {
 	return buildEventRow(sessionId, "1", {
 		cache_read_input_tokens: "100000",
@@ -617,5 +677,27 @@ function buildCodexDisplayEvent(
 		service_tier: "auto",
 		source: "codex",
 		uncached_input_tokens: "100000",
+		...overrides,
+	});
+}
+
+function buildSyntheticZeroEvent(
+	sessionId: string,
+	rowEventId: string,
+): RudelUsageEventsRow {
+	return buildEventRow(sessionId, "1", {
+		cache_read_input_tokens: "0",
+		cache_write_1h_input_tokens: "0",
+		cache_write_5m_input_tokens: "0",
+		context_input_tokens: "0",
+		event_id: rowEventId,
+		first_observed_line: 30,
+		model_status: "synthetic",
+		occurred_at: "2026-08-04 08:02:00.000",
+		output_tokens: "0",
+		quality_flags: ["synthetic_model"],
+		raw_model: "",
+		resolved_model: "",
+		uncached_input_tokens: "0",
 	});
 }

--- a/apps/api/src/services/usage-event-analytics.service.test.ts
+++ b/apps/api/src/services/usage-event-analytics.service.test.ts
@@ -64,6 +64,16 @@ describe("usage-event analytics query contract", () => {
 		expect(sql).not.toMatch(/match\(lowerUTF8\(sa\.model_used\)/u);
 	});
 
+	test("repairs an unknown display label only for one unanimous event model", () => {
+		const sql = buildUsageEventAnalyticsCte();
+
+		expect(sql).toContain("uniqExactIf(");
+		expect(sql).toContain("AS resolved_model_count");
+		expect(sql).toContain("AS single_resolved_model");
+		expect(sql).toContain("ifNull(r.resolved_model_count, 0) = 1");
+		expect(sql).toContain("ifNull(s.resolved_model_count, 0) = 1");
+	});
+
 	test("prices exact provenance and fails closed for unsupported dimensions", () => {
 		const sql = buildUsageEventAnalyticsCte();
 

--- a/apps/api/src/services/usage-event-analytics.service.test.ts
+++ b/apps/api/src/services/usage-event-analytics.service.test.ts
@@ -64,14 +64,22 @@ describe("usage-event analytics query contract", () => {
 		expect(sql).not.toMatch(/match\(lowerUTF8\(sa\.model_used\)/u);
 	});
 
-	test("repairs an unknown display label only for one unanimous event model", () => {
+	test("uses the latest resolved main event as display metadata", () => {
 		const sql = buildUsageEventAnalyticsCte();
 
-		expect(sql).toContain("uniqExactIf(");
-		expect(sql).toContain("AS resolved_model_count");
-		expect(sql).toContain("AS single_resolved_model");
-		expect(sql).toContain("ifNull(r.resolved_model_count, 0) = 1");
-		expect(sql).toContain("ifNull(s.resolved_model_count, 0) = 1");
+		expect(sql).toContain("argMaxIf(");
+		expect(sql).toContain("p.agent_id = 'main'");
+		expect(sql).toContain("AS latest_main_model");
+		expect(sql).toContain("AS latest_resolved_model");
+		expect(sql).toContain(
+			"if(r.latest_main_model != '', r.latest_main_model, r.latest_resolved_model) AS model_used",
+		);
+		expect(sql).toContain(
+			"if(s.latest_main_model != '', s.latest_main_model, s.latest_resolved_model) AS model_used",
+		);
+		expect(sql).not.toContain("resolved_model_count");
+		expect(sql).not.toContain("single_resolved_model");
+		expect(sql).not.toContain("lowerUTF8(trimBoth(sa.model_used))");
 	});
 
 	test("prices exact provenance and fails closed for unsupported dimensions", () => {

--- a/apps/api/src/services/usage-event-analytics.service.ts
+++ b/apps/api/src/services/usage-event-analytics.service.ts
@@ -81,7 +81,6 @@ const SESSION_METADATA_COLUMNS = `
 	sa.long_pauses AS long_pauses,
 	sa.error_count AS error_count,
 	sa.error_pattern AS error_pattern,
-	sa.model_used AS model_used,
 	sa.has_commit AS has_commit,
 	sa.session_archetype AS session_archetype,
 	sa.success_score AS success_score,
@@ -304,7 +303,15 @@ export function buildUsageEventAnalyticsCte(
 				toUInt8(countIf(
 					isNull(p.estimated_cost)
 					OR has(p.quality_flags, 'inference_geo_not_available')
-				) = 0) AS cost_is_complete
+				) = 0) AS cost_is_complete,
+				uniqExactIf(
+					p.resolved_model,
+					p.model_status = 'resolved' AND p.resolved_model != ''
+				) AS resolved_model_count,
+				anyIf(
+					p.resolved_model,
+					p.model_status = 'resolved' AND p.resolved_model != ''
+				) AS single_resolved_model
 			FROM priced_usage_events AS p
 			GROUP BY p.organization_id, p.user_id, p.source, p.session_id
 		),
@@ -336,6 +343,12 @@ export function buildUsageEventAnalyticsCte(
 		usage_analytics_sessions AS (
 			SELECT
 				${SESSION_METADATA_COLUMNS},
+				if(
+					lowerUTF8(trimBoth(sa.model_used)) IN ('', 'unknown', '<synthetic>')
+						AND ifNull(r.resolved_model_count, 0) = 1,
+					r.single_resolved_model,
+					sa.model_used
+				) AS model_used,
 				ifNull(r.input_tokens, 0) AS input_tokens,
 				ifNull(r.output_tokens, 0) AS output_tokens,
 				ifNull(r.cache_read_input_tokens, 0) AS cache_read_input_tokens,
@@ -358,6 +371,12 @@ export function buildUsageEventAnalyticsCte(
 		usage_analytics_daily_sessions AS (
 			SELECT
 				${SESSION_METADATA_COLUMNS},
+				if(
+					lowerUTF8(trimBoth(sa.model_used)) IN ('', 'unknown', '<synthetic>')
+						AND ifNull(s.resolved_model_count, 0) = 1,
+					s.single_resolved_model,
+					sa.model_used
+				) AS model_used,
 				r.usage_date,
 				r.input_tokens,
 				r.output_tokens,
@@ -372,6 +391,11 @@ export function buildUsageEventAnalyticsCte(
 				AND sa.user_id = r.user_id
 				AND sa.source = r.source
 				AND sa.session_id = r.session_id
+			LEFT ANY JOIN usage_event_session_rollups AS s
+				ON s.organization_id = r.organization_id
+				AND s.user_id = r.user_id
+				AND s.source = r.source
+				AND s.session_id = r.session_id
 		)
 	`;
 }

--- a/apps/api/src/services/usage-event-analytics.service.ts
+++ b/apps/api/src/services/usage-event-analytics.service.ts
@@ -304,14 +304,28 @@ export function buildUsageEventAnalyticsCte(
 					isNull(p.estimated_cost)
 					OR has(p.quality_flags, 'inference_geo_not_available')
 				) = 0) AS cost_is_complete,
-				uniqExactIf(
+				argMaxIf(
 					p.resolved_model,
-					p.model_status = 'resolved' AND p.resolved_model != ''
-				) AS resolved_model_count,
-				anyIf(
+					tuple(
+						p.has_valid_timestamp,
+						p.occurred_at,
+						p.first_observed_line,
+						p.event_id
+					),
+					p.agent_id = 'main'
+						AND p.model_status = 'resolved'
+						AND p.resolved_model != ''
+				) AS latest_main_model,
+				argMaxIf(
 					p.resolved_model,
+					tuple(
+						p.has_valid_timestamp,
+						p.occurred_at,
+						p.first_observed_line,
+						p.event_id
+					),
 					p.model_status = 'resolved' AND p.resolved_model != ''
-				) AS single_resolved_model
+				) AS latest_resolved_model
 			FROM priced_usage_events AS p
 			GROUP BY p.organization_id, p.user_id, p.source, p.session_id
 		),
@@ -343,12 +357,7 @@ export function buildUsageEventAnalyticsCte(
 		usage_analytics_sessions AS (
 			SELECT
 				${SESSION_METADATA_COLUMNS},
-				if(
-					lowerUTF8(trimBoth(sa.model_used)) IN ('', 'unknown', '<synthetic>')
-						AND ifNull(r.resolved_model_count, 0) = 1,
-					r.single_resolved_model,
-					sa.model_used
-				) AS model_used,
+				if(r.latest_main_model != '', r.latest_main_model, r.latest_resolved_model) AS model_used,
 				ifNull(r.input_tokens, 0) AS input_tokens,
 				ifNull(r.output_tokens, 0) AS output_tokens,
 				ifNull(r.cache_read_input_tokens, 0) AS cache_read_input_tokens,
@@ -371,12 +380,7 @@ export function buildUsageEventAnalyticsCte(
 		usage_analytics_daily_sessions AS (
 			SELECT
 				${SESSION_METADATA_COLUMNS},
-				if(
-					lowerUTF8(trimBoth(sa.model_used)) IN ('', 'unknown', '<synthetic>')
-						AND ifNull(s.resolved_model_count, 0) = 1,
-					s.single_resolved_model,
-					sa.model_used
-				) AS model_used,
+				if(s.latest_main_model != '', s.latest_main_model, s.latest_resolved_model) AS model_used,
 				r.usage_date AS usage_date,
 				r.input_tokens AS input_tokens,
 				r.output_tokens AS output_tokens,

--- a/apps/api/src/services/usage-event-analytics.service.ts
+++ b/apps/api/src/services/usage-event-analytics.service.ts
@@ -377,14 +377,14 @@ export function buildUsageEventAnalyticsCte(
 					s.single_resolved_model,
 					sa.model_used
 				) AS model_used,
-				r.usage_date,
-				r.input_tokens,
-				r.output_tokens,
-				r.cache_read_input_tokens,
-				r.cache_creation_input_tokens,
-				r.total_tokens,
-				r.estimated_cost,
-				r.cost_is_complete
+				r.usage_date AS usage_date,
+				r.input_tokens AS input_tokens,
+				r.output_tokens AS output_tokens,
+				r.cache_read_input_tokens AS cache_read_input_tokens,
+				r.cache_creation_input_tokens AS cache_creation_input_tokens,
+				r.total_tokens AS total_tokens,
+				r.estimated_cost AS estimated_cost,
+				r.cost_is_complete AS cost_is_complete
 			FROM usage_event_daily_rollups AS r
 			ANY INNER JOIN usage_analytics_metadata AS sa
 				ON sa.organization_id = r.organization_id


### PR DESCRIPTION
## Summary
- derive the session display model only from resolved usage events, preferring the latest main-agent event and falling back to the latest resolved event
- never fall back to the legacy session label, so terminal zero-token bookkeeping records cannot expose `<synthetic>` or `unknown`
- leave synthetic-only zero-token sessions unlabeled instead of inventing a model; request-level pricing remains unchanged
- preserve explicit aliases in daily rollups and add real ClickHouse fixtures for terminal-synthetic, synthetic-only, and mixed-model sessions

## Production evidence
- bounded read-only census found 209 synthetic usage records across 113 sessions; all had zero tokens
- all 1,493 positive-token Claude/Codex sessions in the owner organization had a resolved main-event model
- all 30 positive-token sessions with an invalid legacy label recover an exact model through this event-only rule

## Test plan
- [x] focused service suite: 50/50
- [x] API suite: 298/298
- [x] API TypeScript check
- [x] Biome check on changed files
- [x] `bun run verify`
- [x] GitHub disposable-ClickHouse integration job

No schema migration, pricing change, or production write is included in this PR.