### PR TITLE
perf(analytics): prune session detail raw reads

### DIFF
--- a/apps/api/src/__tests__/clickhouse.test.ts
+++ b/apps/api/src/__tests__/clickhouse.test.ts
@@ -76,17 +76,32 @@ describe("clickhouse helpers", () => {
 		);
 
 		const sql = buildLatestRawSessionContentSql({
+			sessionDate: true,
 			sessionId: true,
 			userId: true,
 		});
 
 		expect(sql.match(/session_id = \{sessionId:String\}/g)).toHaveLength(2);
 		expect(sql.match(/user_id = \{userId:String\}/g)).toHaveLength(2);
+		expect(
+			sql.match(
+				/session_date = parseDateTime64BestEffort\(\{sessionDate:String\}, 3, 'UTC'\)/g,
+			),
+		).toHaveLength(2);
 		expect(sql).toContain("argMax(content, ingested_at)");
 		expect(sql).toContain(
 			"GROUP BY source, organization_id, user_id, session_id",
 		);
 		expect(sql).not.toContain("ORDER BY ingested_at");
+
+		const sourceScopedSql = buildLatestRawSessionContentSql({
+			sessionDate: true,
+			sessionId: true,
+			source: true,
+			userId: true,
+		});
+		expect(sourceScopedSql).toContain("{source:String} = 'claude_code'");
+		expect(sourceScopedSql).toContain("{source:String} = 'codex'");
 	});
 });
 
