### PR TITLE
fix(cli): repair hooks, endpoints, and dry runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: bun run check-types:decimal-e2e
 
       - name: Verify
-        run: bun run turbo run lint check-types test build
+        run: bun run turbo run lint check-types test build --concurrency=2
 
       - name: Verify browser resource budgets in Chrome
         run: bun run --cwd apps/web test:resource-budgets:chrome

--- a/apps/cli/src/__tests__/api-upload.integration.ts
+++ b/apps/cli/src/__tests__/api-upload.integration.ts
@@ -10,7 +10,7 @@ import {
 import assert from "node:assert/strict";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
 	type IngestSessionInput,
 	REDACTION_BUDGET_EXCEEDED_CODE,
@@ -48,6 +48,7 @@ import {
 	stopAllBoundaryRelays,
 	writeCliCredentials,
 } from "./helpers/cli-e2e.js";
+import { codexRolloutPath } from "./helpers/ingest-stub.js";
 import { createStoredSessionReaders } from "./helpers/stored-sessions.js";
 
 setDefaultTimeout(60_000);
@@ -859,7 +860,7 @@ describe("CLI upload to local API", () => {
 		const home = join(tempDir, sessionId);
 		const configDir = join(home, ".rudel");
 		const projectDir = join(home, "codex-project");
-		const sessionFile = join(projectDir, `${sessionId}.jsonl`);
+		const sessionFile = codexRolloutPath(home, sessionId);
 		const rawContent = renderFixture(
 			codexSessionTemplate,
 			sessionId,
@@ -881,6 +882,7 @@ describe("CLI upload to local API", () => {
 		await Promise.all([
 			mkdir(configDir, { recursive: true }),
 			mkdir(projectDir, { recursive: true }),
+			mkdir(dirname(sessionFile), { recursive: true }),
 		]);
 		await Promise.all([
 			writeCliCredentials(configDir, bearerToken, relay.baseUrl),
@@ -889,21 +891,25 @@ describe("CLI upload to local API", () => {
 
 		expect(hasRealisticCodexShape(parseJsonl(rawContent))).toBe(true);
 
-		const result = await runBuiltCli(["hooks", "codex", "turn-complete"], {
-			configDir,
-			env: {
-				RUDEL_API_BASE: relay.baseUrl,
-				RUDEL_ALLOW_INSECURE_ENDPOINT: "",
-			},
-			home,
-			stdin: JSON.stringify({
-				type: "agent-turn-complete",
-				thread_id: sessionId,
-				turn_id: "88888888-8888-4888-8888-888888888888",
-				cwd: projectDir,
-				transcript_path: sessionFile,
-			}),
+		const notification = JSON.stringify({
+			type: "agent-turn-complete",
+			"thread-id": sessionId,
+			"turn-id": "88888888-8888-4888-8888-888888888888",
+			cwd: projectDir,
+			"input-messages": ["test"],
+			"last-assistant-message": "done",
 		});
+		const result = await runBuiltCli(
+			["hooks", "codex", "turn-complete", notification],
+			{
+				configDir,
+				env: {
+					RUDEL_API_BASE: relay.baseUrl,
+					RUDEL_ALLOW_INSECURE_ENDPOINT: "",
+				},
+				home,
+			},
+		);
 
 		const hookLog = await readFile(
 			join(home, ".rudel", "logs", "hook-upload.log"),

--- a/apps/cli/src/__tests__/helpers/cli-e2e.ts
+++ b/apps/cli/src/__tests__/helpers/cli-e2e.ts
@@ -238,6 +238,7 @@ export async function runBuiltCli(
 		env: {
 			...process.env,
 			HOME: options.home,
+			USERPROFILE: options.home,
 			RUDEL_CONFIG_DIR: options.configDir,
 			POSTHOG_ENABLED: "false",
 			...options.env,

--- a/apps/cli/src/__tests__/helpers/ingest-stub.ts
+++ b/apps/cli/src/__tests__/helpers/ingest-stub.ts
@@ -229,6 +229,7 @@ export async function runCli(
 		env: {
 			...process.env,
 			HOME: fixture.home,
+			USERPROFILE: fixture.home,
 			RUDEL_CONFIG_DIR: join(fixture.home, ".rudel"),
 			POSTHOG_ENABLED: "false",
 			...options.env,

--- a/apps/cli/src/__tests__/helpers/ingest-stub.ts
+++ b/apps/cli/src/__tests__/helpers/ingest-stub.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 /**
  * Loopback ingest stub and CLI fixture helpers, extracted from
@@ -94,41 +94,50 @@ export function startIngestStub(options: IngestStubOptions = {}): IngestStub {
 
 export interface HookCase {
 	readonly name: string;
-	readonly command: readonly string[];
 	readonly source: "claude_code" | "codex";
-	buildInput(options: {
+	buildInvocation(options: {
 		sessionId: string;
 		transcriptPath: string;
 		projectPath: string;
-	}): string;
+	}): {
+		readonly command: readonly string[];
+		readonly stdin?: string;
+	};
 }
 
 export const HOOK_CASES: readonly HookCase[] = [
 	{
 		name: "Claude Code SessionEnd",
-		command: ["hooks", "claude", "session-end"],
 		source: "claude_code",
-		buildInput: ({ sessionId, transcriptPath, projectPath }) =>
-			JSON.stringify({
+		buildInvocation: ({ sessionId, transcriptPath, projectPath }) => ({
+			command: ["hooks", "claude", "session-end"],
+			stdin: JSON.stringify({
 				session_id: sessionId,
 				transcript_path: transcriptPath,
 				cwd: projectPath,
 				hook_event_name: "SessionEnd",
 				reason: "other",
 			}),
+		}),
 	},
 	{
 		name: "Codex turn-complete",
-		command: ["hooks", "codex", "turn-complete"],
 		source: "codex",
-		buildInput: ({ sessionId, transcriptPath, projectPath }) =>
-			JSON.stringify({
-				type: "agent-turn-complete",
-				thread_id: sessionId,
-				turn_id: "test-turn",
-				cwd: projectPath,
-				transcript_path: transcriptPath,
-			}),
+		buildInvocation: ({ sessionId, projectPath }) => ({
+			command: [
+				"hooks",
+				"codex",
+				"turn-complete",
+				JSON.stringify({
+					type: "agent-turn-complete",
+					"thread-id": sessionId,
+					"turn-id": "test-turn",
+					cwd: projectPath,
+					"input-messages": ["test"],
+					"last-assistant-message": "done",
+				}),
+			],
+		}),
 	},
 ];
 
@@ -145,6 +154,22 @@ export interface CliResult {
 	readonly stdout: string;
 }
 
+/**
+ * Codex rollout transcripts live under dated subdirectories of
+ * ~/.codex/sessions, where findActiveRolloutFile discovers them by session ID.
+ */
+export function codexRolloutPath(home: string, sessionId: string): string {
+	return join(
+		home,
+		".codex",
+		"sessions",
+		"2026",
+		"08",
+		"12",
+		`${sessionId}.jsonl`,
+	);
+}
+
 export async function createCliFixture(
 	source: HookCase["source"],
 ): Promise<CliFixture> {
@@ -152,10 +177,14 @@ export async function createCliFixture(
 	const configDir = join(home, ".rudel");
 	const projectPath = join(home, "project");
 	const sessionId = `${source}-endpoint-security-session`;
-	const transcriptPath = join(projectPath, `${sessionId}.jsonl`);
+	const transcriptPath =
+		source === "codex"
+			? codexRolloutPath(home, sessionId)
+			: join(projectPath, `${sessionId}.jsonl`);
 	await Promise.all([
 		mkdir(configDir, { recursive: true }),
 		mkdir(projectPath, { recursive: true }),
+		mkdir(dirname(transcriptPath), { recursive: true }),
 	]);
 	await Promise.all([
 		writeFile(

--- a/apps/cli/src/__tests__/packed-cli-smoke.integration.ts
+++ b/apps/cli/src/__tests__/packed-cli-smoke.integration.ts
@@ -320,11 +320,12 @@ test.each(
 			);
 		}
 
-		const result = await runBuiltCli([...hookCase.command], {
+		const invocation = hookCase.buildInvocation(fixture);
+		const result = await runBuiltCli(invocation.command, {
 			home: fixture.home,
 			configDir: fixtureConfigDir(fixture),
 			cliPath: packedCliPath,
-			stdin: hookCase.buildInput(fixture),
+			stdin: invocation.stdin,
 			env: {
 				RUDEL_API_BASE: stub.loopbackBase,
 				RUDEL_ALLOW_INSECURE_ENDPOINT: "",

--- a/apps/cli/src/__tests__/release-pressure.integration.ts
+++ b/apps/cli/src/__tests__/release-pressure.integration.ts
@@ -10,7 +10,7 @@ import {
 import assert from "node:assert/strict";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { claudeCodeAdapter, type SessionFile } from "@rudel/agent-adapters";
 import {
 	INGEST_LIMIT_REASONS,
@@ -51,6 +51,7 @@ import {
 	stopAllBoundaryRelays,
 	writeCliCredentials,
 } from "./helpers/cli-e2e.js";
+import { codexRolloutPath } from "./helpers/ingest-stub.js";
 import { createStoredSessionReaders } from "./helpers/stored-sessions.js";
 
 setDefaultTimeout(90_000);
@@ -740,7 +741,9 @@ describe("release pressure: E2E integration", () => {
 			const home = join(tempDir, sessionId);
 			const configDir = join(home, ".rudel");
 			const projectDir = join(home, "hook-project");
-			const sessionFile = join(projectDir, `${sessionId}.jsonl`);
+			const sessionFile = isClaude
+				? join(projectDir, `${sessionId}.jsonl`)
+				: codexRolloutPath(home, sessionId);
 			const template = isClaude ? claudeSessionTemplate : codexSessionTemplate;
 			const rawContent = renderFixture(template, sessionId, secrets, false);
 			const expectedContent = renderFixture(template, sessionId, secrets, true);
@@ -748,6 +751,7 @@ describe("release pressure: E2E integration", () => {
 			await Promise.all([
 				mkdir(configDir, { recursive: true }),
 				mkdir(projectDir, { recursive: true }),
+				mkdir(dirname(sessionFile), { recursive: true }),
 			]);
 			await Promise.all([
 				writeCliCredentials(configDir, bearerToken, sharedRelay.baseUrl),
@@ -769,7 +773,7 @@ describe("release pressure: E2E integration", () => {
 				);
 			}
 
-			const stdin = isClaude
+			const notification = isClaude
 				? JSON.stringify({
 						session_id: sessionId,
 						transcript_path: sessionFile,
@@ -777,14 +781,16 @@ describe("release pressure: E2E integration", () => {
 					})
 				: JSON.stringify({
 						type: "agent-turn-complete",
-						thread_id: sessionId,
-						turn_id: "99999999-9999-4999-8999-999999999999",
+						"thread-id": sessionId,
+						"turn-id": "99999999-9999-4999-8999-999999999999",
 						cwd: projectDir,
-						transcript_path: sessionFile,
+						"input-messages": ["test"],
+						"last-assistant-message": "done",
 					});
 			const hookArgs = isClaude
 				? ["hooks", "claude", "session-end"]
-				: ["hooks", "codex", "turn-complete"];
+				: ["hooks", "codex", "turn-complete", notification];
+			const stdin = isClaude ? notification : undefined;
 
 			// Phase 1: dead loopback endpoint. Hooks must exit 0 on transport
 			// failures (they only exit 1 on endpointRejected) and queue the session.

--- a/apps/cli/src/__tests__/upload-destination.integration.test.ts
+++ b/apps/cli/src/__tests__/upload-destination.integration.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
 	createCliFixture,
@@ -10,6 +11,140 @@ import {
 } from "./helpers/ingest-stub.js";
 
 const TEST_TOKEN = INGEST_STUB_TEST_TOKEN;
+
+async function pointCredentialsAt(
+	home: string,
+	apiBaseUrl: string,
+): Promise<void> {
+	await writeFile(
+		join(home, ".rudel", "credentials.json"),
+		JSON.stringify({
+			token: TEST_TOKEN,
+			apiBaseUrl,
+			authType: "api-key",
+		}),
+	);
+}
+
+test("upload defaults to the authenticated API base", async () => {
+	const stub = startIngestStub();
+	const fixture = await createCliFixture("claude_code");
+	try {
+		await pointCredentialsAt(fixture.home, stub.loopbackBase);
+
+		const result = await runCli(["upload", fixture.transcriptPath], fixture);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("Upload successful!");
+		expect(stub.requests).toEqual([
+			{
+				apiKey: TEST_TOKEN,
+				pathname: "/rpc/ingestSession",
+			},
+		]);
+	} finally {
+		await stub.server.stop(true);
+		await rm(fixture.home, { recursive: true, force: true });
+	}
+}, 30_000);
+
+test("retry defaults to the authenticated API base", async () => {
+	const stub = startIngestStub();
+	const fixture = await createCliFixture("claude_code");
+	try {
+		await pointCredentialsAt(fixture.home, stub.loopbackBase);
+		await writeFile(
+			join(fixture.home, ".rudel", "failed-uploads.json"),
+			JSON.stringify({
+				failures: [
+					{
+						sessionId: fixture.sessionId,
+						transcriptPath: fixture.transcriptPath,
+						projectPath: fixture.projectPath,
+						source: "claude_code",
+						error: "network failure",
+						failedAt: "2026-08-12T10:00:00.000Z",
+						status: "retryable",
+					},
+				],
+			}),
+		);
+
+		const result = await runCli(["upload", "--retry", "--yes"], fixture);
+
+		expect(result.exitCode).toBe(0);
+		expect(stub.requests).toHaveLength(1);
+		expect(stub.requests[0]).toEqual({
+			apiKey: TEST_TOKEN,
+			pathname: "/rpc/ingestSession",
+		});
+	} finally {
+		await stub.server.stop(true);
+		await rm(fixture.home, { recursive: true, force: true });
+	}
+}, 30_000);
+
+test("retry dry-run performs no network or persistent-state writes", async () => {
+	const stub = startIngestStub();
+	const fixture = await createCliFixture("claude_code");
+	const queuePath = join(fixture.home, ".rudel", "failed-uploads.json");
+	const queue = JSON.stringify(
+		{
+			failures: [
+				{
+					sessionId: fixture.sessionId,
+					transcriptPath: fixture.transcriptPath,
+					projectPath: fixture.projectPath,
+					source: "claude_code",
+					error: "network failure",
+					failedAt: "2026-08-12T10:00:00.000Z",
+					status: "retryable",
+				},
+			],
+		},
+		null,
+		2,
+	);
+	try {
+		await pointCredentialsAt(fixture.home, stub.loopbackBase);
+		await writeFile(queuePath, queue);
+
+		const result = await runCli(["upload", "--retry", "--dry-run"], fixture);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("Dry run complete");
+		expect(result.stderr).not.toContain("failed");
+		expect(stub.requests).toHaveLength(0);
+		expect(await readFile(queuePath, "utf8")).toBe(queue);
+	} finally {
+		await stub.server.stop(true);
+		await rm(fixture.home, { recursive: true, force: true });
+	}
+}, 30_000);
+
+test("single-session dry-run does not launch the classifier", async () => {
+	const fixture = await createCliFixture("claude_code");
+	const fakeBin = join(fixture.home, "bin");
+	const marker = join(fixture.home, "classifier-was-launched");
+	try {
+		await mkdir(fakeBin, { recursive: true });
+		const fakeClaude = join(fakeBin, "claude");
+		await writeFile(fakeClaude, `#!/bin/sh\ntouch "${marker}"\n`);
+		await chmod(fakeClaude, 0o755);
+
+		const result = await runCli(
+			["upload", fixture.transcriptPath, "--dry-run", "--classify"],
+			fixture,
+			{ env: { PATH: `${fakeBin}:${process.env.PATH ?? ""}` } },
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("Dry run - would upload:");
+		expect(existsSync(marker)).toBe(false);
+	} finally {
+		await rm(fixture.home, { recursive: true, force: true });
+	}
+}, 30_000);
 
 test("upload --endpoint refuses plaintext non-loopback without an opt-in", async () => {
 	const stub = startIngestStub();
@@ -121,8 +256,9 @@ test.each(
 	const stub = startIngestStub();
 	const fixture = await createCliFixture(hookCase.source);
 	try {
-		const result = await runCli(hookCase.command, fixture, {
-			stdin: hookCase.buildInput(fixture),
+		const invocation = hookCase.buildInvocation(fixture);
+		const result = await runCli(invocation.command, fixture, {
+			stdin: invocation.stdin,
 			env: {
 				RUDEL_API_BASE: stub.nonLoopbackBase,
 				RUDEL_ALLOW_INSECURE_ENDPOINT: "",
@@ -160,8 +296,9 @@ test.each(
 	const stub = startIngestStub();
 	const fixture = await createCliFixture(hookCase.source);
 	try {
-		const result = await runCli(hookCase.command, fixture, {
-			stdin: hookCase.buildInput(fixture),
+		const invocation = hookCase.buildInvocation(fixture);
+		const result = await runCli(invocation.command, fixture, {
+			stdin: invocation.stdin,
 			env: {
 				RUDEL_API_BASE: stub.nonLoopbackBase,
 				RUDEL_ALLOW_INSECURE_ENDPOINT: "1",
@@ -205,8 +342,9 @@ test.each(
 	});
 	const fixture = await createCliFixture(hookCase.source);
 	try {
-		const result = await runCli(hookCase.command, fixture, {
-			stdin: hookCase.buildInput(fixture),
+		const invocation = hookCase.buildInvocation(fixture);
+		const result = await runCli(invocation.command, fixture, {
+			stdin: invocation.stdin,
 			env: { RUDEL_API_BASE: stub.loopbackBase },
 		});
 

--- a/apps/cli/src/commands/hooks/codex/turn-complete.ts
+++ b/apps/cli/src/commands/hooks/codex/turn-complete.ts
@@ -18,51 +18,57 @@ import {
 import { disposeLogging, setupHookLogging } from "../../../logging.js";
 
 interface CodexNotifyInput {
-	type: string;
-	thread_id: string;
-	turn_id?: string;
+	type: "agent-turn-complete";
+	threadId: string;
 	cwd: string;
-	transcript_path?: string;
 }
 
-async function readStdin(): Promise<string> {
-	const chunks: string[] = [];
-	for await (const chunk of process.stdin) {
-		chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+function parseNotification(raw: string): CodexNotifyInput | null {
+	const parsed: unknown = JSON.parse(raw);
+	if (typeof parsed !== "object" || parsed === null) return null;
+	if (!("type" in parsed) || parsed.type !== "agent-turn-complete") return null;
+	if (!("thread-id" in parsed) || typeof parsed["thread-id"] !== "string") {
+		return null;
 	}
-	return chunks.join("");
+	if (!("cwd" in parsed) || typeof parsed.cwd !== "string") return null;
+	return {
+		type: parsed.type,
+		threadId: parsed["thread-id"],
+		cwd: parsed.cwd,
+	};
 }
 
-async function runTurnComplete(): Promise<undefined | Error> {
+async function runTurnComplete(
+	_flags: Record<string, never>,
+	notification: string,
+): Promise<undefined | Error> {
 	await setupHookLogging();
 	const logger = getLogger(["rudel", "cli", "hook"]);
 
 	try {
-		const raw = await readStdin();
-		if (!raw.trim()) return;
+		if (!notification.trim()) return;
 
-		const input = JSON.parse(raw) as CodexNotifyInput;
-		if (!input.thread_id || !input.cwd) return;
+		const input = parseNotification(notification);
+		if (!input) return;
 
 		const credentials = loadCredentials();
 		if (!credentials) {
 			process.stderr.write(
-				`Rudel hook upload skipped for session ${input.thread_id}: not authenticated; run \`rudel login\`.\n`,
+				`Rudel hook upload skipped for session ${input.threadId}: not authenticated; run \`rudel login\`.\n`,
 			);
 			return;
 		}
 
-		const transcriptPath =
-			input.transcript_path ?? (await findActiveRolloutFile(input.thread_id));
+		const transcriptPath = await findActiveRolloutFile(input.threadId);
 		if (!transcriptPath) {
 			process.stderr.write(
-				`Rudel hook upload skipped for session ${input.thread_id}: transcript file was not found.\n`,
+				`Rudel hook upload skipped for session ${input.threadId}: transcript file was not found.\n`,
 			);
 			return;
 		}
 
 		const sessionFile: SessionFile = {
-			sessionId: input.thread_id,
+			sessionId: input.threadId,
 			transcriptPath,
 			projectPath: input.cwd,
 		};
@@ -93,10 +99,10 @@ async function runTurnComplete(): Promise<undefined | Error> {
 			if (redactionSummary) {
 				logger.info("{redactionSummary}", { redactionSummary });
 			}
-			await removeFailedUpload(input.thread_id);
+			await removeFailedUpload(input.threadId);
 		} else {
 			const hookError = await reportHookUploadFailure(logger, result, {
-				sessionId: input.thread_id,
+				sessionId: input.threadId,
 				transcriptPath,
 				projectPath: input.cwd,
 				source: codexAdapter.source,
@@ -116,7 +122,19 @@ async function runTurnComplete(): Promise<undefined | Error> {
 
 export const turnCompleteCommand = buildCommand({
 	loader: async () => ({ default: runTurnComplete }),
-	parameters: {},
+	parameters: {
+		flags: {},
+		positional: {
+			kind: "tuple",
+			parameters: [
+				{
+					brief: "Codex notification JSON",
+					parse: String,
+					placeholder: "notification",
+				},
+			],
+		},
+	},
 	docs: {
 		brief: "Handle Codex agent-turn-complete hook",
 	},

--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -11,7 +11,7 @@ import { buildCommand } from "@stricli/core";
 import type { BatchUploadItem } from "../lib/batch-upload.js";
 import { renderBatchSummary, runBatchUpload } from "../lib/batch-upload-ui.js";
 import { classifySession } from "../lib/classifier.js";
-import { loadCredentials } from "../lib/credentials.js";
+import { type Credentials, loadCredentials } from "../lib/credentials.js";
 import {
 	isRetryCandidate,
 	loadFailedUploads,
@@ -35,7 +35,7 @@ import {
 
 interface UploadFlags {
 	tag?: SessionTag;
-	endpoint: string;
+	endpoint?: string;
 	allowInsecureEndpoint: boolean;
 	classify: boolean;
 	dryRun: boolean;
@@ -46,21 +46,23 @@ interface UploadFlags {
 	forceReplace: boolean;
 }
 
-async function runInteractiveUpload(
-	flags: UploadFlags,
-	allowPlaintextEndpoint: boolean,
-): Promise<undefined | Error> {
-	const credentials = loadCredentials();
-	if (!credentials && !flags.dryRun) {
-		return new Error("Not authenticated. Run `rudel login` first.");
-	}
+interface ResolvedUploadFlags extends UploadFlags {
+	endpoint: string;
+}
 
+async function runInteractiveUpload(
+	flags: ResolvedUploadFlags,
+	allowPlaintextEndpoint: boolean,
+	credentials: Credentials | null,
+): Promise<undefined | Error> {
 	p.intro("rudel upload");
 
 	const spin = p.spinner();
 	spin.start("Scanning projects...");
 
-	const { projects: allProjects, groups } = await scanAndGroupProjects();
+	const { projects: allProjects, groups } = await scanAndGroupProjects({
+		persistRemoteCache: !flags.dryRun,
+	});
 
 	spin.stop(`Found ${allProjects.length} project(s)`);
 
@@ -106,15 +108,30 @@ async function runInteractiveUpload(
 		(sum, proj) => sum + proj.sessionCount,
 		0,
 	);
+
+	if (flags.dryRun) {
+		for (const project of selected) {
+			p.log.info(
+				`Would upload ${sessionCountHint(project.sessionCount)} from [${getAdapterName(project.source)}] ${project.displayPath}`,
+			);
+		}
+		p.outro("Dry run complete — no sessions were uploaded.");
+		return;
+	}
+
+	if (!credentials) {
+		return new Error("Not authenticated. Run `rudel login` first.");
+	}
+
 	p.log.info(
 		`Uploading ${totalSessions} session(s) from ${selected.length} project(s)`,
 	);
 
 	const uploadConfig: UploadConfig = {
 		endpoint: flags.endpoint,
-		token: credentials?.token ?? "",
+		token: credentials.token,
 		allowInsecureEndpoint: allowPlaintextEndpoint,
-		authType: credentials?.authType,
+		authType: credentials.authType,
 	};
 
 	// Flatten all sessions with their project context for concurrent upload
@@ -174,21 +191,13 @@ async function runInteractiveUpload(
 				}
 			}
 
-			if (flags.dryRun) {
-				return { success: true };
-			}
-
 			return uploadSession(request, { ...uploadConfig, onRetry });
 		},
 	});
 
 	renderBatchSummary(summary, { showRetryHint: summary.failed > 0 });
 
-	if (flags.dryRun) {
-		p.outro("Dry run complete — no sessions were uploaded.");
-	} else {
-		p.outro("Done!");
-	}
+	p.outro("Done!");
 
 	if (summary.failed > 0) {
 		return new Error(`${summary.failed} upload(s) failed.`);
@@ -204,18 +213,14 @@ function sessionCountHint(count: number): string {
 }
 
 async function runSingleUpload(
-	flags: UploadFlags,
+	flags: ResolvedUploadFlags,
 	session: string,
 	allowPlaintextEndpoint: boolean,
+	credentials: Credentials | null,
 ): Promise<undefined | Error> {
 	const write = (msg: string) => {
 		process.stdout.write(`${msg}\n`);
 	};
-
-	const credentials = loadCredentials();
-	if (!credentials && !flags.dryRun) {
-		return new Error("Not authenticated. Run `rudel login` first.");
-	}
 
 	write(`Resolving session: ${session}`);
 	let sessionInfo: Awaited<ReturnType<typeof resolveSession>>;
@@ -267,14 +272,6 @@ async function runSingleUpload(
 		write(`Subagents: ${request.subagents.length} file(s)`);
 	}
 
-	if (!flags.tag && flags.classify) {
-		write("Classifying session...");
-		const classified = await classifySession(request.content);
-		if (classified) {
-			(request as { tag?: string }).tag = classified;
-			write(`Classified as: ${classified}`);
-		}
-	}
 	if (flags.forceReplace) request.force_replace = true;
 
 	if (flags.dryRun) {
@@ -291,13 +288,25 @@ async function runSingleUpload(
 		return;
 	}
 
+	if (!credentials) {
+		return new Error("Not authenticated. Run `rudel login` first.");
+	}
+
+	if (!flags.tag && flags.classify) {
+		write("Classifying session...");
+		const classified = await classifySession(request.content);
+		if (classified) {
+			(request as { tag?: string }).tag = classified;
+			write(`Classified as: ${classified}`);
+		}
+	}
+
 	write("Uploading...");
 	const result = await uploadSession(request, {
 		endpoint: flags.endpoint,
-		// biome-ignore lint/style/noNonNullAssertion: validated above with early return
-		token: credentials!.token,
+		token: credentials.token,
 		allowInsecureEndpoint: allowPlaintextEndpoint,
-		authType: credentials?.authType,
+		authType: credentials.authType,
 	});
 
 	if (result.success) {
@@ -316,14 +325,10 @@ async function runSingleUpload(
 }
 
 async function runRetryUpload(
-	flags: UploadFlags,
+	flags: ResolvedUploadFlags,
 	allowPlaintextEndpoint: boolean,
+	credentials: Credentials | null,
 ): Promise<undefined | Error> {
-	const credentials = loadCredentials();
-	if (!credentials) {
-		return new Error("Not authenticated. Run `rudel login` first.");
-	}
-
 	p.intro("rudel upload --retry");
 
 	const failures = await loadFailedUploads();
@@ -359,6 +364,17 @@ async function runRetryUpload(
 		return;
 	}
 
+	if (flags.dryRun) {
+		p.outro(
+			`Dry run complete — ${retryableFailures.length} retryable upload(s) were not sent.`,
+		);
+		return;
+	}
+
+	if (!credentials) {
+		return new Error("Not authenticated. Run `rudel login` first.");
+	}
+
 	if (!flags.yes) {
 		const shouldRetry = await p.confirm({
 			message: `Retry ${retryableFailures.length} retryable upload(s)?`,
@@ -370,8 +386,6 @@ async function runRetryUpload(
 			return;
 		}
 	}
-
-	const endpoint = flags.endpoint;
 
 	type RetryItem = BatchUploadItem & {
 		failure: (typeof failures)[number];
@@ -387,6 +401,7 @@ async function runRetryUpload(
 		failure: f,
 	}));
 
+	const { token, authType } = credentials;
 	const summary = await runBatchUpload({
 		items,
 		label: "Retrying uploads...",
@@ -415,10 +430,10 @@ async function runRetryUpload(
 			if (flags.forceReplace) request.force_replace = true;
 
 			return uploadSession(request, {
-				endpoint,
-				token: credentials.token,
+				endpoint: flags.endpoint,
+				token,
 				allowInsecureEndpoint: allowPlaintextEndpoint,
-				authType: credentials.authType,
+				authType,
 				onRetry,
 			});
 		},
@@ -437,16 +452,36 @@ async function runUpload(
 	flags: UploadFlags,
 	...sessions: string[]
 ): Promise<undefined | Error> {
+	const credentials = loadCredentials();
+	if (!credentials && !flags.dryRun) {
+		return new Error("Not authenticated. Run `rudel login` first.");
+	}
+	const apiBaseUrl = credentials?.apiBaseUrl.replace(/\/+$/u, "");
+	const resolvedFlags: ResolvedUploadFlags = {
+		...flags,
+		endpoint:
+			flags.endpoint ??
+			(apiBaseUrl === undefined ? DEFAULT_ENDPOINT : `${apiBaseUrl}/rpc`),
+	};
 	const allowPlaintextEndpoint = allowsInsecureEndpoint(
-		flags.allowInsecureEndpoint,
+		resolvedFlags.allowInsecureEndpoint,
 	);
-	if (flags.retry) {
-		return runRetryUpload(flags, allowPlaintextEndpoint);
+	if (resolvedFlags.retry) {
+		return runRetryUpload(resolvedFlags, allowPlaintextEndpoint, credentials);
 	}
 	if (sessions.length === 0) {
-		return runInteractiveUpload(flags, allowPlaintextEndpoint);
+		return runInteractiveUpload(
+			resolvedFlags,
+			allowPlaintextEndpoint,
+			credentials,
+		);
 	}
-	return runSingleUpload(flags, sessions[0] as string, allowPlaintextEndpoint);
+	return runSingleUpload(
+		resolvedFlags,
+		sessions[0] as string,
+		allowPlaintextEndpoint,
+		credentials,
+	);
 }
 
 export const uploadCommand = buildCommand({
@@ -471,7 +506,7 @@ export const uploadCommand = buildCommand({
 				kind: "parsed",
 				parse: String,
 				brief: "Override the upload endpoint URL",
-				default: DEFAULT_ENDPOINT,
+				optional: true,
 			},
 			allowInsecureEndpoint: {
 				kind: "boolean",

--- a/apps/cli/src/lib/batch-upload.ts
+++ b/apps/cli/src/lib/batch-upload.ts
@@ -6,7 +6,11 @@ import {
 	SecretFilterJsonIntegrityError,
 } from "@rudel/secret-filter";
 import pMap from "p-map";
-import { recordFailedUpload, removeFailedUpload } from "./failed-uploads.js";
+import {
+	type FailedUpload,
+	recordFailedUpload,
+	removeFailedUpload,
+} from "./failed-uploads.js";
 import type { UploadResult } from "./types.js";
 
 export interface BatchUploadItem {
@@ -49,6 +53,23 @@ export async function batchUpload<T extends BatchUploadItem>(
 	options: BatchUploadOptions<T>,
 ): Promise<BatchUploadSummary> {
 	const { items, upload, concurrency = 5, onItemComplete, onRetry } = options;
+	const recordFailure = async (
+		item: T,
+		failure: {
+			error: string;
+			status: FailedUpload["status"];
+			failureKind?: FailedUpload["failureKind"];
+		},
+	) => {
+		await recordFailedUpload({
+			sessionId: item.sessionId,
+			transcriptPath: item.transcriptPath,
+			projectPath: item.projectPath,
+			source: item.source,
+			organizationId: item.organizationId,
+			...failure,
+		});
+	};
 	const total = items.length;
 	let succeeded = 0;
 	let failed = 0;
@@ -68,15 +89,7 @@ export async function batchUpload<T extends BatchUploadItem>(
 				deferred++;
 				const error =
 					"Skipped — rate limit reached. Run `rudel upload --retry` to upload remaining sessions.";
-				await recordFailedUpload({
-					sessionId: item.sessionId,
-					transcriptPath: item.transcriptPath,
-					projectPath: item.projectPath,
-					source: item.source,
-					organizationId: item.organizationId,
-					error,
-					status: "retryable",
-				});
+				await recordFailure(item, { error, status: "retryable" });
 				completed++;
 				onItemComplete?.(completed, total);
 				return;
@@ -103,12 +116,7 @@ export async function batchUpload<T extends BatchUploadItem>(
 						label: item.label,
 						reason: result.error ?? "Upload cannot be retried",
 					});
-					await recordFailedUpload({
-						sessionId: item.sessionId,
-						transcriptPath: item.transcriptPath,
-						projectPath: item.projectPath,
-						source: item.source,
-						organizationId: item.organizationId,
+					await recordFailure(item, {
 						error: result.error ?? "Upload cannot be retried",
 						failureKind: result.failureKind,
 						status: "permanent",
@@ -120,12 +128,7 @@ export async function batchUpload<T extends BatchUploadItem>(
 					if (result.rateLimited) {
 						rateLimited = true;
 					}
-					await recordFailedUpload({
-						sessionId: item.sessionId,
-						transcriptPath: item.transcriptPath,
-						projectPath: item.projectPath,
-						source: item.source,
-						organizationId: item.organizationId,
+					await recordFailure(item, {
 						error,
 						failureKind: result.failureKind,
 						status: "retryable",
@@ -139,12 +142,7 @@ export async function batchUpload<T extends BatchUploadItem>(
 				) {
 					skipped++;
 					skippedItems.push({ label: item.label, reason: error });
-					await recordFailedUpload({
-						sessionId: item.sessionId,
-						transcriptPath: item.transcriptPath,
-						projectPath: item.projectPath,
-						source: item.source,
-						organizationId: item.organizationId,
+					await recordFailure(item, {
 						error,
 						failureKind:
 							err instanceof SecretFilterJsonIntegrityError
@@ -155,15 +153,7 @@ export async function batchUpload<T extends BatchUploadItem>(
 				} else {
 					failed++;
 					errors.push({ label: item.label, error });
-					await recordFailedUpload({
-						sessionId: item.sessionId,
-						transcriptPath: item.transcriptPath,
-						projectPath: item.projectPath,
-						source: item.source,
-						organizationId: item.organizationId,
-						error,
-						status: "retryable",
-					});
+					await recordFailure(item, { error, status: "retryable" });
 				}
 			} finally {
 				completed++;

--- a/apps/cli/src/lib/project-grouping.ts
+++ b/apps/cli/src/lib/project-grouping.ts
@@ -17,15 +17,20 @@ export interface ScanResult {
 }
 
 export async function scanAndGroupProjects(
-	cwd: string = process.cwd(),
+	options: { persistRemoteCache?: boolean } = {},
 ): Promise<ScanResult> {
+	const cwd = process.cwd();
 	const adapters = getAvailableAdapters();
 	const projects: ScannedProject[] = [];
 	for (const adapter of adapters) {
 		const scanned = await adapter.scanAllSessions();
 		projects.push(...scanned);
 	}
-	const groups = await groupProjectsByRemote(projects, cwd);
+	const groups = await groupProjectsByRemote(
+		projects,
+		cwd,
+		options.persistRemoteCache ?? true,
+	);
 	return { projects, groups };
 }
 
@@ -53,6 +58,7 @@ function encodeProjectPath(projectPath: string): string {
 export async function groupProjectsByRemote(
 	projects: ScannedProject[],
 	cwd: string,
+	persistRemoteCache: boolean = true,
 ): Promise<ProjectGroup[]> {
 	const cache = await getRemoteCache();
 	let cacheUpdated = false;
@@ -158,7 +164,7 @@ export async function groupProjectsByRemote(
 	});
 
 	// Fire-and-forget cache write
-	if (cacheUpdated) {
+	if (persistRemoteCache && cacheUpdated) {
 		cacheRemotes(cache);
 	}
 

--- a/packages/agent-adapters/package.json
+++ b/packages/agent-adapters/package.json
@@ -6,6 +6,9 @@
 	"exports": {
 		".": "./src/index.ts"
 	},
+	"scripts": {
+		"test": "bun test"
+	},
 	"dependencies": {
 		"@rudel/api-routes": "workspace:*",
 		"@rudel/ch-schema": "workspace:*",

--- a/packages/agent-adapters/src/adapters/codex/config.test.ts
+++ b/packages/agent-adapters/src/adapters/codex/config.test.ts
@@ -1,0 +1,112 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse as parseTOML } from "smol-toml";
+import { installHook, isHookInstalled, removeHook } from "./config.js";
+
+let tempDir: string;
+
+beforeAll(async () => {
+	tempDir = await mkdtemp(join(tmpdir(), "rudel-codex-config-"));
+});
+
+afterAll(async () => {
+	await rm(tempDir, { recursive: true, force: true });
+});
+
+function configPath(name: string): string {
+	return join(tempDir, `${name}.toml`);
+}
+
+async function readNotify(path: string): Promise<unknown> {
+	const config = parseTOML(await readFile(path, "utf8"));
+	return config.notify;
+}
+
+describe("Codex notify configuration", () => {
+	test("installs Rudel as one argv vector and is idempotent", async () => {
+		const path = configPath("fresh");
+
+		installHook(path);
+		installHook(path);
+
+		expect(await readNotify(path)).toEqual([
+			"rudel",
+			"hooks",
+			"codex",
+			"turn-complete",
+		]);
+		expect(isHookInstalled(path)).toBe(true);
+	});
+
+	test("migrates Rudel's malformed legacy singleton", async () => {
+		const path = configPath("legacy-singleton");
+		await writeFile(path, 'notify = ["rudel hooks codex turn-complete"]\n', {
+			flag: "wx",
+		});
+
+		installHook(path);
+
+		expect(await readNotify(path)).toEqual([
+			"rudel",
+			"hooks",
+			"codex",
+			"turn-complete",
+		]);
+	});
+
+	test("installs into an explicitly empty notify vector", async () => {
+		const path = configPath("empty");
+		await writeFile(path, "notify = []\n", { flag: "wx" });
+
+		installHook(path);
+
+		expect(await readNotify(path)).toEqual([
+			"rudel",
+			"hooks",
+			"codex",
+			"turn-complete",
+		]);
+	});
+
+	test("preserves an unrelated existing notify command", async () => {
+		const path = configPath("existing");
+		const original = 'notify = ["python3", "/tmp/notify.py"]\n';
+		await writeFile(path, original, { flag: "wx" });
+
+		expect(() => installHook(path)).toThrow("supports only one notify command");
+		expect(await readFile(path, "utf8")).toBe(original);
+		expect(isHookInstalled(path)).toBe(false);
+	});
+
+	test("repairs a previously corrupted notify command without replacing it", async () => {
+		const path = configPath("legacy-appended");
+		await writeFile(
+			path,
+			'notify = ["python3", "/tmp/notify.py", "rudel hooks codex turn-complete"]\n',
+			{ flag: "wx" },
+		);
+
+		expect(() => installHook(path)).toThrow("restoring the previous command");
+		expect(await readNotify(path)).toEqual(["python3", "/tmp/notify.py"]);
+		expect(isHookInstalled(path)).toBe(false);
+	});
+
+	test("removes only Rudel's notify command", async () => {
+		const installedPath = configPath("remove-installed");
+		installHook(installedPath);
+
+		removeHook(installedPath);
+
+		expect(await readNotify(installedPath)).toBeUndefined();
+
+		const existingPath = configPath("remove-existing");
+		const original = 'notify = ["python3", "/tmp/notify.py"]\n';
+		await writeFile(existingPath, original, { flag: "wx" });
+
+		removeHook(existingPath);
+
+		expect(await readFile(existingPath, "utf8")).toBe(original);
+	});
+});

--- a/packages/agent-adapters/src/adapters/codex/config.ts
+++ b/packages/agent-adapters/src/adapters/codex/config.ts
@@ -1,49 +1,90 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { parse as parseTOML, stringify as stringifyTOML } from "smol-toml";
 
 export const CONFIG_PATH = join(homedir(), ".codex", "config.toml");
-const HOOK_COMMAND = "rudel hooks codex turn-complete";
+const HOOK_COMMAND = ["rudel", "hooks", "codex", "turn-complete"] as const;
+const LEGACY_HOOK_COMMAND = "rudel hooks codex turn-complete";
 
 interface CodexConfig {
 	notify?: string[];
 	[key: string]: unknown;
 }
 
-function readConfig(): CodexConfig {
-	if (!existsSync(CONFIG_PATH)) return {};
-	const content = readFileSync(CONFIG_PATH, "utf-8");
+function readConfig(configPath: string): CodexConfig {
+	if (!existsSync(configPath)) return {};
+	const content = readFileSync(configPath, "utf-8");
 	return parseTOML(content) as CodexConfig;
 }
 
-function writeConfig(config: CodexConfig): void {
-	writeFileSync(CONFIG_PATH, stringifyTOML(config));
+function writeConfig(configPath: string, config: CodexConfig): void {
+	mkdirSync(dirname(configPath), { recursive: true });
+	writeFileSync(configPath, stringifyTOML(config));
 }
 
-export function installHook(): void {
-	const config = readConfig();
-	if (!Array.isArray(config.notify)) {
-		config.notify = [];
-	}
-	if (!config.notify.includes(HOOK_COMMAND)) {
-		config.notify.push(HOOK_COMMAND);
-	}
-	writeConfig(config);
+function isRudelHookCommand(command: readonly string[]): boolean {
+	return (
+		command.length === HOOK_COMMAND.length &&
+		command.every((value, index) => value === HOOK_COMMAND[index])
+	);
 }
 
-export function removeHook(): void {
-	const config = readConfig();
+export function installHook(configPath: string = CONFIG_PATH): void {
+	const config = readConfig(configPath);
+	const notify = config.notify;
+	if (notify !== undefined && !Array.isArray(notify)) {
+		throw new Error(
+			`Codex notify is already configured in ${configPath}. Rudel left it unchanged.`,
+		);
+	}
+	const current = notify ?? [];
+	if (isRudelHookCommand(current)) return;
+
+	// A broken earlier release appended the whole command as one string.
+	const withoutLegacy =
+		current.at(-1) === LEGACY_HOOK_COMMAND ? current.slice(0, -1) : current;
+
+	if (withoutLegacy.length === 0) {
+		config.notify = [...HOOK_COMMAND];
+		writeConfig(configPath, config);
+		return;
+	}
+
+	if (withoutLegacy.length < current.length) {
+		config.notify = withoutLegacy;
+		writeConfig(configPath, config);
+		throw new Error(
+			`Removed Rudel's invalid legacy notify entry from ${configPath}, restoring the previous command. Codex supports only one notify command, so Rudel was not installed.`,
+		);
+	}
+
+	throw new Error(
+		`Codex notify is already configured in ${configPath}. Codex supports only one notify command, so Rudel left the existing command unchanged.`,
+	);
+}
+
+export function removeHook(configPath: string = CONFIG_PATH): void {
+	const config = readConfig(configPath);
 	if (!Array.isArray(config.notify)) return;
-	config.notify = config.notify.filter((cmd) => cmd !== HOOK_COMMAND);
-	if (config.notify.length === 0) {
+
+	if (
+		isRudelHookCommand(config.notify) ||
+		(config.notify.length === 1 && config.notify[0] === LEGACY_HOOK_COMMAND)
+	) {
 		delete config.notify;
+		writeConfig(configPath, config);
+		return;
 	}
-	writeConfig(config);
+
+	if (config.notify.at(-1) === LEGACY_HOOK_COMMAND) {
+		config.notify = config.notify.slice(0, -1);
+		writeConfig(configPath, config);
+	}
 }
 
-export function isHookInstalled(): boolean {
-	const config = readConfig();
+export function isHookInstalled(configPath: string = CONFIG_PATH): boolean {
+	const config = readConfig(configPath);
 	if (!Array.isArray(config.notify)) return false;
-	return config.notify.includes(HOOK_COMMAND);
+	return isRudelHookCommand(config.notify);
 }

--- a/packages/secret-filter/src/__tests__/performance.test.ts
+++ b/packages/secret-filter/src/__tests__/performance.test.ts
@@ -1,4 +1,8 @@
 import { expect, test } from "bun:test";
+import {
+	type CompiledSecretRule,
+	filterKnownSecretsWithCompiledRules,
+} from "../filter.js";
 import { filterKnownSecrets } from "../index.js";
 
 const TEN_MB_OF_PROSE = "ordinary transcript content\n".repeat(
@@ -15,16 +19,8 @@ test("filters a 10 MB transcript in low single-digit seconds", () => {
 	expect(durationMs).toBeLessThan(5_000);
 });
 
-test("a clean 10 MB transcript still costs a single rule fold", () => {
-	// The fixpoint loop stops as soon as a pass redacts nothing, so the common
-	// case -- a transcript with no secrets in it -- must not pay for a second
-	// scan. Compare against a transcript that does contain a secret and so
-	// genuinely needs the extra pass.
+test("filters a 10 MB transcript containing a secret within ten seconds", () => {
 	const withSecret = `${TEN_MB_OF_PROSE}AKIACANARY234567ABCDSK${"ab".repeat(16)}`;
-
-	const cleanStart = performance.now();
-	filterKnownSecrets(TEN_MB_OF_PROSE);
-	const cleanMs = performance.now() - cleanStart;
 
 	const secretStart = performance.now();
 	const result = filterKnownSecrets(withSecret);
@@ -34,8 +30,37 @@ test("a clean 10 MB transcript still costs a single rule fold", () => {
 		"aws-access-key-id": 1,
 		"twilio-api-key": 1,
 	});
-	// Two folds instead of one, so allow generous headroom while still catching
-	// a regression that starts scanning many times over.
-	expect(secretMs).toBeLessThan(Math.max(cleanMs * 4, 1_000));
 	expect(secretMs).toBeLessThan(10_000);
 }, 20_000);
+
+test("a clean transcript stops after one rule fold", () => {
+	const definition: CompiledSecretRule["definition"] = {
+		id: "counted-rule",
+		sourceId: "test",
+		regexSource: "(never-matches)",
+		caseInsensitive: false,
+		secretGroup: 1,
+		allowlistRegexSources: [],
+	};
+	const matcher = new CountingRegExp(definition.regexSource, "dgu");
+	const rule: CompiledSecretRule = {
+		definition,
+		matcher,
+		allowlistMatchers: [],
+	};
+
+	const result = filterKnownSecretsWithCompiledRules(TEN_MB_OF_PROSE, [rule]);
+
+	expect(result.text).toBe(TEN_MB_OF_PROSE);
+	expect(result.counts).toEqual({});
+	expect(matcher.executionCount).toBe(1);
+});
+
+class CountingRegExp extends RegExp {
+	executionCount = 0;
+
+	override exec(text: string): RegExpExecArray | null {
+		this.executionCount += 1;
+		return super.exec(text);
+	}
+}


### PR DESCRIPTION
## Summary

- Fix Codex notify installation and argv parsing while preserving existing user notify commands.
- Route authenticated uploads through the credential API base unless `--endpoint` explicitly overrides it.
- Make dry runs inert across classification, retries, failure records, and grouping-cache persistence, with focused unit and packed integration coverage.
- Stabilize post-merge verification by capping Turbo at two concurrent tasks and replacing a load-sensitive benchmark ratio with a deterministic fold-count assertion.

## Deployment follow-up

The CI run after PR #445 merged failed before deployment: the first `verify` attempt killed `@rudel/api#test` with exit 137, and the rerun narrowly missed the secret-filter timing ratio. Limiting verify concurrency addresses runner memory pressure; the benchmark still enforces its absolute 5-second and 10-second ceilings without comparing two noisy wall-clock samples.

## Test plan

- [x] `bun run verify`
- [x] Live Codex 0.137 hook turn against an isolated HOME and localhost capture server
- [x] `bun test packages/secret-filter/src/__tests__/performance.test.ts`
- [x] `bun run --cwd packages/secret-filter check-types`
- [x] `bun run turbo run lint check-types test build --concurrency=2`
