### PR TITLE
fix: move dashboard analytics server-side

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -34,7 +34,7 @@
 		"@rudel/usage-events": "workspace:*",
 		"better-auth": "^1.5.4",
 		"drizzle-orm": "0.45.1",
-		"posthog-node": "^5.8.0",
+		"posthog-node": "5.46.1",
 		"postgres": "^3.4.5",
 		"resend": "^6.9.3"
 	},

--- a/apps/api/src/handlers/product-analytics.ts
+++ b/apps/api/src/handlers/product-analytics.ts
@@ -1,0 +1,57 @@
+import { PRODUCT_ANALYTICS_EVENTS } from "@rudel/api-routes";
+import { captureApiProductAnalyticsEvent } from "../lib/product-analytics.js";
+import { orgMiddleware, os } from "../middleware.js";
+
+const dashboardViewed = os.productAnalytics.dashboardViewed
+	.use(orgMiddleware)
+	.handler(({ context, input }) => {
+		captureApiProductAnalyticsEvent({
+			distinctId: context.user.id,
+			event: PRODUCT_ANALYTICS_EVENTS.DASHBOARD_VIEWED,
+			payload: {
+				...input,
+				organization_id: context.organizationId,
+				user_id: context.user.id,
+			},
+		});
+
+		return { success: true as const };
+	});
+
+const dashboardFilterChanged = os.productAnalytics.dashboardFilterChanged
+	.use(orgMiddleware)
+	.handler(({ context, input }) => {
+		captureApiProductAnalyticsEvent({
+			distinctId: context.user.id,
+			event: PRODUCT_ANALYTICS_EVENTS.DASHBOARD_FILTER_CHANGED,
+			payload: {
+				...input,
+				organization_id: context.organizationId,
+				user_id: context.user.id,
+			},
+		});
+
+		return { success: true as const };
+	});
+
+const dashboardDrilldownOpened = os.productAnalytics.dashboardDrilldownOpened
+	.use(orgMiddleware)
+	.handler(({ context, input }) => {
+		captureApiProductAnalyticsEvent({
+			distinctId: context.user.id,
+			event: PRODUCT_ANALYTICS_EVENTS.DASHBOARD_DRILLDOWN_OPENED,
+			payload: {
+				...input,
+				organization_id: context.organizationId,
+				user_id: context.user.id,
+			},
+		});
+
+		return { success: true as const };
+	});
+
+export const productAnalyticsRouter = os.productAnalytics.router({
+	dashboardViewed,
+	dashboardFilterChanged,
+	dashboardDrilldownOpened,
+});

