### PR TITLE
fix(pricing): bill legacy session cache writes at the 1-hour tier

### DIFF
--- a/apps/api/src/services/overview.service.ts
+++ b/apps/api/src/services/overview.service.ts
@@ -12,7 +12,6 @@ import {
 	queryClickhouse,
 } from "../clickhouse.js";
 import { sqlClient } from "../db.js";
-import { buildEstimatedCostSql } from "./pricing.service.js";
 import {
 	buildUsageCostSubtotalSql,
 	getUsageAnalyticsQueryContext,
@@ -114,15 +113,7 @@ export async function getModelTokensTrend(
 		"usage_date",
 	);
 	const usage = await getUsageAnalyticsQueryContext(orgId);
-	const estimatedCostSql =
-		usage.mode === "events"
-			? buildUsageCostSubtotalSql("estimated_cost", 4)
-			: `ifNull(${buildEstimatedCostSql({
-					dateExpr: "sa.usage_date",
-					inputExpr: "sum(sa.input_tokens)",
-					modelExpr: "sa.model_used",
-					outputExpr: "sum(sa.output_tokens)",
-				})}, 0)`;
+	const estimatedCostSql = buildUsageCostSubtotalSql("estimated_cost", 4);
 
 	const query = `
 	WITH ${usage.cteDefinitions}

--- a/apps/api/src/services/session-analytics.service.ts
+++ b/apps/api/src/services/session-analytics.service.ts
@@ -11,16 +11,7 @@ import {
 	buildLatestRawSessionContentSql,
 	queryClickhouse,
 } from "../clickhouse.js";
-import { buildEstimatedCostSql } from "./pricing.service.js";
 import { getUsageAnalyticsQueryContext } from "./usage-event-analytics.service.js";
-
-const LEGACY_SESSION_DISPLAY_COST_SQL = buildEstimatedCostSql({
-	dateExpr: "sa.session_date",
-	inputExpr: "ifNull(sa.input_tokens, 0)",
-	modelExpr: "sa.model_used",
-	outputExpr: "ifNull(sa.output_tokens, 0)",
-});
-const LEGACY_SESSION_DISPLAY_COST_WITH_FALLBACK_SQL = `ifNull(${LEGACY_SESSION_DISPLAY_COST_SQL}, 0)`;
 
 export interface SessionAnalyticsRaw {
 	session_id: string;
@@ -162,10 +153,7 @@ export async function getSessionAnalytics(
 		sourceParam: source ? "source" : undefined,
 		userIdParam: user_id ? "userId" : undefined,
 	});
-	const estimatedCostSql =
-		usage.mode === "events"
-			? "sa.estimated_cost"
-			: LEGACY_SESSION_DISPLAY_COST_WITH_FALLBACK_SQL;
+	const estimatedCostSql = "sa.estimated_cost";
 
 	const query = `
 	WITH ${usage.cteDefinitions}
@@ -727,10 +715,7 @@ export async function getSessionDetail(
 		sessionIdParam: "sessionId",
 		userIdParam: "ownerId",
 	});
