### PR TITLE
perf(analytics): reduce usage event query passes

### DIFF
--- a/apps/api/src/__tests__/usage-event-analytics.integration.ts
+++ b/apps/api/src/__tests__/usage-event-analytics.integration.ts
@@ -39,6 +39,8 @@ const invalidTimestampSessionId = `usage_analytics_invalid_timestamp_${runId}`;
 const deletedReceiptSessionId = `usage_analytics_deleted_receipt_${runId}`;
 const tombstonedSessionId = `usage_analytics_tombstone_${runId}`;
 const missingMetadataSessionId = `usage_analytics_missing_metadata_${runId}`;
+const unknownMixedModelSessionId = `usage_analytics_unknown_mixed_${runId}`;
+const unknownSingleModelSessionId = `usage_analytics_unknown_single_${runId}`;
 const eventId = "a".repeat(64);
 const receiptId = "b".repeat(64);
 const executor = createClickHouseExecutor({
@@ -72,6 +74,16 @@ beforeAll(async () => {
 				...buildSessionAnalyticsRow(resolvedSessionId),
 				organization_id: isolatedOrganizationId,
 				user_id: isolatedUserId,
+			},
+			{
+				...buildSessionAnalyticsRow(unknownMixedModelSessionId),
+				model_used: "unknown",
+				source: "codex",
+			},
+			{
+				...buildSessionAnalyticsRow(unknownSingleModelSessionId),
+				model_used: "unknown",
+				source: "codex",
 			},
 		],
 		{ validate: true },
@@ -182,6 +194,23 @@ beforeAll(async () => {
 			buildReceiptRow(tombstonedSessionId, "2", 0, true),
 			buildEventRow(missingMetadataSessionId, "1"),
 			buildReceiptRow(missingMetadataSessionId, "1", 1, true),
+			buildCodexDisplayEvent(
+				unknownMixedModelSessionId,
+				eventId,
+				"gpt-5.6-sol",
+			),
+			buildCodexDisplayEvent(
+				unknownMixedModelSessionId,
+				"f".repeat(64),
+				"gpt-5.6-terra",
+			),
+			buildReceiptRow(unknownMixedModelSessionId, "1", 2, true, "codex"),
+			buildCodexDisplayEvent(
+				unknownSingleModelSessionId,
+				eventId,
+				"gpt-5.6-sol",
+			),
+			buildReceiptRow(unknownSingleModelSessionId, "1", 1, true, "codex"),
 			{
 				...buildEventRow(resolvedSessionId, "1"),
 				organization_id: isolatedOrganizationId,
@@ -291,6 +320,24 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				total_tokens: "5000000",
 			},
 			{
+				cost_is_complete: 1,
+				estimated_cost: 4.97,
+				input_tokens: "400000",
+				model_used: "unknown",
+				output_tokens: "200000",
+				session_id: unknownMixedModelSessionId,
+				total_tokens: "600000",
+			},
+			{
+				cost_is_complete: 1,
+				estimated_cost: 3.55,
+				input_tokens: "200000",
+				model_used: "gpt-5.6-sol",
+				output_tokens: "100000",
+				session_id: unknownSingleModelSessionId,
+				total_tokens: "300000",
+			},
+			{
 				cost_is_complete: 0,
 				estimated_cost: 0,
 				input_tokens: "4000000",
@@ -338,7 +385,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 			query_params: { orgId: organizationId },
 		});
 
-		expect(rows).toEqual([{ cost: 292.3, incomplete_sessions: 5 }]);
+		expect(rows).toEqual([{ cost: 300.82, incomplete_sessions: 5 }]);
 	});
 
 	test("keeps bounded key prefixes visible across the shared query families", async () => {
@@ -550,4 +597,25 @@ function buildReceiptRow(
 			uncached_input_tokens: "0",
 		}),
 	};
+}
+
+function buildCodexDisplayEvent(
+	sessionId: string,
+	rowEventId: string,
+	model: string,
+): RudelUsageEventsRow {
+	return buildEventRow(sessionId, "1", {
+		cache_read_input_tokens: "100000",
+		cache_write_1h_input_tokens: "0",
+		cache_write_5m_input_tokens: "0",
+		context_input_tokens: "200000",
+		event_id: rowEventId,
+		model_provider: "openai",
+		output_tokens: "100000",
+		raw_model: model,
+		resolved_model: model,
+		service_tier: "auto",
+		source: "codex",
+		uncached_input_tokens: "100000",
+	});
 }

--- a/apps/api/src/__tests__/usage-event-analytics.integration.ts
+++ b/apps/api/src/__tests__/usage-event-analytics.integration.ts
@@ -39,6 +39,8 @@ const invalidTimestampSessionId = `usage_analytics_invalid_timestamp_${runId}`;
 const deletedReceiptSessionId = `usage_analytics_deleted_receipt_${runId}`;
 const tombstonedSessionId = `usage_analytics_tombstone_${runId}`;
 const missingMetadataSessionId = `usage_analytics_missing_metadata_${runId}`;
+const syntheticTerminalSessionId = `usage_analytics_synthetic_terminal_${runId}`;
+const syntheticZeroSessionId = `usage_analytics_synthetic_zero_${runId}`;
 const unknownMixedModelSessionId = `usage_analytics_unknown_mixed_${runId}`;
 const unknownSingleModelSessionId = `usage_analytics_unknown_single_${runId}`;
 const eventId = "a".repeat(64);