--- a/apps/api/src/lib/product-analytics.ts
+++ b/apps/api/src/lib/product-analytics.ts
@@ -18,7 +18,9 @@ type ApiCapturePayload<Name extends ProductAnalyticsEventName> = Omit<
 let client: PostHog | null | undefined;
 
 function isAnalyticsEnabled() {
-	return process.env.POSTHOG_ENABLED === "true";
+	return (
+		(process.env.POSTHOG_ENABLED ?? process.env.VITE_POSTHOG_ENABLED) === "true"
+	);
 }
 
 function getEnvironment(): "production" | "staging" | "development" | "local" {
@@ -40,8 +42,16 @@ function getClient() {
 		return client;
 	}
 
-	const key = (process.env.POSTHOG_KEY ?? "").trim();
-	const host = (process.env.POSTHOG_HOST ?? "").trim();
+	const key = (
+		process.env.POSTHOG_KEY ??
+		process.env.VITE_POSTHOG_KEY ??
+		""
+	).trim();
+	const host = (
+		process.env.POSTHOG_HOST ??
+		process.env.VITE_POSTHOG_HOST ??
+		""
+	).trim();
 	if (!isAnalyticsEnabled() || key.length === 0 || host.length === 0) {
 		client = null;
 		return client;

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -26,6 +26,7 @@ import { sqlClient } from "./db.js";
 import { adminRouter } from "./handlers/admin/index.js";
 import { analyticsRouter } from "./handlers/analytics/index.js";
 import { chatwootRouter } from "./handlers/chatwoot.js";
+import { productAnalyticsRouter } from "./handlers/product-analytics.js";
 import { profileRouter } from "./handlers/profile.js";
 import { teamInviteLinkRouter } from "./handlers/team-invite-link.js";
 import { wrappedDecimalClaimRouter } from "./handlers/wrapped-decimal-claim.js";
@@ -872,5 +873,6 @@ export const router = os.router({
 	wrappedResume: wrappedResumeRouter,
 	wrappedShare: wrappedShareRouter,
 	admin: adminRouter,
+	productAnalytics: productAnalyticsRouter,
 	analytics: analyticsRouter,
 });

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -49,7 +49,7 @@
 		"@orpc/client": "^1.13.5",
 		"@orpc/contract": "^1.13.5",
 		"@stricli/core": "^1.2.5",
-		"posthog-node": "^5.8.0",
+		"posthog-node": "5.46.1",
 		"p-map": "^7.0.4"
 	},
 	"devDependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,7 +44,7 @@
 		"lucide-react": "^0.564.0",
 		"motion": "^12.38.0",
 		"next-themes": "^0.4.6",
-		"posthog-js": "^1.292.0",
+		"posthog-js": "1.407.5",
 		"radix-ui": "^1.4.3",
 		"react": "^19.2.0",
 		"react-day-picker": "^9.14.0",

--- a/apps/web/src/features/analytics/tracking/useAnalyticsTracking.ts
+++ b/apps/web/src/features/analytics/tracking/useAnalyticsTracking.ts
@@ -310,7 +310,9 @@ export function useAnalyticsTracking(options?: UseAnalyticsOptions) {
 		}
 
 		captureDashboardFilterChanged({
-			...payload,
+			page_name: payload.page_name,
+			date_range_days: payload.date_range_days,
+			source_component: payload.source_component,
 			filter_name: input.filterName,
 			filter_category: input.filterCategory,
 			change_action: input.changeAction,
@@ -337,7 +339,9 @@ export function useAnalyticsTracking(options?: UseAnalyticsOptions) {
 		}
 
 		captureDashboardDrilldownOpened({
-			...payload,
+			page_name: payload.page_name,
+			date_range_days: payload.date_range_days,
+			source_component: payload.source_component,
 			drilldown_method: input.drilldownMethod,
 			target_type: input.targetType,
 			target_path: input.targetPath,

--- a/apps/web/src/features/analytics/tracking/useTrackProductPageView.ts
+++ b/apps/web/src/features/analytics/tracking/useTrackProductPageView.ts
@@ -259,8 +259,6 @@ export function useTrackProductPageView(options: {
 
 		viewedRangeKeyRef.current = viewedRangeKey;
 		captureDashboardViewed({
-			organization_id: organizationId,
-			user_id: userId,
 			page_name: pageName,
 			has_data: options.hasData,
 			date_range_days: dateRangeDays,

--- a/apps/web/src/lib/product-analytics.ts
+++ b/apps/web/src/lib/product-analytics.ts
@@ -2,12 +2,12 @@ import {
 	type ProductAnalyticsPageName as AppPageName,
 	type AuthenticationActionTriggeredEvent,
 	type ChartExportTriggeredEvent,
-	type DashboardDrilldownOpenedEvent,
-	type DashboardFilterChangedEvent,
+	type DashboardDrilldownOpenedCaptureInput,
+	type DashboardFilterChangedCaptureInput,
 	type DashboardLoadFailedEvent,
 	type DashboardNavigationClickedEvent,
 	type ProductAnalyticsDashboardPageName as DashboardPageName,
-	type DashboardViewedEvent,
+	type DashboardViewedCaptureInput,
 	type OrganizationActionTriggeredEvent,
 	PRODUCT_ANALYTICS_APP_PAGE_NAMES,
 	PRODUCT_ANALYTICS_DASHBOARD_PAGE_NAMES,
@@ -20,6 +20,7 @@ import {
 	type WrappedGrowthLoopEvent,
 } from "@rudel/api-routes";
 import { getWrappedPublicIdFromPath } from "@/app/routes";
+import { client } from "@/lib/orpc";
 
 const EVENT_VERSION = PRODUCT_ANALYTICS_EVENT_VERSION;
 const ANALYTICS_SURFACE = "web";
@@ -285,10 +286,10 @@ export function captureSignUpFailed(
 	captureEvent(PRODUCT_ANALYTICS_EVENTS.SIGN_UP_FAILED, payload);
 }
 
-export function captureDashboardViewed(
-	payload: WebCapturePayload<DashboardViewedEvent>,
-) {
-	captureEvent(PRODUCT_ANALYTICS_EVENTS.DASHBOARD_VIEWED, payload);
+export function captureDashboardViewed(payload: DashboardViewedCaptureInput) {
+	void client.productAnalytics.dashboardViewed(payload).catch(() => {
+		// Product analytics must never break the dashboard.
+	});
 }
 
 export function captureDashboardLoadFailed(
@@ -304,15 +305,19 @@ export function captureDashboardNavigationClicked(
 }
 
 export function captureDashboardFilterChanged(
-	payload: WebCapturePayload<DashboardFilterChangedEvent>,
+	payload: DashboardFilterChangedCaptureInput,
 ) {
-	captureEvent(PRODUCT_ANALYTICS_EVENTS.DASHBOARD_FILTER_CHANGED, payload);
+	void client.productAnalytics.dashboardFilterChanged(payload).catch(() => {
+		// Product analytics must never break the dashboard.
+	});
 }
 
 export function captureDashboardDrilldownOpened(
-	payload: WebCapturePayload<DashboardDrilldownOpenedEvent>,
+	payload: DashboardDrilldownOpenedCaptureInput,
 ) {
-	captureEvent(PRODUCT_ANALYTICS_EVENTS.DASHBOARD_DRILLDOWN_OPENED, payload);
+	void client.productAnalytics.dashboardDrilldownOpened(payload).catch(() => {
+		// Product analytics must never break the dashboard.
+	});
 }
 
 export function captureChartExportTriggered(

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
         "better-auth": "^1.5.4",
         "drizzle-orm": "0.45.1",
         "postgres": "^3.4.5",
-        "posthog-node": "^5.8.0",
+        "posthog-node": "5.46.1",
         "resend": "^6.9.3",
       },
       "devDependencies": {
@@ -44,7 +44,7 @@
     },
     "apps/cli": {
       "name": "rudel",
-      "version": "0.1.11",
+      "version": "0.2.3",
       "bin": {
         "rudel": "./dist/cli.js",
       },
@@ -56,7 +56,7 @@
         "@orpc/contract": "^1.13.5",
         "@stricli/core": "^1.2.5",
         "p-map": "^7.0.4",
-        "posthog-node": "^5.8.0",
+        "posthog-node": "5.46.1",
       },
       "devDependencies": {
         "@rudel/agent-adapters": "workspace:*",
@@ -103,7 +103,7 @@
         "lucide-react": "^0.564.0",
         "motion": "^12.38.0",
         "next-themes": "^0.4.6",
-        "posthog-js": "^1.292.0",
+        "posthog-js": "1.407.5",
         "radix-ui": "^1.4.3",
         "react": "^19.2.0",
         "react-day-picker": "^9.14.0",
@@ -572,26 +572,6 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.208.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg=="],
-
-    "@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
-
-    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/sdk-logs": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg=="],
-
-    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.208.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA=="],
-
-    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.208.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ=="],
-
-    "@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
-
-    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA=="],
-
-    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw=="],
-
-    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw=="],
-
-    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
-
     "@orpc/client": ["@orpc/client@1.13.14", "", { "dependencies": { "@orpc/shared": "1.13.14", "@orpc/standard-server": "1.13.14", "@orpc/standard-server-fetch": "1.13.14", "@orpc/standard-server-peer": "1.13.14" } }, "sha512-JQf3lO//UGHmmkd8+9fuWuh1gga1lhWuKnsT19cui7F6WizBy0NdFSVQerOsSy2c1kxOthlD7GnicGgSY2rhQA=="],
 
     "@orpc/contract": ["@orpc/contract@1.13.14", "", { "dependencies": { "@orpc/client": "1.13.14", "@orpc/shared": "1.13.14", "@standard-schema/spec": "^1.1.0", "openapi-types": "^12.1.3" } }, "sha512-MfsjaQQDVcs4wHmdl5N/7vkwMnQ41nlojWXyRfRXNJHQczqBzM6sYaTJuUPXlw4YbIu64KHZ5nbbtwNCO5YXsg=="],
@@ -618,9 +598,11 @@
 
     "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
-    "@posthog/core": ["@posthog/core@1.23.4", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-gSM1gnIuw5UOBUOTz0IhCTH8jOHoFr5rzSDb5m7fn9ofLHvz3boZT1L1f+bcuk+mvzNJfrJ3ByVQGKmUQnKQ8g=="],
+    "@posthog/browser-common": ["@posthog/browser-common@0.2.4", "", { "dependencies": { "@posthog/core": "^1.45.1", "@posthog/types": "^1.398.0" } }, "sha512-/xI4sIVNiZMJButhNdQFdCHtOcB6v8xM8vtJKznqqB7SMbpYwUNok68iPxGNZHPDwUYM6GAqM/AbMiS80UNyMw=="],
 
-    "@posthog/types": ["@posthog/types@1.360.2", "", {}, "sha512-U48CbtmX5kETZvWjaJVlublSA1aLV99m71TQtgxWksBMXINS/3C7j+KqlMO6wH7SuaEZQnjaxh1KYGH4nRCaaA=="],
+    "@posthog/core": ["@posthog/core@1.45.1", "", { "dependencies": { "@posthog/types": "^1.398.0" } }, "sha512-tLtvzomavb2PPWdGYKsusyIzIeL2Px47v348Smibkay7sMy/83TyPk+Ptsp2NdeOgJsbuwSxWkR2+XA0aSCAaA=="],
+
+    "@posthog/types": ["@posthog/types@1.398.0", "", {}, "sha512-sJMkl4k+u8yS/0fjHsKqE9xTdsAh30a2WvgChiptellnVoE0e8QJKFgqOMD2sk8FaEArPdeFklAhXvmENAt3Sg=="],
 
     "@prisma/client": ["@prisma/client@7.5.0", "", { "dependencies": { "@prisma/client-runtime-utils": "7.5.0" }, "peerDependencies": { "prisma": "*", "typescript": ">=5.4.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-h4hF9ctp+kSRs7ENHGsFQmHAgHcfkOCxbYt6Ti9Xi8x7D+kP4tTi9x51UKmiTH/OqdyJAO+8V+r+JA5AWdav7w=="],
 
@@ -643,26 +625,6 @@
     "@prisma/query-plan-executor": ["@prisma/query-plan-executor@7.2.0", "", {}, "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ=="],
 
     "@prisma/studio-core": ["@prisma/studio-core@0.21.1", "", { "peerDependencies": { "@types/react": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-bOGqG/eMQtKC0XVvcVLRmhWWzm/I+0QUWqAEhEBtetpuS3k3V4IWqKGUONkAIT223DNXJMxMtZp36b1FmcdPeg=="],
-
-    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
-
-    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
-
-    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
-
-    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
-
-    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
-
-    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
-
-    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
-
-    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
-
-    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
-
-    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -1838,13 +1800,13 @@
 
     "postgres": ["postgres@3.4.8", "", {}, "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg=="],
 
-    "posthog-js": ["posthog-js@1.360.2", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.208.0", "@opentelemetry/exporter-logs-otlp-http": "^0.208.0", "@opentelemetry/resources": "^2.2.0", "@opentelemetry/sdk-logs": "^0.208.0", "@posthog/core": "1.23.4", "@posthog/types": "1.360.2", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.28.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.1.0" } }, "sha512-/Wed0mOuRUfyEGT/BRQaokCqBlxrEceE7MDT9A00lU5tXo443/2Pg9ZiqN5sucUluZF47hwGORpYPoVUt32UFw=="],
+    "posthog-js": ["posthog-js@1.407.5", "", { "dependencies": { "@posthog/browser-common": "^0.2.3", "@posthog/core": "^1.45.1", "@posthog/types": "^1.398.0", "core-js": "^3.49.0", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.29.3", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0" } }, "sha512-7YV0aSO8D9NPSawrIjgcOl81SKiPg6op8uFFc7e0qtu3ojYGE5+8MKfR3jEM67duvdkRAeWB9ZwBZQsg9pXu1g=="],
 
-    "posthog-node": ["posthog-node@5.28.2", "", { "dependencies": { "@posthog/core": "1.23.4" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-a+unFAKU8Vtez1DAEgCXB/KOZbroQZE+GvnSr9B35u3uMUxtyPO5ulgLJo8AUcZ4prhv6ia8R1Xjr4BrxPfdsA=="],
+    "posthog-node": ["posthog-node@5.46.1", "", { "dependencies": { "@posthog/core": "^1.45.1" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-WjCqExq44pBdyg9MSsH6UAE0tNZ88p4aIuVFicgqhjf2Fbws6IhS4ioYUa4aBrbUPS9EDRXtBTtF5DpP1ml8Pw=="],
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
-    "preact": ["preact@10.29.0", "", {}, "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg=="],
+    "preact": ["preact@10.29.7", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
@@ -1859,8 +1821,6 @@
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
-
-    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -2192,7 +2152,7 @@
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
-    "web-vitals": ["web-vitals@5.1.0", "", {}, "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg=="],
+    "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
@@ -2257,16 +2217,6 @@
     "@nivo/scales/@types/d3-time-format": ["@types/d3-time-format@3.0.4", "", {}, "sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg=="],
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
-
-    "@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@2.6.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg=="],
-
-    "@opentelemetry/sdk-logs/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
-
-    "@opentelemetry/sdk-metrics/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
-
-    "@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
 
     "@orpc/client/@orpc/shared": ["@orpc/shared@1.13.14", "", { "dependencies": { "radash": "^12.1.1", "type-fest": "^5.4.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-/ri8ttSX+ppoo01d3LdqQ4Xh6VZS5PYRYmHxTvO8tuyiqBJhN18d8P1VtEW4T9hetoK7JZKeU7EAeqVUnCF9WA=="],
 

--- a/packages/api-routes/src/__tests__/dashboard-product-analytics.test.ts
+++ b/packages/api-routes/src/__tests__/dashboard-product-analytics.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import {
+	PRODUCT_ANALYTICS_EVENTS,
+	parseProductAnalyticsEvent,
+} from "../product-analytics.js";
+
+describe("server-owned dashboard product analytics", () => {
+	test("accepts Dashboard Viewed from the API without browser metadata", () => {
+		const payload = {
+			date_range_days: 30,
+			environment: "production",
+			event_version: 1,
+			has_data: true,
+			insight_count: null,
+			organization_id: "org-1",
+			page_name: "overview",
+			surface: "api",
+			user_id: "user-1",
+		} as const;
+
+		expect(
+			parseProductAnalyticsEvent(
+				PRODUCT_ANALYTICS_EVENTS.DASHBOARD_VIEWED,
+				payload,
+			),
+		).toEqual(payload);
+	});
+
+	test("accepts Dashboard Filter Changed from the API", () => {
+		const payload = {
+			affected_scope: "page",
+			change_action: "preset",
+			date_range_days: 30,
+			environment: "production",
+			event_version: 1,
+			filter_category: "date",
+			filter_name: "date_range",
+			organization_id: "org-1",
+			page_name: "overview",
+			source_component: "analytics_date_range_picker",
+			surface: "api",
+			user_id: "user-1",
+			value_key: "last_30_days",
+		} as const;
+
+		expect(
+			parseProductAnalyticsEvent(
+				PRODUCT_ANALYTICS_EVENTS.DASHBOARD_FILTER_CHANGED,
+				payload,
+			),
+		).toEqual(payload);
+	});
+
+	test("accepts Dashboard Drilldown Opened from the API", () => {
+		const payload = {
+			date_range_days: 30,
+			drilldown_method: "table_row",
+			environment: "production",
+			event_version: 1,
+			organization_id: "org-1",
+			page_name: "sessions",
+			source_component: "sessions_table",
+			surface: "api",
+			target_id: "session-1",
+			target_type: "session",
+			user_id: "user-1",
+		} as const;
+
+		expect(
+			parseProductAnalyticsEvent(
+				PRODUCT_ANALYTICS_EVENTS.DASHBOARD_DRILLDOWN_OPENED,
+				payload,
+			),
+		).toEqual(payload);
+	});
+});

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -1,6 +1,9 @@
 import { oc } from "@orpc/contract";
 import { z } from "zod";
 import {
+	DashboardDrilldownOpenedCaptureInputSchema,
+	DashboardFilterChangedCaptureInputSchema,
+	DashboardViewedCaptureInputSchema,
 	ProductAnalyticsClientSurfaceSchema,
 	ProductAnalyticsPlatformOsSchema,
 	ProductAnalyticsUploadModeSchema,
@@ -248,6 +251,10 @@ export const UpdateProfileInputSchema = z.object({
 
 export type UpdateProfileInput = z.infer<typeof UpdateProfileInputSchema>;
 
+const ProductAnalyticsCaptureResultSchema = z.object({
+	success: z.literal(true),
+});
+
 export const contract = {
 	health: oc.output(HealthSchema),
 	me: oc.output(UserSchema),
@@ -362,6 +369,17 @@ export const contract = {
 		deleteUser: oc
 			.input(z.object({ userId: z.string() }))
 			.output(z.object({ success: z.literal(true) })),
+	},
+	productAnalytics: {
+		dashboardViewed: oc
+			.input(DashboardViewedCaptureInputSchema)
+			.output(ProductAnalyticsCaptureResultSchema),
+		dashboardFilterChanged: oc
+			.input(DashboardFilterChangedCaptureInputSchema)
+			.output(ProductAnalyticsCaptureResultSchema),
+		dashboardDrilldownOpened: oc
+			.input(DashboardDrilldownOpenedCaptureInputSchema)
+			.output(ProductAnalyticsCaptureResultSchema),
 	},
 	analytics: {
 		overview: {

--- a/packages/api-routes/src/product-analytics.ts
+++ b/packages/api-routes/src/product-analytics.ts
@@ -227,6 +227,18 @@ const DashboardWebEventSchema = WebEventSchema.extend({
 	user_id: idSchema,
 });
 
+const DashboardCaptureInputSchema = z.object({
+	page_name: ProductAnalyticsDashboardPageNameSchema,
+	date_range_days: z.number().int().nonnegative().optional(),
+	source_component: nonEmptyStringSchema.optional(),
+});
+
+const DashboardApiEventSchema = RequiredCommonSchema.extend({
+	surface: z.literal("api"),
+	organization_id: idSchema,
+	user_id: idSchema,
+});
+
 const ProductAnalyticsActionResultSchema = z.enum([
 	"started",
 	"succeeded",
@@ -394,11 +406,20 @@ export const OrganizationDeletedEventSchema = RequiredCommonSchema.extend({
 	had_uploads_last_30d: z.boolean(),
 }).strict();
 
-export const DashboardViewedEventSchema = DashboardWebEventSchema.extend({
-	has_data: z.boolean(),
-	date_range_days: z.number().int().nonnegative(),
-	insight_count: z.number().int().nonnegative().nullable(),
-}).catchall(webEventValueSchema);
+export const DashboardViewedCaptureInputSchema =
+	DashboardCaptureInputSchema.extend({
+		has_data: z.boolean(),
+		date_range_days: z.number().int().nonnegative(),
+		insight_count: z.number().int().nonnegative().nullable(),
+	}).catchall(webEventValueSchema);
+
+export const DashboardViewedEventSchema = DashboardApiEventSchema.merge(
+	DashboardViewedCaptureInputSchema,
+).catchall(webEventValueSchema);
+
+export type DashboardViewedCaptureInput = z.infer<
+	typeof DashboardViewedCaptureInputSchema
+>;
 
 export const DashboardLoadFailedEventSchema = DashboardWebEventSchema.extend({
 	query_name: nonEmptyStringSchema,
@@ -417,25 +438,41 @@ export const DashboardNavigationClickedEventSchema = WebEventSchema.extend({
 	rank: z.number().int().nonnegative().optional(),
 }).strict();
 
-export const DashboardFilterChangedEventSchema = DashboardWebEventSchema.extend(
-	{
+export const DashboardFilterChangedCaptureInputSchema =
+	DashboardCaptureInputSchema.extend({
 		filter_name: nonEmptyStringSchema,
 		filter_category: nonEmptyStringSchema,
 		change_action: nonEmptyStringSchema,
 		selection_count: z.number().int().nonnegative().optional(),
 		value_key: nonEmptyStringSchema.optional(),
 		affected_scope: nonEmptyStringSchema.optional(),
-	},
+	}).strict();
+
+export const DashboardFilterChangedEventSchema = DashboardApiEventSchema.merge(
+	DashboardFilterChangedCaptureInputSchema,
 ).strict();
 
-export const DashboardDrilldownOpenedEventSchema =
-	DashboardWebEventSchema.extend({
+export type DashboardFilterChangedCaptureInput = z.infer<
+	typeof DashboardFilterChangedCaptureInputSchema
+>;
+
+export const DashboardDrilldownOpenedCaptureInputSchema =
+	DashboardCaptureInputSchema.extend({
 		drilldown_method: nonEmptyStringSchema,
 		target_type: nonEmptyStringSchema,
 		target_path: nonEmptyStringSchema.optional(),
 		target_id: nonEmptyStringSchema.optional(),
 		rank: z.number().int().nonnegative().optional(),
 	}).strict();
+
+export const DashboardDrilldownOpenedEventSchema =
+	DashboardApiEventSchema.merge(
+		DashboardDrilldownOpenedCaptureInputSchema,
+	).strict();
+
+export type DashboardDrilldownOpenedCaptureInput = z.infer<
+	typeof DashboardDrilldownOpenedCaptureInputSchema
+>;
 
 export const ChartExportTriggeredEventSchema = DashboardWebEventSchema.extend({
 	chart_id: nonEmptyStringSchema,


### PR DESCRIPTION
## Summary
- route Dashboard Viewed, Dashboard Filter Changed, and Dashboard Drilldown Opened through authenticated API handlers
- derive organization and user identity on the server while keeping analytics failures off the request path
- support the PostHog environment names already deployed to Fly
- upgrade `posthog-node` to 5.46.1 and `posthog-js` to 1.407.5

## Test plan
- [x] `bun run verify`
- [x] confirmed the production Fly runtime has enabled PostHog host and project-key configuration
- [x] exercised the local sessions dashboard and verified server-side events in PostHog with `surface=api`, `environment=local`, and `posthog-node=5.46.1`