@@ -177,11 +192,11 @@ describe("analytics service guardrails", () => {
 		expect(sessionAnalyticsSource.slice(sessionDetailStart)).not.toContain(
 			"FINAL",
 		);
-		expect(sessionAnalyticsSource.slice(sessionDetailStart)).toContain(
-			"raw.content AS content",
-		);
-		expect(sessionAnalyticsSource.slice(sessionDetailStart)).toContain(
-			"raw.subagents AS subagents",
+		const sessionDetailSource =
+			sessionAnalyticsSource.slice(sessionDetailStart);
+		expect(sessionDetailSource).toContain("sessionDate: true");
+		expect(sessionDetailSource).not.toContain(
+			"INNER ANY JOIN latest_raw_session_content",
 		);
 		expect(backfillSource).toContain("max_bytes_to_read");
 		expect(backfillSource).toContain("max_execution_time");

--- a/apps/api/src/clickhouse.ts
+++ b/apps/api/src/clickhouse.ts
@@ -27,7 +27,9 @@ export interface ClickHouseExecutor {
 }
 
 interface LatestRawSessionContentFilters {
+	sessionDate?: boolean;
 	sessionId?: boolean;
+	source?: boolean;
 	userId?: boolean;
 	projectPath?: boolean;
 	lookbackDays?: boolean;
@@ -43,6 +45,11 @@ export function buildLatestRawSessionContentSql(
 	filters: LatestRawSessionContentFilters,
 ): string {
 	const where = ["organization_id = {orgId:String}"];
+	if (filters.sessionDate) {
+		where.push(
+			"session_date = parseDateTime64BestEffort({sessionDate:String}, 3, 'UTC')",
+		);
+	}
 	if (filters.sessionId) where.push("session_id = {sessionId:String}");
 	if (filters.userId) where.push("user_id = {userId:String}");
 	if (filters.projectPath) where.push("project_path = {projectPath:String}");
@@ -59,6 +66,12 @@ export function buildLatestRawSessionContentSql(
 	}
 
 	const rawWhere = where.join("\n      AND ");
+	const claudeWhere = filters.source
+		? `${rawWhere}\n      AND {source:String} = 'claude_code'`
+		: rawWhere;
+	const codexWhere = filters.source
+		? `${rawWhere}\n      AND {source:String} = 'codex'`
+		: rawWhere;
 
 	return `
   SELECT
@@ -78,7 +91,7 @@ export function buildLatestRawSessionContentSql(
       subagents,
       ingested_at
     FROM rudel.claude_sessions
-    WHERE ${rawWhere}
+    WHERE ${claudeWhere}
 
     UNION ALL
 
@@ -91,7 +104,7 @@ export function buildLatestRawSessionContentSql(
       CAST(map(), 'Map(String, String)') AS subagents,
       ingested_at
     FROM rudel.codex_sessions
-    WHERE ${rawWhere}
+    WHERE ${codexWhere}
   )
   GROUP BY source, organization_id, user_id, session_id
 `;

--- a/apps/api/src/services/session-analytics.service.ts
+++ b/apps/api/src/services/session-analytics.service.ts
@@ -731,23 +731,17 @@ export async function getSessionDetail(
 		usage.mode === "events"
 			? "sa.estimated_cost"
 			: LEGACY_SESSION_DISPLAY_COST_WITH_FALLBACK_SQL;
-	const query = `
-	WITH ${usage.cteDefinitions},
-	latest_raw_session_content AS (
-      ${buildLatestRawSessionContentSql({
-				sessionId: true,
-				userId: true,
-			})}
-    )
+	const metadataQuery = `
+	WITH ${usage.cteDefinitions}
     SELECT
       sa.session_id,
       sa.user_id,
+	  sa.source,
+	  sa.session_date AS raw_session_date,
       formatDateTime(sa.session_date, '%Y-%m-%dT%H:%i:%SZ') as session_date,
       formatDateTime(sa.last_interaction_date, '%Y-%m-%dT%H:%i:%SZ') as last_interaction_date,
       sa.project_path,
       if(sa.git_remote != '', sa.git_remote, if(sa.package_name != '', sa.package_name, sa.project_path)) as repository,
-      raw.content AS content,
-      raw.subagents AS subagents,
       sa.skills,
       sa.slash_commands,
       sa.git_branch,
@@ -761,11 +755,6 @@ export async function getSessionDetail(
       sa.total_interactions,
       sa.model_used
 	FROM ${usage.sessionsRelation} AS sa
-    INNER ANY JOIN latest_raw_session_content AS raw
-      ON raw.source = sa.source
-      AND raw.organization_id = sa.organization_id
-      AND raw.user_id = sa.user_id
-      AND raw.session_id = sa.session_id
     WHERE sa.organization_id = {orgId:String}
       AND sa.session_id = {sessionId:String}
       AND sa.user_id = {ownerId:String}
@@ -773,8 +762,12 @@ export async function getSessionDetail(
     LIMIT 1
   `;
 
-	const results = await queryClickhouse<SessionDetail>({
-		query,
+	type SessionDetailMetadata = Omit<SessionDetail, "content" | "subagents"> & {
+		raw_session_date: string;
+		source: string;
+	};
+	const metadataResults = await queryClickhouse<SessionDetailMetadata>({
+		query: metadataQuery,
 		query_params: {
 			orgId,
 			ownerId,
@@ -783,14 +776,49 @@ export async function getSessionDetail(
 		},
 	});
 
-	const [row] = results;
-	if (!row) {
+	const [metadata] = metadataResults;
+	if (!metadata) {
 		return null;
 	}
+
+	const contentResults = await queryClickhouse<
+		Pick<SessionDetail, "content" | "subagents">
+	>({
+		query: `
+			WITH latest_raw_session_content AS (
+				${buildLatestRawSessionContentSql({
+					sessionDate: true,
+					sessionId: true,
+					source: true,
+					userId: true,
+				})}
+			)
+			SELECT content, subagents
+			FROM latest_raw_session_content
+			WHERE source = {source:String}
+			LIMIT 1
+		`,
+		query_params: {
+			orgId,
+			sessionDate: metadata.raw_session_date,
+			sessionId,
+			source: metadata.source,
+			userId: ownerId,
+		},
+	});
+	const [content] = contentResults;
+	if (!content) return null;
+
+	const {
+		raw_session_date: _rawSessionDate,
+		source: _source,
+		...publicMetadata
+	} = metadata;
 	return {
-		...row,
-		repository: row.repository || null,
-		git_branch: row.git_branch || null,
-		git_sha: row.git_sha || null,
+		...publicMetadata,
+		...content,
+		repository: metadata.repository || null,
+		git_branch: metadata.git_branch || null,
+		git_sha: metadata.git_sha || null,
 	};
 }


### PR DESCRIPTION
## Summary
- split session detail metadata/pricing from raw transcript retrieval
- fetch raw content with the complete `(organization_id, session_date, session_id)` key prefix and source guard
- preserve the existing response contract and raw-retention behavior

## Evidence
- production query log: deployed detail query p50 4,226 ms, ~137k rows / 31 MB read, ~425 MB peak memory
- production key census: 22,271/22,271 retained analytics sessions have an exact raw key match; 0 misses
- Claude and Codex spot checks: bounded and legacy content/subagent hashes match
- 19 KB production session: local event-mode detail median 1.31 s after the change
- `EXPLAIN indexes=1`: exact raw lookup uses binary primary-key search

## Test plan
- [x] `bun run verify`
- [x] raw SQL builder regression coverage
- [x] production read-only hash and key-coverage proofs
- [ ] GitHub ClickHouse integration suite