### PR TITLE
perf(analytics): reduce usage event query work

### DIFF
--- a/apps/api/src/services/pricing.service.ts
+++ b/apps/api/src/services/pricing.service.ts
@@ -3,6 +3,8 @@ export {
 	calculateEstimatedCost,
 	ESTIMATED_PRICING_MODE,
 	getModelPricingCatalog,
+	getModelPricingModifierCatalog,
+	MODEL_LONG_CONTEXT_THRESHOLD_TOKENS,
 	MODEL_RATE_CARD_VERSION,
 	resolveModelPricing,
 } from "@rudel/api-routes";

--- a/apps/api/src/services/usage-event-analytics.service.test.ts
+++ b/apps/api/src/services/usage-event-analytics.service.test.ts
@@ -45,13 +45,30 @@ describe("usage-event analytics query contract", () => {
 		const sql = buildUsageEventAnalyticsCte();
 
 		expect(sql).toContain(
-			"sum(p.uncached_input_tokens + p.cache_read_input_tokens + p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens) AS input_tokens",
+			"sum(p.group_uncached_input_tokens + p.group_cache_read_input_tokens + p.group_cache_write_5m_input_tokens + p.group_cache_write_1h_input_tokens) AS input_tokens",
 		);
-		expect(sql).toContain("e.uncached_input_tokens");
-		expect(sql).toContain("e.cache_read_input_tokens");
-		expect(sql).toContain("e.cache_write_5m_input_tokens");
-		expect(sql).toContain("e.cache_write_1h_input_tokens");
-		expect(sql).toContain("e.output_tokens");
+		for (const tokenClass of [
+			"uncached_input_tokens",
+			"cache_read_input_tokens",
+			"cache_write_5m_input_tokens",
+			"cache_write_1h_input_tokens",
+			"output_tokens",
+		]) {
+			expect(sql).toContain(`sum(e.${tokenClass}) AS group_${tokenClass}`);
+			expect(sql).toContain(`g.group_${tokenClass}`);
+		}
+	});
+
+	test("groups equivalent events before joining the typed rate card", () => {
+		const sql = buildUsageEventAnalyticsCte();
+
+		expect(sql).toContain("usage_event_pricing_groups AS");
+		expect(sql).toContain("usage_event_pricing_rate_card AS");
+		expect(sql).toContain("ANY LEFT JOIN usage_event_pricing_rate_card AS r");
+		expect(sql.indexOf("usage_event_pricing_groups AS")).toBeLessThan(
+			sql.indexOf("ANY LEFT JOIN usage_event_pricing_rate_card AS r"),
+		);
+		expect(sql).not.toContain("match(lowerUTF8(e.resolved_model)");
 	});
 
 	test("never prices from the session display model", () => {
@@ -82,10 +99,12 @@ describe("usage-event analytics query contract", () => {
 	test("prices exact provenance and fails closed for unsupported dimensions", () => {
 		const sql = buildUsageEventAnalyticsCte();
 
-		expect(sql).toContain("lowerUTF8(trimBoth(e.service_tier))");
-		expect(sql).toContain("lowerUTF8(trimBoth(e.model_provider))");
-		expect(sql).toContain("lowerUTF8(trimBoth(e.inference_speed))");
-		expect(sql).toContain("lowerUTF8(trimBoth(e.inference_geo))");
+		expect(sql).toContain("lowerUTF8(trimBoth(g.service_tier))");
+		expect(sql).toContain(
+			"lowerUTF8(trimBoth(g.model_provider)) IN ('', r.provider)",
+		);
+		expect(sql).toContain("lowerUTF8(trimBoth(g.inference_speed))");
+		expect(sql).toContain("lowerUTF8(trimBoth(g.inference_geo))");
 		expect(sql).toContain("IN ('fast', 'priority')");
 		expect(sql).toContain("service_tier_conflict");
 		expect(sql).toContain("unrecognized_service_tier");
@@ -97,11 +116,9 @@ describe("usage-event analytics query contract", () => {
 		const sql = buildUsageEventAnalyticsCte();
 
 		expect(sql).toContain(
-			"toNullable(sum(ifNull(p.estimated_cost, 0))) AS estimated_cost",
+			"toNullable(sum(ifNull(p.group_estimated_cost, 0))) AS estimated_cost",
 		);
-		expect(sql).toContain(
-			"OR has(p.quality_flags, 'inference_geo_not_available')",
-		);
+		expect(sql).toContain("OR p.has_geo_gap = 1");
 		expect(buildUsageCostSubtotalSql("sa.estimated_cost", 4)).toBe(
 			"toNullable(round(sum(ifNull(sa.estimated_cost, 0)), 4))",
 		);

--- a/apps/api/src/services/usage-event-analytics.service.test.ts
+++ b/apps/api/src/services/usage-event-analytics.service.test.ts
@@ -62,10 +62,16 @@ describe("usage-event analytics query contract", () => {
 	test("groups equivalent events before joining the typed rate card", () => {
 		const sql = buildUsageEventAnalyticsCte();
 
+		expect(sql).toContain("usage_event_pricing_candidates AS");
 		expect(sql).toContain("usage_event_pricing_groups AS");
 		expect(sql).toContain("usage_event_pricing_rate_card AS");
+		expect(sql).toContain("match(lowerUTF8(c.resolved_model)");
+		expect(sql).toContain("ON g.pricing_model = r.model");
 		expect(sql).toContain("ANY LEFT JOIN usage_event_pricing_rate_card AS r");
-		expect(sql.indexOf("usage_event_pricing_groups AS")).toBeLessThan(
+		expect(sql.indexOf("usage_event_pricing_candidates AS")).toBeLessThan(
+			sql.indexOf("match(lowerUTF8(c.resolved_model)"),
+		);
+		expect(sql.indexOf("match(lowerUTF8(c.resolved_model)")).toBeLessThan(
 			sql.indexOf("ANY LEFT JOIN usage_event_pricing_rate_card AS r"),
 		);
 		expect(sql).not.toContain("match(lowerUTF8(e.resolved_model)");

--- a/apps/api/src/services/usage-event-analytics.service.ts
+++ b/apps/api/src/services/usage-event-analytics.service.ts
@@ -48,6 +48,8 @@ type PricingModifierDimension =
 	| "inference_geo";
 
 const EVENT_PRICING_RATE_CARD_SQL = buildEventPricingRateCardSql();
+const EVENT_CANONICAL_PRICING_MODEL_SQL =
+	buildCanonicalPricingModelSql("c.resolved_model");
 const EVENT_LONG_CONTEXT_AVAILABLE_SQL = buildLongContextAvailableSql();
 const EVENT_GROUP_COST_SQL = buildEventGroupCostSql();
 
@@ -81,11 +83,34 @@ function buildEventPricingRateCardSql(): string {
 	`;
 }
 
+function buildCanonicalPricingModelSql(modelExpr: string): string {
+	const canonicalModelByPattern = new Map<string, string>();
+	for (const entry of getModelPricingCatalog()) {
+		for (const pattern of entry.match) {
+			const existingModel = canonicalModelByPattern.get(pattern);
+			if (existingModel !== undefined && existingModel !== entry.model) {
+				throw new Error(
+					`Pricing pattern ${pattern} maps to both ${existingModel} and ${entry.model}`,
+				);
+			}
+			canonicalModelByPattern.set(pattern, entry.model);
+		}
+	}
+
+	const clauses = [...canonicalModelByPattern.entries()].flatMap(
+		([pattern, model]) => [
+			`match(lowerUTF8(${modelExpr}), '${escapeSqlString(pattern)}')`,
+			`'${escapeSqlString(model)}'`,
+		],
+	);
+	return `multiIf(${clauses.join(", ")}, '')`;
+}
+
 function buildLongContextAvailableSql(): string {
 	const clauses = getModelPricingCatalog()
 		.filter((entry) => entry.contextBand === "long")
 		.flatMap((entry) => [
-			`g.resolved_model = '${escapeSqlString(entry.model)}'
+			`g.pricing_model = '${escapeSqlString(entry.model)}'
 				AND g.usage_date >= toDate('${entry.effectiveFrom}')
 				AND g.usage_date <= toDate('${entry.effectiveTo ?? "2299-12-31"}')`,
 			"toUInt8(1)",
@@ -165,7 +190,7 @@ function buildModifierDimensionSql(
 		.filter((rule) => rule.dimension === dimension)
 		.flatMap((rule) => {
 			const conditions = [
-				`g.resolved_model = '${escapeSqlString(rule.model)}'`,
+				`g.pricing_model = '${escapeSqlString(rule.model)}'`,
 				`lowerUTF8(trimBoth(${valueExpr})) IN (${rule.values
 					.map((value) => `'${escapeSqlString(value)}'`)
 					.join(", ")})`,
@@ -395,7 +420,7 @@ export function buildUsageEventAnalyticsCte(
 				PARTITION BY organization_id, user_id, source, session_id
 			)
 		),
-		usage_event_pricing_groups AS (
+		usage_event_pricing_candidates AS (
 			SELECT
 				e.organization_id,
 				e.user_id,
@@ -439,6 +464,12 @@ export function buildUsageEventAnalyticsCte(
 				is_priceable,
 				has_geo_gap
 		),
+		usage_event_pricing_groups AS (
+			SELECT
+				c.*,
+				${EVENT_CANONICAL_PRICING_MODEL_SQL} AS pricing_model
+			FROM usage_event_pricing_candidates AS c
+		),
 		usage_event_pricing_rate_card AS (
 			${EVENT_PRICING_RATE_CARD_SQL}
 		),
@@ -448,7 +479,7 @@ export function buildUsageEventAnalyticsCte(
 				${EVENT_GROUP_COST_SQL} AS group_estimated_cost
 			FROM usage_event_pricing_groups AS g
 			ANY LEFT JOIN usage_event_pricing_rate_card AS r
-				ON g.resolved_model = r.model
+				ON g.pricing_model = r.model
 				AND r.context_band = if(
 					g.context_band = 'long'
 						AND ${EVENT_LONG_CONTEXT_AVAILABLE_SQL} = 1,

--- a/apps/api/src/services/usage-event-analytics.service.ts
+++ b/apps/api/src/services/usage-event-analytics.service.ts
@@ -5,7 +5,12 @@ import {
 	getSafeClickHouseTable,
 } from "../clickhouse.js";
 import { shouldUseUsageEventAnalytics } from "../lib/env.js";
-import { buildEstimatedCostSql } from "./pricing.service.js";
+import {
+	buildEstimatedCostSql,
+	getModelPricingCatalog,
+	getModelPricingModifierCatalog,
+	MODEL_LONG_CONTEXT_THRESHOLD_TOKENS,
+} from "./pricing.service.js";
 
 const USAGE_EVENTS_TABLE = "rudel.usage_events";
 const SESSION_ANALYTICS_TABLE = "rudel.session_analytics";
@@ -23,22 +28,6 @@ const LEGACY_SESSION_COST_SQL = buildEstimatedCostSql({
 	cacheCreationInputExpr: "ifNull(sa.cache_creation_input_tokens, 0)",
 });
 
-const EVENT_COST_SQL = buildEstimatedCostSql({
-	modelExpr: "e.resolved_model",
-	dateExpr: "e.usage_date",
-	inputExpr: "e.uncached_input_tokens",
-	outputExpr: "e.output_tokens",
-	cacheReadInputExpr: "e.cache_read_input_tokens",
-	cacheCreationInputExpr: "e.cache_write_5m_input_tokens",
-	cacheCreation1hInputExpr: "e.cache_write_1h_input_tokens",
-	contextInputExpr: "e.context_input_tokens",
-	modelProviderExpr: "e.model_provider",
-	serviceTierExpr: "e.service_tier",
-	inferenceSpeedExpr: "e.inference_speed",
-	inferenceGeoExpr: "e.inference_geo",
-	precision: 12,
-});
-
 const PRICEABLE_EVENT_SQL = `
 	e.model_status = 'resolved'
 	AND e.has_valid_timestamp = 1
@@ -52,6 +41,152 @@ const PRICEABLE_EVENT_SQL = `
 	AND NOT has(e.quality_flags, 'inference_geo_conflict')
 	AND NOT has(e.quality_flags, 'unrecognized_inference_geo')
 `;
+
+type PricingModifierDimension =
+	| "service_tier"
+	| "inference_speed"
+	| "inference_geo";
+
+const EVENT_PRICING_RATE_CARD_SQL = buildEventPricingRateCardSql();
+const EVENT_LONG_CONTEXT_AVAILABLE_SQL = buildLongContextAvailableSql();
+const EVENT_GROUP_COST_SQL = buildEventGroupCostSql();
+
+function escapeSqlString(value: string): string {
+	return value.replaceAll("\\", "\\\\").replaceAll("'", "\\'");
+}
+
+function buildEventPricingRateCardSql(): string {
+	const catalog = getModelPricingCatalog();
+	const rows = catalog.map((entry) => {
+		return `tuple('${escapeSqlString(entry.model)}', '${entry.provider}', '${entry.contextBand}', toDate('${entry.effectiveFrom}'), toDate('${entry.effectiveTo ?? "2299-12-31"}'), toFloat64(${entry.inputPerMTok}), toFloat64(${entry.cacheReadPerMTok ?? -1}), toFloat64(${entry.cacheWrite5mPerMTok ?? -1}), toFloat64(${entry.cacheWrite1hPerMTok ?? -1}), toFloat64(${entry.outputPerMTok}))`;
+	});
+
+	return `
+		SELECT
+			rate.1 AS model,
+			rate.2 AS provider,
+			rate.3 AS context_band,
+			rate.4 AS effective_from,
+			rate.5 AS effective_to,
+			rate.6 AS input_rate,
+			rate.7 AS cache_read_rate,
+			rate.8 AS cache_write_5m_rate,
+			rate.9 AS cache_write_1h_rate,
+			rate.10 AS output_rate
+		FROM (
+			SELECT arrayJoin([
+				${rows.join(",\n\t\t\t\t")}
+			]) AS rate
+		)
+	`;
+}
+
+function buildLongContextAvailableSql(): string {
+	const clauses = getModelPricingCatalog()
+		.filter((entry) => entry.contextBand === "long")
+		.flatMap((entry) => [
+			`g.resolved_model = '${escapeSqlString(entry.model)}'
+				AND g.usage_date >= toDate('${entry.effectiveFrom}')
+				AND g.usage_date <= toDate('${entry.effectiveTo ?? "2299-12-31"}')`,
+			"toUInt8(1)",
+		]);
+	return `multiIf(${clauses.join(", ")}, toUInt8(0))`;
+}
+
+function buildEventGroupCostSql(): string {
+	const modifierMultiplier = [
+		buildModifierDimensionSql("service_tier", "g.service_tier"),
+		buildModifierDimensionSql("inference_speed", "g.inference_speed"),
+		buildModifierDimensionSql("inference_geo", "g.inference_geo"),
+	]
+		.map((expression) => `(${expression})`)
+		.join(" * ");
+	const components = [
+		buildRateComponentSql("g.group_uncached_input_tokens", "r.input_rate"),
+		buildRateComponentSql(
+			"g.group_cache_read_input_tokens",
+			"r.cache_read_rate",
+		),
+		buildRateComponentSql(
+			"g.group_cache_write_5m_input_tokens",
+			"r.cache_write_5m_rate",
+		),
+		buildRateComponentSql(
+			"g.group_cache_write_1h_input_tokens",
+			"r.cache_write_1h_rate",
+		),
+		buildRateComponentSql("g.group_output_tokens", "r.output_rate"),
+	];
+
+	return `if(
+		g.group_uncached_input_tokens
+			+ g.group_cache_read_input_tokens
+			+ g.group_cache_write_5m_input_tokens
+			+ g.group_cache_write_1h_input_tokens
+			+ g.group_output_tokens = 0,
+		toNullable(0.0),
+		if(
+			g.is_priceable = 1
+				AND r.model != ''
+				AND lowerUTF8(trimBoth(g.model_provider)) IN ('', r.provider),
+			round((${components.join(" + ")}) * (${modifierMultiplier}), 12),
+			CAST(NULL, 'Nullable(Float64)')
+		)
+	)`;
+}
+
+function buildRateComponentSql(tokensExpr: string, rateExpr: string): string {
+	return `if(
+		${tokensExpr} = 0,
+		toNullable(0.0),
+		if(
+			${rateExpr} < 0,
+			CAST(NULL, 'Nullable(Float64)'),
+			toNullable(${tokensExpr} / 1000000.0 * ${rateExpr})
+		)
+	)`;
+}
+
+function buildModifierDimensionSql(
+	dimension: PricingModifierDimension,
+	valueExpr: string,
+): string {
+	const baseValues =
+		dimension === "service_tier"
+			? `if(
+				r.provider = 'anthropic',
+				['', 'auto', 'default', 'priority', 'standard'],
+				['', 'auto', 'default', 'standard']
+			)`
+			: dimension === "inference_speed"
+				? "['', 'standard']"
+				: "['', 'global']";
+	const clauses = getModelPricingModifierCatalog()
+		.filter((rule) => rule.dimension === dimension)
+		.flatMap((rule) => {
+			const conditions = [
+				`g.resolved_model = '${escapeSqlString(rule.model)}'`,
+				`lowerUTF8(trimBoth(${valueExpr})) IN (${rule.values
+					.map((value) => `'${escapeSqlString(value)}'`)
+					.join(", ")})`,
+				`g.usage_date >= toDate('${rule.effectiveFrom}')`,
+			];
+			if (rule.effectiveTo) {
+				conditions.push(`g.usage_date <= toDate('${rule.effectiveTo}')`);
+			}
+			if (rule.contextBand) {
+				conditions.push(`r.context_band = '${rule.contextBand}'`);
+			}
+			return [conditions.join(" AND "), `toNullable(${rule.multiplier})`];
+		});
+
+	return `multiIf(
+		lowerUTF8(trimBoth(${valueExpr})) IN ${baseValues},
+		toNullable(1.0),
+		${clauses.join(",\n\t\t")},
+		CAST(NULL, 'Nullable(Float64)')
+	)`;
+}
 
 const SESSION_METADATA_COLUMNS = `
 	sa.session_date AS session_date,
@@ -237,20 +372,6 @@ export function buildUsageEventAnalyticsCte(
 				AND is_deleted = 0
 				AND record_kind IN ('event', 'receipt')
 		),
-		priced_usage_records AS (
-			SELECT
-				e.*,
-				if(
-					e.uncached_input_tokens
-						+ e.cache_read_input_tokens
-						+ e.cache_write_5m_input_tokens
-						+ e.cache_write_1h_input_tokens
-						+ e.output_tokens = 0,
-					toNullable(0.0),
-					if(${PRICEABLE_EVENT_SQL}, ${EVENT_COST_SQL}, CAST(NULL, 'Nullable(Float64)'))
-				) AS estimated_cost
-			FROM consistent_usage_records AS e
-		),
 		usage_records_with_display_model AS (
 			SELECT
 				*,
@@ -269,10 +390,73 @@ export function buildUsageEventAnalyticsCte(
 						AND model_status = 'resolved'
 						AND resolved_model != ''
 				) OVER usage_session_window AS latest_resolved_model
-			FROM priced_usage_records
+			FROM consistent_usage_records
 			WINDOW usage_session_window AS (
 				PARTITION BY organization_id, user_id, source, session_id
 			)
+		),
+		usage_event_pricing_groups AS (
+			SELECT
+				e.organization_id,
+				e.user_id,
+				e.source,
+				e.session_id,
+				e.record_kind,
+				e.usage_date,
+				e.resolved_model,
+				e.model_provider,
+				e.service_tier,
+				e.inference_speed,
+				e.inference_geo,
+				if(
+					e.context_input_tokens > ${MODEL_LONG_CONTEXT_THRESHOLD_TOKENS},
+					'long',
+					'base'
+				) AS context_band,
+				toUInt8(${PRICEABLE_EVENT_SQL}) AS is_priceable,
+				toUInt8(has(e.quality_flags, 'inference_geo_not_available')) AS has_geo_gap,
+				any(e.latest_main_model) AS latest_main_model,
+				any(e.latest_resolved_model) AS latest_resolved_model,
+				sum(e.uncached_input_tokens) AS group_uncached_input_tokens,
+				sum(e.cache_read_input_tokens) AS group_cache_read_input_tokens,
+				sum(e.cache_write_5m_input_tokens) AS group_cache_write_5m_input_tokens,
+				sum(e.cache_write_1h_input_tokens) AS group_cache_write_1h_input_tokens,
+				sum(e.output_tokens) AS group_output_tokens
+			FROM usage_records_with_display_model AS e
+			GROUP BY
+				e.organization_id,
+				e.user_id,
+				e.source,
+				e.session_id,
+				e.record_kind,
+				e.usage_date,
+				e.resolved_model,
+				e.model_provider,
+				e.service_tier,
+				e.inference_speed,
+				e.inference_geo,
+				context_band,
+				is_priceable,
+				has_geo_gap
+		),
+		usage_event_pricing_rate_card AS (
+			${EVENT_PRICING_RATE_CARD_SQL}
+		),
+		priced_usage_groups AS (
+			SELECT
+				g.*,
+				${EVENT_GROUP_COST_SQL} AS group_estimated_cost
+			FROM usage_event_pricing_groups AS g
+			ANY LEFT JOIN usage_event_pricing_rate_card AS r
+				ON g.resolved_model = r.model
+				AND r.context_band = if(
+					g.context_band = 'long'
+						AND ${EVENT_LONG_CONTEXT_AVAILABLE_SQL} = 1,
+					'long',
+					'base'
+				)
+				AND g.usage_date >= r.effective_from
+				AND g.usage_date <= r.effective_to
 		),
 		usage_event_session_rollups AS (
 			SELECT
@@ -280,22 +464,22 @@ export function buildUsageEventAnalyticsCte(
 				p.user_id,
 				p.source,
 				p.session_id,
-				sum(p.uncached_input_tokens + p.cache_read_input_tokens + p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens) AS input_tokens,
-				sum(p.output_tokens) AS output_tokens,
-				sum(p.cache_read_input_tokens) AS cache_read_input_tokens,
-				sum(p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens) AS cache_creation_input_tokens,
-				sum(p.uncached_input_tokens + p.cache_read_input_tokens + p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens + p.output_tokens) AS total_tokens,
-				toNullable(sum(ifNull(p.estimated_cost, 0))) AS estimated_cost,
+				sum(p.group_uncached_input_tokens + p.group_cache_read_input_tokens + p.group_cache_write_5m_input_tokens + p.group_cache_write_1h_input_tokens) AS input_tokens,
+				sum(p.group_output_tokens) AS output_tokens,
+				sum(p.group_cache_read_input_tokens) AS cache_read_input_tokens,
+				sum(p.group_cache_write_5m_input_tokens + p.group_cache_write_1h_input_tokens) AS cache_creation_input_tokens,
+				sum(p.group_uncached_input_tokens + p.group_cache_read_input_tokens + p.group_cache_write_5m_input_tokens + p.group_cache_write_1h_input_tokens + p.group_output_tokens) AS total_tokens,
+				toNullable(sum(ifNull(p.group_estimated_cost, 0))) AS estimated_cost,
 				toUInt8(countIf(
 					p.record_kind = 'event'
 					AND (
-						isNull(p.estimated_cost)
-						OR has(p.quality_flags, 'inference_geo_not_available')
+						isNull(p.group_estimated_cost)
+						OR p.has_geo_gap = 1
 					)
 				) = 0) AS cost_is_complete,
 				any(p.latest_main_model) AS latest_main_model,
 				any(p.latest_resolved_model) AS latest_resolved_model
-			FROM usage_records_with_display_model AS p
+			FROM priced_usage_groups AS p
 			GROUP BY p.organization_id, p.user_id, p.source, p.session_id
 		),
 		usage_event_daily_rollups AS (
@@ -305,19 +489,19 @@ export function buildUsageEventAnalyticsCte(
 				p.source,
 				p.session_id,
 				p.usage_date,
-				sum(p.uncached_input_tokens + p.cache_read_input_tokens + p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens) AS input_tokens,
-				sum(p.output_tokens) AS output_tokens,
-				sum(p.cache_read_input_tokens) AS cache_read_input_tokens,
-				sum(p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens) AS cache_creation_input_tokens,
-				sum(p.uncached_input_tokens + p.cache_read_input_tokens + p.cache_write_5m_input_tokens + p.cache_write_1h_input_tokens + p.output_tokens) AS total_tokens,
-				toNullable(sum(ifNull(p.estimated_cost, 0))) AS estimated_cost,
+				sum(p.group_uncached_input_tokens + p.group_cache_read_input_tokens + p.group_cache_write_5m_input_tokens + p.group_cache_write_1h_input_tokens) AS input_tokens,
+				sum(p.group_output_tokens) AS output_tokens,
+				sum(p.group_cache_read_input_tokens) AS cache_read_input_tokens,
+				sum(p.group_cache_write_5m_input_tokens + p.group_cache_write_1h_input_tokens) AS cache_creation_input_tokens,
+				sum(p.group_uncached_input_tokens + p.group_cache_read_input_tokens + p.group_cache_write_5m_input_tokens + p.group_cache_write_1h_input_tokens + p.group_output_tokens) AS total_tokens,
+				toNullable(sum(ifNull(p.group_estimated_cost, 0))) AS estimated_cost,
 				toUInt8(countIf(
-					isNull(p.estimated_cost)
-					OR has(p.quality_flags, 'inference_geo_not_available')
+					isNull(p.group_estimated_cost)
+					OR p.has_geo_gap = 1
 				) = 0) AS cost_is_complete,
 				any(p.latest_main_model) AS latest_main_model,
 				any(p.latest_resolved_model) AS latest_resolved_model
-			FROM usage_records_with_display_model AS p
+			FROM priced_usage_groups AS p
 			WHERE p.record_kind = 'event'
 			GROUP BY p.organization_id, p.user_id, p.source, p.session_id, p.usage_date
 		),

--- a/apps/web/src/features/dashboard/DashboardPage.test.tsx
+++ b/apps/web/src/features/dashboard/DashboardPage.test.tsx
@@ -60,5 +60,6 @@ describe("DashboardPage", () => {
 		expect(
 			screen.queryByRole("tab", { name: "Tokens" }),
 		).not.toBeInTheDocument();
+		expect(mockUseDashboardPageData).toHaveBeenCalledWith("tokens");
 	});
 });

--- a/apps/web/src/features/dashboard/DashboardPage.tsx
+++ b/apps/web/src/features/dashboard/DashboardPage.tsx
@@ -8,9 +8,10 @@ import { DashboardRepositoriesView } from "@/features/dashboard/components/Dashb
 import { DashboardRepositoryPanel } from "@/features/dashboard/components/DashboardRepositoryPanel";
 import { DashboardSessionsView } from "@/features/dashboard/components/DashboardSessionsView";
 import { DashboardTokensView } from "@/features/dashboard/components/DashboardTokensView";
-import { useDashboardPageData } from "@/features/dashboard/use-dashboard-page-data";
-
-type DashboardView = "tokens" | "commits" | "errors" | "repos" | "sessions";
+import {
+	type DashboardView,
+	useDashboardPageData,
+} from "@/features/dashboard/use-dashboard-page-data";
 
 function isDashboardView(value: string | null): value is DashboardView {
 	return (
@@ -23,6 +24,9 @@ function isDashboardView(value: string | null): value is DashboardView {
 }
 
 export function DashboardPage() {
+	const [searchParams, setSearchParams] = useSearchParams();
+	const requestedView = searchParams.get("view");
+	const activeView = isDashboardView(requestedView) ? requestedView : "tokens";
 	const {
 		endDate,
 		errorDashboard,
@@ -45,10 +49,7 @@ export function DashboardPage() {
 		totalSessionCount,
 		userLabelById,
 		usersTokenUsage,
-	} = useDashboardPageData();
-	const [searchParams, setSearchParams] = useSearchParams();
-	const requestedView = searchParams.get("view");
-	const activeView = isDashboardView(requestedView) ? requestedView : "tokens";
+	} = useDashboardPageData(activeView);
 
 	function setDashboardView(nextView: DashboardView) {
 		setSearchParams(

--- a/apps/web/src/features/dashboard/use-dashboard-page-data.test.ts
+++ b/apps/web/src/features/dashboard/use-dashboard-page-data.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+	type DashboardView,
+	getDashboardQueryRequirements,
+} from "./use-dashboard-page-data";
+
+describe("dashboard query requirements", () => {
+	it.each([
+		[
+			"tokens",
+			{
+				errors: false,
+				modelTokens: true,
+				performance: true,
+				repositoryTrend: false,
+				roi: false,
+				sessionSummary: false,
+			},
+		],
+		[
+			"commits",
+			{
+				errors: false,
+				modelTokens: false,
+				performance: true,
+				repositoryTrend: true,
+				roi: true,
+				sessionSummary: false,
+			},
+		],
+		[
+			"errors",
+			{
+				errors: true,
+				modelTokens: false,
+				performance: false,
+				repositoryTrend: false,
+				roi: false,
+				sessionSummary: false,
+			},
+		],
+		[
+			"repos",
+			{
+				errors: false,
+				modelTokens: false,
+				performance: true,
+				repositoryTrend: true,
+				roi: true,
+				sessionSummary: false,
+			},
+		],
+		[
+			"sessions",
+			{
+				errors: false,
+				modelTokens: false,
+				performance: false,
+				repositoryTrend: true,
+				roi: true,
+				sessionSummary: true,
+			},
+		],
+	] satisfies readonly [
+		DashboardView,
+		ReturnType<typeof getDashboardQueryRequirements>,
+	][])("loads only the %s tab's query families", (view, expected) => {
+		expect(getDashboardQueryRequirements(view)).toEqual(expected);
+	});
+});

--- a/apps/web/src/features/dashboard/use-dashboard-page-data.ts
+++ b/apps/web/src/features/dashboard/use-dashboard-page-data.ts
@@ -14,7 +14,34 @@ import { useFullOrganization } from "@/features/workspace/hooks/useFullOrganizat
 import { useOrganization } from "@/features/workspace/organization/useOrganization";
 import { orpc } from "@/lib/orpc";
 
-export function useDashboardPageData() {
+export type DashboardView =
+	| "tokens"
+	| "commits"
+	| "errors"
+	| "repos"
+	| "sessions";
+
+export function getDashboardQueryRequirements(activeView: DashboardView) {
+	const performance =
+		activeView === "tokens" ||
+		activeView === "commits" ||
+		activeView === "repos";
+	const repositoryTrend =
+		activeView === "commits" ||
+		activeView === "repos" ||
+		activeView === "sessions";
+
+	return {
+		errors: activeView === "errors",
+		modelTokens: activeView === "tokens",
+		performance,
+		repositoryTrend,
+		roi: repositoryTrend,
+		sessionSummary: activeView === "sessions",
+	};
+}
+
+export function useDashboardPageData(activeView: DashboardView) {
 	const { meta, state } = useDateRange();
 	const { state: workspaceState } = useOrganization();
 	const useFixtures = isFrontendFixturesEnabled();
@@ -46,6 +73,7 @@ export function useDashboardPageData() {
 				: null,
 		[fixtureMembers, state.endDate, state.startDate, useFixtures],
 	);
+	const requirements = getDashboardQueryRequirements(activeView);
 	const overviewKpisQuery = useAnalyticsQuery({
 		...orpc.analytics.overview.kpis.queryOptions({
 			input: {
@@ -62,7 +90,7 @@ export function useDashboardPageData() {
 				endDate: state.endDate,
 			},
 		}),
-		enabled: !useFixtures,
+		enabled: !useFixtures && requirements.roi,
 	});
 	const usersTokenUsageQuery = useAnalyticsQuery({
 		...orpc.analytics.overview.usersTokenUsage.queryOptions({
@@ -71,7 +99,7 @@ export function useDashboardPageData() {
 				endDate: state.endDate,
 			},
 		}),
-		enabled: !useFixtures,
+		enabled: !useFixtures && requirements.performance,
 	});
 	const modelTokensTrendQuery = useAnalyticsQuery({
 		...orpc.analytics.overview.modelTokensTrend.queryOptions({
@@ -80,7 +108,7 @@ export function useDashboardPageData() {
 				endDate: state.endDate,
 			},
 		}),
-		enabled: !useFixtures,
+		enabled: !useFixtures && requirements.modelTokens,
 	});
 	const usersDailyTrendQuery = useAnalyticsQuery({
 		...orpc.analytics.overview.usersDailyTrend.queryOptions({
@@ -89,7 +117,7 @@ export function useDashboardPageData() {
 				endDate: state.endDate,
 			},
 		}),
-		enabled: !useFixtures,
+		enabled: !useFixtures && requirements.performance,
 	});
 	const repositoriesDailyTrendQuery = useAnalyticsQuery({
 		...orpc.analytics.overview.repositoriesDailyTrend.queryOptions({
@@ -98,7 +126,7 @@ export function useDashboardPageData() {
 				endDate: state.endDate,
 			},
 		}),
-		enabled: !useFixtures,
+		enabled: !useFixtures && requirements.repositoryTrend,
 	});
 	const errorDashboardQuery = useAnalyticsQuery({
 		...orpc.analytics.errors.dashboard.queryOptions({
@@ -107,7 +135,7 @@ export function useDashboardPageData() {
 				endDate: state.endDate,
 			},
 		}),
-		enabled: !useFixtures,
+		enabled: !useFixtures && requirements.errors,
 	});
 	const errorProjectTrendQuery = useAnalyticsQuery({
 		...orpc.analytics.errors.trends.queryOptions({
@@ -117,7 +145,7 @@ export function useDashboardPageData() {
 				splitBy: "project_path",
 			},
 		}),
-		enabled: !useFixtures,
+		enabled: !useFixtures && requirements.errors,
 	});
 	const errorDeveloperTrendQuery = useAnalyticsQuery({
 		...orpc.analytics.errors.trends.queryOptions({
@@ -127,7 +155,7 @@ export function useDashboardPageData() {
 				splitBy: "user_id",
 			},
 		}),
-		enabled: !useFixtures,
+		enabled: !useFixtures && requirements.errors,
 	});
 	const sessionSummaryComparisonQuery = useAnalyticsQuery({
 		...orpc.analytics.sessions.summaryComparison.queryOptions({
@@ -135,7 +163,7 @@ export function useDashboardPageData() {
 				days: meta.dayCount,
 			},
 		}),
-		enabled: !useFixtures,
+		enabled: !useFixtures && requirements.sessionSummary,
 	});
 	const overviewKpis = fixtureData?.overviewKpis ?? overviewKpisQuery.data;
 	const roiDashboard = fixtureData?.roiDashboard ?? roiDashboardQuery.data;
@@ -203,22 +231,30 @@ export function useDashboardPageData() {
 
 	return {
 		endDate: state.endDate,
-		isDashboardSnapshotPending: !useFixtures && roiDashboardQuery.isPending,
+		isDashboardSnapshotPending:
+			!useFixtures && requirements.roi && roiDashboardQuery.isPending,
 		isPerformanceChartPending:
 			!useFixtures &&
+			requirements.performance &&
 			(usersTokenUsageQuery.isPending || usersDailyTrendQuery.isPending),
 		isOverviewKpisPending: !useFixtures && overviewKpisQuery.isPending,
 		isTokenChartPending:
 			!useFixtures &&
+			requirements.modelTokens &&
 			(usersTokenUsageQuery.isPending ||
 				usersDailyTrendQuery.isPending ||
 				modelTokensTrendQuery.isPending),
 		isSessionSnapshotPending:
-			!useFixtures && sessionSummaryComparisonQuery.isPending,
+			!useFixtures &&
+			requirements.sessionSummary &&
+			sessionSummaryComparisonQuery.isPending,
 		isRepositoryChartPending:
-			!useFixtures && repositoriesDailyTrendQuery.isPending,
+			!useFixtures &&
+			requirements.repositoryTrend &&
+			repositoriesDailyTrendQuery.isPending,
 		isErrorDashboardPending:
 			!useFixtures &&
+			requirements.errors &&
 			(errorDashboardQuery.isPending ||
 				errorProjectTrendQuery.isPending ||
 				errorDeveloperTrendQuery.isPending),

--- a/packages/api-routes/src/model-pricing.ts
+++ b/packages/api-routes/src/model-pricing.ts
@@ -237,6 +237,10 @@ export function getModelPricingCatalog() {
 	return MODEL_RATE_CARD;
 }
 
+export function getModelPricingModifierCatalog() {
+	return MODEL_RATE_MODIFIERS;
+}
+
 function calculateComponent(tokens: number, rate: number | null) {
 	if (tokens === 0) {
 		return 0;


### PR DESCRIPTION
## Summary
- group receipt-valid usage events by pricing-equivalent dimensions before joining the typed rate card, eliminating per-event regex pricing work
- preserve exact token, model, completeness, and cost behavior, including long-context fallback and zero-event receipts
- load only the analytics query families required by the active dashboard tab
- keep schemas, endpoint contracts, and UI output unchanged

## Evidence
- production read-only parity: all 1,503 sessions match current event analytics for tokens, display model, and cost completeness; no cost delta exceeds $0.000001
- core all-org pricing query: roughly 2.2s median before and 0.8–0.9s after on the current production corpus
- point-scoped session pricing query: roughly 1.25–1.39s before and 0.58s after
- no ClickHouse schema or migration changes

## Test plan
- [x] `bun run verify`
- [x] pricing/query contract tests
- [x] dashboard active-tab query requirement tests
- [x] bounded read-only production parity and timing harnesses
- [x] GitHub ClickHouse integration job

## Known boundary
Session detail still transfers and parses the full raw transcript. A representative 4.83 MB session remains around 2.1s end-to-end after the faster pricing lookup; further improvement there requires a separate transcript transport/pagination change.