-	const estimatedCostSql =
-		usage.mode === "events"
-			? "sa.estimated_cost"
-			: LEGACY_SESSION_DISPLAY_COST_WITH_FALLBACK_SQL;
+	const estimatedCostSql = "sa.estimated_cost";
 	const metadataQuery = `
 	WITH ${usage.cteDefinitions}
     SELECT

--- a/apps/api/src/services/usage-event-analytics.service.test.ts
+++ b/apps/api/src/services/usage-event-analytics.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { buildEstimatedCostSql } from "@rudel/api-routes";
 import {
 	buildLegacyUsageAnalyticsCte,
 	buildUsageCostSubtotalSql,
@@ -137,6 +138,34 @@ describe("usage-event analytics query contract", () => {
 		expect(sql).toContain("AS estimated_cost");
 		expect(sql).toContain("toUInt8(1) AS cost_is_complete");
 		expect(sql).toContain("AS usage_date");
+	});
+
+	test("prices legacy cache writes at the 1-hour tier", () => {
+		const sql = buildLegacyUsageAnalyticsCte();
+		const oneHourTierSql = buildEstimatedCostSql({
+			modelExpr: "sa.model_used",
+			dateExpr: "sa.session_date",
+			inputExpr:
+				"(ifNull(sa.input_tokens, 0) - ifNull(sa.cache_read_input_tokens, 0) - ifNull(sa.cache_creation_input_tokens, 0))",
+			outputExpr: "ifNull(sa.output_tokens, 0)",
+			cacheReadInputExpr: "ifNull(sa.cache_read_input_tokens, 0)",
+			cacheCreation1hInputExpr: "ifNull(sa.cache_creation_input_tokens, 0)",
+		});
+		const fiveMinuteTierSql = buildEstimatedCostSql({
+			modelExpr: "sa.model_used",
+			dateExpr: "sa.session_date",
+			inputExpr:
+				"(ifNull(sa.input_tokens, 0) - ifNull(sa.cache_read_input_tokens, 0) - ifNull(sa.cache_creation_input_tokens, 0))",
+			outputExpr: "ifNull(sa.output_tokens, 0)",
+			cacheReadInputExpr: "ifNull(sa.cache_read_input_tokens, 0)",
+			cacheCreationInputExpr: "ifNull(sa.cache_creation_input_tokens, 0)",
+		});
+
+		// session_analytics has no 5m/1h split; ~89% of Claude Code write
+		// tokens are 1-hour tier and Codex reports no cache writes, so the
+		// legacy path bills the undivided total at the 1-hour rate.
+		expect(sql).toContain(oneHourTierSql);
+		expect(sql).not.toContain(fiveMinuteTierSql);
 	});
 
 	test("keeps explicit off mode as a source rollback without probing events", async () => {

--- a/apps/api/src/services/usage-event-analytics.service.ts
+++ b/apps/api/src/services/usage-event-analytics.service.ts
@@ -18,6 +18,12 @@ const READY_TTL_MS = 60_000;
 const DEGRADED_TTL_MS = 5_000;
 const PROBE_TIMEOUT_MS = 2_000;
 
+// session_analytics stores only the undivided cache-write total, so the legacy
+// path must assume a tier. Sampled prod transcripts show ~89% of Claude Code
+// cache-write tokens are 1-hour tier (Codex reports no cache writes at all),
+// so the total is priced at the 1-hour rate: a small overcharge on the 5m
+// minority instead of a 37.5% undercharge on the 1h majority. The events path
+// needs no assumption: usage_events carries the real 5m/1h split.
 const LEGACY_SESSION_COST_SQL = buildEstimatedCostSql({
 	modelExpr: "sa.model_used",
 	dateExpr: "sa.session_date",
@@ -25,7 +31,7 @@ const LEGACY_SESSION_COST_SQL = buildEstimatedCostSql({
 		"(ifNull(sa.input_tokens, 0) - ifNull(sa.cache_read_input_tokens, 0) - ifNull(sa.cache_creation_input_tokens, 0))",
 	outputExpr: "ifNull(sa.output_tokens, 0)",
 	cacheReadInputExpr: "ifNull(sa.cache_read_input_tokens, 0)",
-	cacheCreationInputExpr: "ifNull(sa.cache_creation_input_tokens, 0)",
+	cacheCreation1hInputExpr: "ifNull(sa.cache_creation_input_tokens, 0)",
 });
 
 const PRICEABLE_EVENT_SQL = `


### PR DESCRIPTION
## Summary
- **Bill legacy session cache writes at the 1-hour tier.** `session_analytics` stores only the undivided `cache_creation_input_tokens` total, and the legacy cost path priced all of it at the 5-minute write rate (1.25x input). A hash-sampled sweep of stored prod transcripts shows **~89% of Claude Code cache-write tokens are 1-hour tier** (monthly range 66-99.5%; Codex transcripts report no cache-write tokens at all), so the total is now billed at the 1-hour rate (2x input) via `cacheCreation1hInputExpr`. This trades a ~35% undercharge on the write component for a ~+4% overcharge - on cache-write-heavy sessions the whole-session error moves from ~-8% to ~+1%. The exact split needs no assumption on the events path: `usage_events` carries real 5m/1h columns, so this approximation only covers the transitional legacy mode.
- **Reuse the CTE `estimated_cost` in legacy mode.** The legacy usage-analytics CTE already computes a full per-session cost (input minus cache, cache reads, tier-correct cache writes), but the session list, session detail, and model-trend queries recomputed a degraded input+output-only price for legacy mode. Since `session_analytics.input_tokens` includes cache tokens, that overstated cache-heavy sessions several-fold (a cache-heavy Fable session displayed ~$202 instead of ~$32). Both modes now read the relation's `estimated_cost`, and the duplicate SQL builders are deleted. Note for review: the simplified form came in with #437 ("simplify cost presentation") - if that was a deliberate perf choice for legacy mode, this commit is separable.

Validated against prod ClickHouse (read-only): a reference `claude-fable-5` session whose transcript is 100% 1h-tier writes moves from $29.82 to **$32.42**, matching ccusage to the cent; a reference `gpt-5.6-sol` Codex session stays **$16.75** (no cache-write tokens, per published OpenAI rates). Cost is computed at query time, so historical sessions correct themselves on deploy - no migration, no re-ingest.

## Test plan
- [x] `bun run verify` (10/10 tasks, 300 api tests pass)
- [x] New test: legacy CTE prices cache writes at the 1-hour tier and not the 5-minute tier
- [x] Generated legacy SQL executed against prod ClickHouse for the two reference sessions (values above)
- [x] Prod transcript sample (4% by session hash, all months) measured for the 5m/1h token split backing the tier assumption

🤖 Generated with [Claude Code](https://claude.com/claude-code)