@@ -84,6 +86,14 @@ beforeAll(async () => {
 				...buildSessionAnalyticsRow(unknownSingleModelSessionId),
 				model_used: "unknown",
 				source: "codex",
+			},
+			{
+				...buildSessionAnalyticsRow(syntheticTerminalSessionId),
+				model_used: "<synthetic>",
+			},
+			{
+				...buildSessionAnalyticsRow(syntheticZeroSessionId),
+				model_used: "<synthetic>",
 			},
 		],
 		{ validate: true },
@@ -194,15 +204,40 @@ beforeAll(async () => {
 			buildReceiptRow(tombstonedSessionId, "2", 0, true),
 			buildEventRow(missingMetadataSessionId, "1"),
 			buildReceiptRow(missingMetadataSessionId, "1", 1, true),
+			buildEventRow(syntheticTerminalSessionId, "1", {
+				event_id: "1".repeat(64),
+				first_observed_line: 10,
+				occurred_at: "2026-08-04 08:00:00.000",
+			}),
+			buildEventRow(syntheticTerminalSessionId, "1", {
+				agent_id: "worker",
+				event_id: "2".repeat(64),
+				first_observed_line: 20,
+				occurred_at: "2026-08-04 08:01:00.000",
+				raw_model: "claude-haiku-4-5",
+				resolved_model: "claude-haiku-4-5-20251001",
+			}),
+			buildSyntheticZeroEvent(syntheticTerminalSessionId, "3".repeat(64)),
+			buildReceiptRow(syntheticTerminalSessionId, "1", 3, true),
+			buildSyntheticZeroEvent(syntheticZeroSessionId, "4".repeat(64)),
+			buildReceiptRow(syntheticZeroSessionId, "1", 1, true),
 			buildCodexDisplayEvent(
 				unknownMixedModelSessionId,
 				eventId,
 				"gpt-5.6-sol",
+				{
+					first_observed_line: 10,
+					occurred_at: "2026-08-04 08:00:00.000",
+				},
 			),
 			buildCodexDisplayEvent(
 				unknownMixedModelSessionId,
 				"f".repeat(64),
 				"gpt-5.6-terra",
+				{
+					first_observed_line: 20,
+					occurred_at: "2026-08-04 08:01:00.000",
+				},
 			),
 			buildReceiptRow(unknownMixedModelSessionId, "1", 2, true, "codex"),
 			buildCodexDisplayEvent(
@@ -251,7 +286,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 1,
 				estimated_cost: 102.85,
 				input_tokens: "4000000",
-				model_used: "claude-opus-4-1",
+				model_used: "claude-opus-4-8",
 				output_tokens: "1000000",
 				session_id: claudeFastUsSessionId,
 				total_tokens: "5000000",
@@ -260,7 +295,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 0,
 				estimated_cost: 0,
 				input_tokens: "4000000",
-				model_used: "claude-opus-4-1",
+				model_used: "claude-sonnet-4-5",
 				output_tokens: "1000000",
 				session_id: invalidTimestampSessionId,
 				total_tokens: "5000000",
@@ -269,7 +304,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 1,
 				estimated_cost: 55,
 				input_tokens: "1000000",
-				model_used: "claude-opus-4-1",
+				model_used: "gpt-5.6-sol",
 				output_tokens: "1000000",
 				session_id: longContextSessionId,
 				total_tokens: "2000000",
@@ -278,7 +313,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 1,
 				estimated_cost: 3.55,
 				input_tokens: "200000",
-				model_used: "claude-opus-4-1",
+				model_used: "gpt-5.4",
 				output_tokens: "100000",
 				session_id: openAiFastSessionId,
 				total_tokens: "300000",
@@ -287,7 +322,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 0,
 				estimated_cost: 28.05,
 				input_tokens: "8000000",
-				model_used: "claude-opus-4-1",
+				model_used: "claude-sonnet-4-5",
 				output_tokens: "2000000",
 				session_id: partialSessionId,
 				total_tokens: "10000000",
@@ -296,16 +331,34 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 1,
 				estimated_cost: 56.1,
 				input_tokens: "8000000",
-				model_used: "claude-opus-4-1",
+				model_used: "claude-sonnet-4-5",
 				output_tokens: "2000000",
 				session_id: resolvedSessionId,
 				total_tokens: "10000000",
 			},
 			{
 				cost_is_complete: 1,
+				estimated_cost: 37.4,
+				input_tokens: "8000000",
+				model_used: "claude-sonnet-4-5",
+				output_tokens: "2000000",
+				session_id: syntheticTerminalSessionId,
+				total_tokens: "10000000",
+			},
+			{
+				cost_is_complete: 1,
 				estimated_cost: 0,
 				input_tokens: "0",
-				model_used: "claude-opus-4-1",
+				model_used: "",
+				output_tokens: "0",
+				session_id: syntheticZeroSessionId,
+				total_tokens: "0",
+			},
+			{
+				cost_is_complete: 1,
+				estimated_cost: 0,
+				input_tokens: "0",
+				model_used: "",
 				output_tokens: "0",
 				session_id: tombstonedSessionId,
 				total_tokens: "0",
@@ -314,7 +367,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 0,
 				estimated_cost: 46.75,
 				input_tokens: "4000000",
-				model_used: "claude-opus-4-1",
+				model_used: "claude-opus-4-8",
 				output_tokens: "1000000",
 				session_id: unavailableGeoSessionId,
 				total_tokens: "5000000",
@@ -323,7 +376,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 1,
 				estimated_cost: 4.97,
 				input_tokens: "400000",
-				model_used: "unknown",
+				model_used: "gpt-5.6-terra",
 				output_tokens: "200000",
 				session_id: unknownMixedModelSessionId,
 				total_tokens: "600000",
@@ -341,7 +394,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 0,
 				estimated_cost: 0,
 				input_tokens: "4000000",
-				model_used: "claude-opus-4-1",
+				model_used: "",
 				output_tokens: "1000000",
 				session_id: unresolvedSessionId,
 				total_tokens: "5000000",
@@ -350,12 +403,18 @@ describe("usage-event analytics ClickHouse rollups", () => {
 				cost_is_complete: 0,
 				estimated_cost: 0,
 				input_tokens: "4000000",
-				model_used: "claude-opus-4-1",
+				model_used: "claude-sonnet-4-5",
 				output_tokens: "1000000",
 				session_id: unsupportedTierSessionId,
 				total_tokens: "5000000",
 			},
 		]);
+		expect(
+			rows.every(
+				(row) =>
+					row.model_used !== "unknown" && row.model_used !== "<synthetic>",
+			),
+		).toBe(true);
 		expect(
 			rows.some((row) => row.session_id === missingMetadataSessionId),
 		).toBe(false);
@@ -385,7 +444,7 @@ describe("usage-event analytics ClickHouse rollups", () => {
 			query_params: { orgId: organizationId },
 		});
 
-		expect(rows).toEqual([{ cost: 300.82, incomplete_sessions: 5 }]);
+		expect(rows).toEqual([{ cost: 338.22, incomplete_sessions: 5 }]);
 	});
 
 	test("keeps bounded key prefixes visible across the shared query families", async () => {
@@ -603,6 +662,7 @@ function buildCodexDisplayEvent(
 	sessionId: string,
 	rowEventId: string,
 	model: string,
+	overrides: Partial<RudelUsageEventsRow> = {},
 ): RudelUsageEventsRow {
 	return buildEventRow(sessionId, "1", {
 		cache_read_input_tokens: "100000",
@@ -617,5 +677,27 @@ function buildCodexDisplayEvent(
 		service_tier: "auto",
 		source: "codex",
 		uncached_input_tokens: "100000",
+		...overrides,
+	});
+}
+
+function buildSyntheticZeroEvent(
+	sessionId: string,
+	rowEventId: string,
+): RudelUsageEventsRow {
+	return buildEventRow(sessionId, "1", {
+		cache_read_input_tokens: "0",
+		cache_write_1h_input_tokens: "0",
+		cache_write_5m_input_tokens: "0",
+		context_input_tokens: "0",
+		event_id: rowEventId,
+		first_observed_line: 30,
+		model_status: "synthetic",
+		occurred_at: "2026-08-04 08:02:00.000",
+		output_tokens: "0",
+		quality_flags: ["synthetic_model"],
+		raw_model: "",
+		resolved_model: "",
+		uncached_input_tokens: "0",
 	});
 }

--- a/apps/api/src/scripts/benchmark-usage-event-analytics.ts
+++ b/apps/api/src/scripts/benchmark-usage-event-analytics.ts
@@ -9,6 +9,8 @@ const DAY_WINDOWS = [7, 30, 365] as const;
 const DEFAULT_ITERATIONS = 10;
 const DEFAULT_WARMUPS = 1;
 const MAX_PEAK_MEMORY_BYTES = 512 * 1024 * 1024;
+const MAX_ROWS_TO_READ = 10_000_000;
+const MAX_EXECUTION_TIME_SECONDS = 30;
 const QUERY_LOG_WAIT_ATTEMPTS = 10;
 const QUERY_LOG_WAIT_MS = 1_000;
 
@@ -154,10 +156,14 @@ async function runRollup(
 			: buildLegacyUsageAnalyticsCte();
 
 	await executor.query({
-		clickhouse_settings:
-			logComment === undefined
+		clickhouse_settings: {
+			...(logComment === undefined
 				? { log_queries: 0 }
-				: { log_comment: logComment, log_queries: 1 },
+				: { log_comment: logComment, log_queries: 1 }),
+			max_execution_time: MAX_EXECUTION_TIME_SECONDS,
+			max_rows_to_read: String(MAX_ROWS_TO_READ),
+			timeout_before_checking_execution_speed: 0,
+		},
 		query: `
 			WITH ${cte}
 			SELECT
@@ -177,13 +183,18 @@ async function waitForQueryLogRows(
 ): Promise<QueryLogRow[]> {
 	for (let attempt = 0; attempt < QUERY_LOG_WAIT_ATTEMPTS; attempt += 1) {
 		const rows = await executor.query<QueryLogRow>({
+			clickhouse_settings: {
+				max_execution_time: 10,
+				max_rows_to_read: "100000",
+			},
 			query: `
 				SELECT log_comment, memory_usage
 				FROM system.query_log
 				WHERE type = 'QueryFinish'
 					AND startsWith(log_comment, {runPrefix:String})
+				LIMIT {expectedRows:UInt32}
 			`,
-			query_params: { runPrefix },
+			query_params: { expectedRows, runPrefix },
 		});
 		if (rows.length >= expectedRows) return rows;
 		await Bun.sleep(QUERY_LOG_WAIT_MS);

--- a/apps/api/src/services/usage-event-analytics.service.test.ts
+++ b/apps/api/src/services/usage-event-analytics.service.test.ts
@@ -64,6 +64,16 @@ describe("usage-event analytics query contract", () => {
 		expect(sql).not.toMatch(/match\(lowerUTF8\(sa\.model_used\)/u);
 	});
 
+	test("repairs an unknown display label only for one unanimous event model", () => {
+		const sql = buildUsageEventAnalyticsCte();
+
+		expect(sql).toContain("uniqExactIf(");
+		expect(sql).toContain("AS resolved_model_count");
+		expect(sql).toContain("AS single_resolved_model");
+		expect(sql).toContain("ifNull(r.resolved_model_count, 0) = 1");
+		expect(sql).toContain("ifNull(s.resolved_model_count, 0) = 1");
+	});
+
 	test("prices exact provenance and fails closed for unsupported dimensions", () => {
 		const sql = buildUsageEventAnalyticsCte();
 

--- a/apps/api/src/services/usage-event-analytics.service.test.ts
+++ b/apps/api/src/services/usage-event-analytics.service.test.ts
@@ -8,21 +8,19 @@ import {
 } from "./usage-event-analytics.service.js";
 
 describe("usage-event analytics query contract", () => {
-	test("resolves explicit latest state and admits only consistent complete receipts", () => {
+	test("resolves exact latest state and admits only consistent complete receipts", () => {
 		const sql = buildUsageEventAnalyticsCte();
 
+		expect(sql).toContain("FROM rudel.usage_events FINAL");
+		expect(sql.match(/FROM rudel\.usage_events/gu)).toHaveLength(1);
 		expect(sql).toContain(
-			"LIMIT 1 BY organization_id, user_id, source, session_id, event_id",
+			"argMaxIf(event_version, event_version, record_kind = 'receipt') OVER usage_session_window AS receipt_generation",
 		);
-		expect(sql).not.toContain("usage_events FINAL");
-		expect(sql).toContain(
-			"LIMIT 1 BY organization_id, user_id, source, session_id",
-		);
-		expect(sql).toContain("FROM latest_usage_receipts");
-		expect(sql).toContain("is_deleted = 0 AND receipt_is_complete = 1");
-		expect(sql).toContain("= r.receipt_event_count");
-		expect(sql).toContain("e.event_version = c.generation");
-		expect(sql).toContain("ANY INNER JOIN consistent_usage_sessions AS c");
+		expect(sql).toContain("latest_receipt_is_complete = 1");
+		expect(sql).toContain("active_event_count = latest_receipt_event_count");
+		expect(sql).toContain("event_version = receipt_generation");
+		expect(sql).toContain("record_kind IN ('event', 'receipt')");
+		expect(sql).toContain("ANY INNER JOIN usage_event_session_rollups AS r");
 		expect(sql).toContain("sa.organization_id AS organization_id");
 		expect(sql).toContain("sa.user_id AS user_id");
 	});
@@ -39,7 +37,7 @@ describe("usage-event analytics query contract", () => {
 		expect(sql).toContain("source = {source:String}");
 		expect(sql).toContain("session_id = {sessionId:String}");
 		expect(sql.indexOf("WHERE organization_id = {orgId:String}")).toBeLessThan(
-			sql.indexOf("ANY INNER JOIN consistent_usage_sessions"),
+			sql.indexOf("ANY INNER JOIN usage_event_session_rollups"),
 		);
 	});
 
@@ -68,15 +66,14 @@ describe("usage-event analytics query contract", () => {
 		const sql = buildUsageEventAnalyticsCte();
 
 		expect(sql).toContain("argMaxIf(");
-		expect(sql).toContain("p.agent_id = 'main'");
+		expect(sql).toContain("agent_id = 'main'");
 		expect(sql).toContain("AS latest_main_model");
 		expect(sql).toContain("AS latest_resolved_model");
-		expect(sql).toContain(
-			"if(r.latest_main_model != '', r.latest_main_model, r.latest_resolved_model) AS model_used",
-		);
-		expect(sql).toContain(
-			"if(s.latest_main_model != '', s.latest_main_model, s.latest_resolved_model) AS model_used",
-		);
+		expect(
+			sql.match(
+				/if\(r\.latest_main_model != '', r\.latest_main_model, r\.latest_resolved_model\) AS model_used/gu,
+			),
+		).toHaveLength(2);
 		expect(sql).not.toContain("resolved_model_count");
 		expect(sql).not.toContain("single_resolved_model");
 		expect(sql).not.toContain("lowerUTF8(trimBoth(sa.model_used))");

--- a/apps/api/src/services/usage-event-analytics.service.test.ts
+++ b/apps/api/src/services/usage-event-analytics.service.test.ts
@@ -64,14 +64,22 @@ describe("usage-event analytics query contract", () => {
 		expect(sql).not.toMatch(/match\(lowerUTF8\(sa\.model_used\)/u);
 	});
 
-	test("repairs an unknown display label only for one unanimous event model", () => {
+	test("uses the latest resolved main event as display metadata", () => {
 		const sql = buildUsageEventAnalyticsCte();
 
-		expect(sql).toContain("uniqExactIf(");
-		expect(sql).toContain("AS resolved_model_count");
-		expect(sql).toContain("AS single_resolved_model");
-		expect(sql).toContain("ifNull(r.resolved_model_count, 0) = 1");
-		expect(sql).toContain("ifNull(s.resolved_model_count, 0) = 1");
+		expect(sql).toContain("argMaxIf(");
+		expect(sql).toContain("p.agent_id = 'main'");
+		expect(sql).toContain("AS latest_main_model");
+		expect(sql).toContain("AS latest_resolved_model");
+		expect(sql).toContain(
+			"if(r.latest_main_model != '', r.latest_main_model, r.latest_resolved_model) AS model_used",
+		);
+		expect(sql).toContain(
+			"if(s.latest_main_model != '', s.latest_main_model, s.latest_resolved_model) AS model_used",
+		);
+		expect(sql).not.toContain("resolved_model_count");
+		expect(sql).not.toContain("single_resolved_model");
+		expect(sql).not.toContain("lowerUTF8(trimBoth(sa.model_used))");
 	});
 
 	test("prices exact provenance and fails closed for unsupported dimensions", () => {

--- a/apps/api/src/services/usage-event-analytics.service.ts
+++ b/apps/api/src/services/usage-event-analytics.service.ts
@@ -81,7 +81,6 @@ const SESSION_METADATA_COLUMNS = `
 	sa.long_pauses AS long_pauses,
 	sa.error_count AS error_count,
 	sa.error_pattern AS error_pattern,
-	sa.model_used AS model_used,
 	sa.has_commit AS has_commit,
 	sa.session_archetype AS session_archetype,
 	sa.success_score AS success_score,
@@ -304,7 +303,15 @@ export function buildUsageEventAnalyticsCte(
 				toUInt8(countIf(
 					isNull(p.estimated_cost)
 					OR has(p.quality_flags, 'inference_geo_not_available')
-				) = 0) AS cost_is_complete
+				) = 0) AS cost_is_complete,
+				uniqExactIf(
+					p.resolved_model,
+					p.model_status = 'resolved' AND p.resolved_model != ''
+				) AS resolved_model_count,
+				anyIf(
+					p.resolved_model,
+					p.model_status = 'resolved' AND p.resolved_model != ''
+				) AS single_resolved_model
 			FROM priced_usage_events AS p
 			GROUP BY p.organization_id, p.user_id, p.source, p.session_id
 		),
@@ -336,6 +343,12 @@ export function buildUsageEventAnalyticsCte(
 		usage_analytics_sessions AS (
 			SELECT
 				${SESSION_METADATA_COLUMNS},
+				if(
+					lowerUTF8(trimBoth(sa.model_used)) IN ('', 'unknown', '<synthetic>')
+						AND ifNull(r.resolved_model_count, 0) = 1,
+					r.single_resolved_model,
+					sa.model_used
+				) AS model_used,
 				ifNull(r.input_tokens, 0) AS input_tokens,
 				ifNull(r.output_tokens, 0) AS output_tokens,
 				ifNull(r.cache_read_input_tokens, 0) AS cache_read_input_tokens,
@@ -358,6 +371,12 @@ export function buildUsageEventAnalyticsCte(
 		usage_analytics_daily_sessions AS (
 			SELECT
 				${SESSION_METADATA_COLUMNS},
+				if(
+					lowerUTF8(trimBoth(sa.model_used)) IN ('', 'unknown', '<synthetic>')
+						AND ifNull(s.resolved_model_count, 0) = 1,
+					s.single_resolved_model,
+					sa.model_used
+				) AS model_used,
 				r.usage_date,
 				r.input_tokens,
 				r.output_tokens,
@@ -372,6 +391,11 @@ export function buildUsageEventAnalyticsCte(
 				AND sa.user_id = r.user_id
 				AND sa.source = r.source
 				AND sa.session_id = r.session_id
+			LEFT ANY JOIN usage_event_session_rollups AS s
+				ON s.organization_id = r.organization_id
+				AND s.user_id = r.user_id
+				AND s.source = r.source
+				AND s.session_id = r.session_id
 		)
 	`;
 }

--- a/apps/api/src/services/usage-event-analytics.service.ts
+++ b/apps/api/src/services/usage-event-analytics.service.ts
@@ -304,14 +304,28 @@ export function buildUsageEventAnalyticsCte(
 					isNull(p.estimated_cost)
 					OR has(p.quality_flags, 'inference_geo_not_available')
 				) = 0) AS cost_is_complete,
-				uniqExactIf(
+				argMaxIf(
 					p.resolved_model,
-					p.model_status = 'resolved' AND p.resolved_model != ''
-				) AS resolved_model_count,
-				anyIf(
+					tuple(
+						p.has_valid_timestamp,
+						p.occurred_at,
+						p.first_observed_line,
+						p.event_id
+					),
+					p.agent_id = 'main'
+						AND p.model_status = 'resolved'
+						AND p.resolved_model != ''
+				) AS latest_main_model,
+				argMaxIf(
 					p.resolved_model,
+					tuple(
+						p.has_valid_timestamp,
+						p.occurred_at,
+						p.first_observed_line,
+						p.event_id
+					),
 					p.model_status = 'resolved' AND p.resolved_model != ''
-				) AS single_resolved_model
+				) AS latest_resolved_model
 			FROM priced_usage_events AS p
 			GROUP BY p.organization_id, p.user_id, p.source, p.session_id
 		),
@@ -343,12 +357,7 @@ export function buildUsageEventAnalyticsCte(
 		usage_analytics_sessions AS (
 			SELECT
 				${SESSION_METADATA_COLUMNS},
-				if(
-					lowerUTF8(trimBoth(sa.model_used)) IN ('', 'unknown', '<synthetic>')
-						AND ifNull(r.resolved_model_count, 0) = 1,
-					r.single_resolved_model,
-					sa.model_used
-				) AS model_used,
+				if(r.latest_main_model != '', r.latest_main_model, r.latest_resolved_model) AS model_used,
 				ifNull(r.input_tokens, 0) AS input_tokens,
 				ifNull(r.output_tokens, 0) AS output_tokens,
 				ifNull(r.cache_read_input_tokens, 0) AS cache_read_input_tokens,
@@ -371,12 +380,7 @@ export function buildUsageEventAnalyticsCte(
 		usage_analytics_daily_sessions AS (
 			SELECT
 				${SESSION_METADATA_COLUMNS},
-				if(
-					lowerUTF8(trimBoth(sa.model_used)) IN ('', 'unknown', '<synthetic>')
-						AND ifNull(s.resolved_model_count, 0) = 1,
-					s.single_resolved_model,
-					sa.model_used
-				) AS model_used,
+				if(s.latest_main_model != '', s.latest_main_model, s.latest_resolved_model) AS model_used,
 				r.usage_date AS usage_date,
 				r.input_tokens AS input_tokens,
 				r.output_tokens AS output_tokens,

--- a/apps/api/src/services/usage-event-analytics.service.ts
+++ b/apps/api/src/services/usage-event-analytics.service.ts
@@ -193,88 +193,51 @@ export function buildUsageEventAnalyticsCte(
 	scope: UsageAnalyticsScope = {},
 ): string {
 	const usageEventFilters = buildUsageEventFilters(scope);
+	// The organization/key filters follow the table's primary-key prefix, so FINAL
+	// resolves exact ReplacingMergeTree state without scanning unrelated tenants.
+	// Keep this pipeline single-pass: ClickHouse inlines repeated CTE references.
 	return `
 		latest_usage_records AS (
 			SELECT *
-			FROM (
-				SELECT *
-				FROM ${getSafeClickHouseTable(USAGE_EVENTS_TABLE)}
-				WHERE ${usageEventFilters}
-				ORDER BY
-					organization_id,
-					user_id,
-					source,
-					session_id,
-					event_id,
-					event_version DESC
-				LIMIT 1 BY organization_id, user_id, source, session_id, event_id
+			FROM ${getSafeClickHouseTable(USAGE_EVENTS_TABLE)} FINAL
+			WHERE ${usageEventFilters}
+		),
+		usage_records_with_receipt AS (
+			SELECT
+				*,
+				argMaxIf(event_version, event_version, record_kind = 'receipt') OVER usage_session_window AS receipt_generation,
+				argMaxIf(receipt_event_count, event_version, record_kind = 'receipt') OVER usage_session_window AS latest_receipt_event_count,
+				argMaxIf(receipt_is_complete, event_version, record_kind = 'receipt') OVER usage_session_window AS latest_receipt_is_complete,
+				argMaxIf(is_deleted, event_version, record_kind = 'receipt') OVER usage_session_window AS latest_receipt_is_deleted
+			FROM latest_usage_records
+			WINDOW usage_session_window AS (
+				PARTITION BY organization_id, user_id, source, session_id
 			)
 		),
-		latest_usage_receipts AS (
+		usage_records_with_consistency AS (
+			SELECT
+				*,
+				countIf(
+					record_kind = 'event'
+					AND is_deleted = 0
+					AND event_version = receipt_generation
+				) OVER usage_session_window AS active_event_count
+			FROM usage_records_with_receipt
+			WINDOW usage_session_window AS (
+				PARTITION BY organization_id, user_id, source, session_id
+			)
+		),
+		consistent_usage_records AS (
 			SELECT *
-			FROM (
-				SELECT *
-				FROM latest_usage_records
-				WHERE record_kind = 'receipt'
-				ORDER BY
-					organization_id,
-					user_id,
-					source,
-					session_id,
-					event_version DESC
-				LIMIT 1 BY organization_id, user_id, source, session_id
-			)
+			FROM usage_records_with_consistency
+			WHERE latest_receipt_is_deleted = 0
+				AND latest_receipt_is_complete = 1
+				AND active_event_count = latest_receipt_event_count
+				AND event_version = receipt_generation
+				AND is_deleted = 0
+				AND record_kind IN ('event', 'receipt')
 		),
-		complete_usage_receipts AS (
-			SELECT
-				organization_id,
-				user_id,
-				source,
-				session_id,
-				event_version AS generation,
-				receipt_event_count
-			FROM latest_usage_receipts
-			WHERE is_deleted = 0 AND receipt_is_complete = 1
-		),
-		consistent_usage_sessions AS (
-			SELECT
-				r.organization_id,
-				r.user_id,
-				r.source,
-				r.session_id,
-				r.generation,
-				r.receipt_event_count
-			FROM complete_usage_receipts AS r
-			LEFT JOIN latest_usage_records AS e
-				ON e.organization_id = r.organization_id
-				AND e.user_id = r.user_id
-				AND e.source = r.source
-				AND e.session_id = r.session_id
-			GROUP BY
-				r.organization_id,
-				r.user_id,
-				r.source,
-				r.session_id,
-				r.generation,
-				r.receipt_event_count
-			HAVING countIf(
-				e.record_kind = 'event'
-				AND e.is_deleted = 0
-				AND e.event_version = r.generation
-			) = r.receipt_event_count
-		),
-		active_usage_events AS (
-			SELECT e.*
-			FROM latest_usage_records AS e
-			INNER JOIN consistent_usage_sessions AS c
-				ON e.organization_id = c.organization_id
-				AND e.user_id = c.user_id
-				AND e.source = c.source
-				AND e.session_id = c.session_id
-				AND e.event_version = c.generation
-			WHERE e.record_kind = 'event' AND e.is_deleted = 0
-		),
-		priced_usage_events AS (
+		priced_usage_records AS (
 			SELECT
 				e.*,
 				if(
@@ -286,7 +249,30 @@ export function buildUsageEventAnalyticsCte(
 					toNullable(0.0),
 					if(${PRICEABLE_EVENT_SQL}, ${EVENT_COST_SQL}, CAST(NULL, 'Nullable(Float64)'))
 				) AS estimated_cost
-			FROM active_usage_events AS e
+			FROM consistent_usage_records AS e
+		),
+		usage_records_with_display_model AS (
+			SELECT
+				*,
+				argMaxIf(
+					resolved_model,
+					tuple(has_valid_timestamp, occurred_at, first_observed_line, event_id),
+					record_kind = 'event'
+						AND agent_id = 'main'
+						AND model_status = 'resolved'
+						AND resolved_model != ''
+				) OVER usage_session_window AS latest_main_model,
+				argMaxIf(
+					resolved_model,
+					tuple(has_valid_timestamp, occurred_at, first_observed_line, event_id),
+					record_kind = 'event'
+						AND model_status = 'resolved'
+						AND resolved_model != ''
+				) OVER usage_session_window AS latest_resolved_model
+			FROM priced_usage_records
+			WINDOW usage_session_window AS (
+				PARTITION BY organization_id, user_id, source, session_id
+			)
 		),
 		usage_event_session_rollups AS (
 			SELECT
@@ -301,32 +287,15 @@ export function buildUsageEventAnalyticsCte(
 				sum(p.uncached_input_tokens + p.cache_read_input_tokens + p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens + p.output_tokens) AS total_tokens,
 				toNullable(sum(ifNull(p.estimated_cost, 0))) AS estimated_cost,
 				toUInt8(countIf(
-					isNull(p.estimated_cost)
-					OR has(p.quality_flags, 'inference_geo_not_available')
+					p.record_kind = 'event'
+					AND (
+						isNull(p.estimated_cost)
+						OR has(p.quality_flags, 'inference_geo_not_available')
+					)
 				) = 0) AS cost_is_complete,
-				argMaxIf(
-					p.resolved_model,
-					tuple(
-						p.has_valid_timestamp,
-						p.occurred_at,
-						p.first_observed_line,
-						p.event_id
-					),
-					p.agent_id = 'main'
-						AND p.model_status = 'resolved'
-						AND p.resolved_model != ''
-				) AS latest_main_model,
-				argMaxIf(
-					p.resolved_model,
-					tuple(
-						p.has_valid_timestamp,
-						p.occurred_at,
-						p.first_observed_line,
-						p.event_id
-					),
-					p.model_status = 'resolved' AND p.resolved_model != ''
-				) AS latest_resolved_model
-			FROM priced_usage_events AS p
+				any(p.latest_main_model) AS latest_main_model,
+				any(p.latest_resolved_model) AS latest_resolved_model
+			FROM usage_records_with_display_model AS p
 			GROUP BY p.organization_id, p.user_id, p.source, p.session_id
 		),
 		usage_event_daily_rollups AS (
@@ -345,8 +314,11 @@ export function buildUsageEventAnalyticsCte(
 				toUInt8(countIf(
 					isNull(p.estimated_cost)
 					OR has(p.quality_flags, 'inference_geo_not_available')
-				) = 0) AS cost_is_complete
-			FROM priced_usage_events AS p
+				) = 0) AS cost_is_complete,
+				any(p.latest_main_model) AS latest_main_model,
+				any(p.latest_resolved_model) AS latest_resolved_model
+			FROM usage_records_with_display_model AS p
+			WHERE p.record_kind = 'event'
 			GROUP BY p.organization_id, p.user_id, p.source, p.session_id, p.usage_date
 		),
 		usage_analytics_metadata AS (
@@ -358,20 +330,15 @@ export function buildUsageEventAnalyticsCte(
 			SELECT
 				${SESSION_METADATA_COLUMNS},
 				if(r.latest_main_model != '', r.latest_main_model, r.latest_resolved_model) AS model_used,
-				ifNull(r.input_tokens, 0) AS input_tokens,
-				ifNull(r.output_tokens, 0) AS output_tokens,
-				ifNull(r.cache_read_input_tokens, 0) AS cache_read_input_tokens,
-				ifNull(r.cache_creation_input_tokens, 0) AS cache_creation_input_tokens,
-				ifNull(r.total_tokens, 0) AS total_tokens,
-				if(c.receipt_event_count = 0, toNullable(0.0), r.estimated_cost) AS estimated_cost,
-				if(c.receipt_event_count = 0, toUInt8(1), r.cost_is_complete) AS cost_is_complete
+				r.input_tokens AS input_tokens,
+				r.output_tokens AS output_tokens,
+				r.cache_read_input_tokens AS cache_read_input_tokens,
+				r.cache_creation_input_tokens AS cache_creation_input_tokens,
+				r.total_tokens AS total_tokens,
+				r.estimated_cost AS estimated_cost,
+				r.cost_is_complete AS cost_is_complete
 			FROM usage_analytics_metadata AS sa
-			ANY INNER JOIN consistent_usage_sessions AS c
-				ON sa.organization_id = c.organization_id
-				AND sa.user_id = c.user_id
-				AND sa.source = c.source
-				AND sa.session_id = c.session_id
-			LEFT ANY JOIN usage_event_session_rollups AS r
+			ANY INNER JOIN usage_event_session_rollups AS r
 				ON sa.organization_id = r.organization_id
 				AND sa.user_id = r.user_id
 				AND sa.source = r.source
@@ -380,7 +347,7 @@ export function buildUsageEventAnalyticsCte(
 		usage_analytics_daily_sessions AS (
 			SELECT
 				${SESSION_METADATA_COLUMNS},
-				if(s.latest_main_model != '', s.latest_main_model, s.latest_resolved_model) AS model_used,
+				if(r.latest_main_model != '', r.latest_main_model, r.latest_resolved_model) AS model_used,
 				r.usage_date AS usage_date,
 				r.input_tokens AS input_tokens,
 				r.output_tokens AS output_tokens,
@@ -395,11 +362,6 @@ export function buildUsageEventAnalyticsCte(
 				AND sa.user_id = r.user_id
 				AND sa.source = r.source
 				AND sa.session_id = r.session_id
-			LEFT ANY JOIN usage_event_session_rollups AS s
-				ON s.organization_id = r.organization_id
-				AND s.user_id = r.user_id
-				AND s.source = r.source
-				AND s.session_id = r.session_id
 		)
 	`;
 }

--- a/apps/api/src/services/usage-event-analytics.service.ts
+++ b/apps/api/src/services/usage-event-analytics.service.ts
@@ -377,14 +377,14 @@ export function buildUsageEventAnalyticsCte(
 					s.single_resolved_model,
 					sa.model_used
 				) AS model_used,
-				r.usage_date,
-				r.input_tokens,
-				r.output_tokens,
-				r.cache_read_input_tokens,
-				r.cache_creation_input_tokens,
-				r.total_tokens,
-				r.estimated_cost,
-				r.cost_is_complete
+				r.usage_date AS usage_date,
+				r.input_tokens AS input_tokens,
+				r.output_tokens AS output_tokens,
+				r.cache_read_input_tokens AS cache_read_input_tokens,
+				r.cache_creation_input_tokens AS cache_creation_input_tokens,
+				r.total_tokens AS total_tokens,
+				r.estimated_cost AS estimated_cost,
+				r.cost_is_complete AS cost_is_complete
 			FROM usage_event_daily_rollups AS r
 			ANY INNER JOIN usage_analytics_metadata AS sa
 				ON sa.organization_id = r.organization_id


### PR DESCRIPTION
## Summary
- resolve tenant-scoped `usage_events` replacement state once with `FINAL`, then carry receipt consistency, pricing, and display-model metadata through one pipeline
- remove repeated event-source reads and joins while preserving complete-receipt, tombstone, zero-event, per-event pricing, and display-model semantics
- bound benchmark rollups and query-log inspection so performance checks fail safely
- reduce measured owner-org endpoint latency from roughly 5.2–5.6s to 2.6–3.0s without adding a table or migration

## Correctness evidence
- compared legacy and optimized event queries over 1,503 production sessions: identical session and token totals
- maximum per-session cost delta was 5.7e-14 (floating-point aggregation order); no session differed above 1e-8
- tenant-prefix `EXPLAIN indexes=1` preserved primary-key pruning before metadata joins

## Test plan
- [x] `bun run verify`
- [x] usage-event analytics unit suite (11 tests)
- [x] usage-event analytics ClickHouse integration suite on a disposable local ClickHouse (3 tests, 13 assertions)
- [x] bounded production read-only parity and latency checks

No ClickHouse migration or production write is included